### PR TITLE
Fix Cyberpunk Stress Tests

### DIFF
--- a/src/ArchiveManagement/NexusMods.FileExtractor/FileSignatures/Definitions/magic_sigs.txt
+++ b/src/ArchiveManagement/NexusMods.FileExtractor/FileSignatures/Definitions/magic_sigs.txt
@@ -16,3 +16,4 @@ Gamebryo File Format, 47 61 6d 65 62 72 79 6f 20 46 69 6c 65 20 46 6f 72 6d 61 7
 Creation Engine Plugin, 54 45 53 34, CreationEnginePlugin
 TES4 Plugin, 54 45 53 34, TES4
 PDF file,25 50 44 46,PDF|FDF,Word processing suite,0,25 25 45 4F 46
+Cyberpunk Appearance Preset, 4c 6f 63 4b 65 79 23, Cyberpunk2077AppearancePreset

--- a/src/ArchiveManagement/NexusMods.FileExtractor/FileSignatures/Definitions/mundane_sigs.txt
+++ b/src/ArchiveManagement/NexusMods.FileExtractor/FileSignatures/Definitions/mundane_sigs.txt
@@ -1,2 +1,3 @@
 ﻿Ini Configuration File, INI, .ini
 Text File, TXT, .txt
+JSON File, JSON, .json

--- a/src/ArchiveManagement/NexusMods.FileExtractor/FileSignatures/Signatures.cs
+++ b/src/ArchiveManagement/NexusMods.FileExtractor/FileSignatures/Signatures.cs
@@ -12,10 +12,18 @@ namespace NexusMods.FileExtractor.FileSignatures {
                 /// Creation Engine Plugin
                 /// </summary>
                  CreationEnginePlugin,
+                            /// <summary>
+                /// Cyberpunk Appearance Preset
+                /// </summary>
+                 Cyberpunk2077AppearancePreset,
                         /// <summary>
             /// Ini Configuration File
             /// </summary>
              INI,
+            /// <summary>
+            /// JSON File
+            /// </summary>
+             JSON,
                 /// <summary>
                 /// Morrowind BSA
                 /// </summary>
@@ -139,6 +147,9 @@ namespace NexusMods.FileExtractor.FileSignatures {
                 // PDF file
         (FileType.FDF, new byte[] {0x25, 0x50, 0x44, 0x46}),
 
+                // Cyberpunk Appearance Preset
+        (FileType. Cyberpunk2077AppearancePreset, new byte[] {0x4c, 0x6f, 0x63, 0x4b, 0x65, 0x79, 0x23}),
+
         
     };
 
@@ -148,6 +159,9 @@ namespace NexusMods.FileExtractor.FileSignatures {
 
                 // Text File
         (FileType.TXT, new Extension(".txt")),
+
+                // JSON File
+        (FileType.JSON, new Extension(".json")),
 
         
     };

--- a/src/Games/NexusMods.Games.RedEngine/FileAnalyzers/RedModInfoAnalyzer.cs
+++ b/src/Games/NexusMods.Games.RedEngine/FileAnalyzers/RedModInfoAnalyzer.cs
@@ -1,0 +1,30 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+using NexusMods.DataModel.Abstractions;
+using NexusMods.DataModel.JsonConverters;
+using NexusMods.FileExtractor.FileSignatures;
+using NexusMods.Paths;
+
+namespace NexusMods.Games.RedEngine.FileAnalyzers;
+
+public class RedModInfoAnalyzer : IFileAnalyzer
+{
+    public IEnumerable<FileType> FileTypes => new[] { FileType.JSON };
+    public async IAsyncEnumerable<IFileAnalysisData> AnalyzeAsync(Stream stream, CancellationToken ct = default)
+    {
+        var info = await JsonSerializer.DeserializeAsync<InfoJson>(stream, cancellationToken: ct);
+        yield return new RedModInfo { Name = info.Name };
+    }
+}
+
+internal class InfoJson
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+}
+
+[JsonName("NexusMods.Games.RedEngine.FileAnalyzers.RedModInfo")]
+public record RedModInfo : IFileAnalysisData
+{
+    public required string Name { get; init; }
+}

