### PR TITLE
Adds an IPC subsystem to the DataModel

### DIFF
--- a/benchmarks/NexusMods.Benchmarks/Benchmarks/DataModel.cs
+++ b/benchmarks/NexusMods.Benchmarks/Benchmarks/DataModel.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Hosting;
 using NexusMods.Benchmarks.Interfaces;
 using NexusMods.DataModel;
 using NexusMods.DataModel.Abstractions;
+using NexusMods.DataModel.Interprocess;
 using NexusMods.DataModel.Loadouts;
 using NexusMods.DataModel.Loadouts.ModFiles;
 using NexusMods.Hashing.xxHash64;
@@ -38,7 +39,9 @@ public class DataStoreBenchmark : IBenchmark, IDisposable
             }).Build();
 
         var provider = host.Services.GetRequiredService<IServiceProvider>();
-        _dataStore = new SqliteDataStore(_temporaryFileManager.CreateFile(KnownExtensions.Sqlite).Path, provider);
+        _dataStore = new SqliteDataStore(_temporaryFileManager.CreateFile(KnownExtensions.Sqlite).Path, provider, 
+            provider.GetRequiredService<IMessageProducer<RootChange>>(),
+            provider.GetRequiredService<IMessageConsumer<RootChange>>());
         
         _rawData = new byte[1024];
         Random.Shared.NextBytes(_rawData);

--- a/src/NexusMods.CLI/Verbs/ChangeTracking.cs
+++ b/src/NexusMods.CLI/Verbs/ChangeTracking.cs
@@ -1,4 +1,5 @@
-﻿using NexusMods.DataModel.Abstractions;
+﻿using NexusMods.CLI.DataOutputs;
+using NexusMods.DataModel.Abstractions;
 
 namespace NexusMods.CLI.Verbs;
 
@@ -22,12 +23,15 @@ public class ChangeTracking : AVerb
     public async Task<int> Run(CancellationToken token)
     {
         _store.Changes.Subscribe(s =>
-        HandleEvent(s.Entity));
+        HandleEvent(new Table(new [] {"Type", "From", "To"}, new[]
+        {
+            new object[] {s.Type, s.From, s.To},
+        })));
         
         while (!token.IsCancellationRequested)
             await Task.Delay(1000, token);
         return 0;
     }
 
-    private void HandleEvent(Entity entity) => _renderer.Render(entity);
+    private void HandleEvent(Table entity) => _renderer.Render(entity);
 }

