### PR TITLE
Small codecov fixes

### DIFF
--- a/.github/workflows/validate-codecov.yaml
+++ b/.github/workflows/validate-codecov.yaml
@@ -1,0 +1,25 @@
+name: Validate codecov.yaml
+
+on:
+  push:
+    paths:
+      - "codecov.yaml"
+      - ".github/workflows/validate-codecov.yaml"
+    branches: [ main ]
+  pull_request:
+    paths:
+      - "codecov.yaml"
+      - ".github/workflows/validate-codecov.yaml"
+    branches: [ main ]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Validate
+        shell: bash
+        run: |
+          curl --fail --data-binary @codecov.yaml https://codecov.io/validate

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -2,3 +2,6 @@
   layout: "reach, diff, flags, files"
   behavior: default
   require_changes: false  # if true: only post the comment if coverage changes
+  # prevent codecov from writing a comment before n builds have finished
+  # this number should be the number of operating systems tested
+  after_n_builds: 2 


### PR DESCRIPTION
- adds a [validation](https://api.codecov.io/validate) workflow for `codecov.yaml`
- updates `codecov.yaml` to only post a comment after 2 builds. This prevents codecov from posting a comment when only 1 build finishes, as the comment often contains incomplete information. This value should be updated when more builds are added.