### PR TITLE
Improved: Read & Write Performance of IPC by ~3x

### DIFF
--- a/src/NexusMods.DataModel/Abstractions/IDataStore.cs
+++ b/src/NexusMods.DataModel/Abstractions/IDataStore.cs
@@ -52,19 +52,19 @@ public struct RootChange : IMessage
             {
                 var stream = new PointerByteStream(ptr);
                 var writer = new BitStream<PointerByteStream>(stream);
-                writer.Write((byte)Type);
+                writer.WriteAlignedFast((byte)Type);
 
-                writer.Write((byte)From.Category);
-                writer.Write((byte)From.SpanSize);
+                writer.WriteAlignedFast((byte)From.Category);
+                writer.WriteAlignedFast((byte)From.SpanSize);
                 Span<byte> fromSpan = stackalloc byte[From.SpanSize];
                 From.ToSpan(fromSpan);
-                writer.Write(fromSpan);
+                writer.WriteFast(fromSpan);
                 
-                writer.Write((byte)To.Category);
-                writer.Write((byte)To.SpanSize);
+                writer.WriteAlignedFast((byte)To.Category);
+                writer.WriteAlignedFast((byte)To.SpanSize);
                 Span<byte> toSpan = stackalloc byte[To.SpanSize];
                 To.ToSpan(toSpan);
-                writer.Write(toSpan);
+                writer.WriteFast(toSpan);
             }   
         }
         // 1 byte for type, 2 bytes for each id (category + span size), 2 * span size for each id.
@@ -79,18 +79,18 @@ public struct RootChange : IMessage
             {
                 var stream = new PointerByteStream(ptr);
                 var reader = new BitStream<PointerByteStream>(stream);
-                var type = (RootType)reader.Read<byte>();
+                var type = (RootType)reader.ReadAlignedFast<PointerByteStream, byte>();
                 
-                var fromCategory = (EntityCategory)reader.Read<byte>();
-                var fromSpanSize = reader.Read<byte>();
+                var fromCategory = (EntityCategory)reader.ReadAlignedFast<PointerByteStream, byte>();
+                var fromSpanSize = reader.ReadAlignedFast<PointerByteStream, byte>();
                 Span<byte> fromSpan = stackalloc byte[fromSpanSize];
-                reader.Read(fromSpan);
+                reader.ReadFast(fromSpan);
                 var from = Id.FromSpan(fromCategory, fromSpan);
-                
-                var toCategory = (EntityCategory)reader.Read<byte>();
-                var toSpanSize = reader.Read<byte>();
+
+                var toCategory = (EntityCategory)reader.ReadAlignedFast<PointerByteStream, byte>();
+                var toSpanSize = reader.ReadAlignedFast<PointerByteStream, byte>();
                 Span<byte> toSpan = stackalloc byte[toSpanSize];
-                reader.Read(toSpan);
+                reader.ReadFast(toSpan);
                 var to = Id.FromSpan(toCategory, toSpan);
                 
                 return new RootChange

--- a/src/NexusMods.DataModel/NexusMods.DataModel.csproj
+++ b/src/NexusMods.DataModel/NexusMods.DataModel.csproj
@@ -17,7 +17,7 @@
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
       <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.1" />
       <PackageReference Include="RocksDB" Version="7.7.3.33461" />
-      <PackageReference Include="Sewer56.BitStream" Version="1.2.1" />
+      <PackageReference Include="Sewer56.BitStream" Version="1.3.0" />
       <PackageReference Include="System.Data.SQLite" Version="1.0.117" />
       <PackageReference Include="System.Reactive" Version="5.0.0" />
       <PackageReference Include="Vogen" Version="3.0.11" />


### PR DESCRIPTION
# Improvement

## Previously
We use a zero-allocation BitStream library for quick encoding of IPC messages.  

The library was originally optimised for writing/reading packed messages at the bit level; however we currently only use it as a byte stream. As such; to avoid any potential future bottlenecks where we might want to send a large amount of data; the  `BitStream` library could do with some optimistaions.

## The Improvement

This PR adds a variety of improvements to the `BitStream` library to support our needs and use cases.  
- Byte Level Reads i.e. `ReadAligned`.  
- Extensions for Streams for Optimised Multi-byte Read/Write Implementations i.e. `IStreamWithReadBasicPrimitives` & `ReadAlignedFast` APIs.  
- Extensions for Streams in `Read(Span<byte>)` and `Write(Span<byte>)` to use direct `memcpy` where possible. i.e. `IStreamWithMemoryCopy`

This results in:  
- Improvement of 2.5x - 200x depending on workload. (Estimated ~3x for our project currently).  

As this PR concerns an external library [and our usage of it]; most of the changes contained in this PR are contained within [this merge commit](https://github.com/Sewer56/Sewer56.BitStream/commit/5edb79f694b75be631a709fb00c3cbec1f04450f).