### PR TITLE
Add helpers for game testing

### DIFF
--- a/NexusMods.App.sln
+++ b/NexusMods.App.sln
@@ -103,6 +103,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NexusMods.Games.FOMOD.Tests
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NexusMods.Games.TestFramework", "tests\Games\NexusMods.Games.TestFramework\NexusMods.Games.TestFramework.csproj", "{F9332FAE-1B43-413B-BEA0-780694B77310}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NexusMods.Games.DarkestDungeon.Tests", "tests\Games\NexusMods.Games.DarkestDungeon.Tests\NexusMods.Games.DarkestDungeon.Tests.csproj", "{3DBB08FF-9542-4086-890B-253572C11CFA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -257,6 +259,10 @@ Global
 		{F9332FAE-1B43-413B-BEA0-780694B77310}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F9332FAE-1B43-413B-BEA0-780694B77310}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F9332FAE-1B43-413B-BEA0-780694B77310}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3DBB08FF-9542-4086-890B-253572C11CFA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3DBB08FF-9542-4086-890B-253572C11CFA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3DBB08FF-9542-4086-890B-253572C11CFA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3DBB08FF-9542-4086-890B-253572C11CFA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -292,6 +298,7 @@ Global
 		{B43A31B2-1F08-4D8E-9C45-48015FBA983E} = {B95A2142-2872-4FFD-BAB2-596373401461}
 		{678D0CB7-EA46-4DF2-8C91-E77EA2270C48} = {B95A2142-2872-4FFD-BAB2-596373401461}
 		{F9332FAE-1B43-413B-BEA0-780694B77310} = {B95A2142-2872-4FFD-BAB2-596373401461}
+		{3DBB08FF-9542-4086-890B-253572C11CFA} = {B95A2142-2872-4FFD-BAB2-596373401461}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9F9F8352-34DD-42C0-8564-EE9AF34A3501}

--- a/NexusMods.App.sln
+++ b/NexusMods.App.sln
@@ -101,6 +101,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NexusMods.Games.FOMOD", "sr
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NexusMods.Games.FOMOD.Tests", "tests\Games\NexusMods.Games.FOMOD.Tests\NexusMods.Games.FOMOD.Tests.csproj", "{678D0CB7-EA46-4DF2-8C91-E77EA2270C48}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NexusMods.Games.TestFramework", "tests\Games\NexusMods.Games.TestFramework\NexusMods.Games.TestFramework.csproj", "{F9332FAE-1B43-413B-BEA0-780694B77310}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -251,6 +253,10 @@ Global
 		{678D0CB7-EA46-4DF2-8C91-E77EA2270C48}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{678D0CB7-EA46-4DF2-8C91-E77EA2270C48}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{678D0CB7-EA46-4DF2-8C91-E77EA2270C48}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F9332FAE-1B43-413B-BEA0-780694B77310}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F9332FAE-1B43-413B-BEA0-780694B77310}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F9332FAE-1B43-413B-BEA0-780694B77310}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F9332FAE-1B43-413B-BEA0-780694B77310}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -285,6 +291,7 @@ Global
 		{F9107626-3380-4472-B17F-D5B54C5CEB2D} = {B93AF89E-9ED7-4FD0-B58E-688AA178AB53}
 		{B43A31B2-1F08-4D8E-9C45-48015FBA983E} = {B95A2142-2872-4FFD-BAB2-596373401461}
 		{678D0CB7-EA46-4DF2-8C91-E77EA2270C48} = {B95A2142-2872-4FFD-BAB2-596373401461}
+		{F9332FAE-1B43-413B-BEA0-780694B77310} = {B95A2142-2872-4FFD-BAB2-596373401461}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9F9F8352-34DD-42C0-8564-EE9AF34A3501}

--- a/tests/Games/NexusMods.Games.BethesdaGameStudios.Tests/NexusMods.Games.BethesdaGameStudios.Tests.csproj
+++ b/tests/Games/NexusMods.Games.BethesdaGameStudios.Tests/NexusMods.Games.BethesdaGameStudios.Tests.csproj
@@ -1,19 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+    
     <PropertyGroup>
         <XunitStartupAssembly>NexusMods.Games.BethesdaGameStudios.Tests</XunitStartupAssembly>
     </PropertyGroup>
     
     <ItemGroup>
-      <ProjectReference Include="..\..\..\src\Games\NexusMods.Games.BethesdaGameStudios\NexusMods.Games.BethesdaGameStudios.csproj" />
-      <ProjectReference Include="..\..\..\src\NexusMods.StandardGameLocators\NexusMods.StandardGameLocators.csproj" />
-      <ProjectReference Include="..\..\NexusMods.StandardGameLocators.TestHelpers\NexusMods.StandardGameLocators.TestHelpers.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <PackageReference Update="FluentAssertions" Version="6.10.0" />
-      <PackageReference Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-      <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+        <ProjectReference Include="..\..\..\src\Games\NexusMods.Games.BethesdaGameStudios\NexusMods.Games.BethesdaGameStudios.csproj" />
+        <ProjectReference Include="..\..\..\src\NexusMods.StandardGameLocators\NexusMods.StandardGameLocators.csproj" />
+        <ProjectReference Include="..\..\NexusMods.StandardGameLocators.TestHelpers\NexusMods.StandardGameLocators.TestHelpers.csproj" />
+        <ProjectReference Include="..\NexusMods.Games.TestFramework\NexusMods.Games.TestFramework.csproj" />
     </ItemGroup>
 
     <Target Name="CopyResources" AfterTargets="PostBuildEvent">

