### PR TITLE
Added: XML Documentation for Nexus Web Api & Moved Header Parsing to 

### DIFF
--- a/NexusMods.App.sln.DotSettings
+++ b/NexusMods.App.sln.DotSettings
@@ -3,7 +3,9 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=Xaml_002EStyleClassNotFound/@EntryIndexedValue">HINT</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ative/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Avalonia/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Kibibytes/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Loadout/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Loadouts/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Projektanker/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=skyrim/@EntryIndexedValue">True</s:Boolean>
 	</wpf:ResourceDictionary>

--- a/src/Networking/NexusMods.Networking.NexusWebApi/ApiKeyMessageFactory.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/ApiKeyMessageFactory.cs
@@ -1,47 +1,59 @@
 ﻿using System.Text;
-using Microsoft.Extensions.Logging;
 using NexusMods.DataModel.Abstractions;
 
 namespace NexusMods.Networking.NexusWebApi;
 
+/// <summary>
+/// Injects Nexus API keys into HTTP messages.
+/// </summary>
 public class ApiKeyMessageFactory : IHttpMessageFactory
 {
-    private static Id ApiKeyId = new IdVariableLength(EntityCategory.AuthData, "NexusMods.Networking.NexusWebApi.ApiKey"u8.ToArray()); 
-    
-    private readonly ILogger<ApiKeyMessageFactory> _logger;
-    private readonly IDataStore _store;
+    private static readonly Id ApiKeyId = new IdVariableLength(EntityCategory.AuthData, "NexusMods.Networking.NexusWebApi.ApiKey"u8.ToArray());
 
-    public ApiKeyMessageFactory(ILogger<ApiKeyMessageFactory> logger, IDataStore store)
+    private readonly IDataStore _store;
+    
+    private string? EnvironmentApiKey => Environment.GetEnvironmentVariable("NEXUS_API_KEY");
+
+    private string ApiKey
     {
-        _logger = logger;
+        get
+        {
+            var value = Encoding.UTF8.GetString(_store.GetRaw(ApiKeyId) ?? Array.Empty<byte>());
+            if (!string.IsNullOrWhiteSpace(value)) 
+                return value;
+            
+            return EnvironmentApiKey ?? throw new Exception("No API key set");
+        }
+    }
+
+    // TODO: Remove dependency on external components here.
+    
+    /// <summary/>
+    /// <param name="store"></param>
+    public ApiKeyMessageFactory(IDataStore store)
+    {
         _store = store;
     }
-    
+
+    /// <inheritdoc />
     public ValueTask<HttpRequestMessage> Create(HttpMethod method, Uri uri)
     {
         var msg = new HttpRequestMessage(method, uri);
         msg.Headers.Add("apikey", ApiKey);
         return ValueTask.FromResult(msg);
     }
-    
-    private string ApiKey
-    {
-        get
-        {
-            var value = Encoding.UTF8.GetString(_store.GetRaw(ApiKeyId) ?? Array.Empty<byte>());
-            if (!string.IsNullOrWhiteSpace(value)) return value;
-               return EnvironmentApiKey ?? throw new Exception("No API key set");
-        }
-    }
 
+    /// <inheritdoc />
     public async ValueTask<bool> IsAuthenticated()
     { 
         var dataStoreResult = await ValueTask.FromResult(_store.GetRaw(ApiKeyId) != null);
         return dataStoreResult || EnvironmentApiKey != null;
     }
 
-    private string? EnvironmentApiKey => Environment.GetEnvironmentVariable("NEXUS_API_KEY");
-    
+    /// <summary>
+    /// Sets the API key used for future requests.
+    /// </summary>
+    /// <param name="apiKey">The new API key set.</param>
     public ValueTask SetApiKey(string apiKey)
     {
         _store.PutRaw(ApiKeyId, Encoding.UTF8.GetBytes(apiKey));

--- a/src/Networking/NexusMods.Networking.NexusWebApi/DTOs/Category.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/DTOs/Category.cs
@@ -1,16 +1,39 @@
 ﻿using System.Text.Json.Serialization;
 
+// ReSharper disable UnusedAutoPropertyAccessor.Global
 namespace NexusMods.Networking.NexusWebApi.DTOs;
 
-// Root myDeserializedClass = JsonSerializer.Deserialize<List<Root>>(myJsonResponse);
+// 👇 Suppress uninitialised variables. Currently Nexus has mostly read-only API and we expect server to return the data.
+#pragma warning disable CS8618 
+
+/// <summary>
+/// Mod categories. Unique per game.
+/// i.e. Each game has its own set of categories.
+/// </summary>
 public class Category
 {
+    /// <summary>
+    /// Unique identifier for the category.
+    /// </summary>
     [JsonPropertyName("category_id")]
     public int CategoryId { get; set; }
 
+    /// <summary>
+    /// Human readable of the category.
+    /// This gets displayed to the end user.
+    /// </summary>
     [JsonPropertyName("name")]
     public string Name { get; set; }
 
+    // TODO: Convenient way to handle this.
+    
+    /// <summary>
+    /// Category which owns this category.
+    /// </summary>
+    /// <remarks>
+    ///    This field can either be represented as a <see cref="CategoryId"/> of another category or
+    ///    'false' if there is no parent. 
+    /// </remarks>
     [JsonPropertyName("parent_category")]
     public object ParentCategory { get; set; }
 }

--- a/src/Networking/NexusMods.Networking.NexusWebApi/DTOs/DownloadLink.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/DTOs/DownloadLink.cs
@@ -1,16 +1,30 @@
 ﻿using System.Text.Json.Serialization;
 using NexusMods.Networking.NexusWebApi.Types;
 
+// ReSharper disable UnusedAutoPropertyAccessor.Global
 namespace NexusMods.Networking.NexusWebApi.DTOs;
 
+/// <summary>
+/// Represents an individual download link returned from the API.
+/// </summary>
+/// <remarks>
+///    At the current moment in time; only premium users can receive this; with the exception of NXM links.
+/// </remarks>
 public class DownloadLink
 {
+    /// <summary/>
     [JsonPropertyName("name")]
     public required string Name { get; set; }
     
+    /// <summary>
+    /// Name of the CDN server that handles your download request.
+    /// </summary>
     [JsonPropertyName("short_name")]
     public required CDNName ShortName { get; set; }
     
+    /// <summary>
+    /// Download URI used to download the files.
+    /// </summary>
     [JsonPropertyName("URI")]
     public required Uri Uri { get; set; }
 }

--- a/src/Networking/NexusMods.Networking.NexusWebApi/DTOs/GameInfo.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/DTOs/GameInfo.cs
@@ -1,50 +1,111 @@
 ﻿using System.Text.Json.Serialization;
 using NexusMods.DataModel.Games;
 using NexusMods.Networking.NexusWebApi.Types;
+// ReSharper disable MemberCanBePrivate.Global
 
+// 👇 Suppress uninitialised variables. Currently Nexus has mostly read-only API and we expect server to return the data.
+#pragma warning disable CS8618 
+// ReSharper disable UnusedAutoPropertyAccessor.Global
 namespace NexusMods.Networking.NexusWebApi.DTOs;
 
+/// <summary>
+/// Represents information about an individual game.
+/// </summary>
+/// <remarks>
+///    Usually returned in batch from a single API call.
+/// </remarks>
 public class GameInfo
 {
+    /// <summary>
+    /// Unique identifier for the game.
+    /// </summary>
     [JsonPropertyName("id")]
     public GameId Id { get; set; }
 
+    /// <summary>
+    /// Name of the game.
+    /// </summary>
     [JsonPropertyName("name")] 
-    public string Name { get; set; } = "";
+    public string Name { get; set; }
 
+    /// <summary>
+    /// URL to the forum section on the Nexus forums dedicated to this game.
+    /// </summary>
     [JsonPropertyName("forum_url")]
     public Uri ForumUrl { get; set; }
 
+    /// <summary>
+    /// URL to the Nexus page for this game.
+    /// </summary>
     [JsonPropertyName("nexusmods_url")] 
-    public Uri NexusmodsUrl { get; set; }
+    public Uri NexusModsUrl { get; set; }
 
+    /// <summary>
+    /// Game's main genre.
+    /// </summary>
     [JsonPropertyName("genre")]
-    public string Genre { get; set; } = "";
+    public string Genre { get; set; }
 
+    /// <summary>
+    /// Total number of uploaded files for this game title.
+    /// </summary>
     [JsonPropertyName("file_count")]
     public ulong FileCount { get; set; }
 
+    /// <summary>
+    /// Number of total combined downloads across all mods for this title.
+    /// </summary>
     [JsonPropertyName("downloads")]
     public ulong Downloads { get; set; }
 
+    /// <summary>
+    /// Represents the string id/name of the game on the Nexus site.
+    /// e.g. 'morrowind' for 'https://nexusmods.com/morrowind'
+    /// </summary>
+    /// <remarks>
+    ///    This value is often used in API requests.
+    /// </remarks>
     [JsonPropertyName("domain_name")]
     public GameDomain DomainName { get; set; }
 
+    /// <summary>
+    /// Unix timestamp of when the game was approved by the site staff.
+    /// </summary>
     [JsonPropertyName("approved_date")]
     public int ApprovedDate { get; set; }
 
+    /// <summary>
+    /// Timestamp of when the game was approved by the site staff, expressed as UTC, Coordinated Universal Time.
+    /// </summary>
+    public DateTime ApprovedDateUtc => DateTimeOffset.FromUnixTimeSeconds(ApprovedDate).UtcDateTime;
+
+    /// <summary>
+    /// Number of views on this file.
+    /// </summary>
     [JsonPropertyName("file_views")]
     public ulong? FileViews { get; set; }
 
+    /// <summary>
+    /// Number of individual mod authors.
+    /// </summary>
     [JsonPropertyName("authors")]
     public int Authors { get; set; }
 
+    /// <summary>
+    /// Number of endorsements received on individual files on Nexus
+    /// </summary>
     [JsonPropertyName("file_endorsements")]
     public int FileEndorsements { get; set; }
 
+    /// <summary>
+    /// Total number of mods stored for this game.
+    /// </summary>
     [JsonPropertyName("mods")]
     public ulong Mods { get; set; }
 
+    /// <summary>
+    /// List of available categories for this individual game.
+    /// </summary>
     [JsonPropertyName("categories")]
     public List<Category> Categories { get; set; }
 }

--- a/src/Networking/NexusMods.Networking.NexusWebApi/DTOs/ModFile.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/DTOs/ModFile.cs
@@ -2,64 +2,149 @@
 using NexusMods.Networking.NexusWebApi.Types;
 using NexusMods.Paths;
 
+// 👇 Suppress uninitialised variables. Currently Nexus has mostly read-only API and we expect server to return the data.
+#pragma warning disable CS8618 
+
+// ReSharper disable UnusedAutoPropertyAccessor.Global
 namespace NexusMods.Networking.NexusWebApi.DTOs;
 
+/// <summary>
+/// Abstracts away an individual downloadable file available on a mod page.
+/// </summary>
 public class ModFile
 {
+    /// <summary>
+    ///    Listing of unique identifiers for this file.
+    /// </summary>
+    /// <remarks>
+    ///    Currently this stores a tuple of FileId and GameId [encoded as array].
+    /// </remarks>
     [JsonPropertyName("id")]
     public List<int> Id { get; set; }
 
+    /// <summary>
+    /// Unique [site-wide] ID for this file.
+    /// </summary>
     [JsonPropertyName("uid")]
     public long Uid { get; set; }
 
+    /// <summary>
+    /// Unique ID for this file. 
+    /// </summary>
+    /// <remarks>
+    ///    This ID is unique within the context of the game.
+    ///    i.e. This ID might be used for another mod if you search for mods for another game.
+    /// </remarks>
     [JsonPropertyName("file_id")]
     public FileId FileId { get; set; }
 
+    /// <summary>
+    /// Name (title) of the mod file as seen on the `Files` section of the mod page.
+    /// </summary>
     [JsonPropertyName("name")]
     public string Name { get; set; }
 
+    /// <summary>
+    /// Version of the mod.
+    /// </summary>
+    /// <remarks>
+    ///    The Nexus site does not enforce validation on this field.
+    ///    This field can be set to any arbitrary string
+    /// </remarks>
     [JsonPropertyName("version")]
     public string Version { get; set; }
 
+    /// <summary>
+    /// Unique identifier to the <see cref="Category"/> this item is tied to.
+    /// </summary>
     [JsonPropertyName("category_id")]
     public int CategoryId { get; set; }
 
+    /// <summary>
+    /// Name of the <see cref="Category"/> this item is tied to.
+    /// </summary>
     [JsonPropertyName("category_name")]
     public string CategoryName { get; set; }
 
+    /// <summary>
+    /// True if this is the primary (i.e. 'main'/'top') download for this submission.
+    /// </summary>
     [JsonPropertyName("is_primary")]
     public bool IsPrimary { get; set; }
 
+    /// <summary>
+    /// Size of this item in Kibibytes (KiB); rounded up to the nearest value.
+    /// </summary>
     [JsonPropertyName("size")]
     public int Size { get; set; }
 
+    /// <summary>
+    /// Full name of this file as downloaded to the user's PC.
+    /// </summary>
+    /// <remarks>
+    ///    This is (usually) composed of the original name of file appended with <see cref="ModId"/> and upload date/time.
+    /// </remarks>
     [JsonPropertyName("file_name")]
     public string FileName { get; set; }
 
+    /// <summary>
+    /// Unix timestamp for the time this file was uploaded.
+    /// </summary>
     [JsonPropertyName("uploaded_timestamp")]
     public int UploadedTimestamp { get; set; }
 
+    /// <summary>
+    /// Specifies when this mod was uploaded.  
+    /// This is equivalent to <see cref="UploadedTimestamp"/>.  
+    /// </summary>
+    /// <remarks>
+    ///    Expressed as ISO 8601 compatible date/time notation.
+    /// </remarks>
     [JsonPropertyName("uploaded_time")]
     public DateTime UploadedTime { get; set; }
 
+    /// <summary>
+    /// Version of the mod. See <see cref="Version"/> for more details.
+    /// </summary>
     [JsonPropertyName("mod_version")]
     public string ModVersion { get; set; }
 
+    /// <summary>
+    /// URL for a 3rd party (VirusTotal) scan for the uploaded files.
+    /// </summary>
     [JsonPropertyName("external_virus_scan_url")]
     public string ExternalVirusScanUrl { get; set; }
 
+    /// <summary>
+    /// Description for this individual downloaded item. Usually appears under file title.
+    /// </summary>
     [JsonPropertyName("description")]
     public string Description { get; set; }
 
+    /// <summary>
+    /// (Same as <see cref="Size"/>). Size of this item in Kibibytes (KiB); rounded up to the nearest value.
+    /// </summary>
+    /// <remarks>
+    ///    Uses KiB (1 KiB = 1024) bytes; not KB (1000 bytes).
+    /// </remarks>
     [JsonPropertyName("size_kb")]
     public int SizeKb { get; set; }
 
+    /// <summary>
+    /// Full size of the file expressed as bytes.
+    /// </summary>
     [JsonPropertyName("size_in_bytes")]
     public Size? SizeInBytes { get; set; }
 
+    /// <summary>
+    /// The changelog for this item, expressed as raw HTML.
+    /// </summary>
     [JsonPropertyName("changelog_html")]
     public string ChangelogHtml { get; set; }
 
+    /// <summary>
+    /// Link to a .json file which specifies all of the files inside this uploaded archive.
+    /// </summary>
     [JsonPropertyName("content_preview_link")]
     public string ContentPreviewLink { get; set; }
 }

--- a/src/Networking/NexusMods.Networking.NexusWebApi/DTOs/ModFiles.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/DTOs/ModFiles.cs
@@ -1,9 +1,17 @@
 ﻿using System.Text.Json.Serialization;
 
+// 👇 Suppress uninitialised variables. Currently Nexus has mostly read-only API and we expect server to return the data.
+#pragma warning disable CS8618 
+
+// ReSharper disable UnusedAutoPropertyAccessor.Global
 namespace NexusMods.Networking.NexusWebApi.DTOs;
 
+/// <summary>
+/// Represents the collection of downloadable files tied to a mod.
+/// </summary>
 public class ModFiles
 {
+    /// <summary/>
     [JsonPropertyName("files")]
     public ModFile[] Files { get; set; }
 }

--- a/src/Networking/NexusMods.Networking.NexusWebApi/DTOs/ModUpdate.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/DTOs/ModUpdate.cs
@@ -1,16 +1,42 @@
 ﻿using System.Text.Json.Serialization;
 using NexusMods.Networking.NexusWebApi.Types;
 
+
+// 👇 Suppress uninitialised variables. Currently Nexus has mostly read-only API and we expect server to return the data.
+#pragma warning disable CS8618 
+
+// ReSharper disable UnusedAutoPropertyAccessor.Global
 namespace NexusMods.Networking.NexusWebApi.DTOs;
 
+/// <summary>
+/// Represents an individual item from a list of mods that have been updated in a
+/// given period, with timestamps of their last update. Cached for 5 minutes.
+/// </summary>
 public class ModUpdate
 {
+    /// <summary>
+    /// An individual mod ID that is unique for this game.
+    /// </summary>
     [JsonPropertyName("mod_id")]
     public ModId ModId { get; set; }
-    
+
+    // TODO: This is only referenced from test harness (right now). I think this might be incorrectly defined; since API returns timestamps; which shouldn't deserialize here.
+
+    /// <summary>
+    /// The last time a file on the mod page was updated.
+    /// </summary>
+    /// <remarks>
+    ///    Expressed as a Unix timestamp.
+    /// </remarks>
     [JsonPropertyName("LatestFileUpdated")]
     public DateTime LatestFileUpdated { get; set; }
     
+    /// <summary>
+    /// The last time any change was made to the mod page.
+    /// </summary>
+    /// <remarks>
+    ///    Expressed as a Unix timestamp.
+    /// </remarks>
     [JsonPropertyName("LatestModActivity")]
     public DateTime LatestModActivity { get; set; }
 }

--- a/src/Networking/NexusMods.Networking.NexusWebApi/DTOs/ModUpdate.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/DTOs/ModUpdate.cs
@@ -29,7 +29,12 @@ public class ModUpdate
     ///    Expressed as a Unix timestamp.
     /// </remarks>
     [JsonPropertyName("LatestFileUpdated")]
-    public DateTime LatestFileUpdated { get; set; }
+    public long LatestFileUpdated { get; set; }
+    
+    /// <summary>
+    /// The last time a file on the mod page was updated.
+    /// </summary>
+    public DateTime LatestFileUpdatedUtc => DateTimeOffset.FromUnixTimeSeconds(LatestFileUpdated).UtcDateTime;
     
     /// <summary>
     /// The last time any change was made to the mod page.
@@ -38,5 +43,10 @@ public class ModUpdate
     ///    Expressed as a Unix timestamp.
     /// </remarks>
     [JsonPropertyName("LatestModActivity")]
-    public DateTime LatestModActivity { get; set; }
+    public long LatestModActivity { get; set; }
+    
+    /// <summary>
+    /// The last time any change was made to the mod page.
+    /// </summary>
+    public DateTime LatestModActivityUtc => DateTimeOffset.FromUnixTimeSeconds(LatestModActivity).UtcDateTime;
 }

--- a/src/Networking/NexusMods.Networking.NexusWebApi/DTOs/Response.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/DTOs/Response.cs
@@ -2,9 +2,25 @@
 
 namespace NexusMods.Networking.NexusWebApi.DTOs;
 
+/// <summary>
+/// Represents an individual response from a Nexus API request; containing the received raw data
+/// and any useful metadata as an accessible object.
+/// </summary>
+/// <typeparam name="T"></typeparam>
 public class Response<T>
 {
+    /// <summary>
+    /// The data contained within the actual response, i.e. one of the members in <see cref="DTOs"/>.
+    /// </summary>
     public required T Data { get; init; }
+    
+    /// <summary>
+    /// Contains useful metadata sourced from the response header.
+    /// </summary>
     public required ResponseMetadata Metadata { get; init; }
+    
+    /// <summary>
+    /// Returned HTTP Status Code.
+    /// </summary>
     public required HttpStatusCode StatusCode { get; init; }
 }

--- a/src/Networking/NexusMods.Networking.NexusWebApi/DTOs/ResponseMetadata.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/DTOs/ResponseMetadata.cs
@@ -1,17 +1,88 @@
-﻿namespace NexusMods.Networking.NexusWebApi.DTOs;
+﻿// ReSharper disable UnusedAutoPropertyAccessor.Global
+// ReSharper disable MemberCanBePrivate.Global
+namespace NexusMods.Networking.NexusWebApi.DTOs;
 
 /// <summary>
 /// Metadata and rate limit information. Returned in the headers of every response.
 /// </summary>
 public class ResponseMetadata
 {
+    /// <summary>
+    /// [Rate Limit] Stores the limit your <see cref="DailyRemaining"/> will be reset to once
+    /// <see cref="DailyReset"/> occurs.
+    /// </summary>
     public int DailyLimit { get; set; }
+    
+    /// <summary>
+    /// [Rate Limit] Number of API requests available for the rest of this day period.
+    /// </summary>
     public int DailyRemaining { get; set; }
+    
+    /// <summary>
+    /// [Rate Limit] Stores the time when the daily limit is next reset.
+    /// </summary>
     public DateTime DailyReset { get; set; }
+    
+    /// <summary>
+    /// [Rate Limit] Stores the limit your <see cref="HourlyRemaining"/> will be reset to once
+    /// <see cref="HourlyReset"/> occurs.
+    /// </summary>
     public int HourlyLimit { get; set; }
+    
+    /// <summary>
+    /// [Rate Limit] Number of API requests available for the rest of this hour period.
+    /// </summary>
     public int HourlyRemaining { get; set; }
+    
+    /// <summary>
+    /// [Rate Limit] Stores the time when the hourly limit is next reset.
+    /// </summary>
     public DateTime HourlyReset { get; set; }
+    
+    /// <summary>
+    /// Time taken to execute the request server side, in seconds.
+    /// </summary>
     public double Runtime { get; set; }
 
-    public bool IsReal { get; set; } = true;
+    /// <summary>
+    /// Extracts the response metadata from a returned HTTP header.
+    /// </summary>
+    public static ResponseMetadata FromHttpHeaders(HttpResponseMessage result)
+    {
+        var metaData = new ResponseMetadata();
+        void ParseInt(string headerName, out int output)
+        {
+            output = default;
+            if (result.Headers.TryGetValues(headerName, out var values))
+                if (int.TryParse(values.First(), out var limit))
+                    output = limit;
+        }
+        
+        void ParseDateTime(string headerName, out DateTime output)
+        {
+            output = default;
+            if (result.Headers.TryGetValues(headerName, out var values))
+                if (DateTime.TryParse(values.First(), out DateTime limit))
+                    output = limit;
+        }
+        
+        ParseInt("x-rl-daily-limit", out var dailyLimit);
+        ParseInt("x-rl-daily-remaining", out var dailyRemaining);
+        ParseDateTime("x-rl-daily-reset", out var dailyReset);
+        ParseInt("x-rl-hourly-limit", out var hourlyLimit);
+        ParseInt("x-rl-hourly-remaining", out var hourlyRemaining);
+        ParseDateTime("x-rl-hourly-reset", out var hourlyReset);
+        metaData.DailyLimit = dailyLimit;
+        metaData.DailyRemaining = dailyRemaining;
+        metaData.DailyReset = dailyReset;
+        metaData.HourlyLimit = hourlyLimit;
+        metaData.HourlyRemaining = hourlyRemaining;
+        metaData.HourlyReset = hourlyReset;
+        
+        if (result.Headers.TryGetValues("x-runtime", out var runtimes))
+            if (double.TryParse(runtimes.First(), out var reset))
+                metaData.Runtime = reset;
+
+        return metaData;
+    }
 }

--- a/src/Networking/NexusMods.Networking.NexusWebApi/DTOs/ValidateInfo.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/DTOs/ValidateInfo.cs
@@ -1,33 +1,71 @@
 ﻿using System.Text.Json.Serialization;
+using NexusMods.Networking.NexusWebApi.Types;
+// ReSharper disable InconsistentNaming
 
 namespace NexusMods.Networking.NexusWebApi.DTOs;
 
+/// <summary>
+/// Contains the current user's details.
+/// Returned from an API call used to validate API key.  
+/// </summary>
 public class ValidateInfo
 {
+    /// <summary>
+    /// Unique identifier for the current user.
+    /// </summary>
     [JsonPropertyName("user_id")] 
-    public int UserId { get; set; }
+    public UserId UserId { get; set; }
 
+    /// <summary>
+    /// The API key associated with this request.
+    /// </summary>
     [JsonPropertyName("key")] 
     public string Key { get; set; } = "";
 
+    /// <summary>
+    /// The user's display name.
+    /// </summary>
     [JsonPropertyName("name")] 
     public string Name { get; set; } = "";
-
+    
+    /// <summary>
+    /// <see cref="IsPremium"/>
+    /// </summary>
+    [Obsolete($"Use {nameof(IsPremium)} instead.")]
     [JsonPropertyName("is_premium?")] 
     public bool _IsPremium { get; set; }
-
+    
+    /// <summary>
+    /// <see cref="IsSupporter"/>
+    /// </summary>
+    [Obsolete($"Use {nameof(IsSupporter)} instead.")]
     [JsonPropertyName("is_supporter?")] 
     public bool _IsSupporter { get; set; }
 
+    /// <summary>
+    /// User's full email address.
+    /// </summary>
     [JsonPropertyName("email")] 
     public string Email { get; set; } = "";
 
+    /// <summary>
+    /// URL of the user's avatar on the website.
+    /// </summary>
     [JsonPropertyName("profile_url")] 
     public Uri? ProfileUrl { get; set; }
-
+    
+    /// <summary>
+    /// Returns true if this member is a 'supporter' of Nexus.<br/>
+    /// Supporters are users that meet the following criteria:  <br/>
+    /// - Don't use an ad blocker or<br/>
+    /// - Have previously in the past bought premium.  <br/>
+    /// </summary>
     [JsonPropertyName("is_supporter")] 
     public bool IsSupporter { get; set; }
 
+    /// <summary>
+    /// True if this user is currently a premium subscriber.
+    /// </summary>
     [JsonPropertyName("is_premium")] 
     public bool IsPremium { get; set; }
 }

--- a/src/Networking/NexusMods.Networking.NexusWebApi/IHttpMessageFactory.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/IHttpMessageFactory.cs
@@ -9,10 +9,10 @@ public interface IHttpMessageFactory
     /// <summary>
     /// Creates a new <see cref="HttpRequestMessage"/> for the given <paramref name="method"/> and <paramref name="uri"/>
     /// </summary>
-    /// <param name="method"></param>
-    /// <param name="uri"></param>
-    /// <returns></returns>
     public ValueTask<HttpRequestMessage> Create(HttpMethod method, Uri uri);
     
+    /// <summary>
+    /// Returns true if the user is authenticated [has a saved or set API key]; else false.
+    /// </summary>
     public ValueTask<bool> IsAuthenticated();
 }

