### PR TITLE
Perf: Improve Sorting Algorithm Performance, Improve Sorting Benchmark

### DIFF
--- a/benchmarks/NexusMods.DataModel.Benchmarks/Program.cs
+++ b/benchmarks/NexusMods.DataModel.Benchmarks/Program.cs
@@ -5,3 +5,10 @@ using NexusMods.DataModel.Benchmarks;
 using NexusMods.DataModel.Sorting;
 
 BenchmarkRunner.Run<Sorting>();
+/*
+var sorting = new Sorting();
+sorting.NumItems = 1000;
+sorting.Setup();
+sorting.Sort();
+var a = 5;
+*/

--- a/benchmarks/NexusMods.DataModel.Benchmarks/Program.cs
+++ b/benchmarks/NexusMods.DataModel.Benchmarks/Program.cs
@@ -5,10 +5,3 @@ using NexusMods.DataModel.Benchmarks;
 using NexusMods.DataModel.Sorting;
 
 BenchmarkRunner.Run<Sorting>();
-/*
-var sorting = new Sorting();
-sorting.NumItems = 1000;
-sorting.Setup();
-sorting.Sort();
-var a = 5;
-*/

--- a/benchmarks/NexusMods.DataModel.Benchmarks/Program.cs
+++ b/benchmarks/NexusMods.DataModel.Benchmarks/Program.cs
@@ -5,5 +5,3 @@ using NexusMods.DataModel.Benchmarks;
 using NexusMods.DataModel.Sorting;
 
 BenchmarkRunner.Run<Sorting>();
-
-//new Sorting().Sort();

--- a/benchmarks/NexusMods.DataModel.Benchmarks/Sorting.cs
+++ b/benchmarks/NexusMods.DataModel.Benchmarks/Sorting.cs
@@ -5,14 +5,19 @@ using NexusMods.DataModel.Sorting.Rules;
 
 namespace NexusMods.DataModel.Benchmarks;
 
