### PR TITLE
More FileSystem changes for Wine

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -60,6 +60,12 @@ tab_width = 4
 # CS4014: Task not awaited
 dotnet_diagnostic.cs4014.severity = error
 
+# CS8509: Missing switch case for named enum value
+dotnet_diagnostic.CS8509.severity = error
+
+# CS824: Missing switch case for unnamed enum value
+dotnet_diagnostic.CS8524.severity = none
+
 [{*.yaml,*.yml}]
 indent_style = space
 indent_size = 2

--- a/src/NexusMods.Paths/AbsolutePath.cs
+++ b/src/NexusMods.Paths/AbsolutePath.cs
@@ -88,7 +88,7 @@ public readonly partial struct AbsolutePath : IEquatable<AbsolutePath>, IPath
         // path is not rooted
         var rootLength = GetRootLength(span);
         if (rootLength == 0)
-            throw new ArgumentException("The provided path is not rooted.", nameof(fullPath));
+            throw new ArgumentException($"The provided path is not rooted: {fullPath}", nameof(fullPath));
 
         // path is only the root directory
         if (span.Length == rootLength)

--- a/src/NexusMods.Paths/FileSystemAbstraction/BaseFileSystem.cs
+++ b/src/NexusMods.Paths/FileSystemAbstraction/BaseFileSystem.cs
@@ -1,5 +1,8 @@
+using System.Diagnostics;
 using System.Text;
 using JetBrains.Annotations;
+using NexusMods.Paths.Extensions;
+using NexusMods.Paths.HighPerformance.CommunityToolkit;
 
 namespace NexusMods.Paths;
 
@@ -11,6 +14,7 @@ namespace NexusMods.Paths;
 public abstract class BaseFileSystem : IFileSystem
 {
     private readonly Dictionary<AbsolutePath, AbsolutePath> _pathMappings = new();
+    private readonly bool _convertCrossPlatformPaths;
 
     /// <summary>
     /// Constructor.
@@ -21,9 +25,13 @@ public abstract class BaseFileSystem : IFileSystem
     /// Constructor that accepts path mappings.
     /// </summary>
     /// <param name="pathMappings"></param>
-    protected BaseFileSystem(Dictionary<AbsolutePath, AbsolutePath> pathMappings)
+    /// <param name="convertCrossPlatformPaths"></param>
+    protected BaseFileSystem(
+        Dictionary<AbsolutePath, AbsolutePath> pathMappings,
+        bool convertCrossPlatformPaths)
     {
         _pathMappings = pathMappings;
+        _convertCrossPlatformPaths = convertCrossPlatformPaths;
     }
 
     internal AbsolutePath GetMappedPath(AbsolutePath originalPath)
@@ -31,6 +39,10 @@ public abstract class BaseFileSystem : IFileSystem
         // direct mapping
         if (_pathMappings.TryGetValue(originalPath, out var mappedPath))
             return mappedPath;
+
+        // check if the path has already been mapped
+        if (_pathMappings.FirstOrDefault(kv => originalPath.InFolder(kv.Value)).Key != default)
+            return originalPath;
 
         // indirect mapping via parent directory
         var (originalParentDirectory, newParentDirectory) = _pathMappings
@@ -44,24 +56,55 @@ public abstract class BaseFileSystem : IFileSystem
         return newPath;
     }
 
+    private string ConvertCrossPlatformPath(string input)
+    {
+        if (!OperatingSystem.IsLinux()) return input;
+        if (!_convertCrossPlatformPaths) return input;
+        if (input.Length < 3) return input;
+        var inputSpan = input.AsSpan();
+        if (inputSpan.DangerousGetReferenceAt(1) != ':') return input;
+
+        var result = string.Create(
+            input.Length,
+            input,
+            (span, s) =>
+            {
+                // C:\foo\bar -> /c/foo/bar
+                var inputSpan = s.AsSpan();
+
+                span[0] = '/';
+                span[1] = char.ToLower(inputSpan.DangerousGetReferenceAt(0));
+                inputSpan.SliceFast(2).CopyTo(span.SliceFast(2));
+                span.Replace('\\', '/', span);
+            });
+
+        return result;
+    }
+
     #region IFileStream Implementation
 
     /// <inheritdoc/>
     public abstract IFileSystem CreateOverlayFileSystem(
-        Dictionary<AbsolutePath, AbsolutePath> pathMappings);
+        Dictionary<AbsolutePath, AbsolutePath> pathMappings,
+        bool convertCrossPlatformPaths = false);
 
     /// <inheritdoc/>
     public virtual AbsolutePath GetKnownPath(KnownPath knownPath)
     {
+        Debug.Assert(Enum.IsDefined(knownPath));
+
+        // NOTE(erri120): if you change this method, make sure to update the docs in the KnownPath enum.
         var path = knownPath switch
         {
             KnownPath.EntryDirectory => FromFullPath(AppContext.BaseDirectory),
             KnownPath.CurrentDirectory => FromFullPath(Environment.CurrentDirectory),
+            KnownPath.CommonApplicationDataDirectory => FromFullPath(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData)),
             KnownPath.TempDirectory => FromFullPath(Path.GetTempPath()),
             KnownPath.HomeDirectory => FromFullPath(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)),