--- a/tests/Games/NexusMods.Games.BethesdaGameStudios.Tests/Startup.cs
+++ b/tests/Games/NexusMods.Games.BethesdaGameStudios.Tests/Startup.cs
@@ -5,6 +5,7 @@ using NexusMods.DataModel;
 using NexusMods.DataModel.RateLimiting;
 using NexusMods.FileExtractor;
 using NexusMods.FileExtractor.Extractors;
+using NexusMods.Games.TestFramework;
 using NexusMods.Paths;
 using NexusMods.Paths.Utilities;
 using NexusMods.StandardGameLocators.TestHelpers;
@@ -17,24 +18,11 @@ public class Startup
 {
     public void ConfigureServices(IServiceCollection services)
     {
-        var prefix = KnownFolders.EntryFolder.CombineUnchecked("DataModel")
-            .CombineUnchecked(Guid.NewGuid().ToString());
-
-        services.AddUniversalGameLocator<SkyrimSpecialEdition>(new Version("1.6.659.0"))
-                .AddBethesdaGameStudios()
-
-                .AddLogging(builder => builder.SetMinimumLevel(LogLevel.Debug))
-                .AddDataModel(new DataModelSettings(prefix))
-                .AddAllSingleton<IResource, IResource<FileContentsCache, Size>>(_ =>
-                    new Resource<FileContentsCache, Size>("File Analysis"))
-                .AddAllSingleton<IResource, IResource<IExtractor, Size>>(_ =>
-                    new Resource<IExtractor, Size>("File Extraction"))
-                .AddFileExtractors(new FileExtractorSettings())
-
-                .AddSingleton<TemporaryFileManager>(_ =>
-                    new TemporaryFileManager(
-                        KnownFolders.EntryFolder.CombineUnchecked("tempFiles")))
-                .Validate();
+        services
+            .AddDefaultServicesForTesting()
+            .AddUniversalGameLocator<SkyrimSpecialEdition>(new Version("1.6.659.0"))
+            .AddBethesdaGameStudios()
+            .Validate();
     }
 
     public void Configure(ILoggerFactory loggerFactory, ITestOutputHelperAccessor accessor) =>

--- a/tests/Games/NexusMods.Games.DarkestDungeon.Tests/DarkestDungeonModInstallerTests.cs
+++ b/tests/Games/NexusMods.Games.DarkestDungeon.Tests/DarkestDungeonModInstallerTests.cs
@@ -1,0 +1,26 @@
+using FluentAssertions;
+using NexusMods.Games.TestFramework;
+using NexusMods.Hashing.xxHash64;
+using NexusMods.Networking.NexusWebApi.Types;
+
+namespace NexusMods.Games.DarkestDungeon.Tests;
+
+[Trait("RequiresNetworking", "True")]
+public class DarkestDungeonModInstallerTests : AModInstallerTest<DarkestDungeon, DarkestDungeonModInstaller>
+{
+    public DarkestDungeonModInstallerTests(IServiceProvider serviceProvider) : base(serviceProvider) { }
+
+    [Fact]
+    public async Task Test_ModInstaller()
+    {
+        // Marvin Seo's Lamia Class Mod: Lamia Main File (Version 1.03)
+        var (file, hash) = await DownloadModAsync(Game.Domain, ModId.From(501), FileId.From(2705));
+        hash.Should().Be(Hash.From(0x34C32E580205FC36));
+
+        await using (file)
+        {
+            var filesToExtract = await GetFilesToExtractFromInstaller(file.Path);
+            filesToExtract.Should().HaveCount(181);
+        }
+    }
+}

--- a/tests/Games/NexusMods.Games.DarkestDungeon.Tests/NexusMods.Games.DarkestDungeon.Tests.csproj
+++ b/tests/Games/NexusMods.Games.DarkestDungeon.Tests/NexusMods.Games.DarkestDungeon.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+    <PropertyGroup>
+        <XunitStartupAssembly>NexusMods.Games.DarkestDungeon.Tests</XunitStartupAssembly>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\src\Games\NexusMods.Games.DarkestDungeon\NexusMods.Games.DarkestDungeon.csproj" />
+        <ProjectReference Include="..\NexusMods.Games.TestFramework\NexusMods.Games.TestFramework.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/Games/NexusMods.Games.DarkestDungeon.Tests/Startup.cs
+++ b/tests/Games/NexusMods.Games.DarkestDungeon.Tests/Startup.cs
@@ -1,0 +1,25 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NexusMods.Common;
+using NexusMods.Games.TestFramework;
+using NexusMods.StandardGameLocators.TestHelpers;
+using Xunit.DependencyInjection;
+using Xunit.DependencyInjection.Logging;
+
+namespace NexusMods.Games.DarkestDungeon.Tests;
+
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection container)
+    {
+        container
+            .AddDefaultServicesForTesting()
+            .AddUniversalGameLocator<DarkestDungeon>(new Version())
+            .AddDarkestDungeon()
+            .Validate();
+    }
+
+    // ReSharper disable once UnusedMember.Global
+    public void Configure(ILoggerFactory loggerFactory, ITestOutputHelperAccessor accessor) =>
+        loggerFactory.AddProvider(new XunitTestOutputLoggerProvider(accessor, delegate { return true;}));
+}

