### PR TITLE
Rework the IPC system

### DIFF
--- a/src/NexusMods.DataModel/Interprocess/InterprocessProducer.cs
+++ b/src/NexusMods.DataModel/Interprocess/InterprocessProducer.cs
@@ -1,4 +1,3 @@
-using Cloudtoid.Interprocess;
 using Microsoft.Extensions.Logging;
 
 namespace NexusMods.DataModel.Interprocess;
@@ -7,27 +6,20 @@ namespace NexusMods.DataModel.Interprocess;
 /// Implementation of <see cref="IMessageProducer{T}"/> that uses an interprocess queue.
 /// </summary>
 /// <typeparam name="T"></typeparam>
-public class InterprocessProducer<T> : IMessageProducer<T>, IDisposable where T : IMessage
+public class InterprocessProducer<T> : IMessageProducer<T> where T : IMessage
 {
-    private readonly ILogger<InterprocessProducer<T>> _logger;
-    private readonly IQueueFactory _queueFactory;
-    private readonly IPublisher _queue;
     private readonly string _queueName;
+    private readonly SqliteIPC _sqliteIpc;
 
     /// <summary>
     /// DI Constructor
     /// </summary>
     /// <param name="logger">Logger</param>
     /// <param name="queueFactory">Queue Factory</param>
-    public InterprocessProducer(ILogger<InterprocessProducer<T>> logger, IQueueFactory queueFactory)
+    public InterprocessProducer(ILogger<InterprocessProducer<T>> logger, SqliteIPC sqliteIpc)
     {
-        _queueFactory = queueFactory;
-        _logger = logger;
-        _queueName = "NexusMods.DataModel.Interprocess." + typeof(T).Name;
-
-        _queue = queueFactory.CreatePublisher(new QueueOptions(
-            _queueName,
-            T.MaxSize * 16));
+        _queueName = typeof(T).Name;
+        _sqliteIpc = sqliteIpc;
     }
 
     /// <summary>
@@ -36,22 +28,10 @@ public class InterprocessProducer<T> : IMessageProducer<T>, IDisposable where T 
     /// <param name="message"></param>
     /// <param name="token"></param>
     /// <exception cref="TaskCanceledException"></exception>
-    public async ValueTask Write(T message, CancellationToken token)
+    public ValueTask Write(T message, CancellationToken token)
     {
-        _logger.LogTrace("Writing message {Message} to queue {Queue}", message, _queueName);
-
-        while (!token.IsCancellationRequested)
-        {
-            if (WriteInner(message))
-            {
-                return;
-            }
-
-            _logger.LogDebug("Failed to write {Message} to queue {Queue}, retrying", message, _queueName);
-            await Task.Delay(100, token);
-        }
-
-        throw new TaskCanceledException();
+        WriteInner(message);
+        return ValueTask.CompletedTask;
     }
 
     /// <summary>
@@ -59,17 +39,12 @@ public class InterprocessProducer<T> : IMessageProducer<T>, IDisposable where T 
     /// </summary>
     /// <param name="message"></param>
     /// <returns></returns>
-    private bool WriteInner(T message)
+    private void WriteInner(T message)
     {
         // This means we re-encode the message on every attempt, but it is assumed that failed messages
         // are rare and the cost of re-encoding is negligible.
         Span<byte> buffer = stackalloc byte[T.MaxSize];
         var used = message.Write(buffer);
-        return _queue.TryEnqueue(buffer[..used]);
-    }
-
-    public void Dispose()
-    {
-        _queue.Dispose();
+        _sqliteIpc.Send(_queueName, buffer[..used]);
     }
 }

--- a/src/NexusMods.DataModel/Interprocess/SqliteIPC.cs
+++ b/src/NexusMods.DataModel/Interprocess/SqliteIPC.cs
@@ -20,7 +20,6 @@ public class SqliteIPC : IDisposable
     private static int CleanupJitter = 2000; // Jitter cleanup by up to 2 second
 
     private readonly AbsolutePath _storePath;
-    private readonly AbsolutePath _syncPath;
     private readonly string _connectionString;
     private readonly SQLiteConnection _conn;
 
@@ -38,11 +37,10 @@ public class SqliteIPC : IDisposable
     /// <param name="logger"></param>
     /// <param name="storePath"></param>
     /// <param name="syncPath"></param>