--- a/src/NexusMods.CLI/Verbs/ChangeTracking.cs
+++ b/src/NexusMods.CLI/Verbs/ChangeTracking.cs
@@ -22,7 +22,7 @@ public class ChangeTracking : AVerb
     
     public async Task<int> Run(CancellationToken token)
     {
-        _store.Changes.Subscribe(s =>
+        using var _ = _store.Changes.Subscribe(s =>
         HandleEvent(new Table(new [] {"Type", "From", "To"}, new[]
         {
             new object[] {s.Type, s.From, s.To},

--- a/src/NexusMods.DataModel/Abstractions/IDataStore.cs
+++ b/src/NexusMods.DataModel/Abstractions/IDataStore.cs
@@ -1,4 +1,8 @@
-﻿namespace NexusMods.DataModel.Abstractions;
+﻿using NexusMods.DataModel.Interprocess;
+using Sewer56.BitStream;
+using Sewer56.BitStream.ByteStreams;
+
+namespace NexusMods.DataModel.Abstractions;
 
 public interface IDataStore
 {
@@ -12,5 +16,90 @@ public interface IDataStore
     void PutRaw(Id key, ReadOnlySpan<byte> val);
     Task<long> PutRaw(IAsyncEnumerable<(Id Key, byte[] Value)> kvs, CancellationToken token = default);
     IEnumerable<T> GetByPrefix<T>(Id prefix) where T : Entity;
-    IObservable<(Id Id, Entity Entity)> Changes { get; }
+    IObservable<RootChange> Changes { get; }
+}
+
+/// <summary>
+/// Represents a change of a root from one id to another.
+/// </summary>
+public struct RootChange : IMessage
+{
+    /// <summary>
+    /// The root type that changed.
+    /// </summary>
+    public required RootType Type { get; init; }
+    
+    /// <summary>
+    /// The old Id of the root.
+    /// </summary>
+    public required Id From { get; init; }
+    
+    /// <summary>
+    /// The new Id of the root.
+    /// </summary>
+    public required Id To { get; init; }
+
+    /// <summary>
+    /// We'll assume the max id size is 128 bytes.
+    /// </summary>
+    public static int MaxSize => 1 * 128 * 128;
+    
+    public int Write(Span<byte> buffer)
+    {
+        unsafe
+        {
+            fixed (byte* ptr = buffer)
+            {
+                var stream = new PointerByteStream(ptr);
+                var writer = new BitStream<PointerByteStream>(stream);
+                writer.Write((byte)Type);
+
+                writer.Write((byte)From.Category);
+                writer.Write((byte)From.SpanSize);
+                Span<byte> fromSpan = stackalloc byte[From.SpanSize];
+                From.ToSpan(fromSpan);
+                writer.Write(fromSpan);
+                
+                writer.Write((byte)To.Category);
+                writer.Write((byte)To.SpanSize);
+                Span<byte> toSpan = stackalloc byte[To.SpanSize];
+                To.ToSpan(toSpan);
+                writer.Write(toSpan);
+            }   
+        }
+        // 1 byte for type, 2 bytes for each id (category + span size), 2 * span size for each id.
+        return 5 + From.SpanSize + To.SpanSize;
+    }
+
+    public static IMessage Read(ReadOnlySpan<byte> buffer)
+    {
+        unsafe
+        {
+            fixed (byte* ptr = buffer)
+            {
+                var stream = new PointerByteStream(ptr);
+                var reader = new BitStream<PointerByteStream>(stream);
+                var type = (RootType)reader.Read<byte>();
+                
+                var fromCategory = (EntityCategory)reader.Read<byte>();
+                var fromSpanSize = reader.Read<byte>();
+                Span<byte> fromSpan = stackalloc byte[fromSpanSize];
+                reader.Read(fromSpan);
+                var from = Id.FromSpan(fromCategory, fromSpan);
+                
+                var toCategory = (EntityCategory)reader.Read<byte>();
+                var toSpanSize = reader.Read<byte>();
+                Span<byte> toSpan = stackalloc byte[toSpanSize];
+                reader.Read(toSpan);
+                var to = Id.FromSpan(toCategory, toSpan);
+                
+                return new RootChange
+                {
+                    Type = type,
+                    From = from,
+                    To = to
+                };
+            }
+        }
+    }
 }

--- a/src/NexusMods.DataModel/Interprocess/IMessage.cs
+++ b/src/NexusMods.DataModel/Interprocess/IMessage.cs
@@ -3,8 +3,7 @@
 public interface IMessage
 {
     /// <summary>
-    /// Maximum size of the message. Must be greater than 16 bytes. Internally enough buffer space
-    /// will be allocated to hold 16 messages.
+    /// Maximum size of the message. Internally enough buffer space will be allocated to hold 16 messages.
     /// </summary>
     public static abstract int MaxSize { get; }
     

--- a/src/NexusMods.DataModel/Interprocess/IMessage.cs
+++ b/src/NexusMods.DataModel/Interprocess/IMessage.cs
@@ -1,0 +1,24 @@
+﻿namespace NexusMods.DataModel.Interprocess;
+
+public interface IMessage
+{
+    /// <summary>
+    /// Maximum size of the message. Must be greater than 16 bytes. Internally enough buffer space
+    /// will be allocated to hold 16 messages.
+    /// </summary>
+    public static abstract int MaxSize { get; }
+    
+    /// <summary>
+    /// Writes the message to the buffer.
+    /// </summary>
+    /// <param name="buffer">Buffer that will be MaxSize in length</param>
+    /// <returns>The number of bytes written to the buffer</returns>
+    public int Write(Span<byte> buffer);
+
+    /// <summary>
+    /// Reads the message from the buffer.
+    /// </summary>
+    /// <param name="buffer">Buffer that will be MaxSize in length</param>
+    /// <returns></returns>
+    public static abstract IMessage Read(ReadOnlySpan<byte> buffer);
+}

--- a/src/NexusMods.DataModel/Interprocess/IMessageConsumer.cs
+++ b/src/NexusMods.DataModel/Interprocess/IMessageConsumer.cs
@@ -1,0 +1,15 @@
+﻿using System.Reactive.Subjects;
+
+namespace NexusMods.DataModel.Interprocess;
+
+/// <summary>
+/// A message consumer for receiving messages from other processes.
+/// </summary>
+/// <typeparam name="T">The types of messages being sent/received on the queue </typeparam>
+public interface IMessageConsumer<T> where T : IMessage
+{
+    /// <summary>
+    /// A subject that will receive messages from the queue.
+    /// </summary>
+    public IObservable<T> Messages { get; }
+}

--- a/src/NexusMods.DataModel/Interprocess/IMessageProducer.cs
+++ b/src/NexusMods.DataModel/Interprocess/IMessageProducer.cs
@@ -1,0 +1,14 @@
+﻿namespace NexusMods.DataModel.Interprocess;
+
+/// <summary>
+/// A message producer for sending messages to other processes.
+/// </summary>
+/// <typeparam name="T">Message type to send, each message type gets its own queue</typeparam>
+public interface IMessageProducer<T> where T : IMessage
+{
+    /// <summary>
+    /// Sends a message to the queue.
+    /// </summary>
+    /// <param name="message"></param>
+    public ValueTask Write(T message, CancellationToken token);
+}

--- a/src/NexusMods.DataModel/Interprocess/InterprocessConsumer.cs
+++ b/src/NexusMods.DataModel/Interprocess/InterprocessConsumer.cs
@@ -1,0 +1,51 @@
+﻿using System.Reactive.Subjects;
+using Cloudtoid.Interprocess;
+using Microsoft.Extensions.Logging;
+
+namespace NexusMods.DataModel.Interprocess;
+
+public class InterprocessConsumer<T> : IMessageConsumer<T>, IDisposable where T : IMessage
+{
+    private readonly IQueueFactory _queueFactory;
+    private readonly string _queueName;
+    private readonly ISubscriber _queue;
+    private CancellationTokenSource _tcs;
+    private Subject<T> _messages = new();
+    private readonly Task _task;
+    private readonly ILogger<InterprocessConsumer<T>> _logger;
+
+    public InterprocessConsumer(ILogger<InterprocessConsumer<T>> logger, IQueueFactory queueFactory)
+    {
+        _logger = logger;
+        _queueFactory = queueFactory;
+        _queueName = "NexusMods.DataModel.Interprocess." + typeof(T).Name;
+        _queue = queueFactory.CreateSubscriber(new QueueOptions(_queueName, T.MaxSize * 16));
+
+        _tcs = new CancellationTokenSource();
+        _task = Task.Run(StartDequeueLoop);
+    }
+
+    private async Task StartDequeueLoop()
+    {
+        var buffer = new Memory<byte>(new byte[T.MaxSize * 16]);
+        while (!_tcs.Token.IsCancellationRequested)
+        {
+            if (_queue.TryDequeue(buffer, _tcs.Token, out var read))
+            {
+                _logger.LogTrace("Read {Size} byte message from queue {Queue}", read.Length, _queueName); 
+                _messages.OnNext((T)T.Read(read.Span));
+                continue;
+            }
+            
+            await Task.Delay(100, _tcs.Token);
+        }
+    }
+
+    public IObservable<T> Messages => _messages;
+    
+    public void Dispose()
+    {
+        _tcs.Cancel();
+        _queue.Dispose();
+    }
+}

--- a/src/NexusMods.DataModel/Interprocess/InterprocessProducer.cs
+++ b/src/NexusMods.DataModel/Interprocess/InterprocessProducer.cs
@@ -38,7 +38,7 @@ public class InterprocessProducer<T> : IMessageProducer<T>, IDisposable where T 
     /// <exception cref="TaskCanceledException"></exception>
     public async ValueTask Write(T message, CancellationToken token)
     {
-        _logger.LogDebug("Writing message {Message} to queue {Queue}", message, _queueName);
+        _logger.LogTrace("Writing message {Message} to queue {Queue}", message, _queueName);
 
         while (!token.IsCancellationRequested)
         {
@@ -47,7 +47,7 @@ public class InterprocessProducer<T> : IMessageProducer<T>, IDisposable where T 
                 return;
             }
 
-            _logger.LogTrace("Failed to write {Message} to queue {Queue}, retrying", message, _queueName);
+            _logger.LogDebug("Failed to write {Message} to queue {Queue}, retrying", message, _queueName);
             await Task.Delay(100, token);
         }
 

--- a/src/NexusMods.DataModel/Interprocess/InterprocessProducer.cs
+++ b/src/NexusMods.DataModel/Interprocess/InterprocessProducer.cs
@@ -1,0 +1,75 @@
+﻿using Cloudtoid.Interprocess;
+using Microsoft.Extensions.Logging;
+
+namespace NexusMods.DataModel.Interprocess;
+
+/// <summary>
+/// Implementation of <see cref="IMessageProducer{T}"/> that uses an interprocess queue.
+/// </summary>
+/// <typeparam name="T"></typeparam>
+public class InterprocessProducer<T> : IMessageProducer<T>, IDisposable where T : IMessage
+{
+    private readonly ILogger<InterprocessProducer<T>> _logger;
+    private readonly IQueueFactory _queueFactory;
+    private readonly IPublisher _queue;
+    private readonly string _queueName;
+
+    /// <summary>
+    /// DI Constructor
+    /// </summary>
+    /// <param name="logger">Logger</param>
+    /// <param name="queueFactory">Queue Factory</param>
+    public InterprocessProducer(ILogger<InterprocessProducer<T>> logger, IQueueFactory queueFactory)
+    {
+        _queueFactory = queueFactory;
+        _logger = logger;
+        _queueName = "NexusMods.DataModel.Interprocess." + typeof(T).Name;
+
+        _queue = queueFactory.CreatePublisher(new QueueOptions(
+            _queueName,
+            T.MaxSize * 16));
+    }
+
+    /// <summary>
+    /// Writes a message to the queue.
+    /// </summary>
+    /// <param name="message"></param>
+    /// <param name="token"></param>
+    /// <exception cref="TaskCanceledException"></exception>
+    public async ValueTask Write(T message, CancellationToken token)
+    {
+        _logger.LogDebug("Writing message {Message} to queue {Queue}", message, _queueName);
+
+        while (!token.IsCancellationRequested)
+        {
+            if (WriteInner(message))
+            {
+                return;
+            }
+
+            _logger.LogTrace("Failed to write {Message} to queue {Queue}, retrying", message, _queueName);
+            await Task.Delay(100, token);
+        }
+
+        throw new TaskCanceledException();
+    }
+
+    /// <summary>
+    /// Split out so we can use stack allocation in an otherwise async method.
+    /// </summary>
+    /// <param name="message"></param>
+    /// <returns></returns>
+    private bool WriteInner(T message)
+    {
+        // This means we re-encode the message on every attempt, but it is assumed that failed messages
+        // are rare and the cost of re-encoding is negligible.
+        Span<byte> buffer = stackalloc byte[T.MaxSize];
+        var used = message.Write(buffer);
+        return _queue.TryEnqueue(buffer[..used]);
+    }
+
+    public void Dispose()
+    {
+        _queue.Dispose();
+    }
+}

--- a/src/NexusMods.DataModel/NexusMods.DataModel.csproj
+++ b/src/NexusMods.DataModel/NexusMods.DataModel.csproj
@@ -17,6 +17,7 @@
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
       <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.1" />
       <PackageReference Include="RocksDB" Version="7.7.3.33461" />
+      <PackageReference Include="Sewer56.BitStream" Version="1.2.1" />
       <PackageReference Include="System.Data.SQLite" Version="1.0.117" />
       <PackageReference Include="System.Reactive" Version="5.0.0" />
       <PackageReference Include="Vogen" Version="3.0.11" />

--- a/tests/NexusMods.DataModel.Tests/DataStoreTests.cs
+++ b/tests/NexusMods.DataModel.Tests/DataStoreTests.cs
@@ -74,4 +74,28 @@ public class DataStoreTests
             modLoaded!.Files[itm.Id].Should().Be(itm);
         }
     }
+
+    [Fact]
+    public async Task CanGetRootUpdates()
+    {
+        var src = new List<Id>();
+        var dest = new List<Id>();
+
+        DataStore.Changes.Subscribe(c => dest.Add(c.To));
+
+        var oldId = DataStore.GetRoot(RootType.Tests) ?? IdEmpty.Empty;
+
+        foreach (var itm in Enumerable.Range(0, 128))
+        {
+            var newId = new Id64(EntityCategory.TestData, (ulong)itm);
+            DataStore.PutRoot(RootType.Tests, oldId, newId).Should().BeTrue();
+            src.Add(newId);
+            oldId = newId;
+        }
+
+        await Task.Delay(1000);
+
+        dest.Count.Should().Be(src.Count);
+        dest.Should().BeEquivalentTo(src, opt => opt.WithStrictOrdering());
+    }
 }

--- a/tests/NexusMods.DataModel.Tests/InterprocessTests.cs
+++ b/tests/NexusMods.DataModel.Tests/InterprocessTests.cs
@@ -12,7 +12,7 @@ public class InterprocessTests
     public class Message : IMessage
     {
         public int Value { get; init; }
-        public static int MaxSize => 128;
+        public static int MaxSize => 4;
         public int Write(Span<byte> buffer)
         {
             BinaryPrimitives.WriteInt32BigEndian(buffer, Value);
@@ -35,7 +35,7 @@ public class InterprocessTests
     [Fact]
     public async Task CanSendAndReceiveMessages()
     {
-        var src = Enumerable.Range(0, 32).ToList();
+        var src = Enumerable.Range(0, 128).ToList();
         var dest = new List<int>();
         using var _ = _consumer.Messages.Subscribe(x => dest.Add(x.Value));
         

--- a/tests/NexusMods.DataModel.Tests/InterprocessTests.cs
+++ b/tests/NexusMods.DataModel.Tests/InterprocessTests.cs
@@ -1,0 +1,51 @@
+﻿using System.Buffers.Binary;
+using FluentAssertions;
+using NexusMods.DataModel.Interprocess;
+
+namespace NexusMods.DataModel.Tests;
+
+public class InterprocessTests
+{
+    private readonly IMessageProducer<Message> _producer;
+    private readonly IMessageConsumer<Message> _consumer;
+
+    public class Message : IMessage
+    {
+        public int Value { get; init; }
+        public static int MaxSize => 128;
+        public int Write(Span<byte> buffer)
+        {
+            BinaryPrimitives.WriteInt32BigEndian(buffer, Value);
+            return sizeof(int);
+        }
+
+        public static IMessage Read(ReadOnlySpan<byte> buffer)
+        {
+            int value = BinaryPrimitives.ReadInt32BigEndian(buffer);
+            return new Message() {Value = value};
+        }
+    }
+
+    public InterprocessTests(IMessageProducer<Message> producer, IMessageConsumer<Message> consumer)
+    {
+        _producer = producer;
+        _consumer = consumer;
+    }
+
+    [Fact]
+    public async Task CanSendAndReceiveMessages()
+    {
+        var src = Enumerable.Range(0, 32).ToList();
+        var dest = new List<int>();
+        using var _ = _consumer.Messages.Subscribe(x => dest.Add(x.Value));
+        
+        foreach (var i in src)
+        {
+            await _producer.Write(new Message {Value = i}, CancellationToken.None);
+        }
+        
+        await Task.Delay(500);
+        dest.Should().BeEquivalentTo(src, opt => opt.WithStrictOrdering());
+    }
+    
+}

--- a/tests/NexusMods.DataModel.Tests/ModelTests.cs
+++ b/tests/NexusMods.DataModel.Tests/ModelTests.cs
@@ -44,7 +44,7 @@ public class ModelTests : ADataModelTest<ModelTests>
         var list = new HashSet<string>();
         
         var loadout = await LoadoutManager.ManageGame(Install, "OldName");
-        loadout.Changes.Subscribe(f => list.Add(f.Name));
+        using var _ = loadout.Changes.Subscribe(f => list.Add(f.Name));
         loadout.Alter(m => m with {Name = "NewName"});
 
         loadout.Value.Name.Should().Be("NewName");


### PR DESCRIPTION
Implements a simple but effective IPC system into the app. 

* Can create a Producer/Consumer by requesting a `IMessageProducer<T>` or `IMessageConsumer<T>` from the DI system. `T` must be an instance of `IMessage`.
* Tests include basic sanity checks for sending integers. 
* The Default Datastore now properly tracks and publishes changes to roots. Calls to `PutRoot` publish on the `IMessageConsumer<RootChange>`, this can be leveraged later on to update the UI when a CLI operation finishes modifying a loadout.
* `nexusmods.app.exe change-tracking` can be used to visualize changes to the roots. It subscribes to `RootChange` notices and prints them to the console.