--- a/tests/Games/NexusMods.Games.DarkestDungeon.Tests/Usings.cs
+++ b/tests/Games/NexusMods.Games.DarkestDungeon.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/Games/NexusMods.Games.FOMOD.Tests/NexusMods.Games.FOMOD.Tests.csproj
+++ b/tests/Games/NexusMods.Games.FOMOD.Tests/NexusMods.Games.FOMOD.Tests.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
     <PropertyGroup>
         <XunitStartupAssembly>NexusMods.Games.FOMOD.Tests</XunitStartupAssembly>
@@ -8,16 +9,7 @@
       <ProjectReference Include="..\..\..\src\Games\NexusMods.Games.FOMOD\NexusMods.Games.FOMOD.csproj" />
       <ProjectReference Include="..\..\..\src\NexusMods.App\NexusMods.App.csproj" />
       <ProjectReference Include="..\..\..\src\NexusMods.Paths.TestingHelpers\NexusMods.Paths.TestingHelpers.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <PackageReference Update="FluentAssertions" Version="6.10.0" />
-        <PackageReference Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-        <PackageReference Include="FluentAssertions" Version="6.10.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-        <PackageReference Include="Moq" Version="4.18.4" />
-        <PackageReference Include="Xunit.DependencyInjection" Version="8.7.0" />
-        <PackageReference Include="Xunit.DependencyInjection.Logging" Version="8.0.1" />
+      <ProjectReference Include="..\NexusMods.Games.TestFramework\NexusMods.Games.TestFramework.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/Games/NexusMods.Games.FOMOD.Tests/Startup.cs
+++ b/tests/Games/NexusMods.Games.FOMOD.Tests/Startup.cs
@@ -1,10 +1,12 @@
 ﻿using FomodInstaller.Interface;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using NexusMods.Common;
 using NexusMods.DataModel;
 using NexusMods.DataModel.RateLimiting;
 using NexusMods.FileExtractor;
 using NexusMods.FileExtractor.Extractors;
+using NexusMods.Games.TestFramework;
 using NexusMods.Paths;
 using Xunit.DependencyInjection;
 using Xunit.DependencyInjection.Logging;
@@ -16,16 +18,10 @@ public class Startup
     public void ConfigureServices(IServiceCollection container)
     {
         container
-            .AddLogging(builder => builder.SetMinimumLevel(LogLevel.Debug))
-            .AddDataModel(new DataModelSettings(FileSystem.Shared.GetKnownPath(KnownPath.EntryDirectory).CombineUnchecked("FomodTests")))
-            .AddFileExtractors()
+            .AddDefaultServicesForTesting()
             .AddFomod()
-            .AddSingleton<TemporaryFileManager>()
-            .AddSingleton<IResource<IExtractor, Size>>(_ => new Resource<IExtractor, Size>("File Extraction"))
-            .AddSingleton<IResource<FileContentsCache, Size>>(_ => new Resource<FileContentsCache, Size>("Dummy Contents Cache"))
-            .AddSingleton<IResource<FileHashCache, Size>>(_ => new Resource<FileHashCache, Size>("Dummy Hash Cache"))
-            .AddSingleton<FileExtractor.FileExtractor>()
-            .AddSingleton<ICoreDelegates, MockDelegates>();
+            .AddSingleton<ICoreDelegates, MockDelegates>()
+            .Validate();
     }
 
     // ReSharper disable once UnusedMember.Global

--- a/tests/Games/NexusMods.Games.RedEngine.Tests/NexusMods.Games.RedEngine.Tests.csproj
+++ b/tests/Games/NexusMods.Games.RedEngine.Tests/NexusMods.Games.RedEngine.Tests.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+    
     <PropertyGroup>
         <XunitStartupAssembly>NexusMods.Games.RedEngine.Tests</XunitStartupAssembly>
     </PropertyGroup>
@@ -11,12 +12,7 @@
       <ProjectReference Include="..\..\..\src\NexusMods.StandardGameLocators\NexusMods.StandardGameLocators.csproj" />
       <ProjectReference Include="..\..\..\src\Games\NexusMods.Games.TestHarness\NexusMods.Games.TestHarness.csproj" />
       <ProjectReference Include="..\..\NexusMods.StandardGameLocators.TestHelpers\NexusMods.StandardGameLocators.TestHelpers.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <PackageReference Update="FluentAssertions" Version="6.10.0" />
-      <PackageReference Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-      <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+      <ProjectReference Include="..\NexusMods.Games.TestFramework\NexusMods.Games.TestFramework.csproj" />
     </ItemGroup>
 
     <Target Name="CopyResources" AfterTargets="PostBuildEvent">

