### PR TITLE
Explicit Persistence and removing the Datastore on entities

### DIFF
--- a/benchmarks/NexusMods.Benchmarks/Benchmarks/DataModel.cs
+++ b/benchmarks/NexusMods.Benchmarks/Benchmarks/DataModel.cs
@@ -62,7 +62,6 @@ public class DataStoreBenchmark : IBenchmark, IDisposable
         _record = new FromArchive
         {
             Id = ModFileId.New(),
-            Store = _dataStore,
             From = _fromPutPath,
             Size = Size.From(1024),
             Hash = Hash.From(42),
@@ -95,7 +94,6 @@ public class DataStoreBenchmark : IBenchmark, IDisposable
         var record = new FromArchive
         {
             Id = ModFileId.New(),
-            Store = _dataStore,
             From = _fromPutPath,
             Size = Size.From(1024),
             Hash = Hash.From(42),

--- a/src/Games/NexusMods.Games.BethesdaGameStudios/Installers/LooseFileInstaller.cs
+++ b/src/Games/NexusMods.Games.BethesdaGameStudios/Installers/LooseFileInstaller.cs
@@ -66,8 +66,7 @@ public class LooseFileInstaller : IModInstaller
                     From = new HashRelativePath(srcArchive, file.Path),
                     To = new GamePath(GameFolderType.Game, outFile),
                     Hash = file.Entry.Hash,
-                    Size = file.Entry.Size,
-                    Store = _store
+                    Size = file.Entry.Size
                 };
             });
     }

--- a/src/Games/NexusMods.Games.BethesdaGameStudios/SkyrimSpecialEdition.cs
+++ b/src/Games/NexusMods.Games.BethesdaGameStudios/SkyrimSpecialEdition.cs
@@ -47,8 +47,7 @@ public class SkyrimSpecialEdition : AGame, ISteamGame, IGogGame
             Id = ModFileId.New(),
             To = new GamePath(GameFolderType.AppData, "plugins.txt"),
             Size = Size.Zero,
-            Hash = Hash.Zero,
-            Store = store
+            Hash = Hash.Zero
         };
     }
 

--- a/src/Games/NexusMods.Games.DarkestDungeon/DarkestDungeonModInstaller.cs
+++ b/src/Games/NexusMods.Games.DarkestDungeon/DarkestDungeonModInstaller.cs
@@ -42,8 +42,7 @@ public class DarkestDungeonModInstaller : IModInstaller
                 To = new GamePath(GameFolderType.Game, ModFolder.Join(f.Key)),
                 From = new HashRelativePath(srcArchive, f.Key),
                 Hash = f.Value.Hash,
-                Size = f.Value.Size,
-                Store = _store
+                Size = f.Value.Size
             });
     }
 }

--- a/src/Games/NexusMods.Games.RedEngine/ModInstallers/AppearancePreset.cs
+++ b/src/Games/NexusMods.Games.RedEngine/ModInstallers/AppearancePreset.cs
@@ -44,8 +44,7 @@ public class AppearancePreset : IModInstaller
                     From = new HashRelativePath(srcArchive, path),
                     To = new GamePath(GameFolderType.Game, relPath.Join(path.FileName)),
                     Hash = file.Hash,
-                    Size = file.Size,
-                    Store = file.Store
+                    Size = file.Size
                 };
             }
         }

--- a/src/Games/NexusMods.Games.RedEngine/ModInstallers/FolderlessModInstaller.cs
+++ b/src/Games/NexusMods.Games.RedEngine/ModInstallers/FolderlessModInstaller.cs
@@ -44,8 +44,7 @@ public class FolderlessModInstaller : IModInstaller
                 From = new HashRelativePath(srcArchive, path),
                 To = new GamePath(GameFolderType.Game, @"archive\pc\mod\".ToRelativePath().Join(path.FileName)),
                 Hash = file.Hash,
-                Size = file.Size,
-                Store = file.Store
+                Size = file.Size
             };
         }
     }

