### PR TITLE
Fixed: Added GameStore To Differentiate Installations

### DIFF
--- a/src/NexusMods.CLI/Verbs/ListGames.cs
+++ b/src/NexusMods.CLI/Verbs/ListGames.cs
@@ -27,8 +27,8 @@ public class ListGames : AVerb
             from install in game.Installations.OrderBy(g => g.Version)
             select install;
         
-        await _renderer.Render(new Table(new[] { "Game", "Version", "Path" },
-            installs.Select(i => new object[] { i.Game, i.Version, i.Locations[GameFolderType.Game]})));
+        await _renderer.Render(new Table(new[] { "Game", "Version", "Path", "Store" },
+            installs.Select(i => new object[] { i.Game, i.Version, i.Locations[GameFolderType.Game], i.Store })));
         
         return 0;
     }

--- a/src/NexusMods.DataModel/Games/AGame.cs
+++ b/src/NexusMods.DataModel/Games/AGame.cs
@@ -32,7 +32,8 @@ public abstract class AGame : IGame
                 {
                     Game = this,
                     Locations = new Dictionary<GameFolderType, AbsolutePath>(GetLocations(locator, installation)),
-                    Version = installation.Version ?? GetVersion(locator, installation)
+                    Version = installation.Version ?? GetVersion(locator, installation),
+                    Store = installation.Store,
                 })
                 .DistinctBy(g => g.Locations[GameFolderType.Game])
                 .ToList();

--- a/src/NexusMods.DataModel/Games/GameInstallation.cs
+++ b/src/NexusMods.DataModel/Games/GameInstallation.cs
@@ -28,6 +28,11 @@ public class GameInstallation
     /// </summary>
     public static GameInstallation Empty => new();
 
+    /// <summary>
+    /// The Store that provides the game
+    /// </summary>
+    public GameStore Store { get; init; } = GameStore.Unknown;
+
 
     /// <summary>
     /// Returns the game name and version as 

--- a/src/NexusMods.DataModel/Games/GameLocatorResult.cs
+++ b/src/NexusMods.DataModel/Games/GameLocatorResult.cs
@@ -7,5 +7,6 @@ namespace NexusMods.DataModel.Games;
 /// which will stop the rest of the system from trying to find the version by other means (such as file analysis).
 /// </summary>
 /// <param name="Path"></param>
+/// <param name="Store"></param>
 /// <param name="Version"></param>
-public record GameLocatorResult(AbsolutePath Path, Version? Version = null);
+public record GameLocatorResult(AbsolutePath Path, GameStore Store, Version? Version = null);

--- a/src/NexusMods.DataModel/Games/GameStore.cs
+++ b/src/NexusMods.DataModel/Games/GameStore.cs
@@ -1,0 +1,14 @@
+﻿using Vogen;
+
+namespace NexusMods.DataModel.Games;
+
+[ValueObject<string>]
+[Instance("Unknown", "unknown")]
+[Instance("Steam", "steam")]
+[Instance("Gog", "gog")]
+[Instance("Epic", "epic")]
+[Instance("Origin", "origin")]
+[Instance("EADesktop", "eadesktop")]
+public partial class GameStore
+{
+}

--- a/src/NexusMods.DataModel/Games/UnknownGame.cs
+++ b/src/NexusMods.DataModel/Games/UnknownGame.cs
@@ -24,7 +24,8 @@ public class UnknownGame : IGame
         {
             Game = this,
             Locations = new Dictionary<GameFolderType, AbsolutePath>(),
-            Version = _version
+            Version = _version,
+            Store = GameStore.Unknown,
         }
     };
 

--- a/src/NexusMods.StandardGameLocators/AGameLocator.cs
+++ b/src/NexusMods.StandardGameLocators/AGameLocator.cs
@@ -11,11 +11,13 @@ where TRecord : class
 where TGame : IGame
 {
     private readonly ILogger _logger;
+    private readonly GameStore _gameStore;
     private readonly AHandler<TRecord,TId> _handler;
 
-    protected AGameLocator(ILogger logger, AHandler<TRecord, TId> handler)
+    protected AGameLocator(ILogger logger, GameStore gameStore, AHandler<TRecord, TId> handler)
     {
         _logger = logger;
+        _gameStore = gameStore;
         _handler = handler;
     }
 
@@ -33,7 +35,7 @@ where TGame : IGame
             }
             else
             {
-                yield return new GameLocatorResult(Path(found));
+                yield return new GameLocatorResult(Path(found), _gameStore);
             }
         }
     }