--- a/tests/Games/NexusMods.Games.RedEngine.Tests/RedModInfoAnalyzerTests.cs
+++ b/tests/Games/NexusMods.Games.RedEngine.Tests/RedModInfoAnalyzerTests.cs
@@ -1,0 +1,27 @@
+using FluentAssertions;
+using NexusMods.Games.RedEngine.FileAnalyzers;
+using NexusMods.Games.TestFramework;
+using NexusMods.Paths;
+
+namespace NexusMods.Games.RedEngine.Tests;
+
+public class RedModInfoAnalyzerTests : AFileAnalyzerTest<Cyberpunk2077, RedModInfoAnalyzer>
+{
+    public RedModInfoAnalyzerTests(IServiceProvider serviceProvider) : base(serviceProvider) { }
+
+    [Theory]
+    [InlineData("foo")]
+    public async Task Test_FileAnalyzer(string name)
+    {
+        var contents = $@"{{ ""name"": ""{name}"" }}";
+
+        await using var file = await CreateTestFile(contents, new Extension(".json"));
+        var res = await AnalyzeFile(file.Path);
+        res
+            .Should().ContainSingle()
+            .Which
+            .Should().BeOfType<RedModInfo>()
+            .Which.Name
+            .Should().Be(name);
+    }
+}

--- a/tests/Games/NexusMods.Games.RedEngine.Tests/Startup.cs
+++ b/tests/Games/NexusMods.Games.RedEngine.Tests/Startup.cs
@@ -1,14 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NexusMods.Common;
-using NexusMods.DataModel;
-using NexusMods.DataModel.RateLimiting;
-using NexusMods.FileExtractor;
-using NexusMods.FileExtractor.Extractors;
-using NexusMods.Networking.HttpDownloader;
-using NexusMods.Networking.NexusWebApi;
-using NexusMods.Paths;
-using NexusMods.Paths.Utilities;
+using NexusMods.Games.TestFramework;
 using NexusMods.StandardGameLocators.TestHelpers;
 using Xunit.DependencyInjection;
 using Xunit.DependencyInjection.Logging;
@@ -19,24 +12,11 @@ public class Startup
 {
     public void ConfigureServices(IServiceCollection container)
     {
-        var prefix = KnownFolders.EntryFolder.CombineUnchecked("DataModel").CombineUnchecked(Guid.NewGuid().ToString());
-        container.AddUniversalGameLocator<Cyberpunk2077>(new Version("1.61"))
-                 .AddRedEngineGames()
-                 .AddNexusWebApi(true)
-                 .AddHttpDownloader()
-
-                 .AddSingleton<HttpClient>()
-                 .AddLogging(builder => builder.SetMinimumLevel(LogLevel.Debug))
-                 .AddDataModel(new DataModelSettings(prefix))
-                 .AddAllSingleton<IResource, IResource<FileContentsCache, Size>>(_ =>
-            new Resource<FileContentsCache, Size>("File Analysis"))
-                 .AddAllSingleton<IResource, IResource<IExtractor, Size>>(_ =>
-            new Resource<IExtractor, Size>("File Extraction"))
-                 .AddFileExtractors(new FileExtractorSettings())
-
-                 .AddSingleton<TemporaryFileManager>(_ =>
-            new TemporaryFileManager(KnownFolders.EntryFolder.CombineUnchecked("tempFiles")))
-                 .Validate();
+        container
+            .AddDefaultServicesForTesting()
+            .AddUniversalGameLocator<Cyberpunk2077>(new Version("1.61"))
+            .AddRedEngineGames()
+            .Validate();
     }
 
     public void Configure(ILoggerFactory loggerFactory, ITestOutputHelperAccessor accessor) =>

--- a/tests/Games/NexusMods.Games.TestFramework/AFileAnalyzerTest.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/AFileAnalyzerTest.cs
@@ -1,0 +1,42 @@
+using JetBrains.Annotations;
+using NexusMods.DataModel.Abstractions;
+using NexusMods.DataModel.Games;
+using NexusMods.Paths;
+
+namespace NexusMods.Games.TestFramework;
+
+[PublicAPI]
+public class AFileAnalyzerTest<TGame, TFileAnalyzer> : AGameTest<TGame>
+    where TGame : AGame
+    where TFileAnalyzer : IFileAnalyzer
+{
+    protected readonly TFileAnalyzer FileAnalyzer;
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    protected AFileAnalyzerTest(IServiceProvider serviceProvider) : base(serviceProvider)
+    {
+        FileAnalyzer = serviceProvider.FindImplementationInContainer<TFileAnalyzer, IFileAnalyzer>();
+    }
+
+    /// <summary>
+    /// Uses <typeparamref name="TFileAnalyzer"/> to analyze the provided
+    /// file and returns the analysis data.
+    /// </summary>
+    /// <param name="path"></param>
+    /// <returns></returns>
+    protected async Task<IFileAnalysisData[]> AnalyzeFile(AbsolutePath path)
+    {
+        await using var stream = FileSystem.ReadFile(path);
+
+        var asyncEnumerable = FileAnalyzer.AnalyzeAsync(new FileAnalyzerInfo
+        {
+            FileName = path.FileName,
+            Stream = stream
+        });
+
+        var res = await asyncEnumerable.ToArrayAsync();
+        return res;
+    }
+}

--- a/tests/Games/NexusMods.Games.TestFramework/AGameTest.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/AGameTest.cs
@@ -1,4 +1,6 @@
+using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
+using NexusMods.DataModel.Abstractions;
 using NexusMods.DataModel.Games;
 using NexusMods.DataModel.Loadouts;
 using NexusMods.DataModel.Loadouts.Markers;
@@ -11,6 +13,7 @@ using ModId = NexusMods.Networking.NexusWebApi.Types.ModId;
 
 namespace NexusMods.Games.TestFramework;
 
+[PublicAPI]
 public abstract class AGameTest<TGame> where TGame : AGame
 {
     protected readonly IServiceProvider ServiceProvider;
@@ -19,6 +22,7 @@ public abstract class AGameTest<TGame> where TGame : AGame
 
     protected readonly TemporaryFileManager TemporaryFileManager;
     protected readonly LoadoutManager LoadoutManager;
+    protected readonly IDataStore DataStore;
 
     protected readonly Client NexusClient;
     protected readonly IHttpDownloader HttpDownloader;
@@ -31,6 +35,7 @@ public abstract class AGameTest<TGame> where TGame : AGame
 
         TemporaryFileManager = serviceProvider.GetRequiredService<TemporaryFileManager>();
         LoadoutManager = serviceProvider.GetRequiredService<LoadoutManager>();
+        DataStore = serviceProvider.GetRequiredService<IDataStore>();
 
         NexusClient = serviceProvider.GetRequiredService<Client>();
         HttpDownloader = serviceProvider.GetRequiredService<IHttpDownloader>();

--- a/tests/Games/NexusMods.Games.TestFramework/AGameTest.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/AGameTest.cs
@@ -1,4 +1,5 @@
 using System.IO.Compression;
+using System.Text;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using NexusMods.DataModel;
@@ -90,6 +91,12 @@ public abstract class AGameTest<TGame> where TGame : AGame
         return loadout.Value.Mods[modId];
     }
 
+    /// <summary>
+    /// Creates a ZIP archive using <see cref="ZipArchive"/> and returns the
+    /// <see cref="TemporaryPath"/> to it.
+    /// </summary>
+    /// <param name="filesToZip"></param>
+    /// <returns></returns>
     protected async Task<TemporaryPath> CreateTestArchive(IDictionary<RelativePath, byte[]> filesToZip)
     {
         var file = TemporaryFileManager.CreateFile();
@@ -110,4 +117,14 @@ public abstract class AGameTest<TGame> where TGame : AGame
 
         return file;
     }
+
+    protected async Task<TemporaryPath> CreateTestFile(byte[] contents, Extension? extension)
+    {
+        var file = TemporaryFileManager.CreateFile(extension);
+        await FileSystem.WriteAllBytesAsync(file.Path, contents);
+        return file;
+    }
+
+    protected Task<TemporaryPath> CreateTestFile(string contents, Extension? extension, Encoding? encoding = null)
+        => CreateTestFile((encoding ?? Encoding.UTF8).GetBytes(contents), extension);
 }