--- a/src/Games/NexusMods.Games.RedEngine/ModInstallers/RedModInstaller.cs
+++ b/src/Games/NexusMods.Games.RedEngine/ModInstallers/RedModInstaller.cs
@@ -36,8 +36,7 @@ public class RedModInstaller : IModInstaller
                     From = new HashRelativePath(srcArchive, path),
                     To = new GamePath(GameFolderType.Game, @"mods".ToRelativePath().Join(parentName).Join(path.RelativeTo(parent))),
                     Hash = file.Hash,
-                    Size = file.Size,
-                    Store = file.Store
+                    Size = file.Size
                 };
             }
         }

--- a/src/Games/NexusMods.Games.RedEngine/ModInstallers/SimpleOverlayModInstaller.cs
+++ b/src/Games/NexusMods.Games.RedEngine/ModInstallers/SimpleOverlayModInstaller.cs
@@ -84,8 +84,7 @@ public class SimpleOverlayModInstaller : IModInstaller
                 From = new HashRelativePath(srcArchive, path),
                 To = new GamePath(GameFolderType.Game, path.DropFirst(root)),
                 Hash = file.Hash,
-                Size = file.Size,
-                Store = file.Store
+                Size = file.Size
             };
         }
     }

--- a/src/Games/NexusMods.Games.Reshade/ReshadePresetInstaller.cs
+++ b/src/Games/NexusMods.Games.Reshade/ReshadePresetInstaller.cs
@@ -69,8 +69,7 @@ public class ReshadePresetInstaller : IModInstaller
                 To = new GamePath(GameFolderType.Game, folder.Join(file.Key.FileName)),
                 From = new HashRelativePath(srcArchive, file.Key),
                 Hash = file.Value.Hash,
-                Size = file.Value.Size,
-                Store = file.Value.Store
+                Size = file.Value.Size
             };
         }
     }

--- a/src/Games/NexusMods.Games.TestHarness/NexusModFile.cs
+++ b/src/Games/NexusMods.Games.TestHarness/NexusModFile.cs
@@ -20,10 +20,10 @@ public record NexusModFile : Entity
     public required DateTime LastUpdated { get; init; }
 
 
-    protected override IId Persist()
+    protected override IId Persist(IDataStore store)
     {
         var id = MakeId(Domain, ModId, FileId);
-        Store.Put<Entity>(id, this);
+        store.Put<Entity>(id, this);
         return id;
     }
 

--- a/src/Games/NexusMods.Games.TestHarness/RecentModsTests.cs
+++ b/src/Games/NexusMods.Games.TestHarness/RecentModsTests.cs
@@ -75,8 +75,7 @@ public class RecentModsTest
                 ModId = file.ModId,
                 FileId = FileId.From((ulong)file.File.FileId),
                 Domain = _game.Domain,
-                Hash = Hash.Zero,
-                Store = _store
+                Hash = Hash.Zero
             };
 
             _logger.LogInformation("Downloading {FileName}", record.FileName);
@@ -89,7 +88,7 @@ public class RecentModsTest
             await tempFileLocation.MoveToAsync(fileLocation);
 
             record = record with { Hash = hash };
-            record.EnsureStored();
+            record.EnsurePersisted(_store);
 
         }
 

--- a/src/Networking/NexusMods.Networking.NexusWebApi/LoginManager.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/LoginManager.cs
@@ -71,8 +71,7 @@ public class LoginManager
         _dataStore.Put(JWTTokenEntity.StoreId, new JWTTokenEntity
         {
             RefreshToken = jwtToken.RefreshToken,
-            AccessToken = jwtToken.AccessToken,
-            Store = _dataStore
+            AccessToken = jwtToken.AccessToken
         });
     }
 

--- a/src/Networking/NexusMods.Networking.NexusWebApi/OAuth2MessageFactory.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/OAuth2MessageFactory.cs
@@ -155,8 +155,7 @@ public class OAuth2MessageFactory : IAuthenticatingMessageFactory
             _store.Put(JWTTokenEntity.StoreId, new JWTTokenEntity
             {
                 RefreshToken = newToken.RefreshToken,
-                AccessToken = newToken.AccessToken,
-                Store = _store
+                AccessToken = newToken.AccessToken
             });
 
             var msg = new HttpRequestMessage(original.Method, original.RequestUri);

