### PR TITLE
Add `.gitattributes` file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,61 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Documents
+*.md        text diff=markdown
+
+# Graphics
+*.png       binary
+*.jpg       binary
+*.jpeg      binary
+*.gif       binary
+*.ico       binary
+*.svg       binary
+
+# Scripts (Unix)
+*.bash      text eol=lf
+*.sh        text eol=lf
+*.zsh       text eol=lf
+
+# Scripts (Windows)
+*.bat       text eol=crlf
+*.cmd       text eol=crlf
+*.ps1       text eol=crlf
+
+# Archives
+*.7z        binary
+*.gz        binary
+*.tar       binary
+*.tgz       binary
+*.zip       binary
+
+# Code files
+*.cs        text diff=csharp
+
+# Project files
+*.sln       text eol=crlf
+*.csproj    text eol=crlf
+
+*.props     text eol=crlf
+*.targets   text eol=crlf
+*.filters   text eol=crlf
+*.filters   text eol=crlf
+*.vcxitems  text eol=crlf
+
+# Dynamic libraries
+*.so        binary
+*.dylib     binary
+*.dll       binary
+
+# Executables
+*.exe       binary
+*.out       binary
+*.app       binary
+
+# Text files where line endings should be preserved
+*.patch     -text
+
+# Exclude files from exporting
+.gitattributes  export-ignore
+.gitignore      export-ignore
+.gitkeep        export-ignore

--- a/NexusMods.App.sln
+++ b/NexusMods.App.sln
@@ -83,6 +83,15 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NexusMods.UI.Tests", "tests
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NexusMods.Common.Tests", "src\NexusMods.CommonTests\NexusMods.Common.Tests.csproj", "{774EAA0D-268E-4A12-B8CC-7B22058A14A3}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".solutionItems", ".solutionItems", "{D9476FF9-B9A1-4C63-A58F-2E19BE356770}"
+	ProjectSection(SolutionItems) = preProject
+		codecov.yaml = codecov.yaml
+		Directory.Build.props = Directory.Build.props
+		LICENSE.md = LICENSE.md
+		NuGet.Build.props = NuGet.Build.props
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/NexusMods.App.sln
+++ b/NexusMods.App.sln
@@ -90,6 +90,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".solutionItems", ".solution
 		LICENSE.md = LICENSE.md
 		NuGet.Build.props = NuGet.Build.props
 		README.md = README.md
+		.gitattributes = .gitattributes
 	EndProjectSection
 EndProject
 Global


### PR DESCRIPTION
The [`.gitattributes`](https://www.git-scm.com/docs/gitattributes) file can be used to tell git how to handle certain files. It can also be used to influence the [GitHub language detection](https://github.com/open-papyrus/docs/blob/master/.gitattributes).

The important changes here are the LF normalization and EOL specification for certain text files to prevent any cross-platform issues.