--- a/tests/Games/NexusMods.Games.TestFramework/AGameTest.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/AGameTest.cs
@@ -1,0 +1,81 @@
+using Microsoft.Extensions.DependencyInjection;
+using NexusMods.DataModel.Games;
+using NexusMods.DataModel.Loadouts;
+using NexusMods.DataModel.Loadouts.Markers;
+using NexusMods.Hashing.xxHash64;
+using NexusMods.Networking.HttpDownloader;
+using NexusMods.Networking.NexusWebApi;
+using NexusMods.Networking.NexusWebApi.Types;
+using NexusMods.Paths;
+using ModId = NexusMods.Networking.NexusWebApi.Types.ModId;
+
+namespace NexusMods.Games.TestFramework;
+
+public abstract class AGameTest<TGame> where TGame : AGame
+{
+    protected readonly IServiceProvider ServiceProvider;
+    protected readonly TGame Game;
+    protected readonly GameInstallation GameInstallation;
+
+    protected readonly TemporaryFileManager TemporaryFileManager;
+    protected readonly LoadoutManager LoadoutManager;
+
+    protected readonly Client NexusClient;
+    protected readonly IHttpDownloader HttpDownloader;
+
+    protected AGameTest(IServiceProvider serviceProvider)
+    {
+        ServiceProvider = serviceProvider;
+        Game = serviceProvider.FindImplementationInContainer<TGame, IGame>();
+        GameInstallation = Game.Installations.First();
+
+        TemporaryFileManager = serviceProvider.GetRequiredService<TemporaryFileManager>();
+        LoadoutManager = serviceProvider.GetRequiredService<LoadoutManager>();
+
+        NexusClient = serviceProvider.GetRequiredService<Client>();
+        HttpDownloader = serviceProvider.GetRequiredService<IHttpDownloader>();
+    }
+
+    /// <summary>
+    /// Creates a new loadout and returns the <see cref="LoadoutMarker"/> of it.
+    /// </summary>
+    /// <returns></returns>
+    protected async Task<LoadoutMarker> CreateLoadout()
+    {
+        var loadout = await LoadoutManager.ManageGameAsync(GameInstallation, Guid.NewGuid().ToString("N"));
+        return loadout;
+    }
+
+    /// <summary>
+    /// Downloads a mod and returns the <see cref="TemporaryPath"/> and <see cref="Hash"/> of it.
+    /// </summary>
+    /// <param name="gameDomain"></param>
+    /// <param name="modId"></param>
+    /// <param name="fileId"></param>
+    /// <returns></returns>
+    protected async Task<(TemporaryPath file, Hash downloadHash)> DownloadModAsync(GameDomain gameDomain, ModId modId, FileId fileId)
+    {
+        var links = await NexusClient.DownloadLinks(gameDomain, modId, fileId);
+        var file = TemporaryFileManager.CreateFile();
+
+        var downloadHash = await HttpDownloader.DownloadAsync(
+            links.Data.Select(u => new HttpRequestMessage(HttpMethod.Get, u.Uri)).ToArray(),
+            file
+        );
+
+        return (file, downloadHash);
+    }
+
+    /// <summary>
+    /// Installs a mod into the loadout and returns the <see cref="Mod"/> of it.
+    /// </summary>
+    /// <param name="loadout"></param>
+    /// <param name="path"></param>
+    /// <param name="modName"></param>
+    /// <returns></returns>
+    protected async Task<Mod> InstallModIntoLoadoutAsync(LoadoutMarker loadout, AbsolutePath path, string? modName = null)
+    {
+        var modId = await loadout.InstallModAsync(path, modName ?? Guid.NewGuid().ToString("N"));
+        return loadout.Value.Mods[modId];
+    }
+}