+            KnownPath.ApplicationDataDirectory => FromFullPath(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)),
+            KnownPath.LocalApplicationDataDirectory => FromFullPath(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)),
             KnownPath.MyDocumentsDirectory => FromFullPath(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments)),
             KnownPath.MyGamesDirectory => FromDirectoryAndFileName(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "My Games"),
-            _ => throw new ArgumentOutOfRangeException(nameof(knownPath), knownPath, null)
         };
 
         return GetMappedPath(path);
@@ -69,11 +112,11 @@ public abstract class BaseFileSystem : IFileSystem
 
     /// <inheritdoc/>
     public AbsolutePath FromFullPath(string fullPath)
-        => AbsolutePath.FromFullPath(fullPath, this);
+        => GetMappedPath(AbsolutePath.FromFullPath(ConvertCrossPlatformPath(fullPath), this));
 
     /// <inheritdoc/>
     public AbsolutePath FromDirectoryAndFileName(string directoryPath, string fullPath)
-        => AbsolutePath.FromDirectoryAndFileName(directoryPath, fullPath, this);
+        => GetMappedPath(AbsolutePath.FromDirectoryAndFileName(ConvertCrossPlatformPath(directoryPath), fullPath, this));
 
     /// <inheritdoc/>
     public IFileEntry GetFileEntry(AbsolutePath path)

