### PR TITLE
Archive Content Cache Invalidation

### DIFF
--- a/src/ArchiveManagement/NexusMods.FileExtractor/FileSignatures/Definitions/magic_sigs.txt
+++ b/src/ArchiveManagement/NexusMods.FileExtractor/FileSignatures/Definitions/magic_sigs.txt
@@ -17,3 +17,4 @@ Creation Engine Plugin, 54 45 53 34, CreationEnginePlugin
 TES4 Plugin, 54 45 53 34, TES4
 PDF file,25 50 44 46,PDF|FDF,Word processing suite,0,25 25 45 4F 46
 Cyberpunk Appearance Preset, 4c 6f 63 4b 65 79 23, Cyberpunk2077AppearancePreset
+Test files, 4A 55 53 54 54 45 53 54, JustTest

--- a/src/ArchiveManagement/NexusMods.FileExtractor/FileSignatures/Signatures.cs
+++ b/src/ArchiveManagement/NexusMods.FileExtractor/FileSignatures/Signatures.cs
@@ -25,6 +25,10 @@ namespace NexusMods.FileExtractor.FileSignatures {
             /// </summary>
              JSON,
                 /// <summary>
+                /// Test files
+                /// </summary>
+                 JustTest,
+                            /// <summary>
                 /// Morrowind BSA
                 /// </summary>
                  MorrowindBSA,
@@ -153,6 +157,9 @@ namespace NexusMods.FileExtractor.FileSignatures {
 
                 // Cyberpunk Appearance Preset
         (FileType. Cyberpunk2077AppearancePreset, new byte[] {0x4c, 0x6f, 0x63, 0x4b, 0x65, 0x79, 0x23}),
+
+                // Test files
+        (FileType. JustTest, new byte[] {0x4A, 0x55, 0x53, 0x54, 0x54, 0x45, 0x53, 0x54}),
 
         
     };

--- a/src/Games/NexusMods.Games.BethesdaGameStudios/PluginAnalyzer.cs
+++ b/src/Games/NexusMods.Games.BethesdaGameStudios/PluginAnalyzer.cs
@@ -2,6 +2,7 @@ using System.Runtime.CompilerServices;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Skyrim;
 using NexusMods.DataModel.Abstractions;
+using NexusMods.DataModel.Abstractions.Ids;
 using NexusMods.FileExtractor.FileSignatures;
 using NexusMods.Paths;
 using NexusMods.Paths.Extensions;
@@ -10,6 +11,8 @@ namespace NexusMods.Games.BethesdaGameStudios;
 
 public class PluginAnalyzer : IFileAnalyzer
 {
+    public FileAnalyzerId Id { get; } = FileAnalyzerId.New("9c673a4f-064f-4b1e-83e3-4bf0454575cd", 1);
+
     public IEnumerable<FileType> FileTypes => new[] { FileType.TES4 };
 
 #pragma warning disable CS1998

--- a/src/Games/NexusMods.Games.FOMOD/FomodAnalyzer.cs
+++ b/src/Games/NexusMods.Games.FOMOD/FomodAnalyzer.cs
@@ -3,6 +3,7 @@ using FomodInstaller.Scripting.XmlScript;
 using JetBrains.Annotations;
 using Microsoft.Extensions.Logging;
 using NexusMods.DataModel.Abstractions;
+using NexusMods.DataModel.Abstractions.Ids;
 using NexusMods.DataModel.JsonConverters;
 using NexusMods.FileExtractor.FileSignatures;
 using NexusMods.Paths;
@@ -12,6 +13,8 @@ namespace NexusMods.Games.FOMOD;
 
 public class FomodAnalyzer : IFileAnalyzer
 {
+    public FileAnalyzerId Id { get; } = FileAnalyzerId.New("e5dcce84-ad7c-4882-8873-4f6a2e45a279", 1);
+
     private readonly ILogger<FomodAnalyzer> _logger;
     private readonly IFileSystem _fileSystem;
 

--- a/src/Games/NexusMods.Games.Generic/FileAnalyzers/IniAnalzyer.cs
+++ b/src/Games/NexusMods.Games.Generic/FileAnalyzers/IniAnalzyer.cs
@@ -2,6 +2,7 @@ using System.Runtime.CompilerServices;
 using IniParser;
 using IniParser.Parser;
 using NexusMods.DataModel.Abstractions;
+using NexusMods.DataModel.Abstractions.Ids;
 using NexusMods.FileExtractor.FileSignatures;
 using NexusMods.Games.Generic.Entities;
 using NexusMods.Paths;
@@ -11,6 +12,7 @@ namespace NexusMods.Games.Generic.FileAnalyzers;
 
 public class IniAnalzyer : IFileAnalyzer
 {
+    public FileAnalyzerId Id { get; } = FileAnalyzerId.New("904bca7b-fbd6-4350-b4e2-6fdbd034ec76", 1);
     public IEnumerable<FileType> FileTypes => new[] { FileType.INI };
 
 #pragma warning disable CS1998

--- a/src/Games/NexusMods.Games.RedEngine/FileAnalyzers/RedModInfoAnalyzer.cs
+++ b/src/Games/NexusMods.Games.RedEngine/FileAnalyzers/RedModInfoAnalyzer.cs
@@ -2,6 +2,7 @@ using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using NexusMods.DataModel.Abstractions;
+using NexusMods.DataModel.Abstractions.Ids;
 using NexusMods.DataModel.JsonConverters;
 using NexusMods.FileExtractor.FileSignatures;
 using NexusMods.Paths;
@@ -10,6 +11,8 @@ namespace NexusMods.Games.RedEngine.FileAnalyzers;
 
 public class RedModInfoAnalyzer : IFileAnalyzer
 {
+    public FileAnalyzerId Id { get; } = FileAnalyzerId.New("8bf03d10-c48e-4929-906f-852b6afecd5e", 1);
+    
     public IEnumerable<FileType> FileTypes => new[] { FileType.JSON };
     public async IAsyncEnumerable<IFileAnalysisData> AnalyzeAsync(FileAnalyzerInfo info, [EnumeratorCancellation] CancellationToken ct = default)
     {

--- a/src/NexusMods.DataModel/Abstractions/IFileAnalyzer.cs
+++ b/src/NexusMods.DataModel/Abstractions/IFileAnalyzer.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices.JavaScript;
+using NexusMods.DataModel.Abstractions.Ids;
 using NexusMods.FileExtractor.FileSignatures;
 using NexusMods.Paths;
 
@@ -12,6 +13,13 @@ namespace NexusMods.DataModel.Abstractions;
 /// </summary>
 public interface IFileAnalyzer
 {
+    /// <summary>
+    /// The unique identifier for this file analyzer, includes a revision number that
+    /// should be updated whenever changes to the analyzer necessitate a re-analysis
+    /// of archive files. 
+    /// </summary>
+    public FileAnalyzerId Id { get; }
+    
     /// <summary>
     /// Defines the file types supported by this file analyzer.
     /// </summary>

--- a/src/NexusMods.DataModel/Abstractions/Ids/FileAnalyzerId.cs
+++ b/src/NexusMods.DataModel/Abstractions/Ids/FileAnalyzerId.cs
@@ -1,0 +1,6 @@
+﻿namespace NexusMods.DataModel.Abstractions.Ids;
+
+public record FileAnalyzerId(Guid Analyzer, uint Revision)
+{
+    public static FileAnalyzerId New(string guid, uint revision) => new(Guid.Parse(guid), revision);
+}

--- a/src/NexusMods.DataModel/ArchiveContents/AnalyzedFile.cs
+++ b/src/NexusMods.DataModel/ArchiveContents/AnalyzedFile.cs
@@ -27,6 +27,11 @@ public record AnalyzedFile : Entity
     /// Individual hash of the file.
     /// </summary>
     public required Hash Hash { get; init; }
+    
+    /// <summary>
+    /// Hash of the ids of the analyzers used to analyze this file.
+    /// </summary>
+    public required Hash AnalyzersHash { get; init; }
 
     /// <summary>
     /// Stores the types of file this file is classified by.

--- a/tests/NexusMods.DataModel.Tests/ArchiveContentsCacheTests.cs
+++ b/tests/NexusMods.DataModel.Tests/ArchiveContentsCacheTests.cs
@@ -2,7 +2,9 @@ using FluentAssertions;
 using NexusMods.DataModel.Abstractions;
 using NexusMods.DataModel.Abstractions.Ids;
 using NexusMods.DataModel.ArchiveContents;
+using NexusMods.DataModel.JsonConverters;
 using NexusMods.DataModel.Tests.Harness;
+using NexusMods.FileExtractor.FileSignatures;
 using NexusMods.Hashing.xxHash64;
 using NexusMods.Paths.Extensions;
 
@@ -10,6 +12,7 @@ namespace NexusMods.DataModel.Tests;
 
 public class ArchiveContentsCacheTests : ADataModelTest<ArchiveContentsCacheTests>
 {
+
     public ArchiveContentsCacheTests(IServiceProvider provider) : base(provider)
     {
     }
@@ -31,9 +34,46 @@ public class ArchiveContentsCacheTests : ADataModelTest<ArchiveContentsCacheTest
         var reverse = ArchiveContentsCache.ArchivesThatContain(file.Hash).ToArray();
         reverse.Length.Should().BeGreaterThan(0);
         reverse.Select(r => r.Parent).Should().Contain(analyzed.Hash);
+    }
 
+    [Fact]
+    public async Task UpdatingFileAnalyzersRerunsAnalyzers()
+    {
+        var analyzed = await ArchiveContentsCache.AnalyzeFileAsync(DataTest, CancellationToken.None);
+        var data = analyzed.AnalysisData.OfType<MutatingFileAnalysisData>()
+            .FirstOrDefault();
+        data.Should().NotBeNull();
+        
+        data!.Revision.Should().Be(_revision, "before the file was indexed");
+        _revision = 44;
+        
+        analyzed = await ArchiveContentsCache.AnalyzeFileAsync(DataTest, CancellationToken.None);
+        data = analyzed.AnalysisData.OfType<MutatingFileAnalysisData>()
+            .FirstOrDefault();
+        data.Should().NotBeNull();
+        data!.Revision.Should().Be(_revision, "the file was reindexed");
+
+        
     }
 
 
+    private static uint _revision = 42;
+    public class MutatingFileAnalyzer : IFileAnalyzer
+    {
+        public FileAnalyzerId Id => FileAnalyzerId.New("deadbeef-c48e-4929-906f-852b6afecd5e", _revision);
+        public IEnumerable<FileType> FileTypes { get; } = new []{FileType.JustTest};
 
+        public async IAsyncEnumerable<IFileAnalysisData> AnalyzeAsync(FileAnalyzerInfo info,
+            CancellationToken token = default)
+        {
+            yield return new MutatingFileAnalysisData()
+                { Revision = Id.Revision };
+        }
+    }
+
+    [JsonName("TEST_MutatingFileAnalysisData")]
+    public class MutatingFileAnalysisData : IFileAnalysisData
+    {
+        public uint Revision { get; set; }
+    }
 }

--- a/tests/NexusMods.DataModel.Tests/ArchiveContentsCacheTests.cs
+++ b/tests/NexusMods.DataModel.Tests/ArchiveContentsCacheTests.cs
@@ -43,17 +43,21 @@ public class ArchiveContentsCacheTests : ADataModelTest<ArchiveContentsCacheTest
         var data = analyzed.AnalysisData.OfType<MutatingFileAnalysisData>()
             .FirstOrDefault();
         data.Should().NotBeNull();
-        
+
         data!.Revision.Should().Be(_revision, "before the file was indexed");
         _revision = 44;
-        
+        var oldSig = ArchiveContentsCache.AnalyzersSignature;
+        ArchiveContentsCache.RecalculateAnalyzerSignature();
+        ArchiveContentsCache.AnalyzersSignature.Should().NotBe(oldSig, "an analyzer changed its revision");
+
+
         analyzed = await ArchiveContentsCache.AnalyzeFileAsync(DataTest, CancellationToken.None);
         data = analyzed.AnalysisData.OfType<MutatingFileAnalysisData>()
             .FirstOrDefault();
         data.Should().NotBeNull();
         data!.Revision.Should().Be(_revision, "the file was reindexed");
 
-        
+
     }
 
 

--- a/tests/NexusMods.DataModel.Tests/Harness/ADataModelTest.cs
+++ b/tests/NexusMods.DataModel.Tests/Harness/ADataModelTest.cs
@@ -20,6 +20,9 @@ public abstract class ADataModelTest<T> : IDisposable, IAsyncLifetime
     public static readonly AbsolutePath DataZipLzma = KnownFolders.EntryFolder.CombineUnchecked(@"Resources\data_zip_lzma.zip");
     public static readonly AbsolutePath Data7ZLzma2 = KnownFolders.EntryFolder.CombineUnchecked(@"Resources\data_7zip_lzma2.7z");
 
+    public static readonly AbsolutePath DataTest =
+        KnownFolders.EntryFolder.CombineUnchecked(@"Resources\data.test");
+
     public static readonly RelativePath[] DataNames = new[]
     {
         "rootFile.txt",

--- a/tests/NexusMods.DataModel.Tests/NexusMods.DataModel.Tests.csproj
+++ b/tests/NexusMods.DataModel.Tests/NexusMods.DataModel.Tests.csproj
@@ -16,6 +16,12 @@
       <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     </ItemGroup>
 
+    <ItemGroup>
+      <None Update="Resources\data.test">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+    </ItemGroup>
+
 
     <Target Name="CopyResources" AfterTargets="PostBuildEvent">
         <ItemGroup>

--- a/tests/NexusMods.DataModel.Tests/Resources/data.test
+++ b/tests/NexusMods.DataModel.Tests/Resources/data.test
@@ -1,0 +1,1 @@
+JUSTTEST, Just some test data, nothing to see here.

--- a/tests/NexusMods.DataModel.Tests/Startup.cs
+++ b/tests/NexusMods.DataModel.Tests/Startup.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NexusMods.Common;
+using NexusMods.DataModel.Abstractions;
 using NexusMods.DataModel.JsonConverters.ExpressionGenerator;
 using NexusMods.DataModel.RateLimiting;
 using NexusMods.FileExtractor;
@@ -31,6 +32,7 @@ public class Startup
             new Resource<FileContentsCache, Size>("File Analysis"))
                  .AddAllSingleton<IResource, IResource<IExtractor, Size>>(_ =>
             new Resource<IExtractor, Size>("File Extraction"))
+                 .AddSingleton<IFileAnalyzer, ArchiveContentsCacheTests.MutatingFileAnalyzer>()
 
                  .AddSingleton<ITypeFinder>(_ => new AssemblyTypeFinder(typeof(Startup).Assembly))
                  .Validate();


### PR DESCRIPTION
Adds a Id and Revision pair to every `IFileAnalyzer`, changing the Revision number of an Analyzer will trigger a re-analysis of a file once it opens the next time. 

Unfortunately, because files can contain other files, we have to invalidate everything in the cache whenever a single IFileAnalyzer is updated. This shouldn't be too bad though as right now analysis data is only ever used during mod installation. More complex code could likely improve the user experience here, but at least for now we don't get bad analysis data whenever the code updates. 