--- a/tests/Games/NexusMods.Games.TestFramework/AModInstallerTest.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/AModInstallerTest.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.DependencyInjection;
+using NexusMods.DataModel;
+using NexusMods.DataModel.Games;
+using NexusMods.DataModel.Loadouts.Markers;
+using NexusMods.DataModel.ModInstallers;
+using NexusMods.Paths;
+
+namespace NexusMods.Games.TestFramework;
+
+public abstract class AModInstallerTest<TGame, TModInstaller> : AGameTest<TGame>
+    where TGame : AGame
+    where TModInstaller : IModInstaller
+{
+    protected readonly TModInstaller ModInstaller;
+
+    protected readonly FileContentsCache FileContentsCache;
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    protected AModInstallerTest(IServiceProvider serviceProvider) : base(serviceProvider)
+    {
+        ModInstaller = serviceProvider.FindImplementationInContainer<TModInstaller, IModInstaller>();
+
+        FileContentsCache = serviceProvider.GetRequiredService<FileContentsCache>();
+    }
+
+    protected async Task InstallModWithInstaller(AbsolutePath path)
+    {
+        // LoadoutManager.ArchiveManager.ArchiveFileAsync()
+
+        var analyzedFile = await FileContentsCache.AnalyzeFileAsync(path);
+        ModInstaller.GetFilesToExtractAsync(GameInstallation, )
+    }
+}

--- a/tests/Games/NexusMods.Games.TestFramework/AModInstallerTest.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/AModInstallerTest.cs
@@ -19,7 +19,6 @@ public abstract class AModInstallerTest<TGame, TModInstaller> : AGameTest<TGame>
 {
     protected readonly TModInstaller ModInstaller;
 
-    protected readonly FileContentsCache FileContentsCache;
 
     /// <summary>
     /// Constructor.
@@ -27,8 +26,6 @@ public abstract class AModInstallerTest<TGame, TModInstaller> : AGameTest<TGame>
     protected AModInstallerTest(IServiceProvider serviceProvider) : base(serviceProvider)
     {
         ModInstaller = serviceProvider.FindImplementationInContainer<TModInstaller, IModInstaller>();
-
-        FileContentsCache = serviceProvider.GetRequiredService<FileContentsCache>();
     }
 
     /// <summary>
@@ -52,7 +49,7 @@ public abstract class AModInstallerTest<TGame, TModInstaller> : AGameTest<TGame>
             analyzedFile.Hash,
             analyzedArchive.Contents);
 
-        return contents.ToArray();
+        return contents.WithPersist(DataStore).ToArray();
     }
 
     /// <summary>

--- a/tests/Games/NexusMods.Games.TestFramework/AModInstallerTest.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/AModInstallerTest.cs
@@ -19,7 +19,6 @@ public abstract class AModInstallerTest<TGame, TModInstaller> : AGameTest<TGame>
 {
     protected readonly TModInstaller ModInstaller;
 
-
     /// <summary>
     /// Constructor.
     /// </summary>

--- a/tests/Games/NexusMods.Games.TestFramework/AModInstallerTest.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/AModInstallerTest.cs
@@ -1,12 +1,18 @@
+using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using NexusMods.DataModel;
+using NexusMods.DataModel.Abstractions;
+using NexusMods.DataModel.Abstractions.Ids;
+using NexusMods.DataModel.ArchiveContents;
 using NexusMods.DataModel.Games;
+using NexusMods.DataModel.Loadouts;
 using NexusMods.DataModel.Loadouts.Markers;
 using NexusMods.DataModel.ModInstallers;
 using NexusMods.Paths;
 
 namespace NexusMods.Games.TestFramework;
 
+[PublicAPI]
 public abstract class AModInstallerTest<TGame, TModInstaller> : AGameTest<TGame>
     where TGame : AGame
     where TModInstaller : IModInstaller
@@ -25,11 +31,49 @@ public abstract class AModInstallerTest<TGame, TModInstaller> : AGameTest<TGame>
         FileContentsCache = serviceProvider.GetRequiredService<FileContentsCache>();
     }
 
