### PR TITLE
Cleanup service registration code and validate IServiceCollections

### DIFF
--- a/benchmarks/NexusMods.Benchmarks/Benchmarks/DataModel.cs
+++ b/benchmarks/NexusMods.Benchmarks/Benchmarks/DataModel.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using NexusMods.Benchmarks.Interfaces;
+using NexusMods.Common;
 using NexusMods.DataModel;
 using NexusMods.DataModel.Abstractions;
 using NexusMods.DataModel.Interprocess;
@@ -36,26 +37,27 @@ public class DataStoreBenchmark : IBenchmark, IDisposable
             .ConfigureServices((_, services) =>
             {
                 services
-                    .AddDataModel();
+                    .AddDataModel()
+                    .Validate();
             }).Build();
 
         var provider = host.Services.GetRequiredService<IServiceProvider>();
         _dataStore = new SqliteDataStore(
             provider.GetRequiredService<ILogger<SqliteDataStore>>(),
-            _temporaryFileManager.CreateFile(KnownExtensions.Sqlite).Path, provider, 
+            _temporaryFileManager.CreateFile(KnownExtensions.Sqlite).Path, provider,
             provider.GetRequiredService<IMessageProducer<RootChange>>(),
-            provider.GetRequiredService<IMessageConsumer<RootChange>>(), 
+            provider.GetRequiredService<IMessageConsumer<RootChange>>(),
         provider.GetRequiredService<IMessageProducer<IdPut>>(),
         provider.GetRequiredService<IMessageConsumer<IdPut>>());
-        
+
         _rawData = new byte[1024];
         Random.Shared.NextBytes(_rawData);
         _rawId = new Id64(EntityCategory.TestData, (ulong)Random.Shared.NextInt64());
         _dataStore.PutRaw(_rawId, _rawData);
-        
+
         _relPutPath = "test.txt".ToRelativePath();
         _fromPutPath = new HashRelativePath(Hash.From((ulong)Random.Shared.NextInt64()), _relPutPath);
-        
+
         _record = new FromArchive
         {
             Id = ModFileId.New(),
@@ -79,7 +81,7 @@ public class DataStoreBenchmark : IBenchmark, IDisposable
     {
         _dataStore.GetRaw(_rawId);
     }
-    
+
     [Benchmark]
     public void PutImmutable()
     {
@@ -100,19 +102,19 @@ public class DataStoreBenchmark : IBenchmark, IDisposable
     {
         _dataStore.Put(_immutableRecord, _record);
     }
-    
+
     [Benchmark]
     public void GetImmutable()
     {
         _dataStore.Get<FromArchive>(_immutableRecord);
     }
-    
+
     [Benchmark]
     public void GetImmutableCached()
     {
         _dataStore.Get<FromArchive>(_immutableRecord, true);
     }
-    
+
     public void Dispose()
     {
         _temporaryFileManager.Dispose();

--- a/src/Networking/NexusMods.Networking.NexusWebApi/Services.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/Services.cs
@@ -35,7 +35,6 @@ public static class Services
         }
 
         return collection
-            .AddDataModel()
             .AddSingleton<ITypeFinder, TypeFinder>()
             .AddSingleton<IProtocolHandler, NXMProtocolHandler>()
             .AddSingleton<Client>()
@@ -46,7 +45,7 @@ public static class Services
             .AddVerb<DownloadLinks>()
             .AddVerb<NexusLogin>()
             .AddVerb<NexusLogout>()
-            
+
             .AddSingleton<IOptionParser<CDNName>, StringOptionParser<CDNName>>()
             .AddSingleton<IOptionParser<ModId>, ULongOptionParser<ModId>>()
             .AddSingleton<IOptionParser<FileId>, ULongOptionParser<FileId>>()

--- a/src/NexusMods.App/Program.cs
+++ b/src/NexusMods.App/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using NexusMods.App;
 using NexusMods.App.UI;
 using NexusMods.CLI;
+using NexusMods.Common;
 using NLog.Extensions.Logging;
 using NLog.Targets;
 using ReactiveUI;
@@ -56,7 +57,10 @@ public class Program
     {
         var host = Host.CreateDefaultBuilder(Environment.GetCommandLineArgs())
             .ConfigureLogging(AddLogging)
-            .ConfigureServices((_, services) => { services.AddApp(); }).Build();
+            .ConfigureServices((_, services) =>
+                services.AddApp()
+                    .Validate())
+            .Build();
         return host;
     }
 

--- a/src/NexusMods.CLI/Services.cs
+++ b/src/NexusMods.CLI/Services.cs
@@ -27,8 +27,6 @@ public static class Services
         services.AddSingleton<IOptionParser<Version>, VersionParser>();
         services.AddSingleton<IOptionParser<Loadout>, LoadoutParser>();
         services.AddSingleton<IOptionParser<ITool>, ToolParser>();
-        services.AddSingleton<TemporaryFileManager>();
-
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             services.AddSingleton<IProtocolRegistration, ProtocolRegistrationWindows>();
@@ -65,4 +63,5 @@ public static class Services
         services.AddAllSingleton<IResource, IResource<FileContentsCache, Size>>(_ => new Resource<FileContentsCache, Size>("File Analysis"));
         return services;
     }
+
 }

