### PR TITLE
Fix Steam locator on Linux

### DIFF
--- a/src/NexusMods.StandardGameLocators/Services.cs
+++ b/src/NexusMods.StandardGameLocators/Services.cs
@@ -9,15 +9,11 @@ using GameFinder.StoreHandlers.Origin;
 using GameFinder.StoreHandlers.Steam;
 using Microsoft.Extensions.DependencyInjection;
 using NexusMods.DataModel.Games;
-using NexusMods.Paths;
-using NexusMods.Paths.Extensions;
-using NexusMods.Paths.Utilities;
 
 namespace NexusMods.StandardGameLocators;
 
 public static class Services
 {
-
     /// <summary>
     /// Registers all the services for the standard store locators
     /// </summary>
@@ -28,8 +24,7 @@ public static class Services
     public static IServiceCollection AddStandardGameLocators(this IServiceCollection services,
         bool registerConcreteLocators = true)
     {
-
-        MaybeAddSteamHandler(services, registerConcreteLocators);
+        services.AddSingleton<IGameLocator, SteamLocator>();
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
@@ -41,7 +36,8 @@ public static class Services
 
         if (!registerConcreteLocators) return services;
 
-#pragma warning disable CA1416
+        MaybeAddSteamHandler(services);
+
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             services.AddSingleton<AHandler<EADesktopGame, string>>(_ => new EADesktopHandler());
@@ -49,38 +45,35 @@ public static class Services
             services.AddSingleton<AHandler<GOGGame, long>>(_ => new GOGHandler());
             services.AddSingleton<AHandler<OriginGame, string>>(_ => new OriginHandler());
         }
-#pragma warning restore CA1416
-        
+
         return services;
     }
 
-    private static void MaybeAddSteamHandler(IServiceCollection services, 
-        bool registerConcreteLocators = true)
+    private static void MaybeAddSteamHandler(IServiceCollection services)
     {
-        services.AddSingleton<IGameLocator, SteamLocator>();
-        
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-#pragma warning disable CA1416
-            if (registerConcreteLocators) 
-                services.AddSingleton<AHandler<SteamGame, int>, SteamHandler>(_ => new SteamHandler(new WindowsRegistry()));
-#pragma warning restore CA1416
-            return;
-        }
-
-        var searchPaths = new[]
+            services.AddSingleton<AHandler<SteamGame, int>, SteamHandler>(_ => new SteamHandler(new WindowsRegistry()));
+        } else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-            KnownFolders.HomeFolder.CombineUnchecked(".steam/debian-installation/".ToRelativePath()),
-            //KnownFolders.HomeFolder.CombineUnchecked(".steam/steam/".ToRelativePath())
-        };
-        
-        var steamPath = searchPaths.FirstOrDefault(p => p.CombineChecked("steam.sh".ToRelativePath()).FileExists);
-        if (steamPath == default) return;
-        
+            var steamPath = Environment.GetEnvironmentVariable(
+                "NMA_STEAM_PATH",
+                EnvironmentVariableTarget.Process);
 
-        
-        if (registerConcreteLocators) 
-            services.AddSingleton<AHandler<SteamGame, int>, SteamHandler>(_ => 
-                new SteamHandler(steamPath.ToString(), new FileSystem(), null));
+            if (steamPath is null)
+            {
+                services.AddSingleton<AHandler<SteamGame, int>, SteamHandler>(_ =>
+                    new SteamHandler(new FileSystem(), null));
+            }
+            else
+            {
+                services.AddSingleton<AHandler<SteamGame, int>, SteamHandler>(_ =>
+                    new SteamHandler(steamPath, new FileSystem(), null));
+            }
+        }
+        else
+        {
+            throw new PlatformNotSupportedException("Steam is not supported on this platform");
+        }
     }
 }


### PR DESCRIPTION
Previously, NMA would look for hardcoded Steam paths instead of letting GameFinder look for Steam. Using environment variables, we can rely on GameFinder for sane installation paths and let the user set the path manually.