### PR TITLE
Fixed: Startup for Projects that Depend(ed) on XUnit DependencyInjection

### DIFF
--- a/tests/NexusMods.CLI.Tests/NexusMods.CLI.Tests.csproj
+++ b/tests/NexusMods.CLI.Tests/NexusMods.CLI.Tests.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
     
+    <PropertyGroup>
+        <XunitStartupAssembly>NexusMods.CLI.Tests</XunitStartupAssembly>
+    </PropertyGroup>
+    
     <ItemGroup>
       <ProjectReference Include="..\..\src\Games\NexusMods.Games.BethesdaGameStudios\NexusMods.Games.BethesdaGameStudios.csproj" />
       <ProjectReference Include="..\..\src\NexusMods.CLI\NexusMods.CLI.csproj" />

--- a/tests/NexusMods.Paths.Tests/NexusMods.Paths.Tests.csproj
+++ b/tests/NexusMods.Paths.Tests/NexusMods.Paths.Tests.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
+    
+    <PropertyGroup>
+        <EnableXunitDependencyInjectionDefaultTestFrameworkAttribute>false</EnableXunitDependencyInjectionDefaultTestFrameworkAttribute>
+    </PropertyGroup>
+    
     <ItemGroup>
         <ProjectReference Include="..\..\src\NexusMods.Paths\NexusMods.Paths.csproj" />
     </ItemGroup>


### PR DESCRIPTION
Fixes an accidental regression in aedce098b04e2140cf83d3c27538aeb2cc3f98b3  ( part of #94  ) ; that can happen while running tests from IDE and wasn't noticed in CI or review.

For our intent and purposes this is just part of the other PR.