--- a/src/NexusMods.Common/Services.cs
+++ b/src/NexusMods.Common/Services.cs
@@ -15,7 +15,7 @@ namespace NexusMods.Common
         {
             services.AddSingleton<IIDGenerator, IDGenerator>()
                     .AddSingleton<IProcessFactory, ProcessFactory>();
-            
+
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 services.AddSingleton<IOSInterop, OSInteropWindows>();
@@ -29,6 +29,38 @@ namespace NexusMods.Common
                 services.AddSingleton<IOSInterop, OSInteropOSX>();
             }
             return services;
+        }
+
+        /// <summary>
+        /// Runs through the list of registered services and verifies that there
+        /// aren't any duplicate registrations. This is a no-op during release builds.
+        /// </summary>
+        /// <param name="serviceCollection"></param>
+        /// <returns></returns>
+        public static IServiceCollection Validate(
+            this IServiceCollection serviceCollection)
+        {
+#if DEBUG
+            var serviceDescriptors = serviceCollection
+                .Where(sd => sd.ImplementationType != null)
+                .GroupBy(sd => (sd.ServiceType, sd.ImplementationType))
+                .Where(g => g.Count() > 1)
+                .Select(g => (g.Key.ServiceType, g.Key.ImplementationType, g.Count()))
+                .ToList();
+
+            if (serviceDescriptors.Any())
+            {
+                var sb = new StringBuilder();
+                foreach (var error in serviceDescriptors)
+                {
+                    sb.AppendLine($"  Service: {error.ServiceType}, Implementation: {error.ImplementationType}, Count: {error.Item3}");
+                }
+
+                throw new InvalidOperationException(
+                    $"Duplicate service registrations found: \n{sb}");
+            }
+#endif
+            return serviceCollection;
         }
     }
 }

--- a/tests/Games/NexusMods.Games.BethesdaGameStudios.Tests/Startup.cs
+++ b/tests/Games/NexusMods.Games.BethesdaGameStudios.Tests/Startup.cs
@@ -16,23 +16,26 @@ namespace NexusMods.Games.BethesdaGameStudios.Tests;
 
 public class Startup
 {
-    public void ConfigureServices(IServiceCollection container)
+    public void ConfigureServices(IServiceCollection services)
     {
-        container.AddUniversalGameLocator<SkyrimSpecialEdition>(new Version("1.6.659.0"));
-        container.AddBethesdaGameStudios();
-        
-        container.AddLogging(builder => builder.SetMinimumLevel(LogLevel.Debug));
-        container.AddDataModel(KnownFolders.EntryFolder.CombineUnchecked("DataModel").CombineUnchecked(Guid.NewGuid().ToString()));
-        container.AddAllSingleton<IResource, IResource<FileContentsCache, Size>>(s =>
-            new Resource<FileContentsCache, Size>("File Analysis"));
-        container.AddAllSingleton<IResource, IResource<IExtractor, Size>>(s =>
-            new Resource<IExtractor, Size>("File Extraction"));
-        container.AddFileExtractors();
+        services.AddUniversalGameLocator<SkyrimSpecialEdition>(new Version("1.6.659.0"))
+                .AddBethesdaGameStudios()
 
-        container.AddSingleton<TemporaryFileManager>(s => 
-            new TemporaryFileManager(KnownFolders.EntryFolder.CombineUnchecked("tempFiles")));
+                .AddLogging(builder => builder.SetMinimumLevel(LogLevel.Debug))
+                .AddDataModel(KnownFolders.EntryFolder.CombineUnchecked("DataModel")
+                    .CombineUnchecked(Guid.NewGuid().ToString()))
+                .AddAllSingleton<IResource, IResource<FileContentsCache, Size>>(s =>
+                    new Resource<FileContentsCache, Size>("File Analysis"))
+                .AddAllSingleton<IResource, IResource<IExtractor, Size>>(s =>
+                    new Resource<IExtractor, Size>("File Extraction"))
+                .AddFileExtractors()
+
+                .AddSingleton<TemporaryFileManager>(s =>
+                    new TemporaryFileManager(
+                        KnownFolders.EntryFolder.CombineUnchecked("tempFiles")))
+                .Validate();
     }
-    
+
     public void Configure(ILoggerFactory loggerFactory, ITestOutputHelperAccessor accessor) =>
         loggerFactory.AddProvider(new XunitTestOutputLoggerProvider(accessor, delegate { return true;}));
 }