--- a/src/Games/NexusMods.Games.RedEngine/ModInstallers/AppearancePreset.cs
+++ b/src/Games/NexusMods.Games.RedEngine/ModInstallers/AppearancePreset.cs
@@ -8,6 +8,8 @@ using NexusMods.DataModel.ModInstallers;
 using NexusMods.FileExtractor.FileSignatures;
 using NexusMods.Hashing.xxHash64;
 using NexusMods.Paths;
+using NexusMods.Paths.Extensions;
+using NexusMods.Paths.Utilities;
 
 namespace NexusMods.Games.RedEngine.ModInstallers;
 
@@ -19,7 +21,7 @@ public class AppearancePreset : IModInstaller
         
         if (files.All(f => Helpers.IgnoreExtensions.Contains(f.Key.Extension) || 
                            (f.Value.FileTypes.Contains(FileType.Cyberpunk2077AppearancePreset) &&
-                            f.Key.Extension == Ext.Preset)))
+                            f.Key.Extension == KnownExtensions.Preset)))
             return Common.Priority.Normal;
 
         return Common.Priority.None;
@@ -32,7 +34,7 @@ public class AppearancePreset : IModInstaller
     
     public IEnumerable<AModFile> Install(GameInstallation installation, Hash srcArchive, EntityDictionary<RelativePath, AnalyzedFile> files)
     {
-        foreach (var (path, file) in files.Where(f => f.Key.Extension == Ext.Preset))
+        foreach (var (path, file) in files.Where(f => f.Key.Extension == KnownExtensions.Preset))
         {
             foreach (var relPath in _paths)
             {

--- a/src/Games/NexusMods.Games.RedEngine/ModInstallers/AppearancePreset.cs
+++ b/src/Games/NexusMods.Games.RedEngine/ModInstallers/AppearancePreset.cs
@@ -1,0 +1,51 @@
+﻿using NexusMods.Common;
+using NexusMods.DataModel.Abstractions;
+using NexusMods.DataModel.ArchiveContents;
+using NexusMods.DataModel.Games;
+using NexusMods.DataModel.Loadouts;
+using NexusMods.DataModel.Loadouts.ModFiles;
+using NexusMods.DataModel.ModInstallers;
+using NexusMods.FileExtractor.FileSignatures;
+using NexusMods.Hashing.xxHash64;
+using NexusMods.Paths;
+
+namespace NexusMods.Games.RedEngine.ModInstallers;
+
+public class AppearancePreset : IModInstaller
+{
+    public Priority Priority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> files)
+    {
+        if (!installation.Is<Cyberpunk2077>()) return Common.Priority.None;
+        
+        if (files.All(f => Helpers.IgnoreExtensions.Contains(f.Key.Extension) || 
+                           (f.Value.FileTypes.Contains(FileType.Cyberpunk2077AppearancePreset) &&
+                            f.Key.Extension == Ext.Preset)))
+            return Common.Priority.Normal;
+
+        return Common.Priority.None;
+    }
+
+    private RelativePath[] _paths = {
+        @"bin\x64\plugins\cyber_engine_tweaks\mods\AppearanceChangeUnlocker\character-preset\female".ToRelativePath(),
+        @"bin\x64\plugins\cyber_engine_tweaks\mods\AppearanceChangeUnlocker\character-preset\male".ToRelativePath()
+    };
+    
+    public IEnumerable<AModFile> Install(GameInstallation installation, Hash srcArchive, EntityDictionary<RelativePath, AnalyzedFile> files)
+    {
+        foreach (var (path, file) in files.Where(f => f.Key.Extension == Ext.Preset))
+        {
+            foreach (var relPath in _paths)
+            {
+                yield return new FromArchive
+                {
+                    Id = ModFileId.New(),
+                    From = new HashRelativePath(srcArchive, path),
+                    To = new GamePath(GameFolderType.Game, relPath.Join(path.FileName)),
+                    Hash = file.Hash,
+                    Size = file.Size,
+                    Store = file.Store
+                };
+            }
+        }
+    }
+}

--- a/src/Games/NexusMods.Games.RedEngine/ModInstallers/FolderlessModInstaller.cs
+++ b/src/Games/NexusMods.Games.RedEngine/ModInstallers/FolderlessModInstaller.cs
@@ -7,6 +7,8 @@ using NexusMods.DataModel.Loadouts.ModFiles;
 using NexusMods.DataModel.ModInstallers;
 using NexusMods.Hashing.xxHash64;
 using NexusMods.Paths;
+using NexusMods.Paths.Extensions;
+using NexusMods.Paths.Utilities;
 
 namespace NexusMods.Games.RedEngine.ModInstallers;
 
@@ -18,7 +20,7 @@ public class FolderlessModInstaller : IModInstaller
     
     private static Extension[] _supportedExtensions =
     {
-        Ext.Archive
+        KnownExtensions.Archive
     };
     
     public Priority Priority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> files)

--- a/src/Games/NexusMods.Games.RedEngine/ModInstallers/FolderlessModInstaller.cs
+++ b/src/Games/NexusMods.Games.RedEngine/ModInstallers/FolderlessModInstaller.cs
@@ -1,0 +1,70 @@
+﻿using NexusMods.Common;
+using NexusMods.DataModel.Abstractions;
+using NexusMods.DataModel.ArchiveContents;
+using NexusMods.DataModel.Games;
+using NexusMods.DataModel.Loadouts;
+using NexusMods.DataModel.Loadouts.ModFiles;
+using NexusMods.DataModel.ModInstallers;
+using NexusMods.Hashing.xxHash64;
+using NexusMods.Paths;
+
+namespace NexusMods.Games.RedEngine.ModInstallers;
+
+/// <summary>
+/// Matches mods that have all the .archive files in the base folder, optionally with other documentation files.
+/// </summary>
+public class FolderlessModInstaller : IModInstaller
+{
+    
+    private static Extension[] _supportedExtensions =
+    {
+        Ext.Archive
+    };
+    
+    public Priority Priority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> files)
+    {
+        if (!installation.Is<Cyberpunk2077>())
+            return Common.Priority.None;
+        
+        // Make sure we don't have any files that are not supported
+        if (!files.All(f => 
+                           _supportedExtensions.Contains(f.Key.Extension) || Helpers.IgnoreExtensions.Contains(f.Key.Extension)))
+            return Common.Priority.None;
+
+        // If all the files are in the base folder, then we can install them
+        if (files.All(f => f.Key.Depth == 1))
+            return Common.Priority.Normal;
+        
+        // If all the files are in the same subfolder, then we can install them
+        var firstFile = files.First().Key;
+        if (firstFile.Depth > 1)
+        {
+            var parentFolder = firstFile.Parent;
+            if (files.All(f => f.Key.Depth == firstFile.Depth &&
+                               f.Key.InFolder(parentFolder)))
+                return Common.Priority.Normal;
+        }
+
+        // Otherwise, we can't install them
+        return Common.Priority.None;
+    }
+
+    public IEnumerable<AModFile> Install(GameInstallation installation, Hash srcArchive, EntityDictionary<RelativePath, AnalyzedFile> files)
+    {
+        foreach (var (path, file) in files)
+        {
+            if (Helpers.IgnoreExtensions.Contains(path.Extension))
+                continue;
+            
+            yield return new FromArchive
+            {
+                Id = ModFileId.New(),
+                From = new HashRelativePath(srcArchive, path),
+                To = new GamePath(GameFolderType.Game, @"archive\pc\mod\".ToRelativePath().Join(path.FileName)),
+                Hash = file.Hash,
+                Size = file.Size,
+                Store = file.Store
+            };
+        }
+    }
+}

--- a/src/Games/NexusMods.Games.RedEngine/ModInstallers/Helpers.cs
+++ b/src/Games/NexusMods.Games.RedEngine/ModInstallers/Helpers.cs
@@ -1,14 +1,15 @@
 ﻿using NexusMods.Paths;
+using NexusMods.Paths.Utilities;
 
 namespace NexusMods.Games.RedEngine.ModInstallers;
 
 public static class Helpers
 {
     public static Extension[] IgnoreExtensions = {
-        Ext.Txt,
-        Ext.Md,
-        Ext.Pdf,
-        Ext.Png
+        KnownExtensions.Txt,
+        KnownExtensions.Md,
+        KnownExtensions.Pdf,
+        KnownExtensions.Png
     };
 
 }

--- a/src/Games/NexusMods.Games.RedEngine/ModInstallers/Helpers.cs
+++ b/src/Games/NexusMods.Games.RedEngine/ModInstallers/Helpers.cs
@@ -1,0 +1,14 @@
+﻿using NexusMods.Paths;
+
+namespace NexusMods.Games.RedEngine.ModInstallers;
+
+public static class Helpers
+{
+    public static Extension[] IgnoreExtensions = {
+        Ext.Txt,
+        Ext.Md,
+        Ext.Pdf,
+        Ext.Png
+    };
+
+}

--- a/src/Games/NexusMods.Games.RedEngine/ModInstallers/RedModInstaller.cs
+++ b/src/Games/NexusMods.Games.RedEngine/ModInstallers/RedModInstaller.cs
@@ -8,6 +8,7 @@ using NexusMods.DataModel.ModInstallers;
 using NexusMods.Games.RedEngine.FileAnalyzers;
 using NexusMods.Hashing.xxHash64;
 using NexusMods.Paths;
+using NexusMods.Paths.Extensions;
 
 namespace NexusMods.Games.RedEngine.ModInstallers;
 

--- a/src/Games/NexusMods.Games.RedEngine/ModInstallers/RedModInstaller.cs
+++ b/src/Games/NexusMods.Games.RedEngine/ModInstallers/RedModInstaller.cs
@@ -1,0 +1,49 @@
+﻿using NexusMods.Common;
+using NexusMods.DataModel.Abstractions;
+using NexusMods.DataModel.ArchiveContents;
+using NexusMods.DataModel.Games;
+using NexusMods.DataModel.Loadouts;
+using NexusMods.DataModel.Loadouts.ModFiles;
+using NexusMods.DataModel.ModInstallers;
+using NexusMods.Games.RedEngine.FileAnalyzers;
+using NexusMods.Hashing.xxHash64;
+using NexusMods.Paths;
+
+namespace NexusMods.Games.RedEngine.ModInstallers;
+
+public class RedModInstaller : IModInstaller
+{
+    private static RelativePath _infoJson = "info.json".ToRelativePath();
+    public Priority Priority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> files)
+    {
+        if (!installation.Is<Cyberpunk2077>()) return Common.Priority.None;
+
+        return files.Any(IsInfoJson) ? Common.Priority.High : Common.Priority.None;
+    }
+
+    public IEnumerable<AModFile> Install(GameInstallation installation, Hash srcArchive, EntityDictionary<RelativePath, AnalyzedFile> files)
+    {
+        foreach (var infoJson in files.Where(IsInfoJson))
+        {
+            var parent = infoJson.Key.Parent;
+            var parentName = parent.FileName;
+            foreach (var (path, file) in files.Where(f => f.Key.InFolder(parent)))
+            {
+                yield return new FromArchive
+                {
+                    Id = ModFileId.New(),
+                    From = new HashRelativePath(srcArchive, path),
+                    To = new GamePath(GameFolderType.Game, @"mods".ToRelativePath().Join(parentName, path.RelativeTo(parent))),
+                    Hash = file.Hash,
+                    Size = file.Size,
+                    Store = file.Store
+                };
+            }
+        }
+    }
+
+    private bool IsInfoJson(KeyValuePair<RelativePath, AnalyzedFile> file)
+    {
+        return file.Key.FileName == _infoJson && file.Value.AnalysisData.OfType<RedModInfo>().Any();
+    }
+}