-    public SqliteIPC(ILogger<SqliteIPC> logger, AbsolutePath storePath, AbsolutePath syncPath)
+    public SqliteIPC(ILogger<SqliteIPC> logger, AbsolutePath storePath)
     {
         _logger = logger;
         _storePath = storePath;
-        _syncPath = syncPath;
 
         _connectionString = string.Intern($"Data Source={_storePath}");
         _conn = new SQLiteConnection(_connectionString);
@@ -73,7 +71,7 @@ public class SqliteIPC : IDisposable
     /// <param name="token"></param>
     public async Task CleanupOnce(CancellationToken token)
     {
-        var oldTime = DateTime.UtcNow - TimeSpan.FromMinutes(1);
+        var oldTime = DateTime.UtcNow - RetentionTime;
 
         _logger.LogTrace("Cleaning up old IPC messages");
         await using var cmd = new SQLiteCommand(

--- a/src/NexusMods.DataModel/Interprocess/SqliteIPC.cs
+++ b/src/NexusMods.DataModel/Interprocess/SqliteIPC.cs
@@ -1,0 +1,187 @@
+﻿using System.Data.SQLite;
+using System.Reactive.Subjects;
+using Microsoft.Extensions.Logging;
+using NexusMods.Paths;
+
+namespace NexusMods.DataModel.Interprocess;
+
+/// <summary>
+/// Fairly simple interprocess communication system using SQLite. This is not intended to be a high performance system,
+/// but rather a simple way to communicate between processes. Messages are stored in a SQLite database and read by a
+/// worker task. The worker task will read all messages from the database, poll for new messages. The worker will pause
+/// periodically and check the file size and last modified time of the database file. If it detects that the file has
+/// changed, it will re-poll the database for new messages. This method of polling allows for fairly simple change detection
+/// without having to run a SQL query every second.
+/// </summary>
+public class SqliteIPC : IDisposable
+{
+    private static TimeSpan RetentionTime = TimeSpan.FromSeconds(10); // Keep messages for 10 seconds
+    private static TimeSpan CleanupInterval = TimeSpan.FromMinutes(10); // Cleanup every 10 minutes
+    private static int CleanupJitter = 2000; // Jitter cleanup by up to 2 second
+
+    private readonly AbsolutePath _storePath;
+    private readonly AbsolutePath _syncPath;
+    private readonly string _connectionString;
+    private readonly SQLiteConnection _conn;
+
+    private Subject<(string Queue, byte[] Message)> _subject = new();
+    private readonly CancellationTokenSource _shutdownToken;
+    private readonly Task _rdrTask;
+    private readonly ILogger<SqliteIPC> _logger;
+    private readonly Task _cleanupTask;
+
+    public IObservable<(string Queue, byte[] Message)> Messages => _subject;
+
+    /// <summary>
+    /// DI Constructor
+    /// </summary>
+    /// <param name="logger"></param>
+    /// <param name="storePath"></param>
+    /// <param name="syncPath"></param>
+    public SqliteIPC(ILogger<SqliteIPC> logger, AbsolutePath storePath, AbsolutePath syncPath)
+    {
+        _logger = logger;
+        _storePath = storePath;
+        _syncPath = syncPath;
+
+        _connectionString = string.Intern($"Data Source={_storePath}");
+        _conn = new SQLiteConnection(_connectionString);
+        _conn.Open();
+
+        EnsureTables();
+
+        _shutdownToken = new CancellationTokenSource();
+        var startId = GetStartId();
+        _rdrTask = Task.Run(() => ReaderLoop(startId, _shutdownToken.Token));
+        _cleanupTask = Task.Run(() => CleanupLoop(_shutdownToken.Token));
+    }
+
+    private async Task CleanupLoop(CancellationToken token, bool force = false)
+    {
+        // Wait a bit so a bunch of CLI processes don't all try to clean up at the same time.
+        await Task.Delay(Random.Shared.Next(CleanupJitter), token);
+        while (!token.IsCancellationRequested)
+        {
+            await CleanupOnce(token);
+            await Task.Delay(CleanupInterval + TimeSpan.FromMilliseconds(Random.Shared.Next(CleanupJitter)), token);
+        }
+    }
+
+    /// <summary>
+    /// Cleanup any old messages left in the queue. This is run automatically, but can be called manually if needed.
+    /// </summary>
+    /// <param name="token"></param>
+    public async Task CleanupOnce(CancellationToken token)
+    {
+        var oldTime = DateTime.UtcNow - TimeSpan.FromMinutes(1);
+
+        _logger.LogTrace("Cleaning up old IPC messages");
+        await using var cmd = new SQLiteCommand(
+            "DELETE from Ipc WHERE TimeStamp < @timestamp",
+            _conn);
+        cmd.Parameters.AddWithValue("@timestamp", oldTime.ToFileTimeUtc());
+        await cmd.ExecuteNonQueryAsync(token);
+    }
+
+    private async Task ReaderLoop(long lastId, CancellationToken shutdownTokenToken)
+    {
+        while (!shutdownTokenToken.IsCancellationRequested)
+        {
+            lastId = ProcessMessages(lastId);
+            var lastEdit = _storePath.FileInfo;
+
+            while (!shutdownTokenToken.IsCancellationRequested)
+            {
+                var currentEdit = _storePath.FileInfo;
+                if (currentEdit.Length != lastEdit.Length || currentEdit.LastWriteTimeUtc != lastEdit.LastWriteTimeUtc)
+                {
+                    break;
+                }
+                await Task.Delay(100, shutdownTokenToken);
+            }
+        }
+    }
+
+    private long GetStartId()
+    {
+        using var cmd = new SQLiteCommand(
+            "SELECT MAX(Id) FROM Ipc WHERE TimeStamp >= @current", _conn);
+        // Subtract 1 second to ensure we don't miss any messages that were written in the last second.
+        cmd.Parameters.AddWithValue("@current", DateTime.UtcNow.ToFileTimeUtc());
+        var reader = cmd.ExecuteReader();
+        while (reader.Read())
+        {
+            return reader.IsDBNull(0) ? 0L : reader.GetInt64(0);
+        }
+
+        return 0L;
+    }
+
+    private long ProcessMessages(long lastId)
+    {
+        try
+        {
+            using var cmd = new SQLiteCommand(
+                "SELECT Id, Queue, Data FROM Ipc WHERE Id > @lastId", _conn);
+            cmd.Parameters.AddWithValue("@lastId", lastId);
+            var reader = cmd.ExecuteReader();
+            while (reader.Read())
+            {
+                lastId = long.Max(lastId, reader.GetInt64(0));
+                var queue = reader.GetString(1);
+                var size = reader.GetBytes(2, 0, null, 0, 0);
+                var bytes = new byte[size];
+                reader.GetBytes(2, 0, bytes, 0, bytes.Length);
+                _subject.OnNext((queue, bytes));
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to process messages after {LastId}", lastId);
+        }
+
+        return lastId;
+    }
+
+    private void EnsureTables()
+    {
+        using var cmd = new SQLiteCommand("CREATE TABLE IF NOT EXISTS Ipc (Id INTEGER PRIMARY KEY AUTOINCREMENT, Queue VARCHAR, Data BLOB, TimeStamp INTEGER)", _conn);
+        cmd.ExecuteNonQuery();
+    }
+
+    /// <summary>
+    /// Send a message to the queue.
+    /// </summary>
+    /// <param name="queue"></param>
+    /// <param name="message"></param>
+    public void Send(string queue, ReadOnlySpan<byte> message)
+    {
+        try
+        {
+            _logger.LogTrace("Sending {Bytes} byte message to queue {Queue}", Size.From(message.Length), queue);
+            using var cmd = new SQLiteCommand(
+                "INSERT INTO Ipc (Queue, Data, TimeStamp) VALUES (@queue, @data, @timestamp);",
+                _conn);
+            cmd.Parameters.AddWithValue("@queue", queue);
+            cmd.Parameters.AddWithValue("@data", message.ToArray());
+            cmd.Parameters.AddWithValue("@timestamp",
+                DateTime.UtcNow.ToFileTimeUtc());
+            cmd.ExecuteNonQuery();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to send message to queue {Queue}", queue);
+        }
+    }
+
+
+    /// <summary>
+    /// Dispose of the IPC connection.
+    /// </summary>
+    public void Dispose()
+    {
+        _shutdownToken.Cancel();
+        _conn.Dispose();
+        _subject.Dispose();
+    }
+}

--- a/src/NexusMods.DataModel/NexusMods.DataModel.csproj
+++ b/src/NexusMods.DataModel/NexusMods.DataModel.csproj
@@ -13,7 +13,6 @@
 
     <ItemGroup>
         <PackageReference Include="BitFaster.Caching" Version="2.1.1" />
-        <PackageReference Include="Cloudtoid.Interprocess" Version="2.0.0-alpha176" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0-preview.1.23110.8" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0-preview.1.23110.8" />
         <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.1" />

--- a/src/NexusMods.DataModel/Services.cs
+++ b/src/NexusMods.DataModel/Services.cs
@@ -1,6 +1,5 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Cloudtoid.Interprocess;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NexusMods.Common;
@@ -54,7 +53,10 @@ public static class Services
         coll.AddSingleton<FileHashCache>();
         coll.AddSingleton<FileContentsCache>();
 
-        coll.AddInterprocessQueue();
+        coll.AddSingleton(s => new SqliteIPC(
+            s.GetRequiredService<ILogger<SqliteIPC>>(),
+            baseFolder.Value.CombineUnchecked("DataModel_IPC.sqlite"),
+            baseFolder.Value.CombineUnchecked("DataModel_IPC.mmap")));
         coll.AddSingleton(typeof(IMessageConsumer<>), typeof(InterprocessConsumer<>));
         coll.AddSingleton(typeof(IMessageProducer<>), typeof(InterprocessProducer<>));
 

--- a/src/NexusMods.DataModel/Services.cs
+++ b/src/NexusMods.DataModel/Services.cs
@@ -55,8 +55,7 @@ public static class Services
 
         coll.AddSingleton(s => new SqliteIPC(
             s.GetRequiredService<ILogger<SqliteIPC>>(),
-            baseFolder.Value.CombineUnchecked("DataModel_IPC.sqlite"),
-            baseFolder.Value.CombineUnchecked("DataModel_IPC.mmap")));
+            baseFolder.Value.CombineUnchecked("DataModel_IPC.sqlite")));
         coll.AddSingleton(typeof(IMessageConsumer<>), typeof(InterprocessConsumer<>));
         coll.AddSingleton(typeof(IMessageProducer<>), typeof(InterprocessProducer<>));
 

--- a/tests/NexusMods.DataModel.Tests/Startup.cs
+++ b/tests/NexusMods.DataModel.Tests/Startup.cs
@@ -21,7 +21,7 @@ public class Startup
         var prefix = KnownFolders.EntryFolder.CombineUnchecked("tempTestData").CombineUnchecked(Guid.NewGuid().ToString());
 
         container.AddDataModel(prefix)
-                 .AddLogging(builder => builder.SetMinimumLevel(LogLevel.Debug))
+                 .AddLogging(builder => builder.SetMinimumLevel(LogLevel.Trace))
                  .AddStandardGameLocators(false)
                  .AddSingleton<TemporaryFileManager>(s => new TemporaryFileManager(prefix.CombineUnchecked("tempFiles")))
                  .AddFileExtractors()

--- a/tests/NexusMods.Paths.Tests/NexusMods.Paths.Tests.csproj
+++ b/tests/NexusMods.Paths.Tests/NexusMods.Paths.Tests.csproj
@@ -21,7 +21,6 @@
       </None>
 
       <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-      <PackageReference Include="FsCheck.Xunit" Version="3.0.0-beta2" />
 
 </ItemGroup>
 


### PR DESCRIPTION
This reworks the IPC code for the App. 

### Old Code:
 * Used a 3rd party socket/shared memory system
 * Project hasn't been updated in a few months
 * Has some rather concerning GitHub issues about leaking resources
 * Is a bit overkill for our project, we're likely to only ever insert a message every few seconds, not thousands per second
 
### New Code:
  * Uses Sqlite as the log store
  * Data is stored in a separate file from the main DataStore so we don't fragment the old data store
  * Messages are deleted after 10 seconds
  * Every ~10 minutes a running process will run a "delete old messages" command
  * The size/last modified file stats for the .sqlite file are used to trigger a new polling
  * Every 10 seconds the file is polled by doing a `SELECT WHERE` just in case some race condition blocked up the cheaper approach. 