--- a/tests/Games/NexusMods.Games.RedEngine.Tests/Startup.cs
+++ b/tests/Games/NexusMods.Games.RedEngine.Tests/Startup.cs
@@ -20,24 +20,25 @@ public class Startup
 {
     public void ConfigureServices(IServiceCollection container)
     {
-        container.AddUniversalGameLocator<Cyberpunk2077>(new Version("1.61"));
-        container.AddRedEngineGames();
-        container.AddNexusWebApi(true);
-        container.AddHttpDownloader();
+        container.AddUniversalGameLocator<Cyberpunk2077>(new Version("1.61"))
+                 .AddRedEngineGames()
+                 .AddNexusWebApi(true)
+                 .AddHttpDownloader()
 
-        container.AddSingleton<HttpClient>();
-        container.AddLogging(builder => builder.SetMinimumLevel(LogLevel.Debug));
-        container.AddDataModel(KnownFolders.EntryFolder.CombineUnchecked("DataModel").CombineUnchecked(Guid.NewGuid().ToString()));
-        container.AddAllSingleton<IResource, IResource<FileContentsCache, Size>>(s =>
-            new Resource<FileContentsCache, Size>("File Analysis"));
-        container.AddAllSingleton<IResource, IResource<IExtractor, Size>>(s =>
-            new Resource<IExtractor, Size>("File Extraction"));
-        container.AddFileExtractors();
+                 .AddSingleton<HttpClient>()
+                 .AddLogging(builder => builder.SetMinimumLevel(LogLevel.Debug))
+                 .AddDataModel(KnownFolders.EntryFolder.CombineUnchecked("DataModel").CombineUnchecked(Guid.NewGuid().ToString()))
+                 .AddAllSingleton<IResource, IResource<FileContentsCache, Size>>(s =>
+            new Resource<FileContentsCache, Size>("File Analysis"))
+                 .AddAllSingleton<IResource, IResource<IExtractor, Size>>(s =>
+            new Resource<IExtractor, Size>("File Extraction"))
+                 .AddFileExtractors()
 
-        container.AddSingleton<TemporaryFileManager>(s => 
-            new TemporaryFileManager(KnownFolders.EntryFolder.CombineUnchecked("tempFiles")));
+                 .AddSingleton<TemporaryFileManager>(s =>
+            new TemporaryFileManager(KnownFolders.EntryFolder.CombineUnchecked("tempFiles")))
+                 .Validate();
     }
-    
+
     public void Configure(ILoggerFactory loggerFactory, ITestOutputHelperAccessor accessor) =>
         loggerFactory.AddProvider(new XunitTestOutputLoggerProvider(accessor, delegate { return true;}));
 }

