### PR TITLE
Support non-rooted Cyberpunk mods

### DIFF
--- a/src/Games/NexusMods.Games.RedEngine/FileAnalyzers/RedModInfoAnalyzer.cs
+++ b/src/Games/NexusMods.Games.RedEngine/FileAnalyzers/RedModInfoAnalyzer.cs
@@ -12,8 +12,17 @@ public class RedModInfoAnalyzer : IFileAnalyzer
     public IEnumerable<FileType> FileTypes => new[] { FileType.JSON };
     public async IAsyncEnumerable<IFileAnalysisData> AnalyzeAsync(Stream stream, CancellationToken ct = default)
     {
-        var info = await JsonSerializer.DeserializeAsync<InfoJson>(stream, cancellationToken: ct);
-        yield return new RedModInfo { Name = info.Name };
+        InfoJson? info;
+        try
+        {
+            info = await JsonSerializer.DeserializeAsync<InfoJson>(stream, cancellationToken: ct);
+        }
+        catch (JsonException)
+        {
+            yield break;
+        }
+        if (info != null)
+            yield return new RedModInfo { Name = info.Name };
     }
 }
 

--- a/src/Games/NexusMods.Games.RedEngine/ModInstallers/FolderlessModInstaller.cs
+++ b/src/Games/NexusMods.Games.RedEngine/ModInstallers/FolderlessModInstaller.cs
@@ -18,36 +18,16 @@ namespace NexusMods.Games.RedEngine.ModInstallers;
 public class FolderlessModInstaller : IModInstaller
 {
     
-    private static Extension[] _supportedExtensions =
-    {
-        KnownExtensions.Archive
-    };
-    
     public Priority Priority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> files)
     {
         if (!installation.Is<Cyberpunk2077>())
             return Common.Priority.None;
         
-        // Make sure we don't have any files that are not supported
-        if (!files.All(f => 
-                           _supportedExtensions.Contains(f.Key.Extension) || Helpers.IgnoreExtensions.Contains(f.Key.Extension)))
-            return Common.Priority.None;
-
-        // If all the files are in the base folder, then we can install them
-        if (files.All(f => f.Key.Depth == 1))
-            return Common.Priority.Normal;
+        if (!installation.Is<Cyberpunk2077>()) return Common.Priority.None;
         
-        // If all the files are in the same subfolder, then we can install them
-        var firstFile = files.First().Key;
-        if (firstFile.Depth > 1)
-        {
-            var parentFolder = firstFile.Parent;
-            if (files.All(f => f.Key.Depth == firstFile.Depth &&
-                               f.Key.InFolder(parentFolder)))
-                return Common.Priority.Normal;
-        }
-
-        // Otherwise, we can't install them
+        if (files.All(f => Helpers.IgnoreExtensions.Contains(f.Key.Extension) ||
+                           f.Key.Extension == KnownExtensions.Archive))
+            return Common.Priority.Low;
         return Common.Priority.None;
     }
 

--- a/src/Games/NexusMods.Games.TestHarness/Verbs/StressTest.cs
+++ b/src/Games/NexusMods.Games.TestHarness/Verbs/StressTest.cs
@@ -89,7 +89,7 @@ public class StressTest : AVerb<IGame, AbsolutePath, AbsolutePath>
                     var tmpPath = _temporaryFileManager.CreateFile();
 
                     var cts = new CancellationTokenSource();
-                    cts.CancelAfter(TimeSpan.FromMinutes(2));
+                    cts.CancelAfter(TimeSpan.FromMinutes(20));
                     
                     hash = await _downloader.Download(urls.Data.Select(d => d.Uri), tmpPath, token: cts.Token);
 

--- a/src/NexusMods.App/Program.cs
+++ b/src/NexusMods.App/Program.cs
@@ -37,7 +37,7 @@ var host = Host.CreateDefaultBuilder(Environment.GetCommandLineArgs())
             .AddStandardGameLocators()
             .AddRenderers()
             .AddNexusWebApi()
-            .AddHttpDownloader()
+            .AddAdvancedHttpDownloader()
             .AddTestHarness();
 
         services.AddSingleton<HttpClient>();

--- a/src/NexusMods.DataModel/FileAnalyzer.cs
+++ b/src/NexusMods.DataModel/FileAnalyzer.cs
@@ -102,8 +102,15 @@ public class FileContentsCache
                 foreach (var analyzer in _analyzers[sig])
                 {
                     hashStream.Position = 0;
-                    await foreach (var data in analyzer.AnalyzeAsync(hashStream, token)) 
-                        analysisData.Add(data);
+                    try
+                    {
+                        await foreach (var data in analyzer.AnalyzeAsync(hashStream, token))
+                            analysisData.Add(data);
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.LogError(e, "Error analyzing {Path} with {Analyzer}", sFn.Name, analyzer.GetType().Name);
+                    }
                 }
             }
         }

