### PR TITLE
Cleanup OAuth2 callback code

### DIFF
--- a/src/Networking/NexusMods.Networking.NexusWebApi/OAuth.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/OAuth.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System.Reactive.Linq;
+using Microsoft.Extensions.Logging;
 using NexusMods.Common;
 using NexusMods.DataModel.Interprocess;
 using NexusMods.Networking.NexusWebApi.Types;
@@ -64,7 +65,7 @@ public struct NXMUrlMessage : IMessage
     public static IMessage Read(ReadOnlySpan<byte> buffer)
     {
         var value = Encoding.UTF8.GetString(buffer);
-        return new NXMUrlMessage() { Value = NXMUrl.Parse(value) };
+        return new NXMUrlMessage { Value = NXMUrl.Parse(value) };
     }
 
     /// <inheritdoc/>
@@ -87,22 +88,22 @@ public class OAuth
     private static string OAuthRedirectURL = "nxm://oauth/callback";
     private static string OAuthClientId = "vortex";
 
-    private IDictionary<string, Action<Exception?, string>> _callbacks = new Dictionary<string, Action<Exception?, string>>();
     private readonly ILogger<OAuth> _logger;
     private readonly HttpClient _http;
     private readonly IOSInterop _os;
     private readonly IIDGenerator _idGen;
+    private readonly IMessageConsumer<NXMUrlMessage> _nxmUrlMessages;
 
     /// <summary>
     /// constructor
     /// </summary>
-    public OAuth(ILogger<OAuth> logger, HttpClient http, IIDGenerator idGen, IOSInterop os, IMessageConsumer<NXMUrlMessage> message)
+    public OAuth(ILogger<OAuth> logger, HttpClient http, IIDGenerator idGen, IOSInterop os, IMessageConsumer<NXMUrlMessage> nxmUrlMessages)
     {
         _logger = logger;
         _http = http;
         _os = os;
         _idGen = idGen;
-        message.Messages.Subscribe(OnNXMUrl);
+        _nxmUrlMessages = nxmUrlMessages;
     }
 
     /// <summary>
@@ -112,8 +113,7 @@ public class OAuth
     /// <returns>task with the jwt token once we receive one</returns>
     public async Task<JwtTokenReply> AuthorizeRequest(CancellationToken cancel)
     {
-        var completionSource = new TaskCompletionSource<JwtTokenReply>();
-
+        _logger.LogInformation("Starting NexusMods OAuth2 authorization request");
         var state = _idGen.UUIDv4();
 
         // see https://www.rfc-editor.org/rfc/rfc7636#section-4.1
@@ -122,35 +122,22 @@ public class OAuth
         using SHA256 sha256 = SHA256.Create();
         var challenge = sha256.ComputeHash(Encoding.UTF8.GetBytes(verifier)).ToBase64();
 
-        // callback will be invoked if/when we heard back from the site
-        _callbacks[state] = (Exception? ex, string code) =>
-            {
-                if (ex != null)
-                {
-                    completionSource.SetException(ex);
-                }
-                else
-                {
-                    AuthorizeToken(verifier, code, CancellationToken.None).ContinueWith(reply =>
-                    {
-                        if (reply.Exception != null)
-                        {
-                            completionSource.SetException(reply.Exception);
-                        }
-                        else
-                        {
-                            completionSource.SetResult(reply.Result);
-                        }
-                    });
-                }
-            };
+        // Start listening first, otherwise we might miss the message
+        var codeTask = _nxmUrlMessages.Messages
+            .Where(url => url.Value.UrlType == NXMUrlType.OAuth)
+            .Where(url => url.Value.OAuth.State == state)
+            .Select(url => url.Value.OAuth.Code!)
+            .ToAsyncEnumerable()
+            .FirstAsync(cancel);
 
-        cancel.Register(() => _callbacks[state].Invoke(new OperationCanceledException(), ""));
-
+        _logger.LogInformation("Opening browser for NexusMods OAuth2 authorization request");
         // see https://www.rfc-editor.org/rfc/rfc7636#section-4.3
         _os.OpenURL(GenerateAuthorizeUrl(challenge, state));
+        var code = await codeTask;
 
-        return await completionSource.Task;
+        _logger.LogInformation("Received OAuth2 authorization code, requesting token");
+        return await AuthorizeToken(verifier, code, cancel);
+
     }
 
     /// <summary>
