### PR TITLE
Add `.editorconfig` file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,68 @@
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+max_line_length = 80
+
+# Microsoft .NET properties
+csharp_new_line_before_members_in_object_initializers = false
+csharp_preferred_modifier_order = public, private, protected, internal, file, new, static, abstract, virtual, sealed, readonly, override, extern, unsafe, volatile, async, required:suggestion
+csharp_style_prefer_utf8_string_literals = true:suggestion
+csharp_style_var_elsewhere = true:warning
+csharp_style_var_for_built_in_types = true:warning
+csharp_style_var_when_type_is_apparent = true:warning
+dotnet_naming_rule.unity_serialized_field_rule.import_to_resharper = True
+dotnet_naming_rule.unity_serialized_field_rule.resharper_description = Unity serialized field
+dotnet_naming_rule.unity_serialized_field_rule.resharper_guid = 5f0fdb63-c892-4d2c-9324-15c80b22a7ef
+dotnet_naming_rule.unity_serialized_field_rule.severity = warning
+dotnet_naming_rule.unity_serialized_field_rule.style = lower_camel_case_style
+dotnet_naming_rule.unity_serialized_field_rule.symbols = unity_serialized_field_symbols
+dotnet_naming_style.lower_camel_case_style.capitalization = camel_case
+dotnet_naming_symbols.unity_serialized_field_symbols.applicable_accessibilities = *
+dotnet_naming_symbols.unity_serialized_field_symbols.applicable_kinds =
+dotnet_naming_symbols.unity_serialized_field_symbols.resharper_applicable_kinds = unity_serialised_field
+dotnet_naming_symbols.unity_serialized_field_symbols.resharper_required_modifiers = instance
+dotnet_style_parentheses_in_arithmetic_binary_operators = never_if_unnecessary:none
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:none
+dotnet_style_parentheses_in_relational_binary_operators = never_if_unnecessary:none
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+dotnet_style_qualification_for_event = false:warning
+dotnet_style_qualification_for_field = false:warning
+dotnet_style_qualification_for_method = false:warning
+dotnet_style_qualification_for_property = false:warning
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:suggestion
+
+# ReSharper properties
+resharper_apply_auto_detected_rules = false
+resharper_autodetect_indent_settings = true
+resharper_csharp_empty_block_style = together_same_line
+resharper_csharp_stick_comment = false
+resharper_outdent_statement_labels = true
+resharper_show_autodetect_configure_formatting_tip = false
+resharper_use_indent_from_vs = false
+resharper_wrap_lines = true
+
+# ReSharper inspection severities
+resharper_arrange_redundant_parentheses_highlighting = hint
+resharper_arrange_type_member_modifiers_highlighting = hint
+resharper_arrange_type_modifiers_highlighting = hint
+resharper_built_in_type_reference_style_for_member_access_highlighting = hint
+resharper_built_in_type_reference_style_highlighting = hint
+
+[*.cs]
+indent_size = 4
+indent_style = space
+tab_width = 4
+
+# CS1591: Missing XML comment for publicly visible type or member
+dotnet_diagnostic.cs1591.severity = suggestion
+
+# CS4014: Task not awaited
+dotnet_diagnostic.cs4014.severity = error
+
+[{*.yaml,*.yml}]
+indent_style = space
+indent_size = 2

--- a/NexusMods.App.sln
+++ b/NexusMods.App.sln
@@ -91,6 +91,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".solutionItems", ".solution
 		NuGet.Build.props = NuGet.Build.props
 		README.md = README.md
 		.gitattributes = .gitattributes
+		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
 Global


### PR DESCRIPTION
- forces UTF-8 (not utf-8-bom, which VS likes to use)
- forces final new line and trims trailing whitespace for better git compatibility and less diff clutter
- changes warning severities:
  - [CS1591](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs1591): "Missing XML comment for publicly visible type or member" from _warning_ to _suggestion_. This reduces clutter in the build log while keeping the suggestions visible in the IDE.
  - [CS4014](https://learn.microsoft.com/en-US/dotnet/csharp/language-reference/compiler-messages/cs4014): "Task not awaited" from _warning_ to **error**. This is just a precaution as nothing in the codebase currently triggers this warning. I changed this to be an error, as an issue related to a not awaited task is very hard to debug.
- contains a couple debatable style choices. These don't really matter, but it's best to have a unified code base and not 20 different coding styles.