--- a/src/NexusMods.Paths/AbsolutePath_IO.cs
+++ b/src/NexusMods.Paths/AbsolutePath_IO.cs
@@ -214,8 +214,21 @@ public partial struct AbsolutePath
             var di = new DirectoryInfo(ToNativePath());
             if (di.Attributes.HasFlag(FileAttributes.ReadOnly))
                 di.Attributes &= ~FileAttributes.ReadOnly;
+
+            var attempts = 0;
+            TopParent:
             
-            Directory.Delete(ToString(), true);
+            try
+            {
+                Directory.Delete(ToString(), true);
+            }
+            catch (System.IO.IOException ex)
+            {
+                if (attempts > 10) throw;
+                Thread.Sleep(100);
+                attempts++;
+                goto TopParent;
+            }
         }
         catch (UnauthorizedAccessException)
         {

--- a/src/NexusMods.Paths/RelativePath.cs
+++ b/src/NexusMods.Paths/RelativePath.cs
@@ -215,4 +215,33 @@ public struct RelativePath : IPath, IEquatable<RelativePath>, IComparable<Relati
     { 
         public int Compare(RelativePath x, RelativePath y) => x.CompareTo(y);
     }
+
+    /// <summary>
+    /// Returns true if this path starts with the given path.
+    /// </summary>
+    /// <param name="subSection"></param>
+    /// <returns></returns>
+    public bool StartsWith(RelativePath subSection)
+    {
+        if (subSection.Parts.Length > Parts.Length)
+            return false;
+        
+        for (var idx = 0; idx < subSection.Parts.Length; idx++)
+            if (!subSection.Parts[idx].Equals(Parts[idx], StringComparison.InvariantCultureIgnoreCase))
+                return false;
+        return true;
+    }
+
+    /// <summary>
+    /// Drops the first i parts of the path.
+    /// </summary>
+    /// <param name="count"></param>
+    /// <returns></returns>
+    /// <exception cref="NotImplementedException"></exception>
+    public RelativePath DropFirst(int count = 1)
+    {
+        if (count >= Parts.Length)
+            throw new ArgumentOutOfRangeException(nameof(count), count, "Can't drop more parts than there are in the path");
+        return new RelativePath(Parts[count..]);
+    }
 }

--- a/tests/Games/NexusMods.Games.RedEngine.Tests/ModInstallerTests.cs
+++ b/tests/Games/NexusMods.Games.RedEngine.Tests/ModInstallerTests.cs
@@ -69,7 +69,7 @@ public class ModInstallerTests
 
     public static IEnumerable<object[]> TestFiles => new[]
     {
-        new object[] {"Cyber Engine Tweaks", ModId.From(107), FileId.From(33156), Hash.From(0x8BCFFD83A0F5FC71), 17},
+        new object[] {"Cyber Engine Tweaks", ModId.From(107), FileId.From(33156), Hash.From(0x8BCFFD83A0F5FC71), 16},
         new object[] {"Redscript", ModId.From(1511), FileId.From(36622), Hash.From(0x8BEF15CA909D8543), 3},
         new object[] {"cybercmd", ModId.From(5176), FileId.From(34566), Hash.From(0xEE78A096C8565B99), 1},
         new object[] {"Archive-XL", ModId.From(4198), FileId.From(36969), Hash.From(0x1D30861A46BA7B8E), 2},
@@ -78,6 +78,9 @@ public class ModInstallerTests
         new object[] {"Panam Romanced Enhanced REDmod", ModId.From(4626), FileId.From(38118), Hash.From(0x46F5AD6A75172F76), 5},
         new object[] {"Tarnished Pack", ModId.From(6072), FileId.From(31953), Hash.From(0x0AAFB35F889500BD), 6},
         new object[] {"Spicy Valentina", ModId.From(7404), FileId.From(39175), Hash.From(0xB354E2BE032A947F), 2},
-        new object[] {"OVE3RCHROME - Alternative LUT", ModId.From(6579), FileId.From(39289), Hash.From(0xC9CF6070A596BFDA), 2}
+        new object[] {"OVE3RCHROME - Alternative LUT", ModId.From(6579), FileId.From(39289), Hash.From(0xC9CF6070A596BFDA), 2},
+        new object[] {"Hair BUNS PACK", ModId.From(6072), FileId.From(31979), Hash.From(0xAFEABDAF2B38E408), 15},
+        new object[] {"Cyberscript Core", ModId.From(6475), FileId.From(39313), Hash.From(0x0A18B74B0A78188F), 442},
+        new object[] {"Een Glish Radio", ModId.From(6172), FileId.From(39296), Hash.From(0x774BB4AB62B00F50), 29}
     };
 }


### PR DESCRIPTION
Fixes for mods that put files under a top level folder, but under that have well defined patterns of `bin/x64/plugins` or something like that