### PR TITLE
Fixed: Missing virtual keyword

### DIFF
--- a/src/Games/NexusMods.Games.BethesdaGameStudios/SkyrimSpecialEdition.cs
+++ b/src/Games/NexusMods.Games.BethesdaGameStudios/SkyrimSpecialEdition.cs
@@ -38,7 +38,7 @@ public class SkyrimSpecialEdition : AGame, ISteamGame, IGogGame
         yield return new(GameFolderType.AppData, appData);
     }
 
-    public IEnumerable<AModFile> GetGameFiles(GameInstallation installation, IDataStore store)
+    public override IEnumerable<AModFile> GetGameFiles(GameInstallation installation, IDataStore store)
     {
         yield return new PluginFile
         {

--- a/src/NexusMods.DataModel/Games/AGame.cs
+++ b/src/NexusMods.DataModel/Games/AGame.cs
@@ -40,7 +40,7 @@ public abstract class AGame : IGame
         }
     }
 
-    public IEnumerable<AModFile> GetGameFiles(GameInstallation installation, IDataStore store)
+    public virtual IEnumerable<AModFile> GetGameFiles(GameInstallation installation, IDataStore store)
     {
         return Array.Empty<AModFile>();
     }


### PR DESCRIPTION
Without the `virtual` keyword, the overridden `GetGameFiles` method won't be used when the game is used as `AGame` type