### PR TITLE
Fix Linux path issues

### DIFF
--- a/src/NexusMods.Paths/AbsolutePath.cs
+++ b/src/NexusMods.Paths/AbsolutePath.cs
@@ -56,7 +56,9 @@ public partial struct AbsolutePath : IEquatable<AbsolutePath>, IPath
         // on Linux: don't do this if the directory is "/"
         if (!string.IsNullOrEmpty(directory))
         {
-            Directory = directory.EndsWith(Path.DirectorySeparatorChar) && directory.Length != 1
+            Directory = directory.EndsWith(Path.DirectorySeparatorChar)
+                        && directory.Length != 1
+                        && directory != DirectorySeparatorCharStr
                 ? directory[..^1]
                 : directory;
         }

--- a/src/NexusMods.Paths/AbsolutePath.cs
+++ b/src/NexusMods.Paths/AbsolutePath.cs
@@ -85,7 +85,7 @@ public partial struct AbsolutePath : IEquatable<AbsolutePath>, IPath
 
         // Windows: "C:\foo", directory should be "C:"
         // Linux: "/foo", directory should be "/"
-        var directory = index == 0 ? $"{fullPath[0]}": fullPath[..index];
+        var directory = index == 0 ? DirectorySeparatorCharStr : fullPath[..index];
 
         var fileName = fullPath[(index + 1)..];
         return new AbsolutePath(directory, fileName);
@@ -111,9 +111,8 @@ public partial struct AbsolutePath : IEquatable<AbsolutePath>, IPath
         if (FileName.Length == 0)
             return Directory;
 
-        // on Linux: Directory="/", FileName="foo" should return "/foo"
-        // and not "//foo"
-        if (Directory.Length == 1 && Directory == DirectorySeparatorCharStr)
+        // on Linux: Directory="/", FileName="foo" should return "/foo" and not "//foo"
+        if (!OperatingSystem.IsWindows() && Directory == DirectorySeparatorCharStr)
             return string.Concat(Directory, FileName);
 
         return string.Concat(Directory, DirectorySeparatorCharStr, FileName);

--- a/src/NexusMods.Paths/AbsolutePath.cs
+++ b/src/NexusMods.Paths/AbsolutePath.cs
@@ -78,9 +78,12 @@ public partial struct AbsolutePath : IEquatable<AbsolutePath>, IPath
             return new AbsolutePath(null, fullPath);
         }
 
-        var directory = fullPath[..index];
+        // Windows: "C:\foo", directory should be "C:"
+        // Linux: "/foo", directory should be "/"
+        var directory = index == 0 ? $"{fullPath[0]}": fullPath[..index];
+
         var fileName = fullPath[(index + 1)..];
-        return new(directory, fileName);
+        return new AbsolutePath(directory, fileName);
     }
 
     /// <summary>

--- a/src/NexusMods.Paths/AbsolutePath.cs
+++ b/src/NexusMods.Paths/AbsolutePath.cs
@@ -52,12 +52,15 @@ public partial struct AbsolutePath : IEquatable<AbsolutePath>, IPath
     /// <param name="fileName">Name of the file. Full path if directory is null.</param>
     internal AbsolutePath(string? directory, string fileName)
     {
+        // remove directory separator at the end of the directory
+        // on Linux: don't do this if the directory is "/"
         if (!string.IsNullOrEmpty(directory))
         {
-            Directory = directory.EndsWith(Path.DirectorySeparatorChar)
+            Directory = directory.EndsWith(Path.DirectorySeparatorChar) && directory.Length != 1
                 ? directory[..^1]
                 : directory;
         }
+
         FileName = fileName;
     }
 

--- a/src/NexusMods.Paths/AbsolutePath.cs
+++ b/src/NexusMods.Paths/AbsolutePath.cs
@@ -109,6 +109,11 @@ public partial struct AbsolutePath : IEquatable<AbsolutePath>, IPath
         if (FileName.Length == 0)
             return Directory;
 
+        // on Linux: Directory="/", FileName="foo" should return "/foo"
+        // and not "//foo"
+        if (Directory.Length == 1 && Directory == DirectorySeparatorCharStr)
+            return string.Concat(Directory, FileName);
+
         return string.Concat(Directory, DirectorySeparatorCharStr, FileName);
     }
 

