### PR TITLE
More KnownPaths and Wine mappings

### DIFF
--- a/src/NexusMods.Paths/AbsolutePath.cs
+++ b/src/NexusMods.Paths/AbsolutePath.cs
@@ -88,7 +88,7 @@ public readonly partial struct AbsolutePath : IEquatable<AbsolutePath>, IPath
         // path is not rooted
         var rootLength = GetRootLength(span);
         if (rootLength == 0)
-            throw new ArgumentException($"The provided path is not rooted: {fullPath}", nameof(fullPath));
+            throw new ArgumentException($"The provided path is not rooted: \"{fullPath}\"", nameof(fullPath));
 
         // path is only the root directory
         if (span.Length == rootLength)

--- a/src/NexusMods.Paths/FileSystemAbstraction/BaseFileSystem.cs
+++ b/src/NexusMods.Paths/FileSystemAbstraction/BaseFileSystem.cs
@@ -108,12 +108,23 @@ public abstract class BaseFileSystem : IFileSystem
     {
         Debug.Assert(Enum.IsDefined(knownPath));
 
+        AbsolutePath ThisOrDefault(string fullPath)
+        {
+            return string.IsNullOrWhiteSpace(fullPath) ? default : FromFullPath(fullPath);
+        }
+
         // NOTE(erri120): if you change this method, make sure to update the docs in the KnownPath enum.
         var path = knownPath switch
         {
             KnownPath.EntryDirectory => FromFullPath(AppContext.BaseDirectory),
             KnownPath.CurrentDirectory => FromFullPath(Environment.CurrentDirectory),
+
             KnownPath.CommonApplicationDataDirectory => FromFullPath(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData)),
+            KnownPath.ProgramFilesDirectory => ThisOrDefault(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles)),
+            KnownPath.ProgramFilesX86Directory => ThisOrDefault(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86)),
+            KnownPath.CommonProgramFilesDirectory => ThisOrDefault(Environment.GetFolderPath(Environment.SpecialFolder.CommonProgramFiles)),
+            KnownPath.CommonProgramFilesX86Directory => ThisOrDefault(Environment.GetFolderPath(Environment.SpecialFolder.CommonProgramFilesX86)),
+
             KnownPath.TempDirectory => FromFullPath(Path.GetTempPath()),
             KnownPath.HomeDirectory => FromFullPath(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)),
             KnownPath.ApplicationDataDirectory => FromFullPath(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)),

--- a/src/NexusMods.Paths/FileSystemAbstraction/IFileSystem.cs
+++ b/src/NexusMods.Paths/FileSystemAbstraction/IFileSystem.cs
@@ -26,6 +26,10 @@ public interface IFileSystem
     /// <summary>
     /// Returns a known path.
     /// </summary>
+    /// <remarks>
+    /// The return value can be <c>default</c>, if <see cref="KnownPath"/>
+    /// is invalid on the current platform.
+    /// </remarks>
     /// <param name="knownPath"></param>
     /// <returns></returns>
     AbsolutePath GetKnownPath(KnownPath knownPath);

--- a/src/NexusMods.Paths/FileSystemAbstraction/KnownPath.cs
+++ b/src/NexusMods.Paths/FileSystemAbstraction/KnownPath.cs
@@ -58,6 +58,108 @@ public enum KnownPath
     CommonApplicationDataDirectory,
 
     /// <summary>