+[MemoryDiagnoser]
 public class Sorting
 {
-    private readonly List<Item> _rules;
+    private List<Item> _rules;
+    
+    [Params(100, 1000, 2000, 5000, 10000)]
+    public int NumItems { get; set; }
 
-    public Sorting()
+    [GlobalSetup]
+    public void Setup()
     {
         var letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".Select(e => e.ToString());
-        var numbers = Enumerable.Range(0, 10000).Select(e => e.ToString());
+        var numbers = Enumerable.Range(0, NumItems).Select(e => e.ToString());
 
         var rules = new List<Item>();
         foreach (var (n, idx) in letters.Select((n, idx) => (n, idx)))

--- a/src/Games/NexusMods.Games.BethesdaGameStudios/PluginFile.cs
+++ b/src/Games/NexusMods.Games.BethesdaGameStudios/PluginFile.cs
@@ -29,33 +29,56 @@ public record PluginFile : AGeneratedFile
             .Select(f => f.File)
             .Where(f => SkyrimSpecialEdition.PluginExtensions.Contains(f.To.Extension))
             .ToArray();
-        var results = Sorter.Sort<AModFile, RelativePath, AModFile[]>(pluginFiles, 
-            i => i.To.FileName,
-            i => GenerateRules(pluginFiles, i),
+        
+        var pluginFileRuleTuples = InitialiseFileRuleTuples(pluginFiles);
+
+        var results = Sorter.Sort<ModRuleTuple, RelativePath, ModRuleTuple[]>(pluginFileRuleTuples, 
+            i => i.Mod.To.FileName,
+            i => i.Rules, //GenerateRules(pluginFiles, i),
             RelativePath.Comparer);
 
-        await stream.WriteAllLinesAsync(results.Select(i => i.To.FileName.ToString()), token: ct);
+        await stream.WriteAllLinesAsync(results.Select(i => i.Mod.To.FileName.ToString()), token: ct);
     }
 
-    private IEnumerable<ISortRule<AModFile, RelativePath>> GenerateRules(AModFile[] modFiles, AModFile aModFile)
+    private ModRuleTuple[] InitialiseFileRuleTuples(AModFile[] pluginFiles)
+    {
+        // Init Mods
+        var pluginFileRuleTuples = GC.AllocateUninitializedArray<ModRuleTuple>(pluginFiles.Length);
+        for (int x = 0; x < pluginFileRuleTuples.Length; x++)
+        {
+            ref var entry = ref pluginFileRuleTuples[x];
+            entry.Mod = pluginFiles[x];
+        }
+
+        // Generate & Cache Rules
+        for (int x = 0; x < pluginFileRuleTuples.Length; x++)
+        {
+            ref var entry = ref pluginFileRuleTuples[x];
+            entry.Rules = GenerateRules(pluginFileRuleTuples, entry.Mod).ToArray();
+        }
+
+        return pluginFileRuleTuples;
+    }
+
+    private IEnumerable<ISortRule<ModRuleTuple, RelativePath>> GenerateRules(ModRuleTuple[] modFiles, AModFile aModFile)
     {
         var defaultIdx = DefaultOrdering.IndexOf(aModFile.To.FileName);
         switch (defaultIdx)
         {
             case 0:
-                yield return new First<AModFile, RelativePath>();
+                yield return new First<ModRuleTuple, RelativePath>();
                 break;
             case > 1:
             {
                 for (var i = 0; i < defaultIdx; i++)
                 {
-                    yield return new After<AModFile, RelativePath>(DefaultOrdering[i]);
+                    yield return new After<ModRuleTuple, RelativePath>(DefaultOrdering[i]);
                 }
 
                 foreach (var itm in modFiles)
                 {
-                    if (DefaultOrdering.Contains(itm.To.FileName)) continue;
-                    yield return new Before<AModFile, RelativePath>(itm.To.FileName);
+                    if (DefaultOrdering.Contains(itm.Mod.To.FileName)) continue;
+                    yield return new Before<ModRuleTuple, RelativePath>(itm.Mod.To.FileName);
                 }
 
                 break;
@@ -66,19 +89,19 @@ public record PluginFile : AGeneratedFile
                 {
                     foreach (var dep in itm.Masters)
                     {
-                        yield return new After<AModFile, RelativePath>(dep);
+                        yield return new After<ModRuleTuple, RelativePath>(dep);
                     }
                 }
 
                 if (aModFile.To.Extension == SkyrimSpecialEdition.ESL)
                 {
-                    foreach (var file in modFiles.Where(m => m.To.Extension == SkyrimSpecialEdition.ESM))
-                        yield return new After<AModFile, RelativePath>(file.To.FileName);
+                    foreach (var file in modFiles.Where(m => m.Mod.To.Extension == SkyrimSpecialEdition.ESM))
+                        yield return new After<ModRuleTuple, RelativePath>(file.Mod.To.FileName);
                 }
                 else if (aModFile.To.Extension == SkyrimSpecialEdition.ESP)
                 {
-                    foreach (var file in modFiles.Where(m => m.To.Extension != SkyrimSpecialEdition.ESP))
-                        yield return new After<AModFile, RelativePath>(file.To.FileName);
+                    foreach (var file in modFiles.Where(m => m.Mod.To.Extension != SkyrimSpecialEdition.ESP))
+                        yield return new After<ModRuleTuple, RelativePath>(file.Mod.To.FileName);
                 }
 
 
@@ -93,5 +116,11 @@ public record PluginFile : AGeneratedFile
         await GenerateAsync(ms, loadout, flattenedList, ct);
         ms.Position = 0;
         return (Size.From(ms.Length), await ms.Hash(token: ct));
+    }
+    
+    private struct ModRuleTuple
+    {
+        public AModFile Mod;
+        public IReadOnlyList<ISortRule<ModRuleTuple, RelativePath>> Rules;
     }
 }

--- a/src/Games/NexusMods.Games.BethesdaGameStudios/PluginFile.cs
+++ b/src/Games/NexusMods.Games.BethesdaGameStudios/PluginFile.cs
@@ -29,8 +29,8 @@ public record PluginFile : AGeneratedFile
             .Select(f => f.File)
             .Where(f => SkyrimSpecialEdition.PluginExtensions.Contains(f.To.Extension))
             .ToArray();
-        var results = Sorter.Sort(pluginFiles, 
-            i => i.To.FileName, 
+        var results = Sorter.Sort<AModFile, RelativePath, AModFile[]>(pluginFiles, 
+            i => i.To.FileName,
             i => GenerateRules(pluginFiles, i),
             RelativePath.Comparer);
 

--- a/src/NexusMods.DataModel/Loadouts/LoadoutManager.cs
+++ b/src/NexusMods.DataModel/Loadouts/LoadoutManager.cs
@@ -59,9 +59,9 @@ public class LoadoutManager
             Id = ModId.New(),
             Name = "Game Files",
             Files = new EntityDictionary<ModFileId, AModFile>(_store, gameFiles.Select(g => new KeyValuePair<ModFileId, Id>(g.Id, g.DataStoreId))),
-            SortRules = ImmutableHashSet<ISortRule<Mod, ModId>>.Empty.Add(new First<Mod, ModId>()),
             Store = _store
         };
+        mod.SortRules.Add(new First<Mod, ModId>());
         
         var n = Loadout.Empty(_store) with
         {

--- a/src/NexusMods.DataModel/Loadouts/Markers/LoadoutMarker.cs
+++ b/src/NexusMods.DataModel/Loadouts/Markers/LoadoutMarker.cs
@@ -40,7 +40,7 @@ public class LoadoutMarker : IMarker<Loadout>
     {
         var list = _manager.Get(_id);
         var projected = new Dictionary<GamePath, (AModFile File, Mod Mod)>();
-        var mods = Sorter.Sort<Mod, ModId>(list.Mods.Values, i => i.Id, m => m.SortRules);
+        var mods = Sorter.SortWithEnumerable<Mod, ModId>(list.Mods.Values, i => i.Id, m => m.SortRules);
         foreach (var mod in mods)
         {
             foreach (var file in mod.Files.Values)

--- a/src/NexusMods.DataModel/Loadouts/Mod.cs
+++ b/src/NexusMods.DataModel/Loadouts/Mod.cs
@@ -13,7 +13,5 @@ public record Mod : Entity, IHasEntityId<ModId>
     public required EntityDictionary<ModFileId, AModFile> Files { get; init; }
     public required string Name { get; init; }
     public override EntityCategory Category => EntityCategory.Loadouts;
-    
-    public ImmutableHashSet<ISortRule<Mod, ModId>> SortRules { get; init; } = ImmutableHashSet<ISortRule<Mod, ModId>>.Empty;
-    
+    public ImmutableList<ISortRule<Mod, ModId>> SortRules { get; init; } = ImmutableList<ISortRule<Mod, ModId>>.Empty;
 }

--- a/src/NexusMods.DataModel/Sorting/Sorter.cs
+++ b/src/NexusMods.DataModel/Sorting/Sorter.cs
@@ -101,7 +101,6 @@ public class Sorter
         var sorted = new List<TItem>(dict.Count);
         var used = new HashSet<TId>(dict.Count);
         
-        // Note: Dictionary does not expose this API publicly so a cast here is needed.
         var values = GC.AllocateUninitializedArray<(TId[] After, TItem Item)>(dict.Count);
         var parallelOptions = new ParallelOptions();
         var parallelState = new ParallelIsSuperset<TId, TItem>()

--- a/src/NexusMods.DataModel/Sorting/Sorter.cs
+++ b/src/NexusMods.DataModel/Sorting/Sorter.cs
@@ -1,39 +1,143 @@
-﻿using NexusMods.DataModel.Abstractions;
+﻿using System.Collections.Concurrent;
+using System.Runtime.InteropServices;
 using NexusMods.DataModel.Sorting.Rules;
 
 namespace NexusMods.DataModel.Sorting;
 
+/// <summary>
+/// Utility class for sorting mods according to a set of defined rules.
+/// </summary>
 public class Sorter
 {
-    public static IEnumerable<TItem> Sort<TItem, TId>(IEnumerable<TItem> items,
+    /// <summary>
+    /// Sorts a collection of user items.
+    /// </summary>
+    /// <param name="items">The items to process.</param>
+    /// <param name="idSelector">Function that extracts an individual id from an item.</param>
+    /// <param name="ruleFn">Function that pulls a list of rules for a specific item.</param>
+    /// <param name="comparer">[Optional] Comparer for items.</param>
+    /// <typeparam name="TItem">The type of item used.</typeparam>
+    /// <typeparam name="TId">The type of ID used for the item.</typeparam>
+    /// <returns>Sorted collection of items.</returns>
+    public static IEnumerable<TItem> SortWithEnumerable<TItem, TId>(IEnumerable<TItem> items,
         Func<TItem, TId> idSelector,
-        Func<TItem, IEnumerable<ISortRule<TItem, TId>>> ruleFn,
+        Func<TItem, IReadOnlyList<ISortRule<TItem, TId>>> ruleFn,
+        IComparer<TId>? comparer = null)
+        where TId : IEquatable<TId>
+    {
+        /*
+             Observation from me (Sewer).  
+             
+             In practice our mods/items are fetched from an IDataStore.  
+             
+             At the current moment in time, this is backed by an in memory database, 
+             so access times should be relatively quick and thus calling `.ToArray()` should be fine.  
+             
+             That said, if this data ever was to be file backed, adding an asynchronous access method
+             might not be too bad.
+        */
+        return Sort(items.ToArray(), idSelector, ruleFn, comparer);
+    }
+    
+    /// <summary>
+    /// Sorts a collection of user items.
+    /// </summary>
+    /// <param name="items">The items to process.</param>
+    /// <param name="idSelector">Function that extracts an individual id from an item.</param>
+    /// <param name="ruleFn">Function that pulls a list of rules for a specific item.</param>
+    /// <param name="comparer">[Optional] Comparer for items.</param>
+    /// <typeparam name="TItem">The type of item used.</typeparam>
+    /// <typeparam name="TId">The type of ID used for the item.</typeparam>
+    /// <returns>Sorted collection of items.</returns>
+    public static IEnumerable<TItem> Sort<TItem, TId>(List<TItem> items,
+        Func<TItem, TId> idSelector,
+        Func<TItem, IReadOnlyList<ISortRule<TItem, TId>>> ruleFn,
         IComparer<TId>? comparer = null) 
         where TId : IEquatable<TId>
     {
-        var indexed = items
-            .AsParallel()
-            .Select(i => (After: RefineRules(i, idSelector, ruleFn, items), Item: i))
-            .ToDictionary(i => idSelector(i.Item), i => i);
+        return Sort<TItem, TId, List<TItem>>(items, idSelector, ruleFn, comparer);
+    }
 
-        var sorted = new List<TItem>();
-        var used = new HashSet<TId>();
+    /// <summary>
+    /// Sorts a collection of user items.
+    /// </summary>
+    /// <param name="items">The items to process.</param>
+    /// <param name="idSelector">Function that extracts an individual id from an item.</param>
+    /// <param name="ruleFn">Function that pulls a list of rules for a specific item.</param>
+    /// <param name="comparer">[Optional] Comparer for items.</param>
+    /// <typeparam name="TItem">The type of item used.</typeparam>
+    /// <typeparam name="TId">The type of ID used for the item.</typeparam>
+    /// <typeparam name="TCollection">Type of collection used.</typeparam>
+    /// <returns>Sorted collection of items.</returns>
+    public static IEnumerable<TItem> Sort<TItem, TId, TCollection>(TCollection items,
+        Func<TItem, TId> idSelector,
+        Func<TItem, IReadOnlyList<ISortRule<TItem, TId>>> ruleFn,
+        IComparer<TId>? comparer = null) 
+        where TId : IEquatable<TId>
+        where TCollection : class, IReadOnlyList<TItem>
+    {
+        var partitioner = Partitioner.Create(0, items.Count);
+        var indexed = new ConcurrentDictionary<TId, (TId[] After, TItem Item)>(Environment.ProcessorCount, items.Count);
         
-        while (indexed.Count > 0)
+        Parallel.ForEach(partitioner, tuple =>
         {
-            var fit = indexed.Values.Where(v => used.IsSupersetOf(v.After));
+            var idBuffer  = new HashSet<TId>(tuple.Item2 - tuple.Item1);
+            
+            // Work on our slice.
+            for (int x = tuple.Item1; x < tuple.Item2; x++)
+            {
+                var item = items[x];
+                var rules = RefineRules(item, idSelector, ruleFn, items, idBuffer);
+                indexed[idSelector(item)] = (rules, item);
+                
+                idBuffer.Clear(); // prepare for reuse
+            }
+        });
+
+        // This copy is necessary because ConcurrentDictionary does not have required APIs
+        // for fast value access, and that bottlenecks us. No better option without custom dict.
+        var dict = new Dictionary<TId, (TId[] After, TItem Item)>(indexed);
+        var sorted = new List<TItem>(dict.Count);
+        var used = new HashSet<TId>(dict.Count);
+        
+        // Note: Dictionary does not expose this API publicly so a cast here is needed.
+        var values = GC.AllocateUninitializedArray<(TId[] After, TItem Item)>(dict.Count);
+        
+        while (dict.Count > 0)
+        {
+            // Copy to values (no alloc), then filter them in-place
+            // Note: For Span<T>, foreach is lowered to for; there is no enumerator allocation.
+            dict.Values.CopyTo(values, 0);
+            var valuesSlice = values.AsSpan(0, dict.Count);
+            
+            int superSetSize = 0;
+            foreach (var value in valuesSlice)
+            {
+                if (IsSupersetOf(used, value.After))
+                    values[superSetSize++] = value;
+            }
+
+            // Slice to our superset.
+            valuesSlice = values.AsSpan(0, superSetSize);
             if (comparer != null)
-                fit = fit.OrderBy(x => idSelector(x.Item), comparer);
+            {
+                valuesSlice.Sort((a, b) =>
+                {
+                    var aId = idSelector(a.Item);
+                    var bId = idSelector(b.Item);
+                    return comparer.Compare(aId, bId);
+                });
+            }
             
             var found = false;
 
-            foreach (var (_, item) in fit)
+            foreach (var value in valuesSlice)
             {
-                var id = idSelector(item);
+                var id = idSelector(value.Item);
                 found = true;
-                sorted.Add(item);
+                sorted.Add(value.Item);
                 used.Add(id);
-                indexed.Remove(id);
+                dict.Remove(id, out _);
             }
 
             if (!found)
@@ -43,56 +147,103 @@ public class Sorter
         return sorted;
     }
 
-    private static HashSet<TId> RefineRules<TItem, TId>(TItem thisItem, 
+    private static TId[] RefineRules<TItem, TId>(TItem thisItem, 
         Func<TItem, TId> idSelector,
-        Func<TItem, IEnumerable<ISortRule<TItem, TId>>> ruleFn, 
-        IEnumerable<TItem> items)
+        Func<TItem, IReadOnlyList<ISortRule<TItem, TId>>> ruleFn, 
+        IReadOnlyList<TItem> items,
+        HashSet<TId> idsBuffer)
     where TId : IEquatable<TId>
     {
-        var rules = ruleFn(thisItem).ToList();
-        var ids = new HashSet<TId>();
         bool haveFirst = false;
-        foreach (var rule in rules)
+        var rulesForThisItem = ruleFn(thisItem);
+        
+        /*
+             Please do not refactor 'for' as foreach in this method.
+             That will lead to enumerator allocation, which in turn is a 
+             lot of allocations made; as this is O(N^2)
+             
+             - Sewer
+        */
+        for (var x = 0; x < rulesForThisItem.Count; x++)
         {
-            switch (rule)
+            switch (rulesForThisItem[x])
             {
                 case First<TItem, TId>:
                     // Handled later
                     haveFirst = true;
                     break;
                 case After<TItem, TId> after:
-                    ids.Add(after.Other);
+                    idsBuffer.Add(after.Other);
                     break;
                 case Before<TItem, TId>:
                     // Handled later
                     break;
             }
         }
-        
-        foreach (var itm in items)
+
+        var idForThisItem = idSelector(thisItem);
+        for (var x = 0; x < items.Count; x++)
         {
-            if (idSelector(itm).Equals(idSelector(thisItem)))
+            var itm = items[x];
+            var otherId = idSelector(itm);
+            if (otherId.Equals(idForThisItem))
                 continue;
-            
-            foreach (var rule in ruleFn(itm))
+
+            var rulesForOtherItem = ruleFn(itm);
+            for (var y = 0; y < rulesForOtherItem.Count; y++)
             {
+                var rule = rulesForOtherItem[y];
                 switch (rule)
                 {
                     case First<TItem, TId>:
-                        if (!haveFirst) 
-                            ids.Add(idSelector(itm));
+                        if (!haveFirst)
+                            idsBuffer.Add(idSelector(itm));
                         break;
                     case After<TItem, TId> after:
                         // Handled above
                         break;
                     case Before<TItem, TId> b:
                         if (b.Other.Equals(idSelector(thisItem)))
-                            ids.Add(idSelector(itm));
+                            idsBuffer.Add(idSelector(itm));
                         break;
                 }
             }
         }
-        
-        return ids;
+
+        return idsBuffer.ToArray();
     }
+
+    #region Modified Runtime Code for No Alloc
+    /// <summary>Determines whether a <see cref="HashSet{T}"/> object is a proper superset of the specified collection.</summary>
+    /// <param name="other">The collection to compare to the current <see cref="HashSet{T}"/> object.</param>
+    /// <returns>true if the <see cref="HashSet{T}"/> object is a superset of <paramref name="other"/>; otherwise, false.</returns>
+    public static bool IsSupersetOf<T>(HashSet<T> set, T[] other)
+    {
+        // Try to fall out early based on counts.
+        if (other is not ICollection<T> otherAsCollection) 
+            return ContainsAllElements(set, other);
+        
+        // If other is the empty set then this is a superset.
+        if (otherAsCollection.Count == 0)
+            return true;
+
+        return ContainsAllElements(set, other);
+    }
+    
+    /// <summary>
+    /// Checks if this contains of other's elements. Iterates over other's elements and
+    /// returns false as soon as it finds an element in other that's not in this.
+    /// </summary>
+    private static bool ContainsAllElements<T>(HashSet<T> set, T[] other)
+    {
+        // Although Roslyn should lower this into for loop, please don't rewrite as foreach.
+        for (var x = 0; x < other.Length; x++)
+        {
+            if (!set.Contains(other[x]))
+                return false;
+        }
+
+        return true;
+    }
+    #endregion
 }

--- a/src/NexusMods.DataModel/Sorting/Sorter.cs
+++ b/src/NexusMods.DataModel/Sorting/Sorter.cs
@@ -24,6 +24,7 @@ public class Sorter
             var fit = indexed.Values.Where(v => used.IsSupersetOf(v.After));
             if (comparer != null)
                 fit = fit.OrderBy(x => idSelector(x.Item), comparer);
+            
             var found = false;
 
             foreach (var (_, item) in fit)

--- a/tests/NexusMods.DataModel.Tests/SortTests.cs
+++ b/tests/NexusMods.DataModel.Tests/SortTests.cs
@@ -21,7 +21,7 @@ public class SortTests
             }},
         };
         
-        Sorter.Sort(data, x => x.Id, x => x.Rules)
+        Sorter.Sort<Item, string>(data, x => x.Id, x => x.Rules)
             .Select(i => i.Id)
             .Should().BeEquivalentTo("A", "B");
     }
@@ -42,7 +42,7 @@ public class SortTests
             }}
         };
         