-    protected async Task InstallModWithInstaller(AbsolutePath path)
+    /// <summary>
+    /// Runs the <typeparamref name="TModInstaller"/> and returns a list of files
+    /// to extract from the provided archive.
+    /// </summary>
+    /// <param name="path">Path to the archive to extract.</param>
+    /// <returns></returns>
+    /// <exception cref="NotImplementedException">The file at the provided path is not an archive.</exception>
+    protected async Task<AModFile[]> GetFilesToExtractFromInstaller(AbsolutePath path)
     {
-        // LoadoutManager.ArchiveManager.ArchiveFileAsync()
-
         var analyzedFile = await FileContentsCache.AnalyzeFileAsync(path);
-        ModInstaller.GetFilesToExtractAsync(GameInstallation, )
+        if (analyzedFile is not AnalyzedArchive analyzedArchive)
+        {
+            // see LoadoutManager.InstallModAsync
+            throw new NotImplementedException();
+        }
+
+        var contents = await ModInstaller.GetFilesToExtractAsync(
+            GameInstallation,
+            analyzedFile.Hash,
+            analyzedArchive.Contents);
+
+        return contents.ToArray();
+    }
+
+    /// <summary>
+    /// Installs the archive at the provided path with the <typeparamref name="TModInstaller"/>
+    /// and returns the <see cref="Mod"/> of it.
+    /// </summary>
+    /// <param name="loadout"></param>
+    /// <param name="path"></param>
+    /// <returns></returns>
+    protected async Task<Mod> InstallModWithInstaller(LoadoutMarker loadout, AbsolutePath path)
+    {
+        var contents = await GetFilesToExtractFromInstaller(path);
+
+        var newMod = new Mod
+        {
+            Id = ModId.New(),
+            Name = path.FileName,
+            Files = new EntityDictionary<ModFileId, AModFile>(DataStore, contents.Select(c => new KeyValuePair<ModFileId, IId>(c.Id, c.DataStoreId)))
+        };
+
+        loadout.Add(newMod);
+        return newMod;
     }
 }

--- a/tests/Games/NexusMods.Games.TestFramework/DependencyInjectionHelper.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/DependencyInjectionHelper.cs
@@ -11,6 +11,9 @@ using NexusMods.Paths;
 
 namespace NexusMods.Games.TestFramework;
 
+/// <summary>
+/// Helper functions for dealing with dependency injection.
+/// </summary>
 public static class DependencyInjectionHelper
 {
     /// <summary>
@@ -45,5 +48,32 @@ public static class DependencyInjectionHelper
             .AddAllSingleton<IResource, IResource<IExtractor, Size>>(_ => new Resource<IExtractor, Size>("File Extraction for tests"))
             .AddAllSingleton<IResource, IResource<FileHashCache, Size>>(_ => new Resource<FileHashCache, Size>("Hash Cache for tests"))
             .AddFileExtractors();
+    }
+
+    /// <summary>
+    /// Finds an implementation <typeparamref name="TImplementation"/> of
+    /// <typeparamref name="TInterface"/> inside the provided DI container.
+    /// </summary>
+    /// <param name="serviceProvider"></param>
+    /// <typeparam name="TImplementation"></typeparam>
+    /// <typeparam name="TInterface"></typeparam>
+    /// <returns></returns>
+    /// <exception cref="Exception">Thrown when the implementation hasn't been registered in the DI container.</exception>
+    public static TImplementation FindImplementationInContainer<TImplementation, TInterface>(this IServiceProvider serviceProvider)
+    {
+        var service = serviceProvider.GetService(typeof(TImplementation));
+        if (service is TImplementation implementation) return implementation;
+
+        var implementations = serviceProvider.GetServices(typeof(TInterface));
+        if (implementations is null)
+            throw new Exception($"{typeof(TImplementation)} is not registered in the DI container!");
+
+        var validImplementations = implementations.OfType<TImplementation>();
+        var validImplementation = validImplementations.FirstOrDefault();
+
+        if (validImplementation is null)
+            throw new Exception($"{typeof(TImplementation)} is not registered in the DI container!");
+
+        return validImplementation;
     }
 }

