### PR TITLE
Nullable warnings as errors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -66,3 +66,6 @@ dotnet_diagnostic.cs4014.severity = error
 [{*.yaml,*.yml}]
 indent_style = space
 indent_size = 2
+
+[*.csproj]
+indent_size = 4

--- a/NexusMods.App.sln
+++ b/NexusMods.App.sln
@@ -92,6 +92,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".solutionItems", ".solution
 		README.md = README.md
 		.gitattributes = .gitattributes
 		.editorconfig = .editorconfig
+		NullableErrors.Build.props = NullableErrors.Build.props
 	EndProjectSection
 EndProject
 Global

--- a/NullableErrors.Build.props
+++ b/NullableErrors.Build.props
@@ -1,0 +1,5 @@
+<Project>
+    <PropertyGroup>
+        <WarningsAsErrors>Nullable</WarningsAsErrors>
+    </PropertyGroup>
+</Project>

--- a/src/ArchiveManagement/NexusMods.FileExtractor/NexusMods.FileExtractor.csproj
+++ b/src/ArchiveManagement/NexusMods.FileExtractor/NexusMods.FileExtractor.csproj
@@ -1,18 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    
+
     <!-- NuGet Package Shared Details -->
     <Import Project="$([MSBuild]::GetPathOfFileAbove('NuGet.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-    