--- a/src/NexusMods.StandardGameLocators/EADesktopLocator.cs
+++ b/src/NexusMods.StandardGameLocators/EADesktopLocator.cs
@@ -9,7 +9,7 @@ namespace NexusMods.StandardGameLocators;
 
 public class EADesktopLocator : AGameLocator<EADesktopHandler, EADesktopGame, string, IEADesktopGame>
 {
-    public EADesktopLocator(ILogger<EADesktopLocator> logger, AHandler<EADesktopGame, string> handler) : base(logger, handler)
+    public EADesktopLocator(ILogger<EADesktopLocator> logger, AHandler<EADesktopGame, string> handler) : base(logger, GameStore.EADesktop, handler)
     {
     }
 

--- a/src/NexusMods.StandardGameLocators/EpicLocator.cs
+++ b/src/NexusMods.StandardGameLocators/EpicLocator.cs
@@ -9,7 +9,7 @@ namespace NexusMods.StandardGameLocators;
 
 public class EpicLocator : AGameLocator<EGSHandler, EGSGame, string, IEpicGame>
 {
-    public EpicLocator(ILogger<EpicLocator> logger, AHandler<EGSGame, string> handler) : base(logger, handler)
+    public EpicLocator(ILogger<EpicLocator> logger, AHandler<EGSGame, string> handler) : base(logger, GameStore.Epic, handler)
     {
     }
 

--- a/src/NexusMods.StandardGameLocators/GogLocator.cs
+++ b/src/NexusMods.StandardGameLocators/GogLocator.cs
@@ -9,7 +9,7 @@ namespace NexusMods.StandardGameLocators;
 
 public class GogLocator : AGameLocator<GOGHandler, GOGGame, long, IGogGame>
 {
-    public GogLocator(ILogger<GogLocator> logger, AHandler<GOGGame, long> handler) : base(logger, handler)
+    public GogLocator(ILogger<GogLocator> logger, AHandler<GOGGame, long> handler) : base(logger, GameStore.Gog, handler)
     {
     }
 

--- a/src/NexusMods.StandardGameLocators/OriginLocator.cs
+++ b/src/NexusMods.StandardGameLocators/OriginLocator.cs
@@ -9,7 +9,7 @@ namespace NexusMods.StandardGameLocators;
 
 public class OriginLocator : AGameLocator<OriginHandler, OriginGame, string, IOriginGame>
 {
-    public OriginLocator(ILogger<OriginLocator> logger, AHandler<OriginGame, string> handler) : base(logger, handler)
+    public OriginLocator(ILogger<OriginLocator> logger, AHandler<OriginGame, string> handler) : base(logger, GameStore.Origin, handler)
     {
     }
 

--- a/src/NexusMods.StandardGameLocators/SteamLocator.cs
+++ b/src/NexusMods.StandardGameLocators/SteamLocator.cs
@@ -9,7 +9,7 @@ namespace NexusMods.StandardGameLocators;
 
 public class SteamLocator : AGameLocator<SteamHandler, SteamGame, int, ISteamGame>
 {
-    public SteamLocator(ILogger<SteamLocator> logger, AHandler<SteamGame, int> handler) : base(logger, handler)
+    public SteamLocator(ILogger<SteamLocator> logger, AHandler<SteamGame, int> handler) : base(logger, GameStore.Steam, handler)
     {
     }
 

--- a/tests/NexusMods.StandardGameLocators.TestHelpers/StubbedGames.cs
+++ b/tests/NexusMods.StandardGameLocators.TestHelpers/StubbedGames.cs
@@ -51,7 +51,8 @@ public class StubbedGame : IEADesktopGame, IEpicGame, IOriginGame, ISteamGame, I
                     {
                         { GameFolderType.Game, EnsureFiles(i.Path) }
                     },
-                    Version = Version.Parse($"0.0.{idx}.0")
+                    Version = Version.Parse($"0.0.{idx}.0"),
+                    Store = GameStore.Unknown,
                 });
         }
     }

--- a/tests/NexusMods.StandardGameLocators.TestHelpers/UniversalStubbedGameLocator.cs
+++ b/tests/NexusMods.StandardGameLocators.TestHelpers/UniversalStubbedGameLocator.cs
@@ -21,6 +21,6 @@ public class UniversalStubbedGameLocator<TGame> : IGameLocator
         if (game is not TGame tg)
             yield break;
         
-        yield return new GameLocatorResult(_path, _version ?? new Version(1, 0, 0, 0));
+        yield return new GameLocatorResult(_path, GameStore.Unknown, _version ?? new Version(1, 0, 0, 0));
     }
 }


### PR DESCRIPTION
I found out while testing with the CLI that if you have multiple game installations with the same version, the discovery mechanism will break at those lines.
https://github.com/Nexus-Mods/NexusMods.App/blob/44194f9f2518b58d38f914a6113a43f17d47feea/src/NexusMods.DataModel/JsonConverters/GameInstallationConverter.cs#L13-L14
There's not enough 'uniqueness' when using only a (Slug, Version) tuple.
This could be fixed by adding some unique GUID for the concrete installation, but if I understand correctly, we have a constraint for any store that you can have only one (Game, Version) tuple installed at any given time.
This means that a store identifier should be enough for solving the 'uniqueness' issue, (Slug, Store, Version) tuple basically.

This is an example of how this could be fixed