--- a/src/Games/NexusMods.Games.RedEngine/ModInstallers/SimpleOverlayModInstaller.cs
+++ b/src/Games/NexusMods.Games.RedEngine/ModInstallers/SimpleOverlayModInstaller.cs
@@ -10,9 +10,9 @@ using NexusMods.Paths;
 using NexusMods.Paths.Extensions;
 using NexusMods.Paths.Utilities;
 
-namespace NexusMods.Games.RedEngine;
+namespace NexusMods.Games.RedEngine.ModInstallers;
 
-public class SimpleOverlyModInstaller : IModInstaller
+public class SimpleOverlayModInstaller : IModInstaller
 {
     private static RelativePath[] _rootPaths = new[]
     {
@@ -32,7 +32,9 @@ public class SimpleOverlyModInstaller : IModInstaller
     
     public Priority Priority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> files)
     {
-        var filtered = files.Where(f => f.Key.Depth > 1 || !_ignoreExtensions.Contains(f.Key.Extension))
+        if (!installation.Is<Cyberpunk2077>()) return Common.Priority.None;
+        
+        var filtered = files.Where(f => f.Key.Depth > 1 || !Helpers.IgnoreExtensions.Contains(f.Key.Extension))
             .Select(f => f.Key);
         
         if (filtered.All(path => _rootPaths.Any(path.InFolder)))
@@ -45,7 +47,7 @@ public class SimpleOverlyModInstaller : IModInstaller
 
     public IEnumerable<AModFile> Install(GameInstallation installation, Hash srcArchive, EntityDictionary<RelativePath, AnalyzedFile> files)
     {
-        var filtered = files.Where(f => f.Key.Depth > 1 || !_ignoreExtensions.Contains(f.Key.Extension));
+        var filtered = files.Where(f => f.Key.Depth > 1 || !Helpers.IgnoreExtensions.Contains(f.Key.Extension));
         
         foreach (var (path, file) in filtered)
         {

--- a/src/Games/NexusMods.Games.RedEngine/Services.cs
+++ b/src/Games/NexusMods.Games.RedEngine/Services.cs
@@ -1,7 +1,11 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Common;
+using NexusMods.DataModel.Abstractions;
 using NexusMods.DataModel.Games;
+using NexusMods.DataModel.JsonConverters.ExpressionGenerator;
 using NexusMods.DataModel.ModInstallers;
+using NexusMods.Games.RedEngine.FileAnalyzers;
+using NexusMods.Games.RedEngine.ModInstallers;
 
 namespace NexusMods.Games.RedEngine;
 
@@ -10,9 +14,14 @@ public static class Services
     public static IServiceCollection AddRedEngineGames(this IServiceCollection services)
     {
         services.AddAllSingleton<IGame, Cyberpunk2077>();
-        services.AddSingleton<IModInstaller, SimpleOverlyModInstaller>();
+        services.AddSingleton<IModInstaller, SimpleOverlayModInstaller>();
+        services.AddSingleton<IModInstaller, FolderlessModInstaller>();
+        services.AddSingleton<IModInstaller, AppearancePreset>();
+        services.AddSingleton<IModInstaller, RedModInstaller>();
+        services.AddSingleton<IFileAnalyzer, RedModInfoAnalyzer>();
         services.AddSingleton<ITool, RunGameTool<Cyberpunk2077>>();
         services.AddSingleton<ITool, RedModDeployTool>();
+        services.AddSingleton<ITypeFinder, TypeFinder>();
         return services;
     }
 }

--- a/src/Games/NexusMods.Games.RedEngine/TypeFinder.cs
+++ b/src/Games/NexusMods.Games.RedEngine/TypeFinder.cs
@@ -1,0 +1,17 @@
+﻿using NexusMods.DataModel.JsonConverters.ExpressionGenerator;
+using NexusMods.Games.RedEngine.FileAnalyzers;
+
+namespace NexusMods.Games.RedEngine;
+
+public class TypeFinder : ITypeFinder
+{
+    public IEnumerable<Type> DescendentsOf(Type type)
+    {
+        return AllTypes.Where(t => t.IsAssignableTo(type));
+    }
+
+    private IEnumerable<Type> AllTypes => new[]
+    {
+        typeof(RedModInfo)
+    };
+}

--- a/src/NexusMods.DataModel/Games/GameInstallation.cs
+++ b/src/NexusMods.DataModel/Games/GameInstallation.cs
@@ -49,4 +49,6 @@ public class GameInstallation
             .Select(l => new GamePath(l.Key, path.RelativeTo(l.Value)))
             .MinBy(x => x.Path.Depth);
     }
+    
+    public bool Is<T>() where T : IGame => Game is T;
 }

--- a/src/NexusMods.Paths/RelativePath.cs
+++ b/src/NexusMods.Paths/RelativePath.cs
@@ -88,6 +88,13 @@ public struct RelativePath : IPath, IEquatable<RelativePath>, IComparable<Relati
         Array.Copy(Parts, 0, newArray, basePath.Parts.Length, Parts.Length);
         return new AbsolutePath(newArray, basePath.PathFormat);
     }