--- a/tests/Networking/NexusMods.Networking.HttpDownloader.Tests/Startup.cs
+++ b/tests/Networking/NexusMods.Networking.HttpDownloader.Tests/Startup.cs
@@ -11,14 +11,15 @@ public class Startup
 {
     public void ConfigureServices(IServiceCollection container)
     {
-        container.AddAdvancedHttpDownloader();
-        container.AddSingleton<SimpleHttpDownloader>();
-        container.AddSingleton<AdvancedHttpDownloader>();
-        container.AddSingleton<TemporaryFileManager>();
-        container.AddSingleton<HttpClient>();
-        container.AddSingleton<LocalHttpServer>();
+        container.AddAdvancedHttpDownloader()
+                 .AddSingleton<SimpleHttpDownloader>()
+                 .AddSingleton<AdvancedHttpDownloader>()
+                 .AddSingleton<TemporaryFileManager>()
+                 .AddSingleton<HttpClient>()
+                 .AddSingleton<LocalHttpServer>()
+                 .Validate();
     }
-    
+
     public void Configure(ILoggerFactory loggerFactory, ITestOutputHelperAccessor accessor) =>
         loggerFactory.AddProvider(new XunitTestOutputLoggerProvider(accessor, delegate { return true;}));
 }

--- a/tests/Networking/NexusMods.Networking.NexusWebApi.Tests/Startup.cs
+++ b/tests/Networking/NexusMods.Networking.NexusWebApi.Tests/Startup.cs
@@ -14,11 +14,11 @@ namespace NexusMods.Networking.NexusWebApi.Tests;
 
 public class Startup
 {
-    public void ConfigureServices(IServiceCollection container)
+    public void ConfigureServices(IServiceCollection services)
     {
         var mockOSInterop = new Mock<IOSInterop>();
 
-        container
+        services
             .AddSingleton<HttpClient>()
             .AddLogging(builder => builder.SetMinimumLevel(LogLevel.Debug))
             .AddHttpDownloader()
@@ -27,9 +27,10 @@ public class Startup
             .AddSingleton(mockOSInterop.Object)
             .AddSingleton<LocalHttpServer>()
             .AddNexusWebApi(true)
-            .AddDataModel();
+            .AddDataModel()
+            .Validate();
     }
-    
+
     public void Configure(ILoggerFactory loggerFactory, ITestOutputHelperAccessor accessor) =>
         loggerFactory.AddProvider(new XunitTestOutputLoggerProvider(accessor, delegate { return true;}));
 }

--- a/tests/NexusMods.CLI.Tests/Startup.cs
+++ b/tests/NexusMods.CLI.Tests/Startup.cs
@@ -10,15 +10,16 @@ namespace NexusMods.CLI.Tests;
 
 public class Startup
 {
-    public void ConfigureServices(IServiceCollection container)
+    public void ConfigureServices(IServiceCollection services)
     {
-        container.AddStandardGameLocators(false)
-            .AddStubbedGameLocators()
-            .AddDataModel()
-            .AddFileExtractors()
-            .AddCLI()
-            .AddAllScoped<IRenderer, LoggingRenderer>()
-            .AddLogging(builder => builder.SetMinimumLevel(LogLevel.Debug));
+        services.AddStandardGameLocators(false)
+                .AddStubbedGameLocators()
+                .AddDataModel()
+                .AddFileExtractors()
+                .AddCLI()
+                .AddAllScoped<IRenderer, LoggingRenderer>()
+                .AddLogging(builder => builder.SetMinimumLevel(LogLevel.Debug))
+                .Validate();
     }
 }
 