--- a/src/Networking/NexusMods.Networking.NexusWebApi/Services.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/Services.cs
@@ -8,8 +8,14 @@ using NexusMods.Networking.NexusWebApi.Verbs;
 
 namespace NexusMods.Networking.NexusWebApi;
 
+/// <summary>
+/// Helps with registration of services for Microsoft DI container.
+/// </summary>
 public static class Services
 {
+    /// <summary>
+    /// Adds the Nexus Web API to your DI Container's service collection.
+    /// </summary>
     public static IServiceCollection AddNexusWebApi(this IServiceCollection collection)
     {
         return collection.AddAllSingleton<IHttpMessageFactory, ApiKeyMessageFactory>()

--- a/src/Networking/NexusMods.Networking.NexusWebApi/Types/CDNName.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/Types/CDNName.cs
@@ -2,8 +2,12 @@
 
 namespace NexusMods.Networking.NexusWebApi.Types;
 
+/// <summary>
+/// Name of the CDN server that handles your download request.
+/// </summary>
 [ValueObject<string>]
-public partial class CDNName
+// ReSharper disable once InconsistentNaming
+public partial struct CDNName
 {
     
 }

--- a/src/Networking/NexusMods.Networking.NexusWebApi/Types/FileId.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/Types/FileId.cs
@@ -2,8 +2,14 @@
 
 namespace NexusMods.Networking.NexusWebApi.Types;
 
+/// <summary>
+/// Unique ID for a game file hosted on a mod page.
+/// 
+/// This ID is unique within the context of the game.
+/// i.e. This ID might be used for another mod if you search for mods for another game.
+/// </summary>
 [ValueObject<ulong>]
-public partial class FileId
+public partial struct FileId
 {
     
 }

--- a/src/Networking/NexusMods.Networking.NexusWebApi/Types/GameId.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/Types/GameId.cs
@@ -2,8 +2,11 @@
 
 namespace NexusMods.Networking.NexusWebApi.Types;
 
+/// <summary>
+/// Unique identifier for an individual game hosted on Nexus.
+/// </summary>
 [ValueObject<int>]
-public partial class GameId
+public partial struct GameId
 {
     
 }

--- a/src/Networking/NexusMods.Networking.NexusWebApi/Types/ModId.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/Types/ModId.cs
@@ -2,8 +2,12 @@
 
 namespace NexusMods.Networking.NexusWebApi.Types;
 
+/// <summary>
+/// An individual mod ID. Unique per game.
+/// i.e. Each game has its own set of IDs and starts with 0.
+/// </summary>
 [ValueObject<ulong>]
-public partial class ModId
+public partial struct ModId
 {
     
 }

--- a/src/Networking/NexusMods.Networking.NexusWebApi/Types/UserId.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/Types/UserId.cs
@@ -1,0 +1,12 @@
+using Vogen;
+
+namespace NexusMods.Networking.NexusWebApi.Types;
+
+/// <summary>
+/// Unique identifier for a given site user.
+/// </summary>
+[ValueObject<ulong>]
+public partial struct UserId
+{
+    
+}

--- a/src/Networking/NexusMods.Networking.NexusWebApi/Verbs/DownloadLinks.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/Verbs/DownloadLinks.cs
@@ -2,6 +2,8 @@
 using NexusMods.CLI.DataOutputs;
 using NexusMods.DataModel.Games;
 using NexusMods.Networking.NexusWebApi.Types;
+// Temporary until moved to CLI project.
+#pragma warning disable CS1591
 
 namespace NexusMods.Networking.NexusWebApi.Verbs;
 

--- a/src/Networking/NexusMods.Networking.NexusWebApi/Verbs/NexusApiVerify.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/Verbs/NexusApiVerify.cs
@@ -1,6 +1,7 @@
 ﻿using NexusMods.CLI;
 using NexusMods.CLI.DataOutputs;
-
+// Temporary until moved to CLI project.
+#pragma warning disable CS1591
 namespace NexusMods.Networking.NexusWebApi.Verbs;
 
 public class NexusApiVerify : AVerb

--- a/src/Networking/NexusMods.Networking.NexusWebApi/Verbs/NexusGames.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/Verbs/NexusGames.cs
@@ -1,6 +1,7 @@
 ﻿using NexusMods.CLI;
 using NexusMods.CLI.DataOutputs;
-
+// Temporary until moved to CLI project.
+#pragma warning disable CS1591
 namespace NexusMods.Networking.NexusWebApi.Verbs;
 
 public class NexusGames : AVerb

--- a/src/Networking/NexusMods.Networking.NexusWebApi/Verbs/SetNexusAPIKey.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/Verbs/SetNexusAPIKey.cs
@@ -1,7 +1,9 @@
 ﻿using NexusMods.CLI;
-
+// Temporary until moved to CLI project.
+#pragma warning disable CS1591
 namespace NexusMods.Networking.NexusWebApi.Verbs;
 
+// ReSharper disable once InconsistentNaming
 public class SetNexusAPIKey : AVerb<string>
 {
     private readonly ApiKeyMessageFactory _factory;
@@ -13,7 +15,7 @@ public class SetNexusAPIKey : AVerb<string>
 
     public static VerbDefinition Definition => new("set-nexus-api-key",
         "Sets the key used in Nexus API calls",
-        new[]
+        new OptionDefinition[]
         {
             new OptionDefinition<string>("k", "key", "Key used in Nexus API call")
         });


### PR DESCRIPTION
This PR performs the following actions:  
- Fully adds XML Documentation to existing API.  
- Adds TODO(s) for items of interest related to cleaning up the API.  
- Adds an additional Vogen `ValueObject` where appropriate.  
- Fixes a minor bug where a field was incorrectly defined.

Something we still need to do is make unit tests for this library; that said, I'm not yet sure if this is in our best interest because ideally we should be moving to the GraphQL based V2 API that's in development. 

Until V2 is fully complete; it might just be better to mix the two; using V1 where V2 doesn't yet have what we need.