--- a/tests/Games/NexusMods.Games.TestFramework/DependencyInjectionHelper.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/DependencyInjectionHelper.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NexusMods.Common;
+using NexusMods.DataModel;
+using NexusMods.DataModel.RateLimiting;
+using NexusMods.FileExtractor;
+using NexusMods.FileExtractor.Extractors;
+using NexusMods.Networking.HttpDownloader;
+using NexusMods.Networking.NexusWebApi;
+using NexusMods.Paths;
+
+namespace NexusMods.Games.TestFramework;
+
+public static class DependencyInjectionHelper
+{
+    /// <summary>
+    /// Adds the following default services to the provided <see cref="IServiceCollection"/> for testing:
+    /// <list type="bullet">
+    ///     <item>Logging via <see cref="LoggingServiceCollectionExtensions.AddLogging(Microsoft.Extensions.DependencyInjection.IServiceCollection)"/></item>
+    ///     <item><see cref="IFileSystem"/> via <see cref="Paths.Services.AddFileSystem"/></item>
+    ///     <item><see cref="TemporaryFileManager"/> singleton</item>
+    ///     <item><see cref="HttpClient"/> singleton</item>
+    ///     <item>Nexus Web API via <see cref="Networking.NexusWebApi.Services.AddNexusWebApi"/></item>
+    ///     <item><see cref="IHttpDownloader"/> via <see cref="Networking.HttpDownloader.Services.AddHttpDownloader"/></item>
+    ///     <item>All services related to the <see cref="NexusMods.DataModel"/> via <see cref="DataModel.Services.AddDataModel"/></item>
+    ///     <item><see cref="IResource{TResource,TUnit}"/> for <see cref="FileContentsCache"/></item>
+    ///     <item><see cref="IResource{TResource,TUnit}"/> for <see cref="IExtractor"/></item>
+    ///     <item><see cref="IResource{TResource,TUnit}"/> for <see cref="FileHashCache"/></item>
+    ///     <item>File extraction services via <see cref="NexusMods.FileExtractor.Services.AddFileExtractors"/></item>
+    /// </list>
+    /// </summary>
+    /// <param name="serviceCollection"></param>
+    /// <returns></returns>
+    public static IServiceCollection AddDefaultServicesForTesting(this IServiceCollection serviceCollection)
+    {
+        return serviceCollection
+            .AddLogging(builder => builder.SetMinimumLevel(LogLevel.Debug))
+            .AddFileSystem()
+            .AddSingleton<TemporaryFileManager>()
+            .AddSingleton<HttpClient>()
+            .AddNexusWebApi(true)
+            .AddHttpDownloader()
+            .AddDataModel(new DataModelSettings())
+            .AddAllSingleton<IResource, IResource<FileContentsCache, Size>>(_ => new Resource<FileContentsCache, Size>("File Analysis for tests"))
+            .AddAllSingleton<IResource, IResource<IExtractor, Size>>(_ => new Resource<IExtractor, Size>("File Extraction for tests"))
+            .AddAllSingleton<IResource, IResource<FileHashCache, Size>>(_ => new Resource<FileHashCache, Size>("Hash Cache for tests"))
+            .AddFileExtractors();
+    }
+}

--- a/tests/Games/NexusMods.Games.TestFramework/DependencyInjectionHelper.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/DependencyInjectionHelper.cs
@@ -1,3 +1,4 @@
+using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NexusMods.Common;
@@ -14,6 +15,7 @@ namespace NexusMods.Games.TestFramework;
 /// <summary>
 /// Helper functions for dealing with dependency injection.
 /// </summary>
+[PublicAPI]
 public static class DependencyInjectionHelper
 {
     /// <summary>

--- a/tests/Games/NexusMods.Games.TestFramework/NexusMods.Games.TestFramework.csproj
+++ b/tests/Games/NexusMods.Games.TestFramework/NexusMods.Games.TestFramework.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\src\Networking\NexusMods.Networking.HttpDownloader\NexusMods.Networking.HttpDownloader.csproj" />
+        <ProjectReference Include="..\..\..\src\Networking\NexusMods.Networking.NexusWebApi\NexusMods.Networking.NexusWebApi.csproj" />
+        <ProjectReference Include="..\..\..\src\NexusMods.DataModel\NexusMods.DataModel.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/Games/NexusMods.Games.TestFramework/NexusMods.Games.TestFramework.csproj
+++ b/tests/Games/NexusMods.Games.TestFramework/NexusMods.Games.TestFramework.csproj
@@ -1,10 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-
     <ItemGroup>
         <ProjectReference Include="..\..\..\src\Networking\NexusMods.Networking.HttpDownloader\NexusMods.Networking.HttpDownloader.csproj" />
         <ProjectReference Include="..\..\..\src\Networking\NexusMods.Networking.NexusWebApi\NexusMods.Networking.NexusWebApi.csproj" />
         <ProjectReference Include="..\..\..\src\NexusMods.DataModel\NexusMods.DataModel.csproj" />
+        <ProjectReference Include="..\..\NexusMods.StandardGameLocators.TestHelpers\NexusMods.StandardGameLocators.TestHelpers.csproj" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Resolves #247

Adds `NexusMods.Games.TestFramework` which simplifies the following aspects:

- `AddDefaultServicesForTesting` is an extension method on `IServiceCollection` which reduces the amount of code duplication in the `Startup.ConfigureServies` methods of the test projects
- `AGameTest<TGame>` is a new abstract class that provides helper methods for creating test archives and files, creating loadouts, as well as downloading and installing mods into loadouts
- `AModInstallerTest<TGame, TModInstaller>` is a new abstract class for testing `IModInstaller` implementations.
- `AFileAnalyzerTest<TGame, TFileAnalyzer>` is a new abstract class for testing `IFileAnalyzer` implementations.

Both `AModInstallerTest` and `AFileAnalyzerTest` inherit from `AGameTest` and provide helper methods that try to only interact with the implementation (`AFileAnalyzerTest.AnalyzeFile` only interacts with the file system and the file analyzer, it doesn't even touch the data store).

These new utilities drastically simplify the amount of code needed to test our game support code. As an example, I've added `RedModInfoAnalyzerTests`, which tests the `IFileAnalyzer` for Cyberpunk info files. I've also created a test project `NexusMods.Games.DarkestDungeon.Tests` to test the previously untested Darkest Dungeon support code. Although our current support code for DD is lacking a lot and is technically wrong, this still serves as an example on how to use the new test framework.