+
+    <!-- nullable warnings as errors -->
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('NullableErrors.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
     <ItemGroup>
-      <ProjectReference Include="..\..\NexusMods.Common\NexusMods.Common.csproj" />
-      <ProjectReference Include="..\..\NexusMods.DataModel.RateLimiting\NexusMods.DataModel.RateLimiting.csproj" />
-      <ProjectReference Include="..\..\NexusMods.Hashing.xxHash64\NexusMods.Hashing.xxHash64.csproj" />
-      <ProjectReference Include="..\..\NexusMods.Paths\NexusMods.Paths.csproj" />
+        <ProjectReference Include="..\..\NexusMods.Common\NexusMods.Common.csproj" />
+        <ProjectReference Include="..\..\NexusMods.DataModel.RateLimiting\NexusMods.DataModel.RateLimiting.csproj" />
+        <ProjectReference Include="..\..\NexusMods.Hashing.xxHash64\NexusMods.Hashing.xxHash64.csproj" />
+        <ProjectReference Include="..\..\NexusMods.Paths\NexusMods.Paths.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CliWrap" Version="3.6.0" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0-preview.1.23110.8" />
+        <PackageReference Include="CliWrap" Version="3.6.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0-preview.1.23110.8" />
     </ItemGroup>
 
     <ItemGroup>
@@ -32,24 +35,24 @@
           <Pack>true</Pack>
           <PackagePath>runtimes/linux-x64</PackagePath>
       </None>
-        
+
       <None Update="FileSignatures\Signatures.tt">
-        <Generator>TextTemplatingFileGenerator</Generator>
-        <LastGenOutput>Signatures.cs</LastGenOutput>
+          <Generator>TextTemplatingFileGenerator</Generator>
+          <LastGenOutput>Signatures.cs</LastGenOutput>
       </None>
-        
+
       <None Update="build\NexusMods.FileExtractor.targets">
-        <Pack>true</Pack>
-        <PackagePath>build</PackagePath>
+          <Pack>true</Pack>
+          <PackagePath>build</PackagePath>
       </None>
     </ItemGroup>
 
     <ItemGroup>
-      <Compile Update="FileSignatures\Signatures.cs">
-        <AutoGen>True</AutoGen>
-        <DesignTime>True</DesignTime>
-        <DependentUpon>Signatures.tt</DependentUpon>
-      </Compile>
+        <Compile Update="FileSignatures\Signatures.cs">
+            <AutoGen>True</AutoGen>
+            <DesignTime>True</DesignTime>
+            <DependentUpon>Signatures.tt</DependentUpon>
+        </Compile>
     </ItemGroup>
 
     <!-- Non-NuGet Only -->

--- a/src/Games/NexusMods.Games.BethesdaGameStudios/NexusMods.Games.BethesdaGameStudios.csproj
+++ b/src/Games/NexusMods.Games.BethesdaGameStudios/NexusMods.Games.BethesdaGameStudios.csproj
@@ -1,17 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
     <!-- NuGet Package Shared Details -->
     <Import Project="$([MSBuild]::GetPathOfFileAbove('NuGet.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-    
+
+    <!-- nullable warnings as errors -->
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('NullableErrors.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
     <ItemGroup>
-      <ProjectReference Include="..\..\NexusMods.DataModel\NexusMods.DataModel.csproj" />
-      <ProjectReference Include="..\..\NexusMods.StandardGameLocators\NexusMods.StandardGameLocators.csproj" />
+        <ProjectReference Include="..\..\NexusMods.DataModel\NexusMods.DataModel.csproj" />
+        <ProjectReference Include="..\..\NexusMods.StandardGameLocators\NexusMods.StandardGameLocators.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0-preview.1.23110.8" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0-preview.1.23110.8" />
-      <PackageReference Include="Mutagen.Bethesda.Skyrim" Version="0.41.0-pr002" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0-preview.1.23110.8" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0-preview.1.23110.8" />
+        <PackageReference Include="Mutagen.Bethesda.Skyrim" Version="0.41.0-pr002" />
     </ItemGroup>
-
 </Project>

--- a/src/Games/NexusMods.Games.DarkestDungeon/NexusMods.Games.DarkestDungeon.csproj
+++ b/src/Games/NexusMods.Games.DarkestDungeon/NexusMods.Games.DarkestDungeon.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
     <!-- NuGet Package Shared Details -->
     <Import Project="$([MSBuild]::GetPathOfFileAbove('NuGet.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-    
-    <ItemGroup>
-      <ProjectReference Include="..\..\NexusMods.DataModel\NexusMods.DataModel.csproj" />
-    </ItemGroup>
 
+    <!-- nullable warnings as errors -->
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('NullableErrors.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\NexusMods.DataModel\NexusMods.DataModel.csproj" />
+    </ItemGroup>
 </Project>

--- a/src/Games/NexusMods.Games.Generic/NexusMods.Games.Generic.csproj
+++ b/src/Games/NexusMods.Games.Generic/NexusMods.Games.Generic.csproj
@@ -1,14 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
     <!-- NuGet Package Shared Details -->
     <Import Project="$([MSBuild]::GetPathOfFileAbove('NuGet.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-    
+
+    <!-- nullable warnings as errors -->
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('NullableErrors.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
     <ItemGroup>
-      <ProjectReference Include="..\..\NexusMods.DataModel\NexusMods.DataModel.csproj" />
+        <ProjectReference Include="..\..\NexusMods.DataModel\NexusMods.DataModel.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="ini-parser-netstandard" Version="2.5.2" />
+        <PackageReference Include="ini-parser-netstandard" Version="2.5.2" />
     </ItemGroup>
-
 </Project>

--- a/src/Games/NexusMods.Games.RedEngine/NexusMods.Games.RedEngine.csproj
+++ b/src/Games/NexusMods.Games.RedEngine/NexusMods.Games.RedEngine.csproj
@@ -1,19 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
     <!-- NuGet Package Shared Details -->
     <Import Project="$([MSBuild]::GetPathOfFileAbove('NuGet.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-    
+
+    <!-- nullable warnings as errors -->
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('NullableErrors.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
     <ItemGroup>
-      <ProjectReference Include="..\..\NexusMods.DataModel\NexusMods.DataModel.csproj" />
+        <ProjectReference Include="..\..\NexusMods.DataModel\NexusMods.DataModel.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CliWrap" Version="3.6.0" />
+        <PackageReference Include="CliWrap" Version="3.6.0" />
     </ItemGroup>
 
     <ItemGroup>
-      <None Remove="Resources\Cyberpunk2077\icon.png" />
-      <EmbeddedResource Include="Resources\Cyberpunk2077\icon.png" />
+        <None Remove="Resources\Cyberpunk2077\icon.png" />
+        <EmbeddedResource Include="Resources\Cyberpunk2077\icon.png" />
     </ItemGroup>
-
 </Project>

--- a/src/Games/NexusMods.Games.Reshade/NexusMods.Games.Reshade.csproj
+++ b/src/Games/NexusMods.Games.Reshade/NexusMods.Games.Reshade.csproj
@@ -1,11 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
     <!-- NuGet Package Shared Details -->
     <Import Project="$([MSBuild]::GetPathOfFileAbove('NuGet.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-    
-    <ItemGroup>
-      <ProjectReference Include="..\..\NexusMods.DataModel\NexusMods.DataModel.csproj" />
-      <ProjectReference Include="..\NexusMods.Games.Generic\NexusMods.Games.Generic.csproj" />
-    </ItemGroup>
 
+    <!-- nullable warnings as errors -->
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('NullableErrors.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\NexusMods.DataModel\NexusMods.DataModel.csproj" />
+        <ProjectReference Include="..\NexusMods.Games.Generic\NexusMods.Games.Generic.csproj" />
+    </ItemGroup>
 </Project>

--- a/src/Games/NexusMods.Games.Reshade/ReshadePresetInstaller.cs
+++ b/src/Games/NexusMods.Games.Reshade/ReshadePresetInstaller.cs
@@ -38,8 +38,12 @@ public class ReshadePresetInstaller : IModInstaller
             return Common.Priority.None;
 
         // Get all the ini data
-        var iniData = filtered.Select(f => f.Value.AnalysisData.OfType<IniAnalysisData>()
-            .FirstOrDefault()).Where(d => d != null)
+        var iniData = filtered
+            .Select(f => f.Value.AnalysisData
+                .OfType<IniAnalysisData>()
+                .FirstOrDefault())
+            .Where(d => d is not null)
+            .Select(d => d!)
             .ToList();
 
         // All the files must have ini data

--- a/src/Networking/NexusMods.Networking.HttpDownloader/NexusMods.Networking.HttpDownloader.csproj
+++ b/src/Networking/NexusMods.Networking.HttpDownloader/NexusMods.Networking.HttpDownloader.csproj
@@ -1,17 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
     <!-- NuGet Package Shared Details -->
     <Import Project="$([MSBuild]::GetPathOfFileAbove('NuGet.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-    
+
+    <!-- nullable warnings as errors -->
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('NullableErrors.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
     <ItemGroup>
-      <ProjectReference Include="..\..\NexusMods.CLI\NexusMods.CLI.csproj" />
-      <ProjectReference Include="..\..\NexusMods.Hashing.xxHash64\NexusMods.Hashing.xxHash64.csproj" />
-      <ProjectReference Include="..\..\NexusMods.Paths\NexusMods.Paths.csproj" />
+        <ProjectReference Include="..\..\NexusMods.CLI\NexusMods.CLI.csproj" />
+        <ProjectReference Include="..\..\NexusMods.Hashing.xxHash64\NexusMods.Hashing.xxHash64.csproj" />
+        <ProjectReference Include="..\..\NexusMods.Paths\NexusMods.Paths.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0-preview.1.23110.8" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0-preview.1.23110.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0-preview.1.23110.8" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0-preview.1.23110.8" />
     </ItemGroup>
-
 </Project>

--- a/src/Networking/NexusMods.Networking.NexusWebApi/DTOs/DownloadLink.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/DTOs/DownloadLink.cs
@@ -22,7 +22,7 @@ public class DownloadLink : IJsonArraySerializable<DownloadLink>
     /// For deserialization only. Please use <see cref="ShortName"/>.
     /// </summary>
     [JsonPropertyName("short_name")]
-    public string _ShortName { get; set; }
+    public string _ShortName { get; set; } = null!;
 
     /// <summary>
     /// Name of the CDN server that handles your download request.

--- a/src/Networking/NexusMods.Networking.NexusWebApi/NexusMods.Networking.NexusWebApi.csproj
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/NexusMods.Networking.NexusWebApi.csproj
@@ -1,14 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
     <!-- NuGet Package Shared Details -->
     <Import Project="$([MSBuild]::GetPathOfFileAbove('NuGet.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
     <ItemGroup>
-      <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.27.0" />
-    </ItemGroup>
-    
-    <ItemGroup>
-      <ProjectReference Include="..\..\NexusMods.CLI\NexusMods.CLI.csproj" />
-      <ProjectReference Include="..\..\NexusMods.DataModel\NexusMods.DataModel.csproj" />
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.27.0" />
     </ItemGroup>
 
+    <ItemGroup>
+        <ProjectReference Include="..\..\NexusMods.CLI\NexusMods.CLI.csproj" />
+        <ProjectReference Include="..\..\NexusMods.DataModel\NexusMods.DataModel.csproj" />
+    </ItemGroup>
 </Project>

--- a/src/Networking/NexusMods.Networking.NexusWebApi/NexusMods.Networking.NexusWebApi.csproj
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/NexusMods.Networking.NexusWebApi.csproj
@@ -2,6 +2,9 @@
     <!-- NuGet Package Shared Details -->
     <Import Project="$([MSBuild]::GetPathOfFileAbove('NuGet.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
+    <!-- nullable warnings as errors -->
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('NullableErrors.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
     <ItemGroup>
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.27.0" />
     </ItemGroup>

--- a/src/Networking/NexusMods.Networking.NexusWebApi/Types/UserInfo.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/Types/UserInfo.cs
@@ -23,5 +23,5 @@ public record UserInfo
     /// <summary>
     /// Uri of the user's avatar
     /// </summary>
-    public Uri Avatar { get; set; }
+    public Uri? Avatar { get; set; }
 }

--- a/src/NexusMods.App/NexusMods.App.csproj
+++ b/src/NexusMods.App/NexusMods.App.csproj
@@ -1,4 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
+    <!-- nullable warnings as errors -->
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('NullableErrors.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -6,22 +8,21 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\Games\NexusMods.Games.DarkestDungeon\NexusMods.Games.DarkestDungeon.csproj" />
-      <ProjectReference Include="..\Games\NexusMods.Games.Generic\NexusMods.Games.Generic.csproj" />
-      <ProjectReference Include="..\Games\NexusMods.Games.RedEngine\NexusMods.Games.RedEngine.csproj" />
-      <ProjectReference Include="..\Games\NexusMods.Games.Reshade\NexusMods.Games.Reshade.csproj" />
-      <ProjectReference Include="..\Games\NexusMods.Games.TestHarness\NexusMods.Games.TestHarness.csproj" />
-      <ProjectReference Include="..\Networking\NexusMods.Networking.HttpDownloader\NexusMods.Networking.HttpDownloader.csproj" />
-      <ProjectReference Include="..\Networking\NexusMods.Networking.NexusWebApi\NexusMods.Networking.NexusWebApi.csproj" />
-      <ProjectReference Include="..\NexusMods.App.UI\NexusMods.App.UI.csproj" />
-      <ProjectReference Include="..\NexusMods.CLI\NexusMods.CLI.csproj" />
+        <ProjectReference Include="..\Games\NexusMods.Games.DarkestDungeon\NexusMods.Games.DarkestDungeon.csproj" />
+        <ProjectReference Include="..\Games\NexusMods.Games.Generic\NexusMods.Games.Generic.csproj" />
+        <ProjectReference Include="..\Games\NexusMods.Games.RedEngine\NexusMods.Games.RedEngine.csproj" />
+        <ProjectReference Include="..\Games\NexusMods.Games.Reshade\NexusMods.Games.Reshade.csproj" />
+        <ProjectReference Include="..\Games\NexusMods.Games.TestHarness\NexusMods.Games.TestHarness.csproj" />
+        <ProjectReference Include="..\Networking\NexusMods.Networking.HttpDownloader\NexusMods.Networking.HttpDownloader.csproj" />
+        <ProjectReference Include="..\Networking\NexusMods.Networking.NexusWebApi\NexusMods.Networking.NexusWebApi.csproj" />
+        <ProjectReference Include="..\NexusMods.App.UI\NexusMods.App.UI.csproj" />
+        <ProjectReference Include="..\NexusMods.CLI\NexusMods.CLI.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0-preview.1.23110.8" />
-      <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0-preview.1.23110.8" />
-      <PackageReference Include="NLog.Extensions.Logging" Version="5.2.2" />
-      <PackageReference Include="Spectre.Console" Version="0.46.1-preview.0.7" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0-preview.1.23110.8" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0-preview.1.23110.8" />
+        <PackageReference Include="NLog.Extensions.Logging" Version="5.2.2" />
+        <PackageReference Include="Spectre.Console" Version="0.46.1-preview.0.7" />
     </ItemGroup>
-
 </Project>

--- a/src/NexusMods.App/Program.cs
+++ b/src/NexusMods.App/Program.cs
@@ -15,12 +15,11 @@ namespace NexusMods.App;
 
 public class Program
 {
-    private static ILogger<Program> _logger;
+    private static ILogger<Program> _logger = default!;
 
     [STAThread]
     public static async Task<int> Main(string[] args)
     {
-
         var host = BuildHost();
 
         _logger = host.Services.GetRequiredService<ILogger<Program>>();

--- a/src/NexusMods.CLI/NexusMods.CLI.csproj
+++ b/src/NexusMods.CLI/NexusMods.CLI.csproj
@@ -1,16 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    
+    <!-- nullable warnings as errors -->
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('NullableErrors.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
     <ItemGroup>
-      <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-      <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
+        <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+        <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\ArchiveManagement\NexusMods.FileExtractor\NexusMods.FileExtractor.csproj" />
-      <ProjectReference Include="..\Games\NexusMods.Games.BethesdaGameStudios\NexusMods.Games.BethesdaGameStudios.csproj" />
-      <ProjectReference Include="..\NexusMods.DataModel\NexusMods.DataModel.csproj" />
-      <ProjectReference Include="..\NexusMods.Paths\NexusMods.Paths.csproj" />
-      <ProjectReference Include="..\NexusMods.StandardGameLocators\NexusMods.StandardGameLocators.csproj" />
+        <ProjectReference Include="..\ArchiveManagement\NexusMods.FileExtractor\NexusMods.FileExtractor.csproj" />
+        <ProjectReference Include="..\Games\NexusMods.Games.BethesdaGameStudios\NexusMods.Games.BethesdaGameStudios.csproj" />
+        <ProjectReference Include="..\NexusMods.DataModel\NexusMods.DataModel.csproj" />
+        <ProjectReference Include="..\NexusMods.Paths\NexusMods.Paths.csproj" />
+        <ProjectReference Include="..\NexusMods.StandardGameLocators\NexusMods.StandardGameLocators.csproj" />
     </ItemGroup>
-
 </Project>

--- a/src/NexusMods.Common/NexusMods.Common.csproj
+++ b/src/NexusMods.Common/NexusMods.Common.csproj
@@ -1,19 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    
+
     <!-- NuGet Package Shared Details -->
     <Import Project="$([MSBuild]::GetPathOfFileAbove('NuGet.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-    
+
+    <!-- nullable warnings as errors -->
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('NullableErrors.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
     <ItemGroup>
-      <ProjectReference Include="..\NexusMods.Paths\NexusMods.Paths.csproj" />
+        <ProjectReference Include="..\NexusMods.Paths\NexusMods.Paths.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CliWrap" Version="3.6.0" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0-preview.1.23110.8" />
+        <PackageReference Include="CliWrap" Version="3.6.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0-preview.1.23110.8" />
     </ItemGroup>
 
     <ItemGroup>
         <InternalsVisibleTo Include="NexusMods.Common.Tests"/>
     </ItemGroup>
-    
+
 </Project>

--- a/src/NexusMods.DataModel.RateLimiting/NexusMods.DataModel.RateLimiting.csproj
+++ b/src/NexusMods.DataModel.RateLimiting/NexusMods.DataModel.RateLimiting.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    
     <!-- NuGet Package Shared Details -->
     <Import Project="$([MSBuild]::GetPathOfFileAbove('NuGet.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-    
-    <ItemGroup>
-      <ProjectReference Include="..\NexusMods.Paths\NexusMods.Paths.csproj" />
-    </ItemGroup>
 
+    <!-- nullable warnings as errors -->
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('NullableErrors.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+    <ItemGroup>
+        <ProjectReference Include="..\NexusMods.Paths\NexusMods.Paths.csproj" />
+    </ItemGroup>
 </Project>

--- a/src/NexusMods.DataModel/Abstractions/EntityDictionary.cs
+++ b/src/NexusMods.DataModel/Abstractions/EntityDictionary.cs
@@ -145,7 +145,7 @@ public struct EntityDictionary<TK, TV> :
     /// Transforms a value found at at given id with a given function.
     /// If the function returns null, the value is removed from the dictionary.
     /// </summary>
-    public EntityDictionary<TK, TV> Keep(TK key, Func<TV?, TV?> func)
+    public EntityDictionary<TK, TV> Keep(TK key, Func<TV, TV?> func)
     {
         var id = _coll[key];
         var val = _store.Get<TV>(id);
@@ -163,7 +163,7 @@ public struct EntityDictionary<TK, TV> :
     ///     Returning a null value discards the item.
     ///     Returning the original value or a new one will keep it.
     /// </param>
-    public EntityDictionary<TK, TV> Keep(Func<TV?, TV?> func)
+    public EntityDictionary<TK, TV> Keep(Func<TV, TV?> func)
     {
         var modified = false;
         var builder = ImmutableDictionary.CreateBuilder<TK, IId>();

--- a/src/NexusMods.DataModel/Games/RunGameTool.cs
+++ b/src/NexusMods.DataModel/Games/RunGameTool.cs
@@ -28,12 +28,11 @@ where T : AGame
         var program = _game.PrimaryFile.CombineChecked(loadout.Installation.Locations[GameFolderType.Game]);
         _logger.LogInformation("Running {Program}", program);
 
-        var psi = new ProcessStartInfo(program.ToString())
-        {
-
-        };
+        // TODO: use IProcessFactory
+        var psi = new ProcessStartInfo(program.ToString());
         var process = Process.Start(psi);
-        await process.WaitForExitAsync();
+        await process!.WaitForExitAsync();
+
         _logger.LogInformation("Finished running {Program}", program);
     }
 

--- a/src/NexusMods.DataModel/JsonConverters/AExpressionConverterGenerator.cs
+++ b/src/NexusMods.DataModel/JsonConverters/AExpressionConverterGenerator.cs
@@ -7,8 +7,8 @@ namespace NexusMods.DataModel.JsonConverters;
 public abstract class AExpressionConverterGenerator<T> : JsonConverter<T>
 {
     protected readonly IServiceProvider Provider;
-    protected Lazy<WriteDelegate> _writerFunction;
-    protected Lazy<ReadDelegate> _readerFunction;
+    protected Lazy<WriteDelegate> _writerFunction = default!;
+    protected Lazy<ReadDelegate> _readerFunction = default!;
     protected readonly Type Type;
 
     protected delegate T? ReadDelegate(ref Utf8JsonReader read, Type typeToConvert, JsonSerializerOptions options);

--- a/src/NexusMods.DataModel/JsonConverters/ConcreteConverterGenerator.cs
+++ b/src/NexusMods.DataModel/JsonConverters/ConcreteConverterGenerator.cs
@@ -80,7 +80,7 @@ public class ConcreteConverterGenerator<T> : AExpressionConverterGenerator<T>
                 Expression.Constant("$type")));
 
         loopExprs.Add(Expression.Switch(Expression.Call(readerParam, "GetString", null),
-            Expression.Throw(Expression.New(typeof(NotImplementedException).GetConstructor(new[] { typeof(string) }),
+            Expression.Throw(Expression.New(typeof(NotImplementedException).GetConstructor(new[] { typeof(string) })!,
                 Expression.Add(
                     Expression.Constant($"Unknown property on {Type.Name}: "),
                     Expression.Call(readerParam, "GetString", null),

--- a/src/NexusMods.DataModel/Loadouts/Loadout.cs
+++ b/src/NexusMods.DataModel/Loadouts/Loadout.cs
@@ -31,7 +31,7 @@ public record Loadout : Entity, IEmptyWithDataStore<Loadout>
         Store = store
     };
 
-    public Loadout Alter(ModId modId, Func<Mod?, Mod?> func)
+    public Loadout Alter(ModId modId, Func<Mod, Mod?> func)
     {
         return this with
         {
@@ -46,7 +46,6 @@ public record Loadout : Entity, IEmptyWithDataStore<Loadout>
             Mods = Mods.With(mod.Id, mod)
         };
     }
-
 
     public Loadout AlterFiles(Func<AModFile, AModFile?> func)
     {

--- a/src/NexusMods.DataModel/Loadouts/Markers/LoadoutMarker.cs
+++ b/src/NexusMods.DataModel/Loadouts/Markers/LoadoutMarker.cs
@@ -228,16 +228,17 @@ public class LoadoutMarker : IMarker<Loadout>
                     }, token);
             });
 
-        var generated = plan.Steps.OfType<CopyFile>().Select(f => (Step: f, From: f.From as AGeneratedFile))
+        var generated = plan.Steps
+            .OfType<CopyFile>()
+            .Select(f => (Step: f, From: f.From as AGeneratedFile))
             .Where(f => f.From is not null);
 
         foreach (var (step, from) in generated)
         {
             await using var stream = step.To.Create();
-            await from.GenerateAsync(stream, loadout, plan.Files, token);
+            await from!.GenerateAsync(stream, loadout, plan.Files, token);
         }
     }
-
 
     public async IAsyncEnumerable<IApplyStep> MakeIngestionPlan(Func<HashedEntry, Mod> modMapper, [EnumeratorCancellation] CancellationToken token)
     {
@@ -390,7 +391,7 @@ public class LoadoutMarker : IMarker<Loadout>
         _manager.Alter(_id, Apply);
     }
 
-    public void Alter(ModId mod, Func<Mod?, Mod?> fn)
+    public void Alter(ModId mod, Func<Mod, Mod?> fn)
     {
         _manager.Alter(_id, l => l.Alter(mod, fn));
     }

--- a/src/NexusMods.DataModel/NexusMods.DataModel.csproj
+++ b/src/NexusMods.DataModel/NexusMods.DataModel.csproj
@@ -1,24 +1,25 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
     <!-- NuGet Package Shared Details -->
     <Import Project="$([MSBuild]::GetPathOfFileAbove('NuGet.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
+    <!-- nullable warnings as errors -->
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('NullableErrors.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
     <ItemGroup>
-      <ProjectReference Include="..\ArchiveManagement\NexusMods.FileExtractor\NexusMods.FileExtractor.csproj" />
-      <ProjectReference Include="..\NexusMods.Hashing.xxHash64\NexusMods.Hashing.xxHash64.csproj" />
-      <ProjectReference Include="..\NexusMods.Paths\NexusMods.Paths.csproj" />
+        <ProjectReference Include="..\ArchiveManagement\NexusMods.FileExtractor\NexusMods.FileExtractor.csproj" />
+        <ProjectReference Include="..\NexusMods.Hashing.xxHash64\NexusMods.Hashing.xxHash64.csproj" />
+        <ProjectReference Include="..\NexusMods.Paths\NexusMods.Paths.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="BitFaster.Caching" Version="2.1.1" />
-      <PackageReference Include="Cloudtoid.Interprocess" Version="2.0.0-alpha176" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0-preview.1.23110.8" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0-preview.1.23110.8" />
-      <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.1" />
-      <PackageReference Include="Sewer56.BitStream" Version="1.3.0" />
-      <PackageReference Include="System.Data.SQLite" Version="1.0.117" />
-      <PackageReference Include="System.Reactive" Version="5.0.0" />
-      <PackageReference Include="Vogen" Version="3.0.12" />
+        <PackageReference Include="BitFaster.Caching" Version="2.1.1" />
+        <PackageReference Include="Cloudtoid.Interprocess" Version="2.0.0-alpha176" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0-preview.1.23110.8" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0-preview.1.23110.8" />
+        <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.1" />
+        <PackageReference Include="Sewer56.BitStream" Version="1.3.0" />
+        <PackageReference Include="System.Data.SQLite" Version="1.0.117" />
+        <PackageReference Include="System.Reactive" Version="5.0.0" />
+        <PackageReference Include="Vogen" Version="3.0.12" />
     </ItemGroup>
-
 </Project>

--- a/src/NexusMods.DataModel/Sorting/Sorter.cs
+++ b/src/NexusMods.DataModel/Sorting/Sorter.cs
@@ -25,13 +25,13 @@ public class Sorter
         where TId : IEquatable<TId>
     {
         /*
-             Observation from me (Sewer).  
-             
-             In practice our mods/items are fetched from an IDataStore.  
-             
-             At the current moment in time, this is backed by an in memory database, 
-             so access times should be relatively quick and thus calling `.ToArray()` should be fine.  
-             
+             Observation from me (Sewer).
+
+             In practice our mods/items are fetched from an IDataStore.
+
+             At the current moment in time, this is backed by an in memory database,
+             so access times should be relatively quick and thus calling `.ToArray()` should be fine.
+
              That said, if this data ever was to be file backed, adding an asynchronous access method
              might not be too bad.
         */
@@ -104,24 +104,23 @@ public class Sorter
         const int MinOperationsPerThread = 666;
         ParallelOptions parallelOptions = default!;
         ParallelIsSuperset<TId, TItem> parallelState = default!;
-        Action<Tuple<int, int>>? doWork = default;
+        Action<Tuple<int, int>> doWork = default!;
 
         if (dict.Count > MultiThreadCutoff)
         {
             parallelOptions = new ParallelOptions();
-            parallelState = new ParallelIsSuperset<TId, TItem>()
-            {
-                values = values,
-                used = used,
-                output = GC.AllocateUninitializedArray<(TId[] After, TItem Item)>(dict.Count)
-            };
+            parallelState = new ParallelIsSuperset<TId, TItem>(
+                used,
+                values,
+                GC.AllocateUninitializedArray<(TId[] After, TItem Item)>(dict.Count)
+            );
             doWork = parallelState.DoWork;
         }
 
         while (dict.Count > 0)
         {
             // Copy to values (no alloc), then filter them in-place
-            dict.Values.CopyTo(values, 0); // <= Bottleneck. 
+            dict.Values.CopyTo(values, 0); // <= Bottleneck.
             var superSetSize = 0;
             var valuesSlice = values.AsSpan(0, dict.Count);
             if (dict.Count > MultiThreadCutoff)
@@ -130,7 +129,7 @@ public class Sorter
                 parallelState.superSetSize = -1;
                 Parallel.ForEach(Partitioner.Create(0, valuesSlice.Length), parallelOptions, doWork);
                 superSetSize = parallelState.NumberOfElements;
-                valuesSlice = parallelState.output.AsSpan(0, superSetSize); // <= assign output span.
+                valuesSlice = parallelState.Output.AsSpan(0, superSetSize); // <= assign output span.
             }
             else
             {
@@ -193,9 +192,9 @@ public class Sorter
 
         /*
              Please do not refactor 'for' as foreach in this method.
-             That will lead to enumerator allocation, which in turn is a 
+             That will lead to enumerator allocation, which in turn is a
              lot of allocations made; as this is O(N^2)
-             
+
              - Sewer
         */
         for (var x = 0; x < rulesForThisItem.Count; x++)
@@ -253,18 +252,27 @@ public class Sorter
     /// </summary>
     private class ParallelIsSuperset<TId, TItem>
     {
-        internal HashSet<TId> used;
-        internal (TId[] After, TItem Item)[] values;
-        internal (TId[] After, TItem Item)[] output;
+        internal HashSet<TId> Used;
+        internal (TId[] After, TItem Item)[] Values;
+        internal (TId[] After, TItem Item)[] Output;
         internal int superSetSize = -1; // after first thread safe increment this is 0
         internal int NumberOfElements => superSetSize + 1;
+
+        internal ParallelIsSuperset(HashSet<TId> used,
+            (TId[] After, TItem Item)[] values,
+            (TId[] After, TItem Item)[] output)
+        {
+            Used = used;
+            Values = values;
+            Output = output;
+        }
 
         internal void DoWork(Tuple<int, int> tuple)
         {
             // Work on our slice.
-            var val = values;
-            var otp = output;
-            var used = this.used;
+            var val = Values;
+            var otp = Output;
+            var used = this.Used;
             for (var x = tuple.Item1; x < tuple.Item2; x++)
             {
                 var value = val[x];

--- a/src/NexusMods.Hashing.xxHash64/NexusMods.Hashing.xxHash64.csproj
+++ b/src/NexusMods.Hashing.xxHash64/NexusMods.Hashing.xxHash64.csproj
@@ -1,15 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    
     <!-- NuGet Package Shared Details -->
     <Import Project="$([MSBuild]::GetPathOfFileAbove('NuGet.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
+    <!-- nullable warnings as errors -->
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('NullableErrors.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
     <ItemGroup>
-      <ProjectReference Include="..\NexusMods.DataModel.RateLimiting\NexusMods.DataModel.RateLimiting.csproj" />
-      <ProjectReference Include="..\NexusMods.Paths\NexusMods.Paths.csproj" />
+        <ProjectReference Include="..\NexusMods.DataModel.RateLimiting\NexusMods.DataModel.RateLimiting.csproj" />
+        <ProjectReference Include="..\NexusMods.Paths\NexusMods.Paths.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Vogen" Version="3.0.12" />
+        <PackageReference Include="Vogen" Version="3.0.12" />
     </ItemGroup>
-
 </Project>

--- a/src/NexusMods.Paths/NexusMods.Paths.csproj
+++ b/src/NexusMods.Paths/NexusMods.Paths.csproj
@@ -1,23 +1,28 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
     <!-- NuGet Package Shared Details -->
     <Import Project="$([MSBuild]::GetPathOfFileAbove('NuGet.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-    
+
+    <!-- nullable warnings as errors -->
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('NullableErrors.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
     <PropertyGroup Condition="'$(IsWindows)'=='true'">
         <DefineConstants>Windows</DefineConstants>
     </PropertyGroup>
+
     <PropertyGroup Condition="'$(IsOSX)'=='true'">
         <DefineConstants>OSX</DefineConstants>
     </PropertyGroup>
+
     <PropertyGroup Condition="'$(IsLinux)'=='true'">
         <DefineConstants>Linux</DefineConstants>
     </PropertyGroup>
+
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0-preview.1.23110.8" />
-      <PackageReference Include="Vogen" Version="3.0.12" />
-    </ItemGroup>
-    <ItemGroup>
-      <Folder Include="Utilities\Extensions" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0-preview.1.23110.8" />
+        <PackageReference Include="Vogen" Version="3.0.12" />
     </ItemGroup>
 
+    <ItemGroup>
+        <Folder Include="Utilities\Extensions" />
+    </ItemGroup>
 </Project>


### PR DESCRIPTION
This adds `NullableErrors.Build.props` which changes the nullable warnings to error:

```xml
<WarningsAsErrors>Nullable</WarningsAsErrors>
```

I imported this file in almost all projects, the only projects that are not using this are:

- all test projects
- `NexusMods.App.UI`

Working with nullability in UI projects is very tedious and would require a lot of changes, which I consider outside the scope of this PR.