--- a/tests/NexusMods.Paths.Tests/New/AbsolutePathTests/ConstructorTests.cs
+++ b/tests/NexusMods.Paths.Tests/New/AbsolutePathTests/ConstructorTests.cs
@@ -6,28 +6,32 @@ namespace NexusMods.Paths.Tests.New.AbsolutePathTests;
 public class ConstructorTests
 {
     [SkippableTheory]
-    [InlineData("C:", "C:", "")]
-    [InlineData("C:\foo", "C:", "foo")]
-    [InlineData("C:\foo\bar", "C:\foo", "bar")]
-    public void Test_Constructor_Windows(string fullPath, string directory, string fileName)
+    [InlineData("C:", "", "C:", "", "C:")]
+    [InlineData("C:", "foo", "C:", "foo", "C:\\foo")]
+    [InlineData("C:\\foo", "bar", "C:\\foo", "bar", "C:\\foo\\bar")]
+    [InlineData("C:\\foo\\", "bar", "C:\\foo", "bar", "C:\\foo\\bar")]
+    public void Test_Constructor_Windows(string inputDirectory, string inputFileName,
+        string expectedDirectory, string expectedFileName, string expectedFullPath)
     {
-        Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
-        var path = new AbsolutePath(directory, fileName);
-        path.Directory.Should().Be(directory);
-        path.FileName.Should().Be(fileName);
-        path.GetFullPath().Should().Be(fullPath);
+        Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
+        var path = new AbsolutePath(inputDirectory, inputFileName);
+        path.Directory.Should().Be(expectedDirectory);
+        path.FileName.Should().Be(expectedFileName);
+        path.GetFullPath().Should().Be(expectedFullPath);
     }
 
     [SkippableTheory]
-    [InlineData("/", "/", "")]
-    [InlineData("/foo", "/", "foo")]
-    [InlineData("/foo/bar", "/foo", "bar")]
-    public void Test_Constructor_Linux(string fullPath, string directory, string fileName)
+    [InlineData("/", "", "/", "", "/")]
+    [InlineData("/", "foo", "/", "foo", "/foo")]
+    [InlineData("/foo", "bar", "/foo", "bar", "/foo/bar")]
+    [InlineData("/foo/", "bar", "/foo", "bar", "/foo/bar")]
+    public void Test_Constructor_Linux(string inputDirectory, string inputFileName,
+        string expectedDirectory, string expectedFileName, string expectedFullPath)
     {
         Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
-        var path = new AbsolutePath(directory, fileName);
-        path.Directory.Should().Be(directory);
-        path.FileName.Should().Be(fileName);
-        path.GetFullPath().Should().Be(fullPath);
+        var path = new AbsolutePath(inputDirectory, inputFileName);
+        path.Directory.Should().Be(expectedDirectory);
+        path.FileName.Should().Be(expectedFileName);
+        path.GetFullPath().Should().Be(expectedFullPath);
     }
 }

--- a/tests/NexusMods.Paths.Tests/New/AbsolutePathTests/ConstructorTests.cs
+++ b/tests/NexusMods.Paths.Tests/New/AbsolutePathTests/ConstructorTests.cs
@@ -1,0 +1,31 @@
+using System.Runtime.InteropServices;
+using FluentAssertions;
+
+namespace NexusMods.Paths.Tests.New.AbsolutePathTests;
+
+public class ConstructorTests
+{
+    [Theory]
+    [InlineData("C:\foo", "C:", "foo")]
+    [InlineData("C:\foo\bar", "C:\foo", "bar")]
+    public void Test_Constructor_Windows(string fullPath, string directory, string fileName)
+    {
+        Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+        var path = new AbsolutePath(directory, fileName);
+        path.Directory.Should().Be(directory);
+        path.FileName.Should().Be(fileName);
+        path.GetFullPath().Should().Be(fullPath);
+    }
+
+    [Theory]
+    [InlineData("/foo", "/", "foo")]
+    [InlineData("/foo/bar", "/foo", "bar")]
+    public void Test_Constructor_Linux(string fullPath, string directory, string fileName)
+    {
+        Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
+        var path = new AbsolutePath(directory, fileName);
+        path.Directory.Should().Be(directory);
+        path.FileName.Should().Be(fileName);
+        path.GetFullPath().Should().Be(fullPath);
+    }
+}