--- a/tests/NexusMods.DataModel.Tests/Startup.cs
+++ b/tests/NexusMods.DataModel.Tests/Startup.cs
@@ -20,24 +20,25 @@ public class Startup
     public void ConfigureServices(IServiceCollection container)
     {
         var prefix = KnownFolders.EntryFolder.CombineUnchecked("tempTestData").CombineUnchecked(Guid.NewGuid().ToString());
-        
-        container.AddDataModel(prefix);
-        container.AddLogging(builder => builder.SetMinimumLevel(LogLevel.Debug));
-        container.AddStandardGameLocators(false);
-        container.AddSingleton<TemporaryFileManager>(s => new TemporaryFileManager(prefix.CombineUnchecked("tempFiles")));
-        container.AddFileExtractors();
-        container.AddSingleton(s => new FileCache(s.GetRequiredService<ILogger<FileCache>>(), KnownFolders.EntryFolder.CombineUnchecked("cache")));
-        
-        container.AddStubbedGameLocators();
 
-        container.AddAllSingleton<IResource, IResource<FileContentsCache, Size>>(s =>
-            new Resource<FileContentsCache, Size>("File Analysis"));
-        container.AddAllSingleton<IResource, IResource<IExtractor, Size>>(s =>
-            new Resource<IExtractor, Size>("File Extraction"));
-        
-        container.AddSingleton<ITypeFinder>(s => new AssemblyTypeFinder(typeof(Startup).Assembly));
+        container.AddDataModel(prefix)
+                 .AddLogging(builder => builder.SetMinimumLevel(LogLevel.Debug))
+                 .AddStandardGameLocators(false)
+                 .AddSingleton<TemporaryFileManager>(s => new TemporaryFileManager(prefix.CombineUnchecked("tempFiles")))
+                 .AddFileExtractors()
+                 .AddSingleton(s => new FileCache(s.GetRequiredService<ILogger<FileCache>>(), KnownFolders.EntryFolder.CombineUnchecked("cache")))
+
+                 .AddStubbedGameLocators()
+
+                 .AddAllSingleton<IResource, IResource<FileContentsCache, Size>>(s =>
+            new Resource<FileContentsCache, Size>("File Analysis"))
+                 .AddAllSingleton<IResource, IResource<IExtractor, Size>>(s =>
+            new Resource<IExtractor, Size>("File Extraction"))
+
+                 .AddSingleton<ITypeFinder>(s => new AssemblyTypeFinder(typeof(Startup).Assembly))
+                 .Validate();
     }
-    
+
     public void Configure(ILoggerFactory loggerFactory, ITestOutputHelperAccessor accessor) =>
         loggerFactory.AddProvider(new XunitTestOutputLoggerProvider(accessor, delegate { return true;}));
 }

--- a/tests/NexusMods.StandardGameLocators.Tests/Startup.cs
+++ b/tests/NexusMods.StandardGameLocators.Tests/Startup.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using NexusMods.Common;
 using NexusMods.Paths;
 using NexusMods.StandardGameLocators.TestHelpers;
 using Xunit.DependencyInjection;
@@ -11,12 +12,13 @@ public class Startup
 {
     public void ConfigureServices(IServiceCollection container)
     {
-        container.AddStandardGameLocators(false);
-        container.AddSingleton<TemporaryFileManager>();
-        container.AddStubbedGameLocators();
-        container.AddLogging(builder => builder.SetMinimumLevel(LogLevel.Debug));
+        container.AddStandardGameLocators(false)
+                 .AddSingleton<TemporaryFileManager>()
+                 .AddStubbedGameLocators()
+                 .AddLogging(builder => builder.SetMinimumLevel(LogLevel.Debug))
+                 .Validate();
     }
-    
+
     public void Configure(ILoggerFactory loggerFactory, ITestOutputHelperAccessor accessor) =>
         loggerFactory.AddProvider(new XunitTestOutputLoggerProvider(accessor, delegate { return true;}));
 }

--- a/tests/NexusMods.UI.Tests/Startup.cs
+++ b/tests/NexusMods.UI.Tests/Startup.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NexusMods.App;
+using NexusMods.Common;
 using NexusMods.DataModel;
 using NexusMods.FileExtractor;
 using NexusMods.Games.RedEngine;
@@ -13,13 +14,14 @@ namespace NexusMods.UI.Tests;
 
 public class Startup
 {
-    public void ConfigureServices(IServiceCollection container)
+    public void ConfigureServices(IServiceCollection services)
     {
-        container.AddUniversalGameLocator<Cyberpunk2077>(new Version("1.61"));
-        container.AddApp(addStandardGameLocators:false)
-            .AddSingleton<AvaloniaApp>();
+        services.AddUniversalGameLocator<Cyberpunk2077>(new Version("1.61"))
+                .AddApp(addStandardGameLocators:false)
+                .AddSingleton<AvaloniaApp>()
+                .Validate();
     }
-    
+
     public void Configure(ILoggerFactory loggerFactory, ITestOutputHelperAccessor accessor) =>
         loggerFactory.AddProvider(new XunitTestOutputLoggerProvider(accessor, delegate { return true;}));
 }


### PR DESCRIPTION
Adds a `IServiceCollection.Validate` method for making sanity checks on service collections. Fixed several duplicate registrations, cleaned up the service registration code a bit. 