@@ -190,22 +177,6 @@ public class OAuth
         var response = await _http.PostAsync($"{OAuthUrl}/token", content, cancel);
         var responseString = await response.Content.ReadAsStringAsync(cancel);
         return JsonSerializer.Deserialize<JwtTokenReply>(responseString);
-    }
-
-    private void OnNXMUrl(NXMUrlMessage url)
-    {
-        if ((url.Value.UrlType == NXMUrlType.OAuth) && (url.Value.OAuth.State != null))
-        {
-            if (_callbacks.ContainsKey(url.Value.OAuth.State))
-            {
-                _callbacks[url.Value.OAuth.State].Invoke(null, url.Value.OAuth.Code ?? "");
-                _callbacks.Remove(url.Value.OAuth.State);
-            }
-            else
-            {
-                _logger.LogWarning("received unexpected oauth callback");
-            }
-        }
     }
 
     private string SanitizeBase64(string input)

--- a/tests/Networking/NexusMods.Networking.NexusWebApi.Tests/OAuthTests.cs
+++ b/tests/Networking/NexusMods.Networking.NexusWebApi.Tests/OAuthTests.cs
@@ -1,21 +1,12 @@
-﻿using Xunit;
-using NexusMods.Networking.NexusWebApi;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using NexusMods.Common;
 using NexusMods.DataModel.Interprocess;
 using Moq;
 using System.Net;
 using Moq.Protected;
 using NexusMods.Networking.NexusWebApi.Types;
-using NexusMods.DataModel.JsonConverters;
 using System.Text.Json;
 using FluentAssertions;
-using System.Data.Entity.Core.Metadata.Edm;
 
 namespace NexusMods.Networking.NexusWebApi.Tests;
 
@@ -57,7 +48,7 @@ public class OAuthTests
         _consumer = consumer;
     }
 
-    [Fact()]
+    [Fact]
     public async void AuthorizeRequestTest()
     {
         #region Setup
@@ -94,7 +85,7 @@ public class OAuthTests
         #endregion
     }
 
-    [Fact()]
+    [Fact]
     public async void RefreshTokenTest()
     {
         #region Setup
@@ -128,31 +119,7 @@ public class OAuthTests
         #endregion
     }
 
-    [Fact()]
-    public async void WarnsOnUnexpectedCallback()
-    {
-        var messageHandler = new Mock<HttpMessageHandler>();
-        HttpClient httpClient = new HttpClient(messageHandler.Object);
-        var idGen = new Mock<IIDGenerator>();
-        var os = new Mock<IOSInterop>();
-        var logger = new Mock<ILogger<OAuth>>();
-
-        var oauth = new OAuth(logger.Object, httpClient, idGen.Object, os.Object, _consumer);
-
-        await _producer.Write(new NXMUrlMessage { Value = NXMUrl.Parse($"nxm://oauth/callback?state=surprise&code=code") }, CancellationToken.None);
-        // allow message to be handled
-        await Task.Delay(100);
-
-        logger.Verify(logger => logger.Log(
-                It.Is<LogLevel>(logLevel => logLevel == LogLevel.Warning),
-                It.Is<EventId>(eventId => eventId.Id == 0),
-                It.IsAny<It.IsAnyType>(),
-                It.IsAny<Exception>(),
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
-    }
-
-    [Fact()]
+    [Fact]
     public async void ThrowsOnInvalidResponse()
     {
         #region Setup
@@ -184,7 +151,7 @@ public class OAuthTests
         #endregion
     }
 
-    [Fact()]
+    [Fact]
     public async void AuthorizationCanBeCanceled()
     {
         #region Setup


### PR DESCRIPTION
I didn't see it in the initial code review, but I was a little unhappy with the callback interactions in the original OAuth2 code. We were using a Dictionary to store callbacks (which technically isn't threadsafe), and using TaskCompletetionSource in cases where we already have `IObservable` interfaces. Turns out it cleaned up quite nicely. 