--- a/src/NexusMods.Paths/FileSystemAbstraction/BaseFileSystem.cs
+++ b/src/NexusMods.Paths/FileSystemAbstraction/BaseFileSystem.cs
@@ -14,6 +14,7 @@ namespace NexusMods.Paths;
 public abstract class BaseFileSystem : IFileSystem
 {
     private readonly Dictionary<AbsolutePath, AbsolutePath> _pathMappings = new();
+    private readonly bool _hasPathMappings;
     private readonly bool _convertCrossPlatformPaths;
 
     /// <summary>
@@ -31,11 +32,15 @@ public abstract class BaseFileSystem : IFileSystem
         bool convertCrossPlatformPaths)
     {
         _pathMappings = pathMappings;
+        _hasPathMappings = _pathMappings.Any();
         _convertCrossPlatformPaths = convertCrossPlatformPaths;
     }
 
     internal AbsolutePath GetMappedPath(AbsolutePath originalPath)
     {
+        // fast exit
+        if (!_hasPathMappings) return originalPath;
+
         // direct mapping
         if (_pathMappings.TryGetValue(originalPath, out var mappedPath))
             return mappedPath;

--- a/src/NexusMods.Paths/FileSystemAbstraction/IFileSystem.cs
+++ b/src/NexusMods.Paths/FileSystemAbstraction/IFileSystem.cs
@@ -12,8 +12,16 @@ public interface IFileSystem
     /// Creates a new <see cref="FileSystem"/> that allows for path mapping.
     /// </summary>
     /// <param name="pathMappings">Path mappings</param>
+    /// <param name="convertCrossPlatformPaths">
+    /// If true, this will convert
+    /// Windows paths to Linux paths: <c>C:\foo\bar</c> will become
+    /// <c>/c/foo/bar</c>. This should not be used by default, and
+    /// is only useful for mapping Windows paths into Linux, eg: for Wine.
+    /// </param>
     /// <returns></returns>
-    IFileSystem CreateOverlayFileSystem(Dictionary<AbsolutePath, AbsolutePath> pathMappings);
+    IFileSystem CreateOverlayFileSystem(
+        Dictionary<AbsolutePath, AbsolutePath> pathMappings,
+        bool convertCrossPlatformPaths = false);
 
     /// <summary>
     /// Returns a known path.

--- a/src/NexusMods.Paths/FileSystemAbstraction/InMemoryFileSystem/InMemoryFileSystem.cs
+++ b/src/NexusMods.Paths/FileSystemAbstraction/InMemoryFileSystem/InMemoryFileSystem.cs
@@ -19,9 +19,11 @@ public partial class InMemoryFileSystem : BaseFileSystem
     /// <summary>
     /// Constructor.
     /// </summary>
-    public InMemoryFileSystem() : this(new Dictionary<AbsolutePath, AbsolutePath>()) { }
+    public InMemoryFileSystem() : this(new Dictionary<AbsolutePath, AbsolutePath>(), false) { }
 
-    private InMemoryFileSystem(Dictionary<AbsolutePath, AbsolutePath> pathMappings) : base(pathMappings)
+    private InMemoryFileSystem(
+        Dictionary<AbsolutePath, AbsolutePath> pathMappings,
+        bool convertCrossPlatformPaths) : base(pathMappings, convertCrossPlatformPaths)
     {
         _rootDirectory = new InMemoryDirectoryEntry(
             AbsolutePath.FromFullPath(OperatingSystem.IsWindows() ? "C:\\" : "/"),
@@ -121,8 +123,10 @@ public partial class InMemoryFileSystem : BaseFileSystem
     #region Implementation
 
     /// <inheritdoc/>
-    public override IFileSystem CreateOverlayFileSystem(Dictionary<AbsolutePath, AbsolutePath> pathMappings)
-        => new InMemoryFileSystem(pathMappings);
+    public override IFileSystem CreateOverlayFileSystem(
+        Dictionary<AbsolutePath, AbsolutePath> pathMappings,
+        bool convertCrossPlatformPaths = false)
+        => new InMemoryFileSystem(pathMappings, convertCrossPlatformPaths);
 
     /// <inheritdoc/>
     protected override IFileEntry InternalGetFileEntry(AbsolutePath path)

--- a/src/NexusMods.Paths/FileSystemAbstraction/KnownPath.cs
+++ b/src/NexusMods.Paths/FileSystemAbstraction/KnownPath.cs
@@ -3,7 +3,8 @@ using JetBrains.Annotations;
 namespace NexusMods.Paths;
 
 /// <summary>
-/// Enum for known paths to folders and files.
+/// Enum of known directory and file paths. This should be
+/// used instead of <see cref="Environment.GetFolderPath(System.Environment.SpecialFolder)"/>.
 /// </summary>
 [PublicAPI]
 public enum KnownPath
@@ -14,6 +15,8 @@ public enum KnownPath
     /// </summary>
     /// <remarks>
     /// This is often the same as <see cref="CurrentDirectory"/>.
+    /// <see cref="BaseFileSystem"/> uses <see cref="AppContext.BaseDirectory"/>
+    /// to get this value.
     /// </remarks>
     EntryDirectory,
 
@@ -22,35 +25,170 @@ public enum KnownPath
     /// </summary>
     /// <remarks>
     /// This is often the same as <see cref="EntryDirectory"/>.
+    /// <see cref="BaseFileSystem"/> uses <see cref="Environment.CurrentDirectory"/>
+    /// to get this value.
     /// </remarks>
     CurrentDirectory,
 
     /// <summary>
-    /// The current user's temporary folder.
+    /// The directory that serves as a common repository for application-specific
+    /// data that is used by all users.
+    /// <list type="table">
+    ///     <listheader>
+    ///         <term>OS</term>
+    ///         <description>Path</description>
+    ///     </listheader>
+    ///     <item>
+    ///         <term>Windows</term>
+    ///         <description>
+    ///             (CSIDL_COMMON_APPDATA) ProgramData folder <c>%ALLUSERSPROFILE%</c>
+    ///             (<c>%ProgramData%"</c>, <c>%SystemDrive%\ProgramData</c>)
+    ///         </description>
+    ///     </item>
+    ///     <item>
+    ///         <term>Linux</term>
+    ///         <description><c>/usr/share</c></description>
+    ///     </item>
+    /// </list>
     /// </summary>
+    /// <remarks>
+    /// <see cref="BaseFileSystem"/> uses <see cref="Environment.GetFolderPath(System.Environment.SpecialFolder)"/>
+    /// with <see cref="Environment.SpecialFolder.CommonApplicationData"/> to get this value.
+    /// </remarks>
+    CommonApplicationDataDirectory,
+
+    /// <summary>
+    /// The current user's temporary folder. On Linux:
+    /// <list type="number">
+    ///     <item>The path specified by the <c>TMPDIR</c> environment variable.</item>
+    ///     <item>The path <c>/tmp</c>.</item>
+    /// </list>
+    /// On Windows:
+    /// <list type="number">
+    ///     <item>The path specified by the <c>TMP</c> environment variable.</item>
+    ///     <item>The path specified by the <c>TEMP</c> environment variable.</item>
+    ///     <item>The path specified by the <c>USERPROFILE</c> environment variable.</item>
+    ///     <item>The Windows directory.</item>
+    /// </list>
+    /// </summary>
+    /// <remarks>
+    /// <see cref="BaseFileSystem"/> uses <see cref="Path.GetTempPath"/> to get this value.
+    /// </remarks>
     TempDirectory,
 
     /// <summary>
     /// The user's profile folder.
+    /// <list type="table">
+    ///     <listheader>
+    ///         <term>OS</term>
+    ///         <description>Path</description>
+    ///     </listheader>
+    ///     <item>
+    ///         <term>Windows</term>
+    ///         <description>
+    ///             (CSIDL_PROFILE) The root users profile folder <c>%USERPROFILE%</c>
+    ///             (<c>%SystemDrive%\Users\%USERNAME%</c>)
+    ///         </description>
+    ///     </item>
+    ///     <item>
+    ///         <term>Linux</term>
+    ///         <description><c>$HOME</c> or <c>/home/$USER</c></description>
+    ///     </item>
+    /// </list>
     /// </summary>
     /// <remarks>
-    /// On Windows, this folder is located at "%USERPROFILE%"
-    /// ("%SystemDrive%\Users\%USERNAME%"). On Linux, this folder
-    /// is located at "$HOME" ("/home/$USER").
+    /// <see cref="BaseFileSystem"/> uses <see cref="Environment.GetFolderPath(System.Environment.SpecialFolder)"/>
+    /// with <see cref="Environment.SpecialFolder.UserProfile"/> to get this value.
     /// </remarks>
     HomeDirectory,
 
     /// <summary>
-    /// Documents (My Documents) folder. On Windows, this folder is
-    /// located at "%USERPROFILE%\Documents". On Linux, this folder
-    /// is located at "$XDG_DOCUMENTS_DIR" ("/home/$USER/Documents").
+    /// The directory that serves as a common repository for application-specific data for the current roaming user. A roaming user works on more than one computer on a network.
+    /// A roaming user's profile is kept on a server on the network and is loaded onto a system when the user logs on.
+    /// <list type="table">
+    ///     <listheader>
+    ///         <term>OS</term>
+    ///         <description>Path</description>
+    ///     </listheader>
+    ///     <item>
+    ///         <term>Windows</term>
+    ///         <description>
+    ///             (CSIDL_APPDATA) Roaming user application data folder
+    ///             <c>%APPDATA%</c> (<c>%USERPROFILE%\AppData\Roaming</c>)
+    ///         </description>
+    ///     </item>
+    ///     <item>
+    ///         <term>Linux</term>
+    ///         <description><c>XDG_CONFIG_HOME</c> or <c>$HOME/.config</c></description>
+    ///     </item>
+    /// </list>
     /// </summary>
+    /// <remarks>
+    /// <see cref="BaseFileSystem"/> uses <see cref="Environment.GetFolderPath(System.Environment.SpecialFolder)"/>
+    /// with <see cref="Environment.SpecialFolder.ApplicationData"/> to get this value.
+    /// </remarks>
+    ApplicationDataDirectory,
+
+    /// <summary>
+    /// The directory that serves as a common repository for
+    /// application-specific data that is used by the current, non-roaming user.
+    /// <list type="table">
+    ///     <listheader>
+    ///         <term>OS</term>
+    ///         <description>Path</description>
+    ///     </listheader>
+    ///     <item>
+    ///         <term>Windows</term>
+    ///         <description>
+    ///             (CSIDL_LOCAL_APPDATA) Local folder
+    ///             <c>%LOCALAPPDATA%</c> (<c>%USERPROFILE%\AppData\Local</c>)
+    ///         </description>
+    ///     </item>
+    ///     <item>
+    ///         <term>Linux</term>
+    ///         <description><c>XDG_DATA_HOME</c> or <c>$HOME/.local/share</c></description>
+    ///     </item>
+    /// </list>
+    /// </summary>
+    /// <remarks>
+    /// <see cref="BaseFileSystem"/> uses <see cref="Environment.GetFolderPath(System.Environment.SpecialFolder)"/>
+    /// with <see cref="Environment.SpecialFolder.LocalApplicationData"/> to get this value.
+    /// </remarks>
+    LocalApplicationDataDirectory,
+
+    /// <summary>
+    /// The My Documents folder.
+    /// <list type="table">
+    ///     <listheader>
+    ///         <term>OS</term>
+    ///         <description>Path</description>
+    ///     </listheader>
+    ///     <item>
+    ///         <term>Windows</term>
+    ///         <description>
+    ///             (CSIDL_MYDOCUMENTS, CSIDL_PERSONAL) Documents (My Documents) folder
+    ///             <c>%USERPROFILE%\Documents</c>
+    ///         </description>
+    ///     </item>
+    ///     <item>
+    ///         <term>Linux</term>
+    ///         <description><c>XDG_DOCUMENTS_DIR</c> or <c>$HOME/Documents</c></description>
+    ///     </item>
+    /// </list>
+    /// </summary>
+    /// <remarks>
+    /// <see cref="BaseFileSystem"/> uses <see cref="Environment.GetFolderPath(System.Environment.SpecialFolder)"/>
+    /// with <see cref="Environment.SpecialFolder.MyDocuments"/> to get this value.
+    /// </remarks>
     MyDocumentsDirectory,
 
     /// <summary>
-    /// The <c>My Games</c> folder, relative to <see cref="HomeDirectory"/>.
-    /// Note: While many games like to use this folder, it is not a special
-    /// folder and doesn't have a CSID.
+    /// The <c>My Games</c> folder, relative to <see cref="MyDocumentsDirectory"/>.
     /// </summary>
+    /// <remarks>
+    /// While many games like to use this folder, it is not a special folder
+    /// and doesn't have a CSID. <see cref="BaseFileSystem"/> simply combines
+    /// <see cref="MyDocumentsDirectory"/> with <c>My Games</c>.
+    /// </remarks>
     MyGamesDirectory,
 }

--- a/src/NexusMods.Paths/FileSystemAbstraction/RealFileSystem/FileSystem.cs
+++ b/src/NexusMods.Paths/FileSystemAbstraction/RealFileSystem/FileSystem.cs
@@ -24,11 +24,15 @@ public partial class FileSystem : BaseFileSystem
 
     #region Implementation
 
-    internal FileSystem(Dictionary<AbsolutePath, AbsolutePath> pathMappings) : base(pathMappings) { }
+    internal FileSystem(
+        Dictionary<AbsolutePath, AbsolutePath> pathMappings,
+        bool convertCrossPlatformPaths) : base(pathMappings, convertCrossPlatformPaths) { }
 
     /// <inheritdoc/>
-    public override IFileSystem CreateOverlayFileSystem(Dictionary<AbsolutePath, AbsolutePath> pathMappings)
-        => new FileSystem(pathMappings);
+    public override IFileSystem CreateOverlayFileSystem(
+        Dictionary<AbsolutePath, AbsolutePath> pathMappings,
+        bool convertCrossPlatformPaths = false)
+        => new FileSystem(pathMappings, convertCrossPlatformPaths);
 
     /// <inheritdoc/>
     protected override IFileEntry InternalGetFileEntry(AbsolutePath path)

--- a/tests/NexusMods.Paths.Tests/FileSystem/BaseFileSystemTests.cs
+++ b/tests/NexusMods.Paths.Tests/FileSystem/BaseFileSystemTests.cs
@@ -35,7 +35,6 @@ public class BaseFileSystemTests
     [SkippableTheory, AutoFileSystem]
     public async Task Test_ReadAllBytesAsync(InMemoryFileSystem fs, AbsolutePath path, byte[] contents)
     {
-        Skip.IfNot(OperatingSystem.IsLinux());
         fs.AddFile(path, contents);
         var result = await fs.ReadAllBytesAsync(path);
         result.Should().BeEquivalentTo(contents);
@@ -44,9 +43,23 @@ public class BaseFileSystemTests
     [SkippableTheory, AutoFileSystem]
     public async Task Test_ReadAllTextAsync(InMemoryFileSystem fs, AbsolutePath path, string contents)
     {
-        Skip.IfNot(OperatingSystem.IsLinux());
         fs.AddFile(path, contents);
         var result = await fs.ReadAllTextAsync(path);
         result.Should().BeEquivalentTo(contents);
+    }
+
+    [SkippableTheory]
+    [InlineData("C:\\", "/c")]
+    [InlineData("C:\\foo\\bar", "/c/foo/bar")]
+    public void Test_ConvertCrossPlatformPath(string input, string output)
+    {
+        Skip.IfNot(OperatingSystem.IsLinux());
+
+        var fs = new InMemoryFileSystem().CreateOverlayFileSystem(
+            new Dictionary<AbsolutePath, AbsolutePath>(),
+            true);
+
+        var path = fs.FromFullPath(input);
+        path.GetFullPath().Should().Be(output);
     }
 }


### PR DESCRIPTION
`BaseFileSystem` will can now convert a Windows path to a Linux path when configured to do so. This is only useful for Wine mappings and is disabled by default.