--- a/src/NexusMods.DataModel/Abstractions/Entity.cs
+++ b/src/NexusMods.DataModel/Abstractions/Entity.cs
@@ -82,9 +82,12 @@ public abstract record Entity : IWalkable<Entity>
     [JsonIgnore]
     public IId DataStoreId
     {
-        get => _id ?? throw new UnpersistedEntity(this);
+        get => _id ?? throw new UnpersistedEntity();
         set => _id = value;
     }
+
+    [JsonIgnore]
+    public bool IsPersisted => _id != null;
 
     /// <inheritdoc />
     public TState Walk<TState>(Func<TState, Entity, TState> visitor, TState initial)

--- a/src/NexusMods.DataModel/Abstractions/Entity.cs
+++ b/src/NexusMods.DataModel/Abstractions/Entity.cs
@@ -82,10 +82,13 @@ public abstract record Entity : IWalkable<Entity>
     [JsonIgnore]
     public IId DataStoreId
     {
-        get => _id ?? throw new UnpersistedEntity();
+        get => _id ?? ThrowUnpersistedEntity();
         set => _id = value;
     }
 
+    /// <summary>
+    /// Returns true if this item is persisted in the data store and has an ID.
+    /// </summary>
     [JsonIgnore]
     public bool IsPersisted => _id != null;
 
@@ -112,5 +115,5 @@ public abstract record Entity : IWalkable<Entity>
     // Throwing prevents inlining which is costly in copy constructor
     // thus I moved the throw into a separate method so the constructor
     // can be inlined for faster mutations. - Sewer
-    private static void ThrowNoDataStoreException() => throw new NoDataStoreException();
+    private static IId ThrowUnpersistedEntity() => throw new UnpersistedEntity();
 }

--- a/src/NexusMods.DataModel/Abstractions/EntityDictionary.cs
+++ b/src/NexusMods.DataModel/Abstractions/EntityDictionary.cs
@@ -78,7 +78,7 @@ public struct EntityDictionary<TK, TV> :
     /// <returns>A new dictionary with the item present in its collection.</returns>
     public EntityDictionary<TK, TV> With(TK key, TV val)
     {
-        return new EntityDictionary<TK, TV>(_store, _coll.SetItem(key, val.DataStoreId));
+        return new EntityDictionary<TK, TV>(_store, _coll.SetItem(key, val.WithPersist(_store).DataStoreId));
     }
 
     /// <summary>
@@ -89,7 +89,7 @@ public struct EntityDictionary<TK, TV> :
     /// <returns>A new dictionary with the item present in its collection.</returns>
     public EntityDictionary<TK, TV> With(TV val, Func<TV, TK> keyFn)
     {
-        return new EntityDictionary<TK, TV>(_store, _coll.SetItem(keyFn(val), val.DataStoreId));
+        return new EntityDictionary<TK, TV>(_store, _coll.SetItem(keyFn(val), val.WithPersist(_store).DataStoreId));
     }
 
     /// <summary>
@@ -103,7 +103,7 @@ public struct EntityDictionary<TK, TV> :
     {
         var builder = _coll.ToBuilder();
         foreach (var v in val)
-            builder[keyFn(v)] = v.DataStoreId;
+            builder[keyFn(v)] = v.WithPersist(_store).DataStoreId;
 
         return new EntityDictionary<TK, TV>(_store, builder.ToImmutable());
     }
@@ -178,7 +178,7 @@ public struct EntityDictionary<TK, TV> :
             }
 
             if (newVal is not null)
-                builder.Add(key, newVal.DataStoreId);
+                builder.Add(key, newVal.WithPersist(_store).DataStoreId);
 
             modified = true;
         }

--- a/src/NexusMods.DataModel/Abstractions/EntityExtensions.cs
+++ b/src/NexusMods.DataModel/Abstractions/EntityExtensions.cs
@@ -1,0 +1,19 @@
+﻿namespace NexusMods.DataModel.Abstractions;
+
+public static class EntityExtensions
+{
+    public static T WithPersist<T>(this T entity, IDataStore store) where T : Entity
+    {
+        entity.EnsurePersisted(store);
+        return entity;
+    }
+
+    public static IEnumerable<T> WithPersist<T>(this IEnumerable<T> entities, IDataStore store) where T : Entity
+    {
+        foreach (var entity in entities)
+        {
+            entity.EnsurePersisted(store);
+            yield return entity;
+        }
+    }
+}