-        Sorter.Sort(data, x => x.Id, x => x.Rules)
+        Sorter.Sort<Item, string>(data, x => x.Id, x => x.Rules)
             .Select(i => i.Id)
             .Should().BeEquivalentTo("A", "B", "C");
     }
@@ -90,7 +90,7 @@ public class SortTests
 
         rules = Shuffle(rules).ToList();
         
-        Sorter.Sort(rules, x => x.Id, x => x.Rules)
+        Sorter.Sort<Item, string>(rules, x => x.Id, x => x.Rules)
             .Select(i => i.Id)
             .Should().BeEquivalentTo(letters.Concat(numbers));
     }


### PR DESCRIPTION
```csharp
| Method | NumItems |         Mean |       Error |      StdDev |      Gen0 |      Gen1 |   Allocated |
|------- |--------- |-------------:|------------:|------------:|----------:|----------:|------------:|
|   Sort |      100 |     232.5 us |     0.76 us |     0.71 us |   13.6719 |    1.9531 |   218.35 KB |
|   Sort |     1000 |   9,651.1 us |    24.59 us |    20.54 us |   46.8750 |   15.6250 |   833.33 KB |
|   Sort |     2000 |  40,248.5 us |   319.33 us |   298.70 us |   76.9231 |         - |  1696.25 KB |
|   Sort |     5000 | 197,204.1 us | 3,727.65 us | 3,661.05 us | 1000.0000 |  500.0000 | 17553.82 KB |
|   Sort |    10000 | 825,593.6 us | 6,677.17 us | 6,245.83 us | 2000.0000 | 1000.0000 | 50161.87 KB |
```

Fixes [#84.](https://github.com/Nexus-Mods/NexusMods.App/issues/84). Improves runtime by around 4x and memory usage by ~100x for big sets.
Additionally improves the benchmark to automatically benchmark against a variable number of items (from 100 to 10000).

Further improvements are still possible [we are mostly bottlenecked by lack of custom collections] but not currently worth in terms of development time.