+    /// The program files directory.
+    /// <list type="table">
+    ///     <listheader>
+    ///         <term>OS</term>
+    ///         <description>Path</description>
+    ///     </listheader>
+    ///     <item>
+    ///         <term>Windows</term>
+    ///         <description>
+    ///             (CSIDL_PROGRAM_FILES) Program Files folder for the current process architecture
+    ///             <c>%ProgramFiles%</c> (<c>%SystemDrive%\Program Files</c>)
+    ///         </description>
+    ///     </item>
+    ///     <item>
+    ///         <term>Linux</term>
+    ///         <description>This folder doesn't exist on Linux!</description>
+    ///     </item>
+    /// </list>
+    /// </summary>
+    /// <remarks>
+    /// <see cref="BaseFileSystem"/> uses <see cref="Environment.GetFolderPath(System.Environment.SpecialFolder)"/>
+    /// with <see cref="Environment.SpecialFolder.ProgramFiles"/> to get this value.
+    /// </remarks>
+    ProgramFilesDirectory,
+
+    /// <summary>
+    /// The 32 bit Program Files directory.
+    /// <list type="table">
+    ///     <listheader>
+    ///         <term>OS</term>
+    ///         <description>Path</description>
+    ///     </listheader>
+    ///     <item>
+    ///         <term>Windows</term>
+    ///         <description>
+    ///             (CSIDL_PROGRAM_FILESX86) 32 bit Program Files folder (available to both 32/64 bit processes)
+    ///         </description>
+    ///     </item>
+    ///     <item>
+    ///         <term>Linux</term>
+    ///         <description>This folder doesn't exist on Linux!</description>
+    ///     </item>
+    /// </list>
+    /// </summary>
+    /// <remarks>
+    /// <see cref="BaseFileSystem"/> uses <see cref="Environment.GetFolderPath(System.Environment.SpecialFolder)"/>
+    /// with <see cref="Environment.SpecialFolder.ProgramFilesX86"/> to get this value.
+    /// </remarks>
+    ProgramFilesX86Directory,
+
+    /// <summary>
+    /// The directory for components that are shared across applications.
+    /// <list type="table">
+    ///     <listheader>
+    ///         <term>OS</term>
+    ///         <description>Path</description>
+    ///     </listheader>
+    ///     <item>
+    ///         <term>Windows</term>
+    ///         <description>
+    ///             (CSIDL_PROGRAM_FILES_COMMON) Common Program Files folder for the current process architecture
+    ///             <c>%ProgramFiles%\Common Files</c>
+    ///         </description>
+    ///     </item>
+    ///     <item>
+    ///         <term>Linux</term>
+    ///         <description>This folder doesn't exist on Linux!</description>
+    ///     </item>
+    /// </list>
+    /// </summary>
+    /// <remarks>
+    /// <see cref="BaseFileSystem"/> uses <see cref="Environment.GetFolderPath(System.Environment.SpecialFolder)"/>
+    /// with <see cref="Environment.SpecialFolder.CommonProgramFiles"/> to get this value.
+    /// </remarks>
+    CommonProgramFilesDirectory,
+
+    /// <summary>
+    /// The directory for components that are shared across applications.
+    /// <list type="table">
+    ///     <listheader>
+    ///         <term>OS</term>
+    ///         <description>Path</description>
+    ///     </listheader>
+    ///     <item>
+    ///         <term>Windows</term>
+    ///         <description>
+    ///             (CSIDL_PROGRAM_FILES_COMMONX86) Common 32 bit Program Files folder (available to both 32/64 bit processes)
+    ///         </description>
+    ///     </item>
+    ///     <item>
+    ///         <term>Linux</term>
+    ///         <description>This folder doesn't exist on Linux!</description>
+    ///     </item>
+    /// </list>
+    /// </summary>
+    /// <remarks>
+    /// <see cref="BaseFileSystem"/> uses <see cref="Environment.GetFolderPath(System.Environment.SpecialFolder)"/>
+    /// with <see cref="Environment.SpecialFolder.CommonProgramFilesX86"/> to get this value.
+    /// </remarks>
+    CommonProgramFilesX86Directory,
+
+    /// <summary>
     /// The current user's temporary folder. On Linux:
     /// <list type="number">
     ///     <item>The path specified by the <c>TMPDIR</c> environment variable.</item>


### PR DESCRIPTION
I originally had `CreateWinePathMappings` in GameFinder, however it would be hard to update, so I decided to put it inside `BaseFileSystem` instead.