--- a/tests/NexusMods.Paths.Tests/New/AbsolutePathTests/ConstructorTests.cs
+++ b/tests/NexusMods.Paths.Tests/New/AbsolutePathTests/ConstructorTests.cs
@@ -5,7 +5,8 @@ namespace NexusMods.Paths.Tests.New.AbsolutePathTests;
 
 public class ConstructorTests
 {
-    [Theory]
+    [SkippableTheory]
+    [InlineData("C:", "C:", "")]
     [InlineData("C:\foo", "C:", "foo")]
     [InlineData("C:\foo\bar", "C:\foo", "bar")]
     public void Test_Constructor_Windows(string fullPath, string directory, string fileName)
@@ -17,7 +18,8 @@ public class ConstructorTests
         path.GetFullPath().Should().Be(fullPath);
     }
 
-    [Theory]
+    [SkippableTheory]
+    [InlineData("/", "/", "")]
     [InlineData("/foo", "/", "foo")]
     [InlineData("/foo/bar", "/foo", "bar")]
     public void Test_Constructor_Linux(string fullPath, string directory, string fileName)

--- a/tests/NexusMods.Paths.Tests/New/AbsolutePathTests/ConstructorTests.cs
+++ b/tests/NexusMods.Paths.Tests/New/AbsolutePathTests/ConstructorTests.cs
@@ -13,7 +13,7 @@ public class ConstructorTests
     public void Test_Constructor_Windows(string inputDirectory, string inputFileName,
         string expectedDirectory, string expectedFileName, string expectedFullPath)
     {
-        Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
+        Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
         var path = new AbsolutePath(inputDirectory, inputFileName);
         path.Directory.Should().Be(expectedDirectory);
         path.FileName.Should().Be(expectedFileName);

--- a/tests/NexusMods.Paths.Tests/New/AbsolutePathTests/FromFullPathTests.cs
+++ b/tests/NexusMods.Paths.Tests/New/AbsolutePathTests/FromFullPathTests.cs
@@ -1,0 +1,27 @@
+using System.Runtime.InteropServices;
+using FluentAssertions;
+
+namespace NexusMods.Paths.Tests.New.AbsolutePathTests;
+
+public class FromFullPathTests
+{
+    [Theory]
+    [InlineData("C:\foo")]
+    [InlineData("C:\foo\bar")]
+    [InlineData("C:\foo\bar\baz")]
+    public void Test_FromFullPath_Windows(string fullPath)
+    {
+        Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+        AbsolutePath.FromFullPath(fullPath).GetFullPath().Should().Be(fullPath);
+    }
+
+    [Theory]
+    [InlineData("/foo")]
+    [InlineData("/foo/bar")]
+    [InlineData("/foo/bar/baz")]
+    public void Test_FromFullPath_Linux(string fullPath)
+    {
+        Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
+        AbsolutePath.FromFullPath(fullPath).GetFullPath().Should().Be(fullPath);
+    }
+}

--- a/tests/NexusMods.Paths.Tests/New/AbsolutePathTests/FromFullPathTests.cs
+++ b/tests/NexusMods.Paths.Tests/New/AbsolutePathTests/FromFullPathTests.cs
@@ -5,7 +5,8 @@ namespace NexusMods.Paths.Tests.New.AbsolutePathTests;
 
 public class FromFullPathTests
 {
-    [Theory]
+    [SkippableTheory]
+    [InlineData("C:")]
     [InlineData("C:\foo")]
     [InlineData("C:\foo\bar")]
     [InlineData("C:\foo\bar\baz")]
@@ -15,7 +16,8 @@ public class FromFullPathTests
         AbsolutePath.FromFullPath(fullPath).GetFullPath().Should().Be(fullPath);
     }
 
-    [Theory]
+    [SkippableTheory]
+    [InlineData("/")]
     [InlineData("/foo")]
     [InlineData("/foo/bar")]
     [InlineData("/foo/bar/baz")]


### PR DESCRIPTION
- `/` is now a valid directory
- fixes `FromFullPath` to use `/` as a directory instead of `""`
- fixes the constructor not to remove `/` from the directory, if the directory is `/`
- fixes `GetFullPath` to not return `//foo` instead of `/foo`