### PR TITLE
Fixed: Double Import of Directory.Build.props (fixes #260)

### DIFF
--- a/tests/Games/NexusMods.Games.BethesdaGameStudios.Tests/NexusMods.Games.BethesdaGameStudios.Tests.csproj
+++ b/tests/Games/NexusMods.Games.BethesdaGameStudios.Tests/NexusMods.Games.BethesdaGameStudios.Tests.csproj
@@ -1,10 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-    
     <PropertyGroup>
         <XunitStartupAssembly>NexusMods.Games.BethesdaGameStudios.Tests</XunitStartupAssembly>
     </PropertyGroup>
-    
+
     <ItemGroup>
         <ProjectReference Include="..\..\..\src\Games\NexusMods.Games.BethesdaGameStudios\NexusMods.Games.BethesdaGameStudios.csproj" />
         <ProjectReference Include="..\..\..\src\NexusMods.StandardGameLocators\NexusMods.StandardGameLocators.csproj" />

--- a/tests/Games/NexusMods.Games.DarkestDungeon.Tests/NexusMods.Games.DarkestDungeon.Tests.csproj
+++ b/tests/Games/NexusMods.Games.DarkestDungeon.Tests/NexusMods.Games.DarkestDungeon.Tests.csproj
@@ -1,6 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-
     <PropertyGroup>
         <XunitStartupAssembly>NexusMods.Games.DarkestDungeon.Tests</XunitStartupAssembly>
     </PropertyGroup>

--- a/tests/Games/NexusMods.Games.FOMOD.Tests/NexusMods.Games.FOMOD.Tests.csproj
+++ b/tests/Games/NexusMods.Games.FOMOD.Tests/NexusMods.Games.FOMOD.Tests.csproj
@@ -1,6 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-
     <PropertyGroup>
         <XunitStartupAssembly>NexusMods.Games.FOMOD.Tests</XunitStartupAssembly>
     </PropertyGroup>

--- a/tests/Games/NexusMods.Games.RedEngine.Tests/NexusMods.Games.RedEngine.Tests.csproj
+++ b/tests/Games/NexusMods.Games.RedEngine.Tests/NexusMods.Games.RedEngine.Tests.csproj
@@ -1,10 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-    
     <PropertyGroup>
         <XunitStartupAssembly>NexusMods.Games.RedEngine.Tests</XunitStartupAssembly>
     </PropertyGroup>
-    
+
     <ItemGroup>
       <ProjectReference Include="..\..\..\src\Games\NexusMods.Games.RedEngine\NexusMods.Games.RedEngine.csproj" />
       <ProjectReference Include="..\..\..\src\Networking\NexusMods.Networking.HttpDownloader\NexusMods.Networking.HttpDownloader.csproj" />


### PR DESCRIPTION
(Description copied from #260)

## Summary

PR https://github.com/Nexus-Mods/NexusMods.App/pull/253 introduced a warning to our build logs, because some of the test projects were modified to include the following line.

```
<Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
```

This is redundant [because](https://learn.microsoft.com/en-us/visualstudio/msbuild/customize-by-directory?view=vs-2022):

> When MSBuild runs, Microsoft.Common.props searches your directory structure for the Directory.Build.props file. If it finds one, it imports the file and reads the properties defined within it. Directory.Build.props is a user-defined file that provides customizations to projects under a directory.

And as a result our CI builds have been reporting warnings such as: 

```
/home/runner/work/NexusMods.App/NexusMods.App/tests/Games/NexusMods.Games.DarkestDungeon.Tests/NexusMods.Games.DarkestDungeon.Tests.csproj(2,5): warning MSB4011: "/home/runner/work/NexusMods.App/NexusMods.App/tests/Directory.Build.props" cannot be imported again. It was already imported at "/usr/share/dotnet/sdk/7.0.202/Current/Microsoft.Common.props (32,3)". This is most likely a build authoring error. This subsequent import will be ignored. 
```

This PR fixes this by removing the line where it isn't necessary.