### PR TITLE
Fix table rendering with Sepctre

### DIFF
--- a/src/NexusMods.App/CLI/Renderers/Spectre.cs
+++ b/src/NexusMods.App/CLI/Renderers/Spectre.cs
@@ -1,6 +1,7 @@
 using NexusMods.CLI;
 using NexusMods.DataModel.RateLimiting;
 using Spectre.Console;
+using Spectre.Console.Rendering;
 
 namespace NexusMods.App.CLI.Renderers;
 
@@ -144,8 +145,10 @@ public class Spectre : IRenderer
 
         foreach (var row in table.Rows)
         {
-            ot.AddRow(row.Select(r => r.ToString()).ToArray()!);
+            var columns = row.Select(r => (IRenderable)new Text(r.ToString() ?? string.Empty));
+            ot.AddRow(columns);
         }
+
         AnsiConsole.Write(ot);
         return Task.CompletedTask;
     }


### PR DESCRIPTION
The overload `ot.AddRow()` that accepts strings converts those strings into [`Markup`](https://spectreconsole.net/markup), which can cause issues depending on the text. Using [`Text`](https://spectreconsole.net/api/spectre.console/text/) directly is safer.