+    
+    public RelativePath RelativeTo(RelativePath basePath)
+    {
+        if (!InFolder(basePath))
+            throw new Exception("Can't create path relative to paths that aren't in the same folder");
+        return new RelativePath(Parts[basePath.Parts.Length..]);
+    }
 
     /// <summary>
     /// Returns true if this path is a child of the given path.

--- a/src/NexusMods.Paths/Utilities/KnownExtensions.cs
+++ b/src/NexusMods.Paths/Utilities/KnownExtensions.cs
@@ -5,6 +5,12 @@
 /// </summary>
 public static class KnownExtensions
 {
+    /// <summary>.archive</summary>
+    public static Extension Archive = new(".archive");
+    
+    /// <summary>.preset</summary>
+    public static Extension Preset = new(".preset");
+    
     /// <summary>.zip</summary>
     public static Extension Zip = new(".zip");
     
@@ -34,6 +40,9 @@ public static class KnownExtensions
     
     /// <summary>.pdf</summary>
     public static Extension Pdf = new(".pdf");
+    
+    /// <summary>.png</summary>
+    public static Extension Png = new(".png");
         
     /// <summary>.ra</summary>
     public static Extension Ra = new(".ra");

--- a/tests/Games/NexusMods.Games.RedEngine.Tests/ModInstallerTests.cs
+++ b/tests/Games/NexusMods.Games.RedEngine.Tests/ModInstallerTests.cs
@@ -76,5 +76,8 @@ public class ModInstallerTests
         new object[] {"Tweak-XL", ModId.From(4197), FileId.From(36048), Hash.From(0x22A45B59423201E1), 2},
         new object[] {"Panam Romanced Enhanced", ModId.From(4626), FileId.From(38117), Hash.From(0xDD0E1C3AEA20E6C1), 3},
         new object[] {"Panam Romanced Enhanced REDmod", ModId.From(4626), FileId.From(38118), Hash.From(0x46F5AD6A75172F76), 5},
+        new object[] {"Tarnished Pack", ModId.From(6072), FileId.From(31953), Hash.From(0x0AAFB35F889500BD), 6},
+        new object[] {"Spicy Valentina", ModId.From(7404), FileId.From(39175), Hash.From(0xB354E2BE032A947F), 2},
+        new object[] {"OVE3RCHROME - Alternative LUT", ModId.From(6579), FileId.From(39289), Hash.From(0xC9CF6070A596BFDA), 2}
     };
 }


### PR DESCRIPTION
This PR adds support for Cyberpunk for the following mod types:

* .archive files scattered in various non-standard archive locations
* RedMod mods with `info.json` files
* Appearance presets