--- a/src/NexusMods.DataModel/Abstractions/EntityExtensions.cs
+++ b/src/NexusMods.DataModel/Abstractions/EntityExtensions.cs
@@ -2,12 +2,26 @@
 
 public static class EntityExtensions
 {
+    /// <summary>
+    /// Persists an entity to the store if it hasn't already been persisted, and returns it.
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <param name="store"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
     public static T WithPersist<T>(this T entity, IDataStore store) where T : Entity
     {
         entity.EnsurePersisted(store);
         return entity;
     }
 
+    /// <summary>
+    /// Persists a collection of entities to the store if they haven't already been persisted, and returns them.
+    /// </summary>
+    /// <param name="entities"></param>
+    /// <param name="store"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
     public static IEnumerable<T> WithPersist<T>(this IEnumerable<T> entities, IDataStore store) where T : Entity
     {
         foreach (var entity in entities)

--- a/src/NexusMods.DataModel/Abstractions/EntityLink.cs
+++ b/src/NexusMods.DataModel/Abstractions/EntityLink.cs
@@ -57,9 +57,6 @@ public record struct EntityLink<T> : IEmptyWithDataStore<EntityLink<T>>,
 
     /// <summary/>
     public static implicit operator T(EntityLink<T> t) => t.Value;
-
-    /// <summary/>
-    public static implicit operator EntityLink<T>(T t) => new(t.DataStoreId, t.Store);
 }
 
 /// <inheritdoc />

--- a/src/NexusMods.DataModel/Abstractions/Root.cs
+++ b/src/NexusMods.DataModel/Abstractions/Root.cs
@@ -78,7 +78,8 @@ public class Root<TRoot> where TRoot : Entity, IEmptyWithDataStore<TRoot>
         var oldRoot = _root.Id == IdEmpty.Empty ? TRoot.Empty(Store) : _root.Value;
 
         var newRoot = f(oldRoot);
-        if (newRoot.DataStoreId.Equals(oldRoot.DataStoreId))
+        newRoot.EnsurePersisted(Store);
+        if (oldRoot.IsPersisted && newRoot.DataStoreId.Equals(oldRoot.DataStoreId))
             return;
 
         if (!Store.PutRoot(Type, _root.Id, newRoot.DataStoreId))

--- a/src/NexusMods.DataModel/ArchiveContents/AnalyzedFile.cs
+++ b/src/NexusMods.DataModel/ArchiveContents/AnalyzedFile.cs
@@ -18,10 +18,15 @@ public record AnalyzedFile : Entity
 
     public override EntityCategory Category => EntityCategory.FileAnalysis;
 
-    protected override IId Persist()
+    /// <summary>
+    /// Persist the entity in the data store. Calculates the ID based on the Hash field.
+    /// </summary>
+    /// <param name="store"></param>
+    /// <returns></returns>
+    protected override IId Persist(IDataStore store)
     {
         var newId = new Id64(Category, (ulong)Hash);
-        Store.Put<Entity>(newId, this);
+        store.Put<Entity>(newId, this);
         return newId;
     }
 }

--- a/src/NexusMods.DataModel/ArchiveContents/FileContainedIn.cs
+++ b/src/NexusMods.DataModel/ArchiveContents/FileContainedIn.cs
@@ -13,10 +13,16 @@ public record FileContainedIn : Entity
     public required Hash Parent { get; init; }
     public required RelativePath Path { get; init; }
 
-    protected override IId Persist()
+    /// <summary>
+    /// Stores the entity in the data store, using a <see cref="TwoId64"/> as the ID.
+    /// Calculated based on the <see cref="Category"/>, <see cref="File"/> and <see cref="Parent"/> fields.
+    /// </summary>
+    /// <param name="store"></param>
+    /// <returns></returns>
+    protected override IId Persist(IDataStore store)
     {
         var id = new TwoId64(Category, (ulong)File, (ulong)Parent);
-        Store.Put(id, this);
+        store.Put(id, this);
         return id;
     }
 

--- a/src/NexusMods.DataModel/Exceptions/UnpersistedEntity.cs
+++ b/src/NexusMods.DataModel/Exceptions/UnpersistedEntity.cs
@@ -1,0 +1,10 @@
+﻿using NexusMods.DataModel.Abstractions;
+
+namespace NexusMods.DataModel.Exceptions;
+
+public class UnpersistedEntity : Exception
+{
+    public UnpersistedEntity(Entity entity) : base(
+        $"Entity {entity} is not persisted in the database, and has no ID.")
+    { }
+}

--- a/src/NexusMods.DataModel/Exceptions/UnpersistedEntity.cs
+++ b/src/NexusMods.DataModel/Exceptions/UnpersistedEntity.cs
@@ -4,7 +4,7 @@ namespace NexusMods.DataModel.Exceptions;
 
 public class UnpersistedEntity : Exception
 {
-    public UnpersistedEntity(Entity entity) : base(
-        $"Entity {entity} is not persisted in the database, and has no ID.")
+    public UnpersistedEntity() : base(
+        $"Entity is not persisted in the database, and has no ID.")
     { }
 }

--- a/src/NexusMods.DataModel/FileAnalyzer.cs
+++ b/src/NexusMods.DataModel/FileAnalyzer.cs
@@ -153,9 +153,12 @@ public class FileContentsCache
                         async (_, entry) =>
                         {
                             var relPath = entry.Path.RelativeTo(tmpFolder.Path);
+                            var analysisRecord = await AnalyzeFileInner(
+                                new NativeFileStreamFactory(entry.Path), token,
+                                level + 1, hash, relPath);
+                            analysisRecord.WithPersist(_store);
                             return (entry.Path,
-                                Results: await AnalyzeFileInner(new NativeFileStreamFactory(entry.Path), token,
-                                    level + 1, hash, relPath));
+                                Results: analysisRecord);
                         },
                         token, "Analyzing Files")
                     .Select(a => KeyValuePair.Create(a.Path.RelativeTo(tmpFolder.Path), a.Results.DataStoreId))

--- a/src/NexusMods.DataModel/FileAnalyzer.cs
+++ b/src/NexusMods.DataModel/FileAnalyzer.cs
@@ -50,7 +50,7 @@ public class FileContentsCache
         if (found != null) return found;
 
         var result = await AnalyzeFileInner(new NativeFileStreamFactory(path), token);
-        result.EnsureStored();
+        result.EnsurePersisted(_store);
         return result;
     }
 
@@ -129,8 +129,7 @@ public class FileContentsCache
             Hash = hash,
             Size = sFn.Size,
             FileTypes = sigs.ToArray(),
-            AnalysisData = analysisData.ToImmutableList(),
-            Store = _store
+            AnalysisData = analysisData.ToImmutableList()
         };
 
         if (parent != Hash.Zero)
@@ -168,8 +167,7 @@ public class FileContentsCache
                 Size = sFn.Size,
                 FileTypes = sigs.ToArray(),
                 AnalysisData = analysisData.ToImmutableList(),
-                Contents = new EntityDictionary<RelativePath, AnalyzedFile>(_store, children),
-                Store = _store
+                Contents = new EntityDictionary<RelativePath, AnalyzedFile>(_store, children)
             };
             return file;
         }
@@ -186,10 +184,9 @@ public class FileContentsCache
         {
             File = hash,
             Parent = parent,
-            Path = parentPath,
-            Store = _store
+            Path = parentPath
         };
-        entity.EnsureStored();
+        entity.EnsurePersisted(_store);
     }
 
     public IEnumerable<FileContainedIn> ArchivesThatContain(Hash hash)

--- a/src/NexusMods.DataModel/Loadouts/Loadout.cs
+++ b/src/NexusMods.DataModel/Loadouts/Loadout.cs
@@ -27,8 +27,7 @@ public record Loadout : Entity, IEmptyWithDataStore<Loadout>
         Mods = EntityDictionary<ModId, Mod>.Empty(store),
         LastModified = DateTime.UtcNow,
         PreviousVersion = EntityLink<Loadout>.Empty(store),
-        ChangeMessage = "",
-        Store = store
+        ChangeMessage = ""
     };
 
     public Loadout Alter(ModId modId, Func<Mod, Mod?> func)

--- a/src/NexusMods.DataModel/Loadouts/LoadoutRegistry.cs
+++ b/src/NexusMods.DataModel/Loadouts/LoadoutRegistry.cs
@@ -12,7 +12,6 @@ public record LoadoutRegistry : Entity, IEmptyWithDataStore<LoadoutRegistry>
     /// <inheritdoc />
     public static LoadoutRegistry Empty(IDataStore store) => new()
     {
-        Lists = EntityDictionary<LoadoutId, Loadout>.Empty(store),
-        Store = store
+        Lists = EntityDictionary<LoadoutId, Loadout>.Empty(store)
     };
 }

--- a/src/NexusMods.DataModel/Loadouts/Markers/LoadoutMarker.cs
+++ b/src/NexusMods.DataModel/Loadouts/Markers/LoadoutMarker.cs
@@ -356,7 +356,6 @@ public class LoadoutMarker : IMarker<Loadout>
                                 From = new HashRelativePath(add.Hash),
                                 Hash = add.Hash,
                                 Size = add.Size,
-                                Store = m.Store,
                                 To = gamePath
                             }, x => x.Id)
                         });
@@ -375,7 +374,6 @@ public class LoadoutMarker : IMarker<Loadout>
                                 From = sourceArchive,
                                 Hash = t.Hash,
                                 Size = t.Size,
-                                Store = m.Store,
                                 To = gamePath
                             }, x => x.Id)
                         });
@@ -421,8 +419,7 @@ public class LoadoutMarker : IMarker<Loadout>
                   {
                       Name = modName,
                       Id = ModId.New(),
-                      Store = Value.Store,
-                      Files = EntityDictionary<ModFileId, AModFile>.Empty(Value.Store)
+                      Files = EntityDictionary<ModFileId, AModFile>.Empty(_manager.Store)
                   };
         Add(mod);
         await ApplyIngest(_ => mod, token);

--- a/tests/Networking/NexusMods.Networking.NexusWebApi.Tests/OAuth2MessageFactoryTests.cs
+++ b/tests/Networking/NexusMods.Networking.NexusWebApi.Tests/OAuth2MessageFactoryTests.cs
@@ -36,8 +36,7 @@ public class OAuth2MessageFactoryTests
         _store.Setup(_ => _.Get<JWTTokenEntity>(JWTTokenEntity.StoreId, false)).Returns(() => new JWTTokenEntity
         {
             AccessToken = "access_token",
-            RefreshToken = "refresh_token",
-            Store = _store.Object
+            RefreshToken = "refresh_token"
         });
 
         var request = await _factory.Create(HttpMethod.Get, new Uri("test://foobar"));
@@ -69,8 +68,7 @@ public class OAuth2MessageFactoryTests
         _store.Setup(_ => _.Get<JWTTokenEntity>(JWTTokenEntity.StoreId, false)).Returns(() => new JWTTokenEntity
         {
             AccessToken = "access_token",
-            RefreshToken = "refresh_token",
-            Store = _store.Object
+            RefreshToken = "refresh_token"
         });
 
         _handler.Protected()

--- a/tests/NexusMods.DataModel.Tests/DataStoreTests.cs
+++ b/tests/NexusMods.DataModel.Tests/DataStoreTests.cs
@@ -34,7 +34,7 @@ public class DataStoreTests
             From = new HashRelativePath((Hash)42L, Array.Empty<RelativePath>()),
             Size = (Size)42L,
             To = new GamePath(GameFolderType.Game, "test.foo")
-        };
+        }.WithPersist(DataStore);
         foo.DataStoreId.ToString().Should().NotBeEmpty();
         DataStore.Get<FromArchive>(foo.DataStoreId).Should().NotBeNull();
     }
@@ -59,7 +59,8 @@ public class DataStoreTests
             Hash = (Hash)(ulong)idx,
             Size = Size.From(idx),
             To = new GamePath(GameFolderType.Game, $"{idx}.file"),
-        }).ToList();
+        }).WithPersist(DataStore)
+            .ToList();
 
         var set = new EntityHashSet<AModFile>(DataStore, files.Select(m => m.DataStoreId));
 

--- a/tests/NexusMods.DataModel.Tests/DataStoreTests.cs
+++ b/tests/NexusMods.DataModel.Tests/DataStoreTests.cs
@@ -30,7 +30,6 @@ public class DataStoreTests
         var foo = new FromArchive
         {
             Id = ModFileId.New(),
-            Store = DataStore,
             Hash = Hash.Zero,
             From = new HashRelativePath((Hash)42L, Array.Empty<RelativePath>()),
             Size = (Size)42L,
@@ -59,7 +58,6 @@ public class DataStoreTests
             From = new HashRelativePath((Hash)(ulong)idx, $"{idx}.file".ToRelativePath()),
             Hash = (Hash)(ulong)idx,
             Size = Size.From(idx),
-            Store = DataStore,
             To = new GamePath(GameFolderType.Game, $"{idx}.file"),
         }).ToList();
 
@@ -69,11 +67,10 @@ public class DataStoreTests
         {
             Id = ModId.New(),
             Name = "Large Entity",
-            Files = EntityDictionary<ModFileId, AModFile>.Empty(DataStore),
-            Store = DataStore,
+            Files = EntityDictionary<ModFileId, AModFile>.Empty(DataStore)
         };
         mod = mod with { Files = mod.Files.With(files, x => x.Id) };
-        mod.EnsureStored();
+        mod.EnsurePersisted(DataStore);
         var modLoaded = DataStore.Get<Mod>(mod.DataStoreId);
 
         foreach (var itm in set)

--- a/tests/NexusMods.DataModel.Tests/ModelTests.cs
+++ b/tests/NexusMods.DataModel.Tests/ModelTests.cs
@@ -30,10 +30,8 @@ public class ModelTests : ADataModelTest<ModelTests>
             To = new GamePath(GameFolderType.Game, "foo/bar.pez"),
             From = new HashRelativePath(Hash.Zero, RelativePath.Empty),
             Hash = (Hash)0x42L,
-            Size = Size.From(44L),
-            Store = DataStore
+            Size = Size.From(44L)
         };
-        file.Store.Should().NotBeNull();
         file.DataStoreId.Should().NotBeNull();
 
         DataStore.Get<FromArchive>(file.DataStoreId)!.To.Should().BeEquivalentTo(file.To);
@@ -122,7 +120,7 @@ public class ModelTests : ADataModelTest<ModelTests>
 
         }
 
-        loadout.Alter(l => l with { Mods = new EntityDictionary<ModId, Mod>(l.Store) });
+        loadout.Alter(l => l with { Mods = new EntityDictionary<ModId, Mod>(DataStore) });
         loadout.Value.Mods.Should().BeEmpty("All mods are removed");
 
         await LoadoutManager.ImportFrom(tempFile, CancellationToken.None);

--- a/tests/NexusMods.DataModel.Tests/ModelTests.cs
+++ b/tests/NexusMods.DataModel.Tests/ModelTests.cs
@@ -32,6 +32,7 @@ public class ModelTests : ADataModelTest<ModelTests>
             Hash = (Hash)0x42L,
             Size = Size.From(44L)
         };
+        file.EnsurePersisted(DataStore);
         file.DataStoreId.Should().NotBeNull();
 
         DataStore.Get<FromArchive>(file.DataStoreId)!.To.Should().BeEquivalentTo(file.To);

--- a/tests/NexusMods.StandardGameLocators.TestHelpers/StubbedGames.cs
+++ b/tests/NexusMods.StandardGameLocators.TestHelpers/StubbedGames.cs
@@ -151,8 +151,7 @@ public class StubbedGameInstaller : IModInstaller
                 From = new HashRelativePath(srcArchive, key),
                 To = new GamePath(GameFolderType.Game, key),
                 Hash = value.Hash,
-                Size = value.Size,
-                Store = _store
+                Size = value.Size
             };
         }
     }


### PR DESCRIPTION
This refactors the Entities so they no longer implicitly persist themselves to the IDataStore. As a side-effect we then have no reason for them to contain a `IDataStore` so I yanked that as well. Collections will still auto-persist any object inserted into them, but that feels natural as we're calling things like `.Add`. If we don't like these semantics we might be able to yank that as well, but for now, having collections write-on-add is nice for code simplicity. 