### PR TITLE
Add support for multiple mods in one archive

### DIFF
--- a/src/Games/NexusMods.Games.BethesdaGameStudios/Installers/SkyrimInstaller.cs
+++ b/src/Games/NexusMods.Games.BethesdaGameStudios/Installers/SkyrimInstaller.cs
@@ -48,7 +48,7 @@ public class SkyrimInstaller : IModInstaller
     public Priority GetPriority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
         if (installation.Game is not SkyrimSpecialEdition)
-            return Common.Priority.None;
+            return Priority.None;
 
         // Determine one of the following:
         // - There is a 'meshes' folder with NIF file.
@@ -65,14 +65,14 @@ public class SkyrimInstaller : IModInstaller
             {
                 var subDirectory = rawPath.AsSpan(separatorIndex + 1);
                 if (AssertPathForPriority(subDirectory))
-                    return Common.Priority.Normal;
+                    return Priority.Normal;
             }
 
             if (AssertPathForPriority(rawPath))
-                return Common.Priority.Normal;
+                return Priority.Normal;
         }
 
-        return Common.Priority.None;
+        return Priority.None;
     }
 
     public ValueTask<IEnumerable<Mod>> GetModsAsync(

--- a/src/Games/NexusMods.Games.BethesdaGameStudios/Installers/SkyrimInstaller.cs
+++ b/src/Games/NexusMods.Games.BethesdaGameStudios/Installers/SkyrimInstaller.cs
@@ -45,7 +45,7 @@ public class SkyrimInstaller : IModInstaller
         _dataStore = dataStore;
     }
 
-    public Priority Priority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> files)
+    public Priority GetPriority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
         if (installation.Game is not SkyrimSpecialEdition)
             return Common.Priority.None;
@@ -54,7 +54,7 @@ public class SkyrimInstaller : IModInstaller
         // - There is a 'meshes' folder with NIF file.
         // - There is a 'textures' folder with DDS file.
         // - There is a folder (max 1 level deep) with either of the following cases.
-        foreach (var file in files)
+        foreach (var file in archiveFiles)
         {
             var path = file.Key;
             var rawPath = file.Key.Path;

--- a/src/Games/NexusMods.Games.BethesdaGameStudios/Installers/SkyrimInstaller.cs
+++ b/src/Games/NexusMods.Games.BethesdaGameStudios/Installers/SkyrimInstaller.cs
@@ -38,13 +38,6 @@ public class SkyrimInstaller : IModInstaller
 
     private static readonly RelativePath Data = "Data".ToRelativePath();
 
-    private readonly IDataStore _dataStore;
-
-    public SkyrimInstaller(IDataStore dataStore)
-    {
-        _dataStore = dataStore;
-    }
-
     public Priority GetPriority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
         if (installation.Game is not SkyrimSpecialEdition)
@@ -75,18 +68,18 @@ public class SkyrimInstaller : IModInstaller
         return Priority.None;
     }
 
-    public ValueTask<IEnumerable<Mod>> GetModsAsync(
+    public ValueTask<IEnumerable<ModInstallerResult>> GetModsAsync(
         GameInstallation gameInstallation,
-        Mod baseMod,
+        ModId baseModId,
         Hash srcArchiveHash,
         EntityDictionary<RelativePath, AnalyzedFile> archiveFiles,
         CancellationToken cancellationToken = default)
     {
-        return ValueTask.FromResult(GetMods(baseMod, srcArchiveHash, archiveFiles));
+        return ValueTask.FromResult(GetMods(baseModId, srcArchiveHash, archiveFiles));
     }
 
-    private IEnumerable<Mod> GetMods(
-        Mod baseMod,
+    private IEnumerable<ModInstallerResult> GetMods(
+        ModId baseModId,
         Hash srcArchiveHash,
         EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
@@ -108,9 +101,10 @@ public class SkyrimInstaller : IModInstaller
                 };
             });
 
-        yield return baseMod with
+        yield return new ModInstallerResult
         {
-            Files = modFiles.ToEntityDictionary(_dataStore)
+            Id = baseModId,
+            Files = modFiles
         };
     }
 

--- a/src/Games/NexusMods.Games.BethesdaGameStudios/Installers/SkyrimInstaller.cs
+++ b/src/Games/NexusMods.Games.BethesdaGameStudios/Installers/SkyrimInstaller.cs
@@ -91,10 +91,8 @@ public class SkyrimInstaller : IModInstaller
         EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
         var prefix = FindFolderPrefixForExtract(archiveFiles).ToString();
-        if (prefix.Length > 0) throw new NotImplementedException();
-
         var modFiles = archiveFiles
-            .Where(kv => kv.Key.StartsWith(prefix))
+            .Where(kv => prefix.Length <= 0 || kv.Key.StartsWith(prefix))
             .Select(kv =>
             {
                 var (path, file) = kv;

--- a/src/Games/NexusMods.Games.DarkestDungeon/DarkestDungeonModInstaller.cs
+++ b/src/Games/NexusMods.Games.DarkestDungeon/DarkestDungeonModInstaller.cs
@@ -27,11 +27,11 @@ public class DarkestDungeonModInstaller : IModInstaller
     public Priority GetPriority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
         if (installation.Game is not DarkestDungeon)
-            return Common.Priority.None;
+            return Priority.None;
 
         return archiveFiles.Keys.Any(f => f.FileName == ModFilesTxt)
-            ? Common.Priority.Normal
-            : Common.Priority.None;
+            ? Priority.Normal
+            : Priority.None;
     }
 
     public ValueTask<IEnumerable<Mod>> GetModsAsync(

--- a/src/Games/NexusMods.Games.DarkestDungeon/DarkestDungeonModInstaller.cs
+++ b/src/Games/NexusMods.Games.DarkestDungeon/DarkestDungeonModInstaller.cs
@@ -17,13 +17,6 @@ public class DarkestDungeonModInstaller : IModInstaller
     private static readonly RelativePath ModFilesTxt = "modfiles.txt".ToRelativePath();
     private static readonly RelativePath ModFolder = "mods".ToRelativePath();
 
-    private readonly IDataStore _dataStore;
-    
-    public DarkestDungeonModInstaller(IDataStore dataStore)
-    {
-        _dataStore = dataStore;
-    }
-    
     public Priority GetPriority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
         if (installation.Game is not DarkestDungeon)
@@ -34,18 +27,18 @@ public class DarkestDungeonModInstaller : IModInstaller
             : Priority.None;
     }
 
-    public ValueTask<IEnumerable<Mod>> GetModsAsync(
+    public ValueTask<IEnumerable<ModInstallerResult>> GetModsAsync(
         GameInstallation gameInstallation,
-        Mod baseMod,
+        ModId baseModId,
         Hash srcArchiveHash,
         EntityDictionary<RelativePath, AnalyzedFile> archiveFiles,
         CancellationToken cancellationToken = default)
     {
-        return ValueTask.FromResult(GetMods(baseMod, srcArchiveHash, archiveFiles));
+        return ValueTask.FromResult(GetMods(baseModId, srcArchiveHash, archiveFiles));
     }
 
-    private IEnumerable<Mod> GetMods(
-        Mod baseMod,
+    private IEnumerable<ModInstallerResult> GetMods(
+        ModId baseModId,
         Hash srcArchiveHash,
         EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
@@ -69,9 +62,10 @@ public class DarkestDungeonModInstaller : IModInstaller
                 };
             });
 
-        yield return baseMod with
+        yield return new ModInstallerResult
         {
-            Files = modFiles.ToEntityDictionary(_dataStore)
+            Id = baseModId,
+            Files = modFiles
         };
     }
 }

--- a/src/Games/NexusMods.Games.DarkestDungeon/DarkestDungeonModInstaller.cs
+++ b/src/Games/NexusMods.Games.DarkestDungeon/DarkestDungeonModInstaller.cs
@@ -24,12 +24,12 @@ public class DarkestDungeonModInstaller : IModInstaller
         _dataStore = dataStore;
     }
     
-    public Priority Priority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> files)
+    public Priority GetPriority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
         if (installation.Game is not DarkestDungeon)
             return Common.Priority.None;
 
-        return files.Keys.Any(f => f.FileName == ModFilesTxt)
+        return archiveFiles.Keys.Any(f => f.FileName == ModFilesTxt)
             ? Common.Priority.Normal
             : Common.Priority.None;
     }

--- a/src/Games/NexusMods.Games.FOMOD/FomodXmlInstaller.cs
+++ b/src/Games/NexusMods.Games.FOMOD/FomodXmlInstaller.cs
@@ -36,9 +36,9 @@ public class FomodXmlInstaller : IModInstaller
         return hasScript ? Priority.High : Priority.None;
     }
 
-    public async ValueTask<IEnumerable<DataModel.Loadouts.Mod>> GetModsAsync(
+    public async ValueTask<IEnumerable<ModInstallerResult>> GetModsAsync(
         GameInstallation gameInstallation,
-        DataModel.Loadouts.Mod baseMod,
+        ModId baseModId,
         Hash srcArchiveHash,
         EntityDictionary<RelativePath, AnalyzedFile> archiveFiles,
         CancellationToken cancellationToken = default)
@@ -53,7 +53,7 @@ public class FomodXmlInstaller : IModInstaller
 
         var analyzerInfo = analyzedFile.AnalysisData.OfType<FomodAnalyzerInfo>().FirstOrDefault();
         if (analyzerInfo == default)
-            return Array.Empty<DataModel.Loadouts.Mod>(); // <= invalid FOMOD, so no analyzer info dumped
+            return Array.Empty<ModInstallerResult>(); // <= invalid FOMOD, so no analyzer info dumped
 
         // Setup mod, exclude script path so it doesn't get picked up and thus double read from disk
         var modFiles = archiveFiles.Keys.Select(x => x.ToString()).ToList();
@@ -75,10 +75,10 @@ public class FomodXmlInstaller : IModInstaller
 
         return new[]
         {
-            baseMod with
+            new ModInstallerResult
             {
+                Id = baseModId,
                 Files = InstructionsToModFiles(instructions, srcArchiveHash, archiveFiles)
-                    .ToEntityDictionary(_dataStore)
             }
         };
     }

--- a/src/Games/NexusMods.Games.FOMOD/FomodXmlInstaller.cs
+++ b/src/Games/NexusMods.Games.FOMOD/FomodXmlInstaller.cs
@@ -33,7 +33,7 @@ public class FomodXmlInstaller : IModInstaller
     public Priority GetPriority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
         var hasScript = archiveFiles.ContainsKey(FomodConstants.XmlConfigRelativePath);
-        return hasScript ? Common.Priority.High : Common.Priority.None;
+        return hasScript ? Priority.High : Priority.None;
     }
 
     public async ValueTask<IEnumerable<DataModel.Loadouts.Mod>> GetModsAsync(

--- a/src/Games/NexusMods.Games.FOMOD/FomodXmlInstaller.cs
+++ b/src/Games/NexusMods.Games.FOMOD/FomodXmlInstaller.cs
@@ -30,9 +30,9 @@ public class FomodXmlInstaller : IModInstaller
         _logger = logger;
     }
 
-    public Priority Priority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> files)
+    public Priority GetPriority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
-        var hasScript = files.ContainsKey(FomodConstants.XmlConfigRelativePath);
+        var hasScript = archiveFiles.ContainsKey(FomodConstants.XmlConfigRelativePath);
         return hasScript ? Common.Priority.High : Common.Priority.None;
     }
 

--- a/src/Games/NexusMods.Games.RedEngine/ModInstallers/AppearancePreset.cs
+++ b/src/Games/NexusMods.Games.RedEngine/ModInstallers/AppearancePreset.cs
@@ -21,13 +21,6 @@ public class AppearancePreset : IModInstaller
         @"bin\x64\plugins\cyber_engine_tweaks\mods\AppearanceChangeUnlocker\character-preset\male".ToRelativePath()
     };
 
-    private readonly IDataStore _dataStore;
-
-    public AppearancePreset(IDataStore dataStore)
-    {
-        _dataStore = dataStore;
-    }
-
     public Priority GetPriority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
         if (!installation.Is<Cyberpunk2077>()) return Priority.None;
@@ -37,18 +30,18 @@ public class AppearancePreset : IModInstaller
             : Priority.None;
     }
 
-    public ValueTask<IEnumerable<Mod>> GetModsAsync(
+    public ValueTask<IEnumerable<ModInstallerResult>> GetModsAsync(
         GameInstallation gameInstallation,
-        Mod baseMod,
+        ModId baseModId,
         Hash srcArchiveHash,
         EntityDictionary<RelativePath, AnalyzedFile> archiveFiles,
         CancellationToken cancellationToken = default)
     {
-        return ValueTask.FromResult(GetMods(baseMod, srcArchiveHash, archiveFiles));
+        return ValueTask.FromResult(GetMods(baseModId, srcArchiveHash, archiveFiles));
     }
 
-    private IEnumerable<Mod> GetMods(
-        Mod baseMod,
+    private IEnumerable<ModInstallerResult> GetMods(
+        ModId baseModId,
         Hash srcArchiveHash,
         EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
@@ -68,9 +61,10 @@ public class AppearancePreset : IModInstaller
                 });
             });
 
-        yield return baseMod with
+        yield return new ModInstallerResult
         {
-            Files = modFiles.ToEntityDictionary(_dataStore)
+            Id = baseModId,
+            Files = modFiles
         };
     }
 }

--- a/src/Games/NexusMods.Games.RedEngine/ModInstallers/AppearancePreset.cs
+++ b/src/Games/NexusMods.Games.RedEngine/ModInstallers/AppearancePreset.cs
@@ -30,11 +30,11 @@ public class AppearancePreset : IModInstaller
 
     public Priority GetPriority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
-        if (!installation.Is<Cyberpunk2077>()) return Common.Priority.None;
+        if (!installation.Is<Cyberpunk2077>()) return Priority.None;
 
         return archiveFiles.All(f => Helpers.IgnoreExtensions.Contains(f.Key.Extension) || (f.Value.FileTypes.Contains(FileType.Cyberpunk2077AppearancePreset) && f.Key.Extension == KnownExtensions.Preset))
-            ? Common.Priority.Normal
-            : Common.Priority.None;
+            ? Priority.Normal
+            : Priority.None;
     }
 
     public ValueTask<IEnumerable<Mod>> GetModsAsync(

--- a/src/Games/NexusMods.Games.RedEngine/ModInstallers/AppearancePreset.cs
+++ b/src/Games/NexusMods.Games.RedEngine/ModInstallers/AppearancePreset.cs
@@ -28,11 +28,11 @@ public class AppearancePreset : IModInstaller
         _dataStore = dataStore;
     }
 
-    public Priority Priority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> files)
+    public Priority GetPriority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
         if (!installation.Is<Cyberpunk2077>()) return Common.Priority.None;
 
-        return files.All(f => Helpers.IgnoreExtensions.Contains(f.Key.Extension) || (f.Value.FileTypes.Contains(FileType.Cyberpunk2077AppearancePreset) && f.Key.Extension == KnownExtensions.Preset))
+        return archiveFiles.All(f => Helpers.IgnoreExtensions.Contains(f.Key.Extension) || (f.Value.FileTypes.Contains(FileType.Cyberpunk2077AppearancePreset) && f.Key.Extension == KnownExtensions.Preset))
             ? Common.Priority.Normal
             : Common.Priority.None;
     }

--- a/src/Games/NexusMods.Games.RedEngine/ModInstallers/FolderlessModInstaller.cs
+++ b/src/Games/NexusMods.Games.RedEngine/ModInstallers/FolderlessModInstaller.cs
@@ -27,11 +27,11 @@ public class FolderlessModInstaller : IModInstaller
         _dataStore = dataStore;
     }
 
-    public Priority Priority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> files)
+    public Priority GetPriority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
         if (!installation.Is<Cyberpunk2077>()) return Common.Priority.None;
 
-        return files.All(f => Helpers.IgnoreExtensions.Contains(f.Key.Extension) || f.Key.Extension == KnownExtensions.Archive)
+        return archiveFiles.All(f => Helpers.IgnoreExtensions.Contains(f.Key.Extension) || f.Key.Extension == KnownExtensions.Archive)
             ? Common.Priority.Low
             : Common.Priority.None;
     }

--- a/src/Games/NexusMods.Games.RedEngine/ModInstallers/FolderlessModInstaller.cs
+++ b/src/Games/NexusMods.Games.RedEngine/ModInstallers/FolderlessModInstaller.cs
@@ -1,6 +1,7 @@
 using NexusMods.Common;
 using NexusMods.DataModel.Abstractions;
 using NexusMods.DataModel.ArchiveContents;
+using NexusMods.DataModel.Extensions;
 using NexusMods.DataModel.Games;
 using NexusMods.DataModel.Loadouts;
 using NexusMods.DataModel.Loadouts.ModFiles;
@@ -17,39 +18,58 @@ namespace NexusMods.Games.RedEngine.ModInstallers;
 /// </summary>
 public class FolderlessModInstaller : IModInstaller
 {
+    private static readonly RelativePath Destination = @"archive\pc\mod".ToRelativePath();
+
+    private readonly IDataStore _dataStore;
+
+    public FolderlessModInstaller(IDataStore dataStore)
+    {
+        _dataStore = dataStore;
+    }
+
     public Priority Priority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> files)
     {
-        if (!installation.Is<Cyberpunk2077>())
-            return Common.Priority.None;
-
         if (!installation.Is<Cyberpunk2077>()) return Common.Priority.None;
 
-        if (files.All(f => Helpers.IgnoreExtensions.Contains(f.Key.Extension) ||
-                           f.Key.Extension == KnownExtensions.Archive))
-            return Common.Priority.Low;
-        return Common.Priority.None;
+        return files.All(f => Helpers.IgnoreExtensions.Contains(f.Key.Extension) || f.Key.Extension == KnownExtensions.Archive)
+            ? Common.Priority.Low
+            : Common.Priority.None;
     }
 
-    public ValueTask<IEnumerable<AModFile>> GetFilesToExtractAsync(GameInstallation installation, Hash srcArchive, EntityDictionary<RelativePath, AnalyzedFile> files, CancellationToken ct)
+    public ValueTask<IEnumerable<Mod>> GetModsAsync(
+        GameInstallation gameInstallation,
+        Mod baseMod,
+        Hash srcArchiveHash,
+        EntityDictionary<RelativePath, AnalyzedFile> archiveFiles,
+        CancellationToken cancellationToken = default)
     {
-        return ValueTask.FromResult(GetFilesToExtractImpl(srcArchive, files));
+        return ValueTask.FromResult(GetMods(baseMod, srcArchiveHash, archiveFiles));
     }
 
-    private IEnumerable<AModFile> GetFilesToExtractImpl(Hash srcArchive, EntityDictionary<RelativePath, AnalyzedFile> files)
+    private IEnumerable<Mod> GetMods(
+        Mod baseMod,
+        Hash srcArchiveHash,
+        EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
-        foreach (var (path, file) in files)
-        {
-            if (Helpers.IgnoreExtensions.Contains(path.Extension))
-                continue;
-
-            yield return new FromArchive
+        var modFiles = archiveFiles
+            .Where(kv => !Helpers.IgnoreExtensions.Contains(kv.Key.Extension))
+            .Select(kv =>
             {
-                Id = ModFileId.New(),
-                From = new HashRelativePath(srcArchive, path),
-                To = new GamePath(GameFolderType.Game, @"archive\pc\mod".ToRelativePath().Join(path.FileName)),
-                Hash = file.Hash,
-                Size = file.Size
-            };
-        }
+                var (path, file) = kv;
+
+                return new FromArchive
+                {
+                    Id = ModFileId.New(),
+                    From = new HashRelativePath(srcArchiveHash, path),
+                    To = new GamePath(GameFolderType.Game, Destination.Join(path)),
+                    Hash = file.Hash,
+                    Size = file.Size
+                };
+            });
+
+        yield return baseMod with
+        {
+            Files = modFiles.ToEntityDictionary(_dataStore)
+        };
     }
 }

--- a/src/Games/NexusMods.Games.RedEngine/ModInstallers/FolderlessModInstaller.cs
+++ b/src/Games/NexusMods.Games.RedEngine/ModInstallers/FolderlessModInstaller.cs
@@ -29,11 +29,11 @@ public class FolderlessModInstaller : IModInstaller
 
     public Priority GetPriority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
-        if (!installation.Is<Cyberpunk2077>()) return Common.Priority.None;
+        if (!installation.Is<Cyberpunk2077>()) return Priority.None;
 
         return archiveFiles.All(f => Helpers.IgnoreExtensions.Contains(f.Key.Extension) || f.Key.Extension == KnownExtensions.Archive)
-            ? Common.Priority.Low
-            : Common.Priority.None;
+            ? Priority.Low
+            : Priority.None;
     }
 
     public ValueTask<IEnumerable<Mod>> GetModsAsync(

--- a/src/Games/NexusMods.Games.RedEngine/ModInstallers/FolderlessModInstaller.cs
+++ b/src/Games/NexusMods.Games.RedEngine/ModInstallers/FolderlessModInstaller.cs
@@ -61,7 +61,7 @@ public class FolderlessModInstaller : IModInstaller
                 {
                     Id = ModFileId.New(),
                     From = new HashRelativePath(srcArchiveHash, path),
-                    To = new GamePath(GameFolderType.Game, Destination.Join(path)),
+                    To = new GamePath(GameFolderType.Game, Destination.Join(path.FileName)),
                     Hash = file.Hash,
                     Size = file.Size
                 };

--- a/src/Games/NexusMods.Games.RedEngine/ModInstallers/FolderlessModInstaller.cs
+++ b/src/Games/NexusMods.Games.RedEngine/ModInstallers/FolderlessModInstaller.cs
@@ -20,13 +20,6 @@ public class FolderlessModInstaller : IModInstaller
 {
     private static readonly RelativePath Destination = @"archive\pc\mod".ToRelativePath();
 
-    private readonly IDataStore _dataStore;
-
-    public FolderlessModInstaller(IDataStore dataStore)
-    {
-        _dataStore = dataStore;
-    }
-
     public Priority GetPriority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
         if (!installation.Is<Cyberpunk2077>()) return Priority.None;
@@ -36,18 +29,18 @@ public class FolderlessModInstaller : IModInstaller
             : Priority.None;
     }
 
-    public ValueTask<IEnumerable<Mod>> GetModsAsync(
+    public ValueTask<IEnumerable<ModInstallerResult>> GetModsAsync(
         GameInstallation gameInstallation,
-        Mod baseMod,
+        ModId baseModId,
         Hash srcArchiveHash,
         EntityDictionary<RelativePath, AnalyzedFile> archiveFiles,
         CancellationToken cancellationToken = default)
     {
-        return ValueTask.FromResult(GetMods(baseMod, srcArchiveHash, archiveFiles));
+        return ValueTask.FromResult(GetMods(baseModId, srcArchiveHash, archiveFiles));
     }
 
-    private IEnumerable<Mod> GetMods(
-        Mod baseMod,
+    private IEnumerable<ModInstallerResult> GetMods(
+        ModId baseModId,
         Hash srcArchiveHash,
         EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
@@ -67,9 +60,10 @@ public class FolderlessModInstaller : IModInstaller
                 };
             });
 
-        yield return baseMod with
+        yield return new ModInstallerResult
         {
-            Files = modFiles.ToEntityDictionary(_dataStore)
+            Id = baseModId,
+            Files = modFiles
         };
     }
 }

--- a/src/Games/NexusMods.Games.RedEngine/ModInstallers/RedModInstaller.cs
+++ b/src/Games/NexusMods.Games.RedEngine/ModInstallers/RedModInstaller.cs
@@ -25,11 +25,11 @@ public class RedModInstaller : IModInstaller
         _dataStore = dataStore;
     }
 
-    public Priority Priority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> files)
+    public Priority GetPriority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
         if (!installation.Is<Cyberpunk2077>()) return Common.Priority.None;
 
-        return files.Any(IsInfoJson) ? Common.Priority.High : Common.Priority.None;
+        return archiveFiles.Any(IsInfoJson) ? Common.Priority.High : Common.Priority.None;
     }
 
     private static bool IsInfoJson(KeyValuePair<RelativePath, AnalyzedFile> file)

--- a/src/Games/NexusMods.Games.RedEngine/ModInstallers/RedModInstaller.cs
+++ b/src/Games/NexusMods.Games.RedEngine/ModInstallers/RedModInstaller.cs
@@ -27,9 +27,9 @@ public class RedModInstaller : IModInstaller
 
     public Priority GetPriority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
-        if (!installation.Is<Cyberpunk2077>()) return Common.Priority.None;
+        if (!installation.Is<Cyberpunk2077>()) return Priority.None;
 
-        return archiveFiles.Any(IsInfoJson) ? Common.Priority.High : Common.Priority.None;
+        return archiveFiles.Any(IsInfoJson) ? Priority.High : Priority.None;
     }
 
     private static bool IsInfoJson(KeyValuePair<RelativePath, AnalyzedFile> file)

--- a/src/Games/NexusMods.Games.RedEngine/ModInstallers/RedModInstaller.cs
+++ b/src/Games/NexusMods.Games.RedEngine/ModInstallers/RedModInstaller.cs
@@ -18,13 +18,6 @@ public class RedModInstaller : IModInstaller
     private static readonly RelativePath InfoJson = "info.json".ToRelativePath();
     private static readonly RelativePath Mods = "mods".ToRelativePath();
 
-    private readonly IDataStore _dataStore;
-
-    public RedModInstaller(IDataStore dataStore)
-    {
-        _dataStore = dataStore;
-    }
-
     public Priority GetPriority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
         if (!installation.Is<Cyberpunk2077>()) return Priority.None;
@@ -37,18 +30,18 @@ public class RedModInstaller : IModInstaller
         return file.Key.FileName == InfoJson && file.Value.AnalysisData.OfType<RedModInfo>().Any();
     }
     
-    public ValueTask<IEnumerable<Mod>> GetModsAsync(
+    public ValueTask<IEnumerable<ModInstallerResult>> GetModsAsync(
         GameInstallation gameInstallation,
-        Mod baseMod,
+        ModId baseModId,
         Hash srcArchiveHash,
         EntityDictionary<RelativePath, AnalyzedFile> archiveFiles,
         CancellationToken cancellationToken = default)
     {
-        return ValueTask.FromResult(GetMods(baseMod, srcArchiveHash, archiveFiles));
+        return ValueTask.FromResult(GetMods(baseModId, srcArchiveHash, archiveFiles));
     }
 
-    private IEnumerable<Mod> GetMods(
-        Mod baseMod,
+    private IEnumerable<ModInstallerResult> GetMods(
+        ModId baseModId,
         Hash srcArchiveHash,
         EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
@@ -76,9 +69,10 @@ public class RedModInstaller : IModInstaller
                     });
             });
 
-        yield return baseMod with
+        yield return new ModInstallerResult
         {
-            Files = modFiles.ToEntityDictionary(_dataStore)
+            Id = baseModId,
+            Files = modFiles
         };
     }
 }

--- a/src/Games/NexusMods.Games.RedEngine/ModInstallers/SimpleOverlayModInstaller.cs
+++ b/src/Games/NexusMods.Games.RedEngine/ModInstallers/SimpleOverlayModInstaller.cs
@@ -32,11 +32,11 @@ public class SimpleOverlayModInstaller : IModInstaller
         _dataStore = dataStore;
     }
 
-    public Priority Priority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> files)
+    public Priority GetPriority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
         if (!installation.Is<Cyberpunk2077>()) return Common.Priority.None;
 
-        var sets = RootFolder(files);
+        var sets = RootFolder(archiveFiles);
         return sets.Count != 1 ? Common.Priority.None : Common.Priority.Normal;
     }
 

--- a/src/Games/NexusMods.Games.RedEngine/ModInstallers/SimpleOverlayModInstaller.cs
+++ b/src/Games/NexusMods.Games.RedEngine/ModInstallers/SimpleOverlayModInstaller.cs
@@ -34,10 +34,10 @@ public class SimpleOverlayModInstaller : IModInstaller
 
     public Priority GetPriority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
-        if (!installation.Is<Cyberpunk2077>()) return Common.Priority.None;
+        if (!installation.Is<Cyberpunk2077>()) return Priority.None;
 
         var sets = RootFolder(archiveFiles);
-        return sets.Count != 1 ? Common.Priority.None : Common.Priority.Normal;
+        return sets.Count != 1 ? Priority.None : Priority.Normal;
     }
 
     private static HashSet<int> RootFolder(EntityDictionary<RelativePath, AnalyzedFile> files)

--- a/src/Games/NexusMods.Games.RedEngine/ModInstallers/SimpleOverlayModInstaller.cs
+++ b/src/Games/NexusMods.Games.RedEngine/ModInstallers/SimpleOverlayModInstaller.cs
@@ -1,6 +1,7 @@
 using NexusMods.Common;
 using NexusMods.DataModel.Abstractions;
 using NexusMods.DataModel.ArchiveContents;
+using NexusMods.DataModel.Extensions;
 using NexusMods.DataModel.Games;
 using NexusMods.DataModel.Loadouts;
 using NexusMods.DataModel.Loadouts.ModFiles;
@@ -13,14 +14,23 @@ namespace NexusMods.Games.RedEngine.ModInstallers;
 
 public class SimpleOverlayModInstaller : IModInstaller
 {
-    private static RelativePath[] _rootPaths = new[]
+    private static readonly RelativePath[] RootPaths = new[]
+        {
+            "bin/x64",
+            "engine",
+            "r6",
+            "red4ext",
+            "archive/pc/mod"
+        }
+        .Select(x => x.ToRelativePath())
+        .ToArray();
+
+    private readonly IDataStore _dataStore;
+
+    public SimpleOverlayModInstaller(IDataStore dataStore)
     {
-        "bin/x64",
-        "engine",
-        "r6",
-        "red4ext",
-        "archive/pc/mod"
-    }.Select(x => x.ToRelativePath()).ToArray();
+        _dataStore = dataStore;
+    }
 
     public Priority Priority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> files)
     {
@@ -30,11 +40,11 @@ public class SimpleOverlayModInstaller : IModInstaller
         return sets.Count != 1 ? Common.Priority.None : Common.Priority.Normal;
     }
 
-    private HashSet<int> RootFolder(EntityDictionary<RelativePath, AnalyzedFile> files)
+    private static HashSet<int> RootFolder(EntityDictionary<RelativePath, AnalyzedFile> files)
     {
         var filtered = files.Where(f => !Helpers.IgnoreExtensions.Contains(f.Key.Extension));
 
-        var sets = filtered.Select(f => _rootPaths.SelectMany(root => GetOffsets(f.Key, root)).ToHashSet())
+        var sets = filtered.Select(f => RootPaths.SelectMany(root => GetOffsets(f.Key, root)).ToHashSet())
             .Aggregate((set, x) =>
             {
                 set.IntersectWith(x);
@@ -49,7 +59,7 @@ public class SimpleOverlayModInstaller : IModInstaller
     /// <param name="basePath"></param>
     /// <param name="subSection"></param>
     /// <returns></returns>
-    private IEnumerable<int> GetOffsets(RelativePath basePath, RelativePath subSection)
+    private static IEnumerable<int> GetOffsets(RelativePath basePath, RelativePath subSection)
     {
         var depth = 0;
         while (true)
@@ -71,26 +81,42 @@ public class SimpleOverlayModInstaller : IModInstaller
         }
     }
 
-    public ValueTask<IEnumerable<AModFile>> GetFilesToExtractAsync(GameInstallation installation, Hash srcArchive, EntityDictionary<RelativePath, AnalyzedFile> files, CancellationToken ct = default)
+    public ValueTask<IEnumerable<Mod>> GetModsAsync(
+        GameInstallation gameInstallation,
+        Mod baseMod,
+        Hash srcArchiveHash,
+        EntityDictionary<RelativePath, AnalyzedFile> archiveFiles,
+        CancellationToken cancellationToken = default)
     {
-        return ValueTask.FromResult(GetFilesToExtractImpl(srcArchive, files));
+        return ValueTask.FromResult(GetMods(baseMod, srcArchiveHash, archiveFiles));
     }
 
-    private IEnumerable<AModFile> GetFilesToExtractImpl(Hash srcArchive, EntityDictionary<RelativePath, AnalyzedFile> files)
+    private IEnumerable<Mod> GetMods(
+        Mod baseMod,
+        Hash srcArchiveHash,
+        EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
-        var root = RootFolder(files).First();
-        var filtered = files.Where(f => !Helpers.IgnoreExtensions.Contains(f.Key.Extension));
+        var root = RootFolder(archiveFiles).First();
 
-        foreach (var (path, file) in filtered)
-        {
-            yield return new FromArchive()
+        var modFiles = archiveFiles
+            .Where(kv => !Helpers.IgnoreExtensions.Contains(kv.Key.Extension))
+            .Select(kv =>
             {
-                Id = ModFileId.New(),
-                From = new HashRelativePath(srcArchive, path),
-                To = new GamePath(GameFolderType.Game, path.DropFirst(root)),
-                Hash = file.Hash,
-                Size = file.Size
-            };
-        }
+                var (path, file) = kv;
+
+                return new FromArchive
+                {
+                    Id = ModFileId.New(),
+                    From = new HashRelativePath(srcArchiveHash, path),
+                    To = new GamePath(GameFolderType.Game, path.DropFirst(root)),
+                    Hash = file.Hash,
+                    Size = file.Size
+                };
+            });
+
+        yield return baseMod with
+        {
+            Files = modFiles.ToEntityDictionary(_dataStore)
+        };
     }
 }

--- a/src/Games/NexusMods.Games.RedEngine/ModInstallers/SimpleOverlayModInstaller.cs
+++ b/src/Games/NexusMods.Games.RedEngine/ModInstallers/SimpleOverlayModInstaller.cs
@@ -25,13 +25,6 @@ public class SimpleOverlayModInstaller : IModInstaller
         .Select(x => x.ToRelativePath())
         .ToArray();
 
-    private readonly IDataStore _dataStore;
-
-    public SimpleOverlayModInstaller(IDataStore dataStore)
-    {
-        _dataStore = dataStore;
-    }
-
     public Priority GetPriority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
         if (!installation.Is<Cyberpunk2077>()) return Priority.None;
@@ -81,18 +74,18 @@ public class SimpleOverlayModInstaller : IModInstaller
         }
     }
 
-    public ValueTask<IEnumerable<Mod>> GetModsAsync(
+    public ValueTask<IEnumerable<ModInstallerResult>> GetModsAsync(
         GameInstallation gameInstallation,
-        Mod baseMod,
+        ModId baseModId,
         Hash srcArchiveHash,
         EntityDictionary<RelativePath, AnalyzedFile> archiveFiles,
         CancellationToken cancellationToken = default)
     {
-        return ValueTask.FromResult(GetMods(baseMod, srcArchiveHash, archiveFiles));
+        return ValueTask.FromResult(GetMods(baseModId, srcArchiveHash, archiveFiles));
     }
 
-    private IEnumerable<Mod> GetMods(
-        Mod baseMod,
+    private IEnumerable<ModInstallerResult> GetMods(
+        ModId baseModId,
         Hash srcArchiveHash,
         EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
@@ -114,9 +107,10 @@ public class SimpleOverlayModInstaller : IModInstaller
                 };
             });
 
-        yield return baseMod with
+        yield return new ModInstallerResult
         {
-            Files = modFiles.ToEntityDictionary(_dataStore)
+            Id = baseModId,
+            Files = modFiles
         };
     }
 }

--- a/src/Games/NexusMods.Games.Reshade/ReshadePresetInstaller.cs
+++ b/src/Games/NexusMods.Games.Reshade/ReshadePresetInstaller.cs
@@ -40,11 +40,11 @@ public class ReshadePresetInstaller : IModInstaller
 
         // We have to be able to find the game's executable
         if (installation.Game is not AGame)
-            return Common.Priority.None;
+            return Priority.None;
 
         // We only support ini files for now
         if (!filtered.All(f => f.Value.FileTypes.Contains(FileType.INI)))
-            return Common.Priority.None;
+            return Priority.None;
 
         // Get all the ini data
         var iniData = filtered
@@ -57,13 +57,13 @@ public class ReshadePresetInstaller : IModInstaller
 
         // All the files must have ini data
         if (iniData.Count != filtered.Count)
-            return Common.Priority.None;
+            return Priority.None;
 
         // All the files must have a section that ends with .fx marking them as likely a reshade preset
         if (!iniData.All(f => f.Sections.All(x => x.EndsWith(".fx", StringComparison.CurrentCultureIgnoreCase))))
-            return Common.Priority.None;
+            return Priority.None;
 
-        return Common.Priority.Low;
+        return Priority.Low;
     }
 
     public ValueTask<IEnumerable<Mod>> GetModsAsync(

--- a/src/Games/NexusMods.Games.Reshade/ReshadePresetInstaller.cs
+++ b/src/Games/NexusMods.Games.Reshade/ReshadePresetInstaller.cs
@@ -32,9 +32,9 @@ public class ReshadePresetInstaller : IModInstaller
         _dataStore = dataStore;
     }
 
-    public Priority Priority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> files)
+    public Priority GetPriority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
-        var filtered = files
+        var filtered = archiveFiles
             .Where(f => !IgnoreFiles.Contains(f.Key.FileName))
             .ToList();
 

--- a/src/Games/NexusMods.Games.Reshade/ReshadePresetInstaller.cs
+++ b/src/Games/NexusMods.Games.Reshade/ReshadePresetInstaller.cs
@@ -25,13 +25,6 @@ public class ReshadePresetInstaller : IModInstaller
         .Select(t => t.ToRelativePath())
         .ToHashSet();
 
-    private readonly IDataStore _dataStore;
-
-    public ReshadePresetInstaller(IDataStore dataStore)
-    {
-        _dataStore = dataStore;
-    }
-
     public Priority GetPriority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
         var filtered = archiveFiles
@@ -66,22 +59,21 @@ public class ReshadePresetInstaller : IModInstaller
         return Priority.Low;
     }
 
-    public ValueTask<IEnumerable<Mod>> GetModsAsync(
+    public ValueTask<IEnumerable<ModInstallerResult>> GetModsAsync(
         GameInstallation gameInstallation,
-        Mod baseMod,
+        ModId baseModId,
         Hash srcArchiveHash,
         EntityDictionary<RelativePath, AnalyzedFile> archiveFiles,
         CancellationToken cancellationToken = default)
     {
-        return ValueTask.FromResult(GetMods(baseMod, srcArchiveHash, archiveFiles));
+        return ValueTask.FromResult(GetMods(baseModId, srcArchiveHash, archiveFiles));
     }
 
-    private IEnumerable<Mod> GetMods(
-        Mod baseMod,
+    private IEnumerable<ModInstallerResult> GetMods(
+        ModId baseModId,
         Hash srcArchiveHash,
         EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
-
         var modFiles = archiveFiles
             .Where(kv => !IgnoreFiles.Contains(kv.Key.FileName))
             .Select(kv =>
@@ -98,9 +90,10 @@ public class ReshadePresetInstaller : IModInstaller
                 };
             });
 
-        yield return baseMod with
+        yield return new ModInstallerResult
         {
-            Files = modFiles.ToEntityDictionary(_dataStore)
+            Id = baseModId,
+            Files = modFiles
         };
     }
 }

--- a/src/Games/NexusMods.Games.Sifu/SifuModInstaller.cs
+++ b/src/Games/NexusMods.Games.Sifu/SifuModInstaller.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using NexusMods.Common;
 using NexusMods.DataModel.Abstractions;
 using NexusMods.DataModel.ArchiveContents;
@@ -12,17 +13,12 @@ using NexusMods.Paths.Extensions;
 
 namespace NexusMods.Games.Sifu;
 
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+[SuppressMessage("ReSharper", "IdentifierTypo")]
 public class SifuModInstaller : IModInstaller
 {
     private static readonly Extension PakExt = new(".pak");
     private static readonly RelativePath ModsPath = @"Content\Paks\~mods".ToRelativePath();
-
-    private readonly IDataStore _dataStore;
-
-    public SifuModInstaller(IDataStore dataStore)
-    {
-        _dataStore = dataStore;
-    }
 
     public Priority GetPriority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
@@ -36,18 +32,18 @@ public class SifuModInstaller : IModInstaller
         return files.Any(kv => kv.Key.Extension == PakExt);
     }
 
-    public ValueTask<IEnumerable<Mod>> GetModsAsync(
+    public ValueTask<IEnumerable<ModInstallerResult>> GetModsAsync(
         GameInstallation gameInstallation,
-        Mod baseMod,
+        ModId baseModId,
         Hash srcArchiveHash,
         EntityDictionary<RelativePath, AnalyzedFile> archiveFiles,
         CancellationToken cancellationToken = default)
     {
-        return ValueTask.FromResult(GetMods(baseMod, srcArchiveHash, archiveFiles));
+        return ValueTask.FromResult(GetMods(baseModId, srcArchiveHash, archiveFiles));
     }
 
-    private IEnumerable<Mod> GetMods(
-        Mod baseMod,
+    private IEnumerable<ModInstallerResult> GetMods(
+        ModId baseModId,
         Hash srcArchiveHash,
         EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
@@ -69,9 +65,10 @@ public class SifuModInstaller : IModInstaller
                 };
             });
 
-        yield return baseMod with
+        yield return new ModInstallerResult
         {
-            Files = modFiles.ToEntityDictionary(_dataStore)
+            Id = baseModId,
+            Files = modFiles
         };
     }
 }

--- a/src/Games/NexusMods.Games.Sifu/SifuModInstaller.cs
+++ b/src/Games/NexusMods.Games.Sifu/SifuModInstaller.cs
@@ -24,9 +24,9 @@ public class SifuModInstaller : IModInstaller
         _dataStore = dataStore;
     }
 
-    public Priority Priority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> files)
+    public Priority GetPriority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
-        return installation.Game is Sifu && ContainsUEModFile(files)
+        return installation.Game is Sifu && ContainsUEModFile(archiveFiles)
             ? Common.Priority.Normal
             : Common.Priority.None;
     }

--- a/src/Games/NexusMods.Games.Sifu/SifuModInstaller.cs
+++ b/src/Games/NexusMods.Games.Sifu/SifuModInstaller.cs
@@ -27,8 +27,8 @@ public class SifuModInstaller : IModInstaller
     public Priority GetPriority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
         return installation.Game is Sifu && ContainsUEModFile(archiveFiles)
-            ? Common.Priority.Normal
-            : Common.Priority.None;
+            ? Priority.Normal
+            : Priority.None;
     }
 
     private static bool ContainsUEModFile(EntityDictionary<RelativePath, AnalyzedFile> files)

--- a/src/Games/NexusMods.Games.StardewValley/Analyzers/SMAPIManifestAnalyzer.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Analyzers/SMAPIManifestAnalyzer.cs
@@ -17,7 +17,7 @@ namespace NexusMods.Games.StardewValley.Analyzers;
 /// </summary>
 public class SMAPIManifestAnalyzer : IFileAnalyzer
 {
-    public FileAnalyzerId Id => FileAnalyzerId.New("f917e906-d28a-472d-b6e5-e7d2c61c60e4", 0);
+    public FileAnalyzerId Id => FileAnalyzerId.New("f917e906-d28a-472d-b6e5-e7d2c61c60e4", 1);
 
     public IEnumerable<FileType> FileTypes => new[] { FileType.JSON };
 
@@ -69,7 +69,8 @@ public record SMAPIManifest : IFileAnalysisData
 }
 
 /// <summary>
-/// https://github.com/Pathoschild/SMAPI/blob/9763bc7484e29cbc9e7f37c61121d794e6720e75/src/SMAPI.Toolkit.CoreInterfaces/IManifestDependency.cs#L4
+/// https://github.com/Pathoschild/SMAPI/blob/9763bc7484e29cbc9e7f37c61121d794e6720e75/src/SMAPI.Toolkit.CoreInterfaces/IManifestDependency.cs
+/// https://github.com/Pathoschild/SMAPI/blob/9763bc7484e29cbc9e7f37c61121d794e6720e75/src/SMAPI.Toolkit/Serialization/Models/ManifestDependency.cs
 /// </summary>
 [PublicAPI]
 [JsonName("NexusMods.Games.StardewValley.SMAPIManifestDependency")]
@@ -81,12 +82,13 @@ public record SMAPIManifestDependency
     public required string UniqueID { get; init; }
 
     /// <summary>
-    /// The minimum required version (if any).
+    /// The minimum required version. This property is optional.
     /// </summary>
     public Version? MinimumVersion { get; init; }
 
     /// <summary>
-    /// Whether the dependency must be installed to use the mod.
+    /// Whether the dependency must be installed to use the mod. This property is
+    /// optional and set to <c>true</c> by default (https://github.com/Pathoschild/SMAPI/blob/9763bc7484e29cbc9e7f37c61121d794e6720e75/src/SMAPI.Toolkit/Serialization/Models/ManifestDependency.cs#L29)
     /// </summary>
-    public required bool IsRequired { get; init; }
+    public bool IsRequired { get; init; } = true;
 }

--- a/src/Games/NexusMods.Games.StardewValley/Installers/SMAPIInstaller.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Installers/SMAPIInstaller.cs
@@ -4,6 +4,7 @@ using NexusMods.Common;
 using NexusMods.DataModel;
 using NexusMods.DataModel.Abstractions;
 using NexusMods.DataModel.ArchiveContents;
+using NexusMods.DataModel.Extensions;
 using NexusMods.DataModel.Games;
 using NexusMods.DataModel.Loadouts;
 using NexusMods.DataModel.Loadouts.ModFiles;
@@ -29,10 +30,12 @@ public class SMAPIInstaller : IModInstaller
     private static readonly RelativePath WindowsFolder = "windows".ToRelativePath();
     private static readonly RelativePath MacOSFolder = "macOS".ToRelativePath();
 
+    private readonly IDataStore _dataStore;
     private readonly FileHashCache _fileHashCache;
 
     public SMAPIInstaller(IDataStore dataStore, FileHashCache fileHashCache)
     {
+        _dataStore = dataStore;
         _fileHashCache = fileHashCache;
     }
 
@@ -64,19 +67,26 @@ public class SMAPIInstaller : IModInstaller
             : Common.Priority.None;
     }
 
-    public ValueTask<IEnumerable<AModFile>> GetFilesToExtractAsync(GameInstallation installation,
-        Hash srcArchiveHash, EntityDictionary<RelativePath, AnalyzedFile> files,
-        CancellationToken ct = default)
+    public ValueTask<IEnumerable<Mod>> GetModsAsync(
+        GameInstallation gameInstallation,
+        Mod baseMod,
+        Hash srcArchiveHash,
+        EntityDictionary<RelativePath, AnalyzedFile> archiveFiles,
+        CancellationToken cancellationToken = default)
     {
-        return ValueTask.FromResult(GetFilesToExtract(installation, files));
+        return ValueTask.FromResult(GetMods(gameInstallation, baseMod, srcArchiveHash, archiveFiles));
     }
 
-    private IEnumerable<AModFile> GetFilesToExtract(
-        GameInstallation installation,
-        EntityDictionary<RelativePath, AnalyzedFile> files)
+    private IEnumerable<Mod> GetMods(
+        GameInstallation gameInstallation,
+        Mod baseMod,
+        Hash srcArchiveHash,
+        EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
-        var installDataFiles = GetInstallDataFiles(files);
-        if (installDataFiles.Length != 3) throw new UnreachableException($"{nameof(SMAPIInstaller)} should guarantee with {nameof(Priority)} that {nameof(GetInstallDataFiles)} returns 3 files when called from {nameof(GetFilesToExtractAsync)} but it has {installDataFiles.Length} files instead!");
+        var modFiles = new List<AModFile>();
+
+        var installDataFiles = GetInstallDataFiles(archiveFiles);
+        if (installDataFiles.Length != 3) throw new UnreachableException($"{nameof(SMAPIInstaller)} should guarantee with {nameof(Priority)} that {nameof(GetInstallDataFiles)} returns 3 files when called from {nameof(GetModsAsync)} but it has {installDataFiles.Length} files instead!");
 
         KeyValuePair<RelativePath, AnalyzedFile> installDataFile;
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
@@ -98,7 +108,7 @@ public class SMAPIInstaller : IModInstaller
         if (file is not AnalyzedArchive archive)
             throw new UnreachableException($"{nameof(AnalyzedFile)} that has the file type {nameof(FileType.ZIP)} is not a {nameof(AnalyzedArchive)}");
 
-        var gameFolderPath = installation.Locations
+        var gameFolderPath = gameInstallation.Locations
             .First(x => x.Key == GameFolderType.Game).Value;
 
         var archiveContents = archive.Contents;
@@ -127,13 +137,18 @@ public class SMAPIInstaller : IModInstaller
         if (!_fileHashCache.TryGetCached(gameDepsFilePath, out var gameDepsFileCache))
             throw new NotImplementedException($"Game file {gameFolderPath} was not found in cache!");
 
-        yield return new GameFile
+        modFiles.Add(new GameFile
         {
             Hash = gameDepsFileCache.Hash,
             Size = gameDepsFileCache.Size,
             Id = ModFileId.New(),
-            Installation = installation,
+            Installation = gameInstallation,
             To = new GamePath(GameFolderType.Game, "StardewModdingAPI.deps.json")
+        });
+
+        yield return baseMod with
+        {
+            Files = modFiles.ToEntityDictionary(_dataStore)
         };
     }
 }

--- a/src/Games/NexusMods.Games.StardewValley/Installers/SMAPIInstaller.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Installers/SMAPIInstaller.cs
@@ -59,12 +59,12 @@ public class SMAPIInstaller : IModInstaller
 
     public Priority GetPriority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
-        if (!installation.Is<StardewValley>()) return Common.Priority.None;
+        if (!installation.Is<StardewValley>()) return Priority.None;
 
         var installDataFiles = GetInstallDataFiles(archiveFiles);
         return installDataFiles.Length == 3
-            ? Common.Priority.Highest
-            : Common.Priority.None;
+            ? Priority.Highest
+            : Priority.None;
     }
 
     public ValueTask<IEnumerable<Mod>> GetModsAsync(

--- a/src/Games/NexusMods.Games.StardewValley/Installers/SMAPIInstaller.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Installers/SMAPIInstaller.cs
@@ -30,12 +30,10 @@ public class SMAPIInstaller : IModInstaller
     private static readonly RelativePath WindowsFolder = "windows".ToRelativePath();
     private static readonly RelativePath MacOSFolder = "macOS".ToRelativePath();
 
-    private readonly IDataStore _dataStore;
     private readonly FileHashCache _fileHashCache;
 
-    public SMAPIInstaller(IDataStore dataStore, FileHashCache fileHashCache)
+    public SMAPIInstaller(FileHashCache fileHashCache)
     {
-        _dataStore = dataStore;
         _fileHashCache = fileHashCache;
     }
 
@@ -67,19 +65,19 @@ public class SMAPIInstaller : IModInstaller
             : Priority.None;
     }
 
-    public ValueTask<IEnumerable<Mod>> GetModsAsync(
+    public ValueTask<IEnumerable<ModInstallerResult>> GetModsAsync(
         GameInstallation gameInstallation,
-        Mod baseMod,
+        ModId baseModId,
         Hash srcArchiveHash,
         EntityDictionary<RelativePath, AnalyzedFile> archiveFiles,
         CancellationToken cancellationToken = default)
     {
-        return ValueTask.FromResult(GetMods(gameInstallation, baseMod, srcArchiveHash, archiveFiles));
+        return ValueTask.FromResult(GetMods(gameInstallation, baseModId, srcArchiveHash, archiveFiles));
     }
 
-    private IEnumerable<Mod> GetMods(
+    private IEnumerable<ModInstallerResult> GetMods(
         GameInstallation gameInstallation,
-        Mod baseMod,
+        ModId baseModId,
         Hash srcArchiveHash,
         EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
@@ -146,9 +144,11 @@ public class SMAPIInstaller : IModInstaller
             To = new GamePath(GameFolderType.Game, "StardewModdingAPI.deps.json")
         });
 
-        yield return baseMod with
+        // TODO: consider adding Name and Version
+        yield return new ModInstallerResult
         {
-            Files = modFiles.ToEntityDictionary(_dataStore)
+            Id = baseModId,
+            Files = modFiles
         };
     }
 }

--- a/src/Games/NexusMods.Games.StardewValley/Installers/SMAPIInstaller.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Installers/SMAPIInstaller.cs
@@ -57,11 +57,11 @@ public class SMAPIInstaller : IModInstaller
         return installDataFiles;
     }
 
-    public Priority Priority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> files)
+    public Priority GetPriority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
         if (!installation.Is<StardewValley>()) return Common.Priority.None;
 
-        var installDataFiles = GetInstallDataFiles(files);
+        var installDataFiles = GetInstallDataFiles(archiveFiles);
         return installDataFiles.Length == 3
             ? Common.Priority.Highest
             : Common.Priority.None;
@@ -86,7 +86,7 @@ public class SMAPIInstaller : IModInstaller
         var modFiles = new List<AModFile>();
 
         var installDataFiles = GetInstallDataFiles(archiveFiles);
-        if (installDataFiles.Length != 3) throw new UnreachableException($"{nameof(SMAPIInstaller)} should guarantee with {nameof(Priority)} that {nameof(GetInstallDataFiles)} returns 3 files when called from {nameof(GetModsAsync)} but it has {installDataFiles.Length} files instead!");
+        if (installDataFiles.Length != 3) throw new UnreachableException($"{nameof(SMAPIInstaller)} should guarantee with {nameof(GetPriority)} that {nameof(GetInstallDataFiles)} returns 3 files when called from {nameof(GetModsAsync)} but it has {installDataFiles.Length} files instead!");
 
         KeyValuePair<RelativePath, AnalyzedFile> installDataFile;
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))

--- a/src/Games/NexusMods.Games.StardewValley/Installers/SMAPIModInstaller.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Installers/SMAPIModInstaller.cs
@@ -49,10 +49,10 @@ public class SMAPIModInstaller : IModInstaller
 
     public Priority GetPriority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
-        if (!installation.Is<StardewValley>()) return Common.Priority.None;
+        if (!installation.Is<StardewValley>()) return Priority.None;
         return GetManifestFiles(archiveFiles).Any()
-            ? Common.Priority.Highest
-            : Common.Priority.None;
+            ? Priority.Highest
+            : Priority.None;
     }
 
     public ValueTask<IEnumerable<Mod>> GetModsAsync(

--- a/src/Games/NexusMods.Games.StardewValley/Installers/SMAPIModInstaller.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Installers/SMAPIModInstaller.cs
@@ -47,10 +47,10 @@ public class SMAPIModInstaller : IModInstaller
         });
     }
 
-    public Priority Priority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> files)
+    public Priority GetPriority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
         if (!installation.Is<StardewValley>()) return Common.Priority.None;
-        return GetManifestFiles(files).Any()
+        return GetManifestFiles(archiveFiles).Any()
             ? Common.Priority.Highest
             : Common.Priority.None;
     }
@@ -72,7 +72,7 @@ public class SMAPIModInstaller : IModInstaller
     {
         var manifestFiles = GetManifestFiles(archiveFiles).ToArray();
         if (!manifestFiles.Any())
-            throw new UnreachableException($"{nameof(SMAPIModInstaller)} should guarantee with {nameof(Priority)} that {nameof(GetModsAsync)} is never called for archives that don't have a SMAPI manifest file.");
+            throw new UnreachableException($"{nameof(SMAPIModInstaller)} should guarantee with {nameof(GetPriority)} that {nameof(GetModsAsync)} is never called for archives that don't have a SMAPI manifest file.");
 
         var mods = manifestFiles
             .Select(manifestFile =>

--- a/src/Games/NexusMods.Games.StardewValley/Installers/SMAPIModInstaller.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Installers/SMAPIModInstaller.cs
@@ -24,13 +24,6 @@ public class SMAPIModInstaller : IModInstaller
     private static readonly RelativePath ModsFolder = "Mods".ToRelativePath();
     private static readonly RelativePath ManifestFile = "manifest.json".ToRelativePath();
 
-    private readonly IDataStore _dataStore;
-
-    public SMAPIModInstaller(IDataStore dataStore)
-    {
-        _dataStore = dataStore;
-    }
-
     private static IEnumerable<KeyValuePair<RelativePath, AnalyzedFile>> GetManifestFiles(
         EntityDictionary<RelativePath, AnalyzedFile> files)
     {
@@ -55,18 +48,17 @@ public class SMAPIModInstaller : IModInstaller
             : Priority.None;
     }
 
-    public ValueTask<IEnumerable<Mod>> GetModsAsync(
+    public ValueTask<IEnumerable<ModInstallerResult>> GetModsAsync(
         GameInstallation gameInstallation,
-        Mod baseMod,
+        ModId baseModId,
         Hash srcArchiveHash,
         EntityDictionary<RelativePath, AnalyzedFile> archiveFiles,
         CancellationToken cancellationToken = default)
     {
-        return ValueTask.FromResult(GetMods(baseMod, srcArchiveHash, archiveFiles));
+        return ValueTask.FromResult(GetMods(srcArchiveHash, archiveFiles));
     }
 
-    private IEnumerable<Mod> GetMods(
-        Mod baseMod,
+    private IEnumerable<ModInstallerResult> GetMods(
         Hash srcArchiveHash,
         EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
@@ -100,10 +92,10 @@ public class SMAPIModInstaller : IModInstaller
                         };
                     });
 
-                return baseMod with
+                return new ModInstallerResult
                 {
                     Id = ModId.New(),
-                    Files = modFiles.ToEntityDictionary(_dataStore),
+                    Files = modFiles,
                     Name = manifest.Name,
                     Version = manifest.Version.ToString()
                 };

--- a/src/Games/NexusMods.Games.TestHarness/Verbs/StressTest.cs
+++ b/src/Games/NexusMods.Games.TestHarness/Verbs/StressTest.cs
@@ -85,7 +85,7 @@ public class StressTest : AVerb<IGame, AbsolutePath, AbsolutePath>
                         file.FileName, file.SizeInBytes);
 
                     var list = await _loadoutManager.ImportFromAsync(loadout, token);
-                    await list.InstallModAsync(tmpPath, "Stress Test Mod", token);
+                    await list.InstallModsFromArchiveAsync(tmpPath, "Stress Test Mod", token);
 
                     results.Add((file.FileName, mod.ModId, file.FileId, hash, true, null));
                     _logger.LogInformation("Installed {ModId} {FileId} {FileName} - {Size}", mod.ModId, file.FileId,

--- a/src/NexusMods.App.UI/RightContent/LoadoutGrid/LoadoutGridViewModel.cs
+++ b/src/NexusMods.App.UI/RightContent/LoadoutGrid/LoadoutGridViewModel.cs
@@ -44,7 +44,7 @@ public class LoadoutGridViewModel : AViewModel<ILoadoutGridViewModel>, ILoadoutG
 
         var _ = Task.Run(async () =>
         {
-            await _loadoutManager.InstallModAsync(LoadoutId, file, file.FileName);
+            await _loadoutManager.InstallModsFromArchiveAsync(LoadoutId, file, file.FileName);
         });
     }
 

--- a/src/NexusMods.CLI/Verbs/InstallMod.cs
+++ b/src/NexusMods.CLI/Verbs/InstallMod.cs
@@ -20,7 +20,7 @@ public class InstallMod : AVerb<LoadoutMarker, AbsolutePath, string>
     {
         await _renderer.WithProgress(token, async () =>
         {
-            await loadout.InstallModAsync(file, name, token);
+            await loadout.InstallModsFromArchiveAsync(file, name, token);
             return file;
         });
         return 0;

--- a/src/NexusMods.DataModel/ArchiveManager.cs
+++ b/src/NexusMods.DataModel/ArchiveManager.cs
@@ -101,10 +101,12 @@ public class ArchiveManager
     /// <returns></returns>
     public bool TryGetPathFor(Hash hash, out AbsolutePath path)
     {
-        var rel = NameForHash(hash);
-        path = _locations.Select(r => r.CombineUnchecked(rel))
-            .FirstOrDefault(r => r.FileExists);
-        return path != default;
+        var relativePath = NameForHash(hash);
+        if (_locations.Select(x => x.CombineUnchecked(relativePath)).TryGetFirst(x => x.FileExists, out path))
+            return true;
+
+        path = default;
+        return false;
     }
 
     /// <summary>

--- a/src/NexusMods.DataModel/Extensions/EntityDictionaryExtensions.cs
+++ b/src/NexusMods.DataModel/Extensions/EntityDictionaryExtensions.cs
@@ -17,15 +17,20 @@ public static class EntityDictionaryExtensions
     /// </summary>
     /// <param name="modFiles"></param>
     /// <param name="dataStore"></param>
+    /// <param name="persist">Whether to use persist the collection of entities in the data store.</param>
     /// <returns></returns>
     public static EntityDictionary<ModFileId, AModFile> ToEntityDictionary(
         [InstantHandle(RequireAwait = false)] this IEnumerable<AModFile> modFiles,
-        IDataStore dataStore)
+        IDataStore dataStore,
+        bool persist = true)
     {
+        var enumerable = persist
+            ? modFiles.WithPersist(dataStore)
+            : modFiles;
+
         return new EntityDictionary<ModFileId, AModFile>(
             dataStore,
-            modFiles
-                .WithPersist(dataStore)
+            enumerable
                 .Select(modFile => new KeyValuePair<ModFileId, IId>(
                     modFile.Id,
                     modFile.DataStoreId)));

--- a/src/NexusMods.DataModel/Extensions/EntityDictionaryExtensions.cs
+++ b/src/NexusMods.DataModel/Extensions/EntityDictionaryExtensions.cs
@@ -1,0 +1,33 @@
+using JetBrains.Annotations;
+using NexusMods.DataModel.Abstractions;
+using NexusMods.DataModel.Abstractions.Ids;
+using NexusMods.DataModel.Loadouts;
+
+namespace NexusMods.DataModel.Extensions;
+
+/// <summary>
+/// Extension methods for <see cref="EntityDictionary{TK,TV}"/>
+/// </summary>
+[PublicAPI]
+public static class EntityDictionaryExtensions
+{
+    /// <summary>
+    /// Creates a new <see cref="EntityDictionary{TK,TV}"/> from an enumerable
+    /// of a collection of items that inherit from <see cref="AModFile"/>.
+    /// </summary>
+    /// <param name="modFiles"></param>
+    /// <param name="dataStore"></param>
+    /// <returns></returns>
+    public static EntityDictionary<ModFileId, AModFile> ToEntityDictionary(
+        [InstantHandle(RequireAwait = false)] this IEnumerable<AModFile> modFiles,
+        IDataStore dataStore)
+    {
+        return new EntityDictionary<ModFileId, AModFile>(
+            dataStore,
+            modFiles
+                .WithPersist(dataStore)
+                .Select(modFile => new KeyValuePair<ModFileId, IId>(
+                    modFile.Id,
+                    modFile.DataStoreId)));
+    }
+}

--- a/src/NexusMods.DataModel/GroupId.cs
+++ b/src/NexusMods.DataModel/GroupId.cs
@@ -10,7 +10,7 @@ namespace NexusMods.DataModel;
 /// </summary>
 [PublicAPI]
 [ValueObject<Guid>(conversions: Conversions.None)]
-[JsonConverter(typeof(ModIdConverter))]
+[JsonConverter(typeof(GroupIdConverter))]
 public readonly partial struct GroupId
 {
     /// <summary>

--- a/src/NexusMods.DataModel/GroupId.cs
+++ b/src/NexusMods.DataModel/GroupId.cs
@@ -17,5 +17,5 @@ public readonly partial struct GroupId
     /// Creates a new <see cref="GroupId"/> from a unique <see cref="Guid"/>.
     /// </summary>
     /// <returns></returns>
-    public static GroupId New() => GroupId.From(Guid.NewGuid());
+    public static GroupId New() => From(Guid.NewGuid());
 }

--- a/src/NexusMods.DataModel/GroupId.cs
+++ b/src/NexusMods.DataModel/GroupId.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+using JetBrains.Annotations;
+using NexusMods.DataModel.JsonConverters;
+using Vogen;
+
+namespace NexusMods.DataModel;
+
+/// <summary>
+/// Represents a unique identifier for a mod group.
+/// </summary>
+[PublicAPI]
+[ValueObject<Guid>(conversions: Conversions.None)]
+[JsonConverter(typeof(ModIdConverter))]
+public readonly partial struct GroupId
+{
+    /// <summary>
+    /// Creates a new <see cref="GroupId"/> from a unique <see cref="Guid"/>.
+    /// </summary>
+    /// <returns></returns>
+    public static GroupId New() => GroupId.From(Guid.NewGuid());
+}

--- a/src/NexusMods.DataModel/GroupMetadata.cs
+++ b/src/NexusMods.DataModel/GroupMetadata.cs
@@ -1,0 +1,33 @@
+using JetBrains.Annotations;
+using NexusMods.DataModel.Loadouts;
+
+namespace NexusMods.DataModel;
+
+/// <summary>
+/// Represents metadata that groups multiple <see cref="Mod"/> entities together.
+/// </summary>
+[PublicAPI]
+public record GroupMetadata : AModMetadata
+{
+    /// <summary>
+    /// Unique identifier of the group.
+    /// </summary>
+    public required GroupId Id { get; init; }
+
+    /// <summary>
+    /// Creation reason of the group.
+    /// </summary>
+    public GroupCreationReason CreationReason { get; set; } = GroupCreationReason.MultipleModsOneArchive;
+}
+
+/// <summary>
+/// Represents the creation reason for a group
+/// </summary>
+[PublicAPI]
+public enum GroupCreationReason : byte
+{
+    /// <summary>
+    /// The group was created because an archive contained multiple mods.
+    /// </summary>
+    MultipleModsOneArchive = 0,
+}

--- a/src/NexusMods.DataModel/JsonConverters/GroupIdConverter.cs
+++ b/src/NexusMods.DataModel/JsonConverters/GroupIdConverter.cs
@@ -1,0 +1,25 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using JetBrains.Annotations;
+
+namespace NexusMods.DataModel.JsonConverters;
+
+/// <inheritdoc />
+[PublicAPI]
+public class GroupIdConverter : JsonConverter<GroupId>
+{
+    /// <inheritdoc />
+    public override GroupId Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var data = reader.GetBytesFromBase64();
+        return GroupId.From(new Guid(data));
+    }
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, GroupId value, JsonSerializerOptions options)
+    {
+        Span<byte> span = stackalloc byte[16];
+        value.Value.TryWriteBytes(span);
+        writer.WriteBase64StringValue(span);
+    }
+}

--- a/src/NexusMods.DataModel/Loadouts/AModMetadata.cs
+++ b/src/NexusMods.DataModel/Loadouts/AModMetadata.cs
@@ -1,0 +1,9 @@
+using JetBrains.Annotations;
+
+namespace NexusMods.DataModel.Loadouts;
+
+/// <summary>
+/// Represents metadata for a <see cref="Mod"/>.
+/// </summary>
+[PublicAPI]
+public abstract record AModMetadata { }

--- a/src/NexusMods.DataModel/Loadouts/AModMetadata.cs
+++ b/src/NexusMods.DataModel/Loadouts/AModMetadata.cs
@@ -6,4 +6,4 @@ namespace NexusMods.DataModel.Loadouts;
 /// Represents metadata for a <see cref="Mod"/>.
 /// </summary>
 [PublicAPI]
-public abstract record AModMetadata { }
+public abstract record AModMetadata;

--- a/src/NexusMods.DataModel/Loadouts/GroupMetadata.cs
+++ b/src/NexusMods.DataModel/Loadouts/GroupMetadata.cs
@@ -1,12 +1,13 @@
 using JetBrains.Annotations;
-using NexusMods.DataModel.Loadouts;
+using NexusMods.DataModel.JsonConverters;
 
-namespace NexusMods.DataModel;
+namespace NexusMods.DataModel.Loadouts;
 
 /// <summary>
 /// Represents metadata that groups multiple <see cref="Mod"/> entities together.
 /// </summary>
 [PublicAPI]
+[JsonName("NexusMods.DataModel.GroupMetadata")]
 public record GroupMetadata : AModMetadata
 {
     /// <summary>

--- a/src/NexusMods.DataModel/Loadouts/Loadout.cs
+++ b/src/NexusMods.DataModel/Loadouts/Loadout.cs
@@ -94,6 +94,19 @@ public record Loadout : Entity, IEmptyWithDataStore<Loadout>
     }
 
     /// <summary>
+    /// Remove an individual mod from this loadout, returning a new loadout.
+    /// </summary>
+    /// <param name="mod"></param>
+    /// <returns></returns>
+    public Loadout Remove(Mod mod)
+    {
+        return this with
+        {
+            Mods = Mods.Without(mod.Id)
+        };
+    }
+
+    /// <summary>
     /// Allows you to change individual files associated with a mod in this collection.
     /// </summary>
     /// <param name="func">Function used to change the files of a given mod.</param>

--- a/src/NexusMods.DataModel/Loadouts/LoadoutManager.cs
+++ b/src/NexusMods.DataModel/Loadouts/LoadoutManager.cs
@@ -282,7 +282,7 @@ public class LoadoutManager
 
             // Step 3: Run the archive through the installers.
             var installer = _installers
-                .Select(i => (Installer: i, Priority: i.Priority(loadout.Value.Installation, archive.Contents)))
+                .Select(i => (Installer: i, Priority: i.GetPriority(loadout.Value.Installation, archive.Contents)))
                 .Where(p => p.Priority != Priority.None)
                 .OrderBy(p => p.Priority)
                 .FirstOrDefault();

--- a/src/NexusMods.DataModel/Loadouts/LoadoutManager.cs
+++ b/src/NexusMods.DataModel/Loadouts/LoadoutManager.cs
@@ -295,14 +295,20 @@ public class LoadoutManager
             }
 
             // Step 4: Install the mods.
-            var mods = (await installer.Installer.GetModsAsync(
-                    loadout.Value.Installation,
-                    baseMod,
-                    analyzed.Hash,
-                    archive.Contents,
-                    cancellationToken))
-                .WithPersist(Store)
-                .ToArray();
+            var results = await installer.Installer.GetModsAsync(
+                loadout.Value.Installation,
+                baseMod.Id,
+                analyzed.Hash,
+                archive.Contents,
+                cancellationToken);
+
+            var mods = results.Select(result => new Mod
+            {
+                Id = result.Id,
+                Files = result.Files.ToEntityDictionary(Store),
+                Name = result.Name ?? baseMod.Name,
+                Version = result.Version ?? baseMod.Version,
+            }).WithPersist(Store).ToArray();
 
             job.Progress = new Percent(0.75);
 

--- a/src/NexusMods.DataModel/Loadouts/LoadoutManager.cs
+++ b/src/NexusMods.DataModel/Loadouts/LoadoutManager.cs
@@ -346,14 +346,15 @@ public class LoadoutManager
                 {
                     loadout.Add(mod with
                     {
-                        Status = ModStatus.Installed
+                        Status = ModStatus.Installed,
+                        Enabled = true,
                     });
                 }
             }
 
             if (!modIds.Contains(baseMod.Id))
             {
-                // TODO: the installer returned new unique mods, what should happen with the base mod?
+                loadout.Remove(baseMod);
             }
 
             job.Progress = Percent.One;

--- a/src/NexusMods.DataModel/Loadouts/Markers/LoadoutMarker.cs
+++ b/src/NexusMods.DataModel/Loadouts/Markers/LoadoutMarker.cs
@@ -44,21 +44,18 @@ public readonly struct LoadoutMarker
     public IEnumerable<ITool> Tools => _manager.Tools(Value.Installation.Game.Domain);
 
     /// <summary>
-    /// Installs a mod to a loadout with a given ID.
+    /// Installs the mods found in the archive to the loadout.
     /// </summary>
-    /// <param name="file">Path of the file to be installed.</param>
-    /// <param name="name">Name of the mod being installed.</param>
-    /// <param name="token">Allows you to cancel the operation.</param>
-    /// <exception cref="Exception">No supported installer.</exception>
-    /// <returns>Unique identifier for the new mod.</returns>
-    /// <remarks>
-    ///    In the context of NMA, 'install' currently means, analyze archives and
-    ///    run archive through installers.
-    ///    For more details, consider reading <a href="https://github.com/Nexus-Mods/NexusMods.App/blob/main/docs/AddingAGame.md#mod-installation">Adding a Game</a>.
-    /// </remarks>
-    public async Task<ModId> InstallModAsync(AbsolutePath file, string name, CancellationToken token = default)
+    /// <param name="archivePath">Archive to analyze and install the mods from.</param>
+    /// <param name="defaultModName">Default name of the mod. This is optional and can be overwritten by the installers.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns></returns>
+    public async Task<ModId[]> InstallModsFromArchiveAsync(
+        AbsolutePath archivePath,
+        string? defaultModName = null,
+        CancellationToken cancellationToken = default)
     {
-        return (await _manager.InstallModAsync(_id, file, name, token)).ModId;
+        return (await _manager.InstallModsFromArchiveAsync(_id, archivePath, defaultModName, cancellationToken)).ModIds;
     }
 
     /// <summary>

--- a/src/NexusMods.DataModel/Loadouts/Markers/LoadoutMarker.cs
+++ b/src/NexusMods.DataModel/Loadouts/Markers/LoadoutMarker.cs
@@ -467,6 +467,15 @@ public readonly struct LoadoutMarker
     }
 
     /// <summary>
+    /// Removes a known mod from the given loadout.
+    /// </summary>
+    /// <param name="oldMod">The mod to remove from the loadout.</param>
+    public void Remove(Mod oldMod)
+    {
+        _manager.Registry.Alter(_id, $"Remove mod: {oldMod.Name}", l => l.Remove(oldMod));
+    }
+
+    /// <summary>
     /// Runs the given tool, integrating the results into the loadout
     /// </summary>
     /// <param name="tool"></param>

--- a/src/NexusMods.DataModel/Loadouts/Mod.cs
+++ b/src/NexusMods.DataModel/Loadouts/Mod.cs
@@ -35,6 +35,11 @@ public record Mod : Entity, IHasEntityId<ModId>
     public required EntityDictionary<ModFileId, AModFile> Files { get; init; }
 
     /// <summary>
+    /// Metadata of the mod.
+    /// </summary>
+    public AModMetadata? Metadata { get; set; }
+
+    /// <summary>
     /// Category of the mod
     /// </summary>
     public string ModCategory { get; set; } = string.Empty;

--- a/src/NexusMods.DataModel/ModInstallers/IModInstaller.cs
+++ b/src/NexusMods.DataModel/ModInstallers/IModInstaller.cs
@@ -1,3 +1,4 @@
+using JetBrains.Annotations;
 using NexusMods.Common;
 using NexusMods.DataModel.Abstractions;
 using NexusMods.DataModel.ArchiveContents;
@@ -12,6 +13,7 @@ namespace NexusMods.DataModel.ModInstallers;
 /// Game specific extension that provides support for the installation of mods
 /// (currently archives) to the game folder.
 /// </summary>
+[PublicAPI]
 public interface IModInstaller
 {
     /// <summary>
@@ -25,12 +27,18 @@ public interface IModInstaller
     public Priority Priority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> files);
 
     /// <summary>
-    /// Determines which files are to be deployed and pushed out to game directory.
+    /// Finds all mods inside the provided archive.
     /// </summary>
-    /// <param name="installation">The game installation to push files out to.</param>
+    /// <param name="gameInstallation">The game installation.</param>
+    /// <param name="baseMod">The base mod.</param>
     /// <param name="srcArchiveHash">Hash of the source archive.</param>
-    /// <param name="files">Files present in the archive.</param>
-    /// <param name="ct">Allows you to cancel the operation prematurely.</param>
-    /// <returns>A list of files to deploy.</returns>
-    public ValueTask<IEnumerable<AModFile>> GetFilesToExtractAsync(GameInstallation installation, Hash srcArchiveHash, EntityDictionary<RelativePath, AnalyzedFile> files, CancellationToken ct = default);
+    /// <param name="archiveFiles">Files from the archive.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns></returns>
+    public ValueTask<IEnumerable<Mod>> GetModsAsync(
+        GameInstallation gameInstallation,
+        Mod baseMod,
+        Hash srcArchiveHash,
+        EntityDictionary<RelativePath, AnalyzedFile> archiveFiles,
+        CancellationToken cancellationToken = default);
 }

--- a/src/NexusMods.DataModel/ModInstallers/IModInstaller.cs
+++ b/src/NexusMods.DataModel/ModInstallers/IModInstaller.cs
@@ -22,9 +22,9 @@ public interface IModInstaller
     /// will be used to deploy an archive.
     /// </summary>
     /// <param name="installation">The installation of the game to use.</param>
-    /// <param name="files">All of the files within an archive.</param>
+    /// <param name="archiveFiles">All of the files within an archive.</param>
     /// <returns>Priority.</returns>
-    public Priority Priority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> files);
+    public Priority GetPriority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> archiveFiles);
 
     /// <summary>
     /// Finds all mods inside the provided archive.

--- a/src/NexusMods.DataModel/ModInstallers/IModInstaller.cs
+++ b/src/NexusMods.DataModel/ModInstallers/IModInstaller.cs
@@ -30,14 +30,14 @@ public interface IModInstaller
     /// Finds all mods inside the provided archive.
     /// </summary>
     /// <param name="gameInstallation">The game installation.</param>
-    /// <param name="baseMod">The base mod.</param>
+    /// <param name="baseModId">The base mod id.</param>
     /// <param name="srcArchiveHash">Hash of the source archive.</param>
     /// <param name="archiveFiles">Files from the archive.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns></returns>
-    public ValueTask<IEnumerable<Mod>> GetModsAsync(
+    public ValueTask<IEnumerable<ModInstallerResult>> GetModsAsync(
         GameInstallation gameInstallation,
-        Mod baseMod,
+        ModId baseModId,
         Hash srcArchiveHash,
         EntityDictionary<RelativePath, AnalyzedFile> archiveFiles,
         CancellationToken cancellationToken = default);

--- a/src/NexusMods.DataModel/ModInstallers/ModInstallerResult.cs
+++ b/src/NexusMods.DataModel/ModInstallers/ModInstallerResult.cs
@@ -1,0 +1,30 @@
+using NexusMods.DataModel.Abstractions;
+using NexusMods.DataModel.Loadouts;
+
+namespace NexusMods.DataModel.ModInstallers;
+
+/// <summary>
+/// Return value of <see cref="IModInstaller"/>. Maps to <see cref="Mod"/> in <see cref="LoadoutManager"/>.
+/// </summary>
+public record ModInstallerResult
+{
+    /// <summary>
+    /// Unique identifier of the mod.
+    /// </summary>
+    public required ModId Id { get; init; }
+
+    /// <summary>
+    /// All files belonging to the mod.
+    /// </summary>
+    public required IEnumerable<AModFile> Files { get; init; }
+
+    /// <summary>
+    /// Optional name of the mod.
+    /// </summary>
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// Optional version of the mod.
+    /// </summary>
+    public string? Version { get; set; }
+}

--- a/src/NexusMods.DataModel/NexusMods.DataModel.csproj
+++ b/src/NexusMods.DataModel/NexusMods.DataModel.csproj
@@ -32,8 +32,4 @@
     <ItemGroup>
         <PackageReference Include="NetEscapades.EnumGenerators" Version="1.0.0-beta07" PrivateAssets="all" ExcludeAssets="compile;runtime" />
     </ItemGroup>
-
-    <ItemGroup>
-      <Folder Include="Loadouts\Extensions" />
-    </ItemGroup>
 </Project>

--- a/src/NexusMods.DataModel/Services.cs
+++ b/src/NexusMods.DataModel/Services.cs
@@ -71,16 +71,12 @@ public static class Services
         coll.AddSingleton(typeof(IMessageProducer<>),
             typeof(InterprocessProducer<>));
 
-        coll.AddSingleton<ITypeFinder>(_ =>
-            new AssemblyTypeFinder(typeof(Services).Assembly));
-        coll.AddSingleton<JsonConverter,
-            AbstractClassConverterFactory<Entity>>();
-        coll.AddSingleton<JsonConverter,
-            AbstractClassConverterFactory<ISortRule<Mod, ModId>>>();
-        coll.AddSingleton<JsonConverter,
-            AbstractClassConverterFactory<IModFileMetadata>>();
-        coll.AddSingleton<JsonConverter,
-            AbstractClassConverterFactory<IFileAnalysisData>>();
+        coll.AddSingleton<ITypeFinder>(_ => new AssemblyTypeFinder(typeof(Services).Assembly));
+        coll.AddSingleton<JsonConverter, AbstractClassConverterFactory<Entity>>();
+        coll.AddSingleton<JsonConverter, AbstractClassConverterFactory<AModMetadata>>();
+        coll.AddSingleton<JsonConverter, AbstractClassConverterFactory<ISortRule<Mod, ModId>>>();
+        coll.AddSingleton<JsonConverter, AbstractClassConverterFactory<IModFileMetadata>>();
+        coll.AddSingleton<JsonConverter, AbstractClassConverterFactory<IFileAnalysisData>>();
 
         coll.AddSingleton(s =>
         {

--- a/src/NexusMods.Paths/AbsolutePath.cs
+++ b/src/NexusMods.Paths/AbsolutePath.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 using NexusMods.Paths.Extensions;
@@ -11,6 +12,7 @@ namespace NexusMods.Paths;
 /// A path that represents a full path to a file or directory.
 /// </summary>
 [PublicAPI]
+[DebuggerDisplay("{Directory}{DirectorySeparatorCharStr}{FileName}")]
 public readonly partial struct AbsolutePath : IEquatable<AbsolutePath>, IPath
 {
     private static readonly char PathSeparatorForInternalOperations = Path.DirectorySeparatorChar;

--- a/tests/Games/NexusMods.Games.BethesdaGameStudios.Tests/Skyrim/Installers/SkyrimInstallerTests.cs
+++ b/tests/Games/NexusMods.Games.BethesdaGameStudios.Tests/Skyrim/Installers/SkyrimInstallerTests.cs
@@ -61,8 +61,12 @@ public class SkyrimInstallerTests : AGameTest<SkyrimSpecialEdition>
         var path = BethesdaTestHelpers.GetDownloadableModFolder(_realFs, folderName);
         var downloaded = await _downloader.DownloadFromManifestAsync(path, _realFs);
 
-        var installedId = await loadout.InstallModAsync(downloaded.Path, downloaded.Manifest.Name);
-        var files = loadout.Value.Mods[installedId].Files;
+        var mod = await InstallModFromArchiveIntoLoadout(
+            loadout,
+            downloaded.Path,
+            downloaded.Manifest.Name);
+
+        var files = mod.Files;
         files.Count.Should().BeGreaterThan(0);
         
         foreach (var file in files)

--- a/tests/Games/NexusMods.Games.DarkestDungeon.Tests/DarkestDungeonModInstallerTests.cs
+++ b/tests/Games/NexusMods.Games.DarkestDungeon.Tests/DarkestDungeonModInstallerTests.cs
@@ -21,9 +21,9 @@ public class DarkestDungeonModInstallerTests : AModInstallerTest<DarkestDungeon,
 
         await using (file)
         {
-            var filesToExtract = await GetFilesToExtractFromInstaller(file.Path);
-            filesToExtract.Should().HaveCount(181);
-            filesToExtract.Should().AllSatisfy(x => x.To.Path.StartsWith("mods"));
+            var (_, modFiles) = await GetModWithFilesFromInstaller(file.Path);
+            modFiles.Should().HaveCount(181);
+            modFiles.Should().AllSatisfy(x => x.To.Path.StartsWith("mods"));
         }
     }
 
@@ -38,11 +38,11 @@ public class DarkestDungeonModInstallerTests : AModInstallerTest<DarkestDungeon,
         var file = await CreateTestArchive(testFiles);
         await using (file)
         {
-            var filesToExtract = await GetFilesToExtractFromInstaller(file.Path);
-            filesToExtract.Should().HaveCount(3);
-            filesToExtract.Should().AllSatisfy(x => x.To.Path.StartsWith("mods"));
-            filesToExtract.Should().Contain(x => x.To.FileName == "foo");
-            filesToExtract.Should().Contain(x => x.To.FileName == "bar");
+            var (_, modFiles) = await GetModWithFilesFromInstaller(file.Path);
+            modFiles.Should().HaveCount(3);
+            modFiles.Should().AllSatisfy(x => x.To.Path.StartsWith("mods"));
+            modFiles.Should().Contain(x => x.To.FileName == "foo");
+            modFiles.Should().Contain(x => x.To.FileName == "bar");
         }
     }
 }

--- a/tests/Games/NexusMods.Games.FOMOD.Tests/FomodXmlInstallerTests.cs
+++ b/tests/Games/NexusMods.Games.FOMOD.Tests/FomodXmlInstallerTests.cs
@@ -236,31 +236,24 @@ public class FomodXmlInstallerTests
         if (analyzed is not AnalyzedArchive archive)
             throw new Exception("FOMOD was not registered as archive.");
 
-        var baseMod = new Mod
-        {
-            Name = string.Empty,
-            Files = new EntityDictionary<ModFileId, AModFile>(),
-            Id = ModId.New()
-        };
-
-        return new TestState(installer, baseMod, tmpFile, archive, dataStore);
+        return new TestState(installer, tmpFile, archive, dataStore);
     }
 
-    private record TestState(FomodXmlInstaller Installer, Mod BaseMod, TemporaryPath DataStorePath, AnalyzedArchive AnalysisResults, SqliteDataStore DataStore) : IDisposable
+    private record TestState(FomodXmlInstaller Installer, TemporaryPath DataStorePath, AnalyzedArchive AnalysisResults, SqliteDataStore DataStore) : IDisposable
     {
         public Priority GetPriority() => Installer.GetPriority(new GameInstallation(), AnalysisResults.Contents);
         public async ValueTask<IEnumerable<AModFile>> GetFilesToExtractAsync()
         {
             var mods = (await Installer.GetModsAsync(
                 new GameInstallation(),
-                BaseMod,
+                ModId.New(),
                 AnalysisResults.Hash,
                 AnalysisResults.Contents)).ToArray();
 
             // broken FOMODs return nothing
             return mods.Length == 0
                 ? Array.Empty<AModFile>()
-                : mods.First().Files.Values.ToArray();
+                : mods.First().Files.ToArray();
         }
 
         public void Dispose()

--- a/tests/Games/NexusMods.Games.FOMOD.Tests/FomodXmlInstallerTests.cs
+++ b/tests/Games/NexusMods.Games.FOMOD.Tests/FomodXmlInstallerTests.cs
@@ -55,81 +55,93 @@ public class FomodXmlInstallerTests
     public async Task InstallsFilesSimple()
     {
         using var testData = await SetupTestFromDirectoryAsync("SimpleInstaller");
-        var installedFiles = await testData.GetFilesToExtractAsync();
+        var installedFiles = (await testData.GetFilesToExtractAsync()).ToArray();
 
-        installedFiles.Count().Should().Be(2);
-        installedFiles.ElementAt(0).To.FileName.Should().Be((RelativePath)"g1p1f1.out.esp");
-        installedFiles.ElementAt(1).To.FileName.Should().Be((RelativePath)"g2p1f1.out.esp");
+        installedFiles
+            .Should().HaveCount(2)
+            .And.Satisfy(
+                x => x.To.FileName == "g1p1f1.out.esp",
+                x => x.To.FileName == "g2p1f1.out.esp"
+            );
     }
 
     [Fact]
     public async Task InstallsFilesComplex_WithImages()
     {
         using var testData = await SetupTestFromDirectoryAsync("WithImages");
-        var installedFiles = await testData.GetFilesToExtractAsync();
+        var installedFiles = (await testData.GetFilesToExtractAsync()).ToArray();
 
-        installedFiles.Count().Should().Be(3);
-
-        // In group 1, the second plugin is recommended
-        installedFiles.ElementAt(0).To.FileName.Should().Be("g1p2f1.out.esp".ToRelativePath());
-
-        // In group 2, both plugins are required
-        installedFiles.ElementAt(1).To.FileName.Should().Be("g2p1f1.out.esp".ToRelativePath());
-        installedFiles.ElementAt(2).To.FileName.Should().Be("g2p2f1.out.esp".ToRelativePath());
+        installedFiles
+            .Should().HaveCount(3)
+            .And.Satisfy(
+                // In group 1, the second plugin is recommended
+                x => x.To.FileName == "g1p2f1.out.esp",
+                // In group 2, both plugins are required
+                x => x.To.FileName == "g2p1f1.out.esp",
+                x => x.To.FileName == "g2p2f1.out.esp"
+            );
     }
 
     [Fact]
     public async Task InstallsFilesComplex_WithMissingImage()
     {
         using var testData = await SetupTestFromDirectoryAsync("WithMissingImage");
-        var installedFiles = await testData.GetFilesToExtractAsync();
+        var installedFiles = (await testData.GetFilesToExtractAsync()).ToArray();
 
-        installedFiles.Count().Should().Be(3);
-
-        // In group 1, the second plugin is recommended
-        installedFiles.ElementAt(0).To.FileName.Should().Be("g1p2f1.out.esp".ToRelativePath());
-
-        // In group 2, both plugins are required
-        installedFiles.ElementAt(1).To.FileName.Should().Be("g2p1f1.out.esp".ToRelativePath());
-        installedFiles.ElementAt(2).To.FileName.Should().Be("g2p2f1.out.esp".ToRelativePath());
+        installedFiles
+            .Should().HaveCount(3)
+            .And.Satisfy(
+                // In group 1, the second plugin is recommended
+                x => x.To.FileName == "g1p2f1.out.esp",
+                // In group 2, both plugins are required
+                x => x.To.FileName == "g2p1f1.out.esp",
+                x => x.To.FileName == "g2p2f1.out.esp"
+            );
     }
 
     [Fact]
     public async Task InstallsFilesSimple_UsingRar()
     {
         using var testData = await SetupTestFromDirectoryAsync("SimpleInstaller-rar");
-        var installedFiles = await testData.GetFilesToExtractAsync();
+        var installedFiles = (await testData.GetFilesToExtractAsync()).ToArray();
 
-        installedFiles.Count().Should().Be(2);
-        installedFiles.ElementAt(0).To.FileName.Should().Be((RelativePath)"g1p1f1.out.esp");
-        installedFiles.ElementAt(1).To.FileName.Should().Be((RelativePath)"g2p1f1.out.esp");
+        installedFiles
+            .Should().HaveCount(2)
+            .And.Satisfy(
+                x => x.To.FileName == "g1p1f1.out.esp",
+                x => x.To.FileName == "g2p1f1.out.esp"
+            );
     }
 
     [Fact]
     public async Task InstallsFilesSimple_Using7z()
     {
         using var testData = await SetupTestFromDirectoryAsync("SimpleInstaller-7z");
-        var installedFiles = await testData.GetFilesToExtractAsync();
+        var installedFiles = (await testData.GetFilesToExtractAsync()).ToArray();
 
-        installedFiles.Count().Should().Be(2);
-        installedFiles.ElementAt(0).To.FileName.Should().Be((RelativePath)"g1p1f1.out.esp");
-        installedFiles.ElementAt(1).To.FileName.Should().Be((RelativePath)"g2p1f1.out.esp");
+        installedFiles
+            .Should().HaveCount(2)
+            .And.Satisfy(
+                x => x.To.FileName == "g1p1f1.out.esp",
+                x => x.To.FileName == "g2p1f1.out.esp"
+            );
     }
 
     [Fact]
     public async Task ObeysTypeDescriptors()
     {
         using var testData = await SetupTestFromDirectoryAsync("ComplexInstaller");
-        var installedFiles = await testData.GetFilesToExtractAsync();
+        var installedFiles = (await testData.GetFilesToExtractAsync()).ToArray();
 
-        installedFiles.Count().Should().Be(3);
-
-        // In group 1, the second plugin is recommended
-        installedFiles.ElementAt(0).To.FileName.Should().Be("g1p2f1.out.esp".ToRelativePath());
-
-        // In group 2, both plugins are required
-        installedFiles.ElementAt(1).To.FileName.Should().Be("g2p1f1.out.esp".ToRelativePath());
-        installedFiles.ElementAt(2).To.FileName.Should().Be("g2p2f1.out.esp".ToRelativePath());
+        installedFiles
+            .Should().HaveCount(3)
+            .And.Satisfy(
+                // In group 1, the second plugin is recommended
+                x => x.To.FileName == "g1p2f1.out.esp",
+                // In group 2, both plugins are required
+                x => x.To.FileName == "g2p1f1.out.esp",
+                x => x.To.FileName == "g2p2f1.out.esp"
+            );
     }
 
     #region Tests for Broken FOMODs. Don't install them, don't throw. Only log. No-Op
@@ -139,7 +151,7 @@ public class FomodXmlInstallerTests
     {
         using var testData = await SetupTestFromDirectoryAsync("Broken-EmptyGroup");
         var installedFiles = await testData.GetFilesToExtractAsync();
-        installedFiles.Count().Should().Be(0);
+        installedFiles.Should().BeEmpty();
     }
 
     [Fact]
@@ -147,7 +159,7 @@ public class FomodXmlInstallerTests
     {
         using var testData = await SetupTestFromDirectoryAsync("Broken-EmptyOption");
         var installedFiles = await testData.GetFilesToExtractAsync();
-        installedFiles.Count().Should().Be(0);
+        installedFiles.Should().BeEmpty();
     }
 
     [Fact]
@@ -155,7 +167,7 @@ public class FomodXmlInstallerTests
     {
         using var testData = await SetupTestFromDirectoryAsync("Broken-EmptyStep");
         var installedFiles = await testData.GetFilesToExtractAsync();
-        installedFiles.Count().Should().Be(0);
+        installedFiles.Should().BeEmpty();
     }
 
     [Fact]
@@ -163,7 +175,7 @@ public class FomodXmlInstallerTests
     {
         using var testData = await SetupTestFromDirectoryAsync("Broken-NoSteps");
         var installedFiles = await testData.GetFilesToExtractAsync();
-        installedFiles.Count().Should().Be(0);
+        installedFiles.Should().BeEmpty();
     }
 
     [Fact]
@@ -171,7 +183,7 @@ public class FomodXmlInstallerTests
     {
         using var testData = await SetupTestFromDirectoryAsync("Broken-NoModuleName");
         var installedFiles = await testData.GetFilesToExtractAsync();
-        installedFiles.Count().Should().Be(0);
+        installedFiles.Should().BeEmpty();
     }
 
     // TODO: Implement Dependencies for FOMODs
@@ -245,8 +257,10 @@ public class FomodXmlInstallerTests
                 AnalysisResults.Hash,
                 AnalysisResults.Contents)).ToArray();
 
-            mods.Should().ContainSingle();
-            return mods.First().Files.Values.ToArray();
+            // broken FOMODs return nothing
+            return mods.Length == 0
+                ? Array.Empty<AModFile>()
+                : mods.First().Files.Values.ToArray();
         }
 
         public void Dispose()

--- a/tests/Games/NexusMods.Games.FOMOD.Tests/FomodXmlInstallerTests.cs
+++ b/tests/Games/NexusMods.Games.FOMOD.Tests/FomodXmlInstallerTests.cs
@@ -248,7 +248,7 @@ public class FomodXmlInstallerTests
 
     private record TestState(FomodXmlInstaller Installer, Mod BaseMod, TemporaryPath DataStorePath, AnalyzedArchive AnalysisResults, SqliteDataStore DataStore) : IDisposable
     {
-        public Priority GetPriority() => Installer.Priority(new GameInstallation(), AnalysisResults.Contents);
+        public Priority GetPriority() => Installer.GetPriority(new GameInstallation(), AnalysisResults.Contents);
         public async ValueTask<IEnumerable<AModFile>> GetFilesToExtractAsync()
         {
             var mods = (await Installer.GetModsAsync(

--- a/tests/Games/NexusMods.Games.RedEngine.Tests/ModInstallerTests.cs
+++ b/tests/Games/NexusMods.Games.RedEngine.Tests/ModInstallerTests.cs
@@ -19,9 +19,8 @@ public class ModInstallerTests : AGameTest<Cyberpunk2077>
         Hash hash, IEnumerable<GamePath> files)
     {
         var loadout = await CreateLoadout(indexGameFiles:false);
-        var downloaded = await DownloadAndCacheMod(
-            loadout.Value.Installation.Game.Domain, modId, fileId, hash);
-        var mod = await InstallModIntoLoadout(loadout, downloaded);
+        var downloaded = await DownloadAndCacheMod(GameInstallation.Game.Domain, modId, fileId, hash);
+        var mod = await InstallModFromArchiveIntoLoadout(loadout, downloaded, name);
 
         mod.Files.Values.Select(file => file.To)
             .Should()

--- a/tests/Games/NexusMods.Games.Sifu.Tests/SifuModInstallerTests.cs
+++ b/tests/Games/NexusMods.Games.Sifu.Tests/SifuModInstallerTests.cs
@@ -1,10 +1,6 @@
-using System.Text;
 using FluentAssertions;
 using NexusMods.Games.TestFramework;
-using NexusMods.Hashing.xxHash64;
-using NexusMods.Networking.NexusWebApi.Types;
 using NexusMods.Paths;
-using NexusMods.Paths.Extensions;
 
 namespace NexusMods.Games.Sifu.Tests;
 
@@ -24,11 +20,13 @@ public class SifuModInstallerTests : AModInstallerTest<Sifu, SifuModInstaller>
         var file = await CreateTestArchive(testFiles);
         await using (file)
         {
-            var filesToExtract = await GetFilesToExtractFromInstaller(file.Path);
-            filesToExtract.Should().HaveCount(2);
-            filesToExtract.Should().AllSatisfy(x => x.To.Path.StartsWith(@"Content\Paks\~mods"));
-            filesToExtract.Should().Contain(x => x.To.FileName == "foo.pak");
-            filesToExtract.Should().Contain(x => x.To.FileName == "foo.txt");
+            var (_, modFiles) = await GetModWithFilesFromInstaller(file);
+            modFiles
+                .Should().HaveCount(2)
+                .And.AllSatisfy(x => x.To.Path.StartsWith(@"Content\Paks\~mods"))
+                .And.Satisfy(
+                    x => x.To.FileName == "foo.pak",
+                    x => x.To.FileName == "foo.txt");
         }
     }
 
@@ -44,11 +42,13 @@ public class SifuModInstallerTests : AModInstallerTest<Sifu, SifuModInstaller>
         var file = await CreateTestArchive(testFiles);
         await using (file)
         {
-            var filesToExtract = await GetFilesToExtractFromInstaller(file.Path);
-            filesToExtract.Should().HaveCount(2);
-            filesToExtract.Should().AllSatisfy(x => x.To.Path.StartsWith(@"Content\Paks\~mods"));
-            filesToExtract.Should().Contain(x => x.To.FileName == "foo.pak");
-            filesToExtract.Should().Contain(x => x.To.FileName == "foo.txt");
+            var (_, modFiles) = await GetModWithFilesFromInstaller(file);
+            modFiles
+                .Should().HaveCount(2)
+                .And.AllSatisfy(x => x.To.Path.StartsWith(@"Content\Paks\~mods"))
+                .And.Satisfy(
+                    x => x.To.FileName == "foo.pak",
+                    x => x.To.FileName == "foo.txt");
         }
     }
 }

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/Analyzers/SMAPIManifestAnalyzerTests.cs
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/Analyzers/SMAPIManifestAnalyzerTests.cs
@@ -27,7 +27,8 @@ public class SMAPIManifestAnalyzerTests : AFileAnalyzerTest<StardewValley, SMAPI
         {
             Name = Guid.NewGuid().ToString("N"),
             Version = new Version(1, 2, 3),
-            UniqueID = Guid.NewGuid().ToString("N")
+            UniqueID = Guid.NewGuid().ToString("N"),
+            MinimumApiVersion = new Version(3, 12, 0),
         };
 
         var bytes = JsonSerializer.SerializeToUtf8Bytes(expected);
@@ -40,5 +41,50 @@ public class SMAPIManifestAnalyzerTests : AFileAnalyzerTest<StardewValley, SMAPI
             .Should().BeOfType<SMAPIManifest>()
             .Which
             .Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task Test_Dependencies()
+    {
+
+        var expected = new SMAPIManifest
+        {
+            Name = "foo",
+            Version = new Version(1, 0, 5),
+            UniqueID = "foo",
+            MinimumApiVersion = new Version(3, 12, 0),
+            Dependencies = new SMAPIManifestDependency[]
+            {
+                new()
+                {
+                    UniqueID = "bar",
+                }
+            }
+        };
+
+        const string input = @"
+{
+    ""Name"": ""foo"",
+    ""UniqueID"": ""foo"",
+    ""Version"": ""1.0.5"",
+    ""Description"": ""This is a cool description."",
+    ""EntryDll"": ""foo.dll"",
+    ""MinimumApiVersion"": ""3.12.0"",
+    ""UpdateKeys"": [""Nexus:0""],
+    ""Dependencies"": [
+        {
+            ""UniqueID"": ""bar""
+        }
+    ]
+}
+";
+
+        await using var path = await CreateTestFile("manifest.json", input);
+
+        var result = await AnalyzeFile(path);
+        result
+            .Should().ContainSingle()
+            .Which
+            .Should().BeEquivalentTo(expected);
     }
 }

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/Installers/SMAPIInstallerTests.cs
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/Installers/SMAPIInstallerTests.cs
@@ -54,7 +54,7 @@ public class SMAPIInstallerTests : AModInstallerTest<StardewValley, SMAPIInstall
         {
             hash.Should().Be(Hash.From(0x8F3F6450139866F3));
 
-            var mod = await InstallModWithInstaller(loadout, path.Path);
+            var mod = await InstallModFromArchiveIntoLoadout(loadout, path);
 
             var files = mod.Files;
             files.Should().NotBeEmpty();

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/Installers/SMAPIModInstallerTests.cs
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/Installers/SMAPIModInstallerTests.cs
@@ -50,10 +50,10 @@ public class SMAPIModInstallerTests : AModInstallerTest<StardewValley, SMAPIModI
 
         await using var path = await CreateTestArchive(testFiles);
 
-        var filesToExtract = await GetFilesToExtractFromInstaller(path);
-        filesToExtract.Should().HaveCount(2);
-        filesToExtract.Should().Contain(x => x.To.Path.Equals($"Mods/{modName}/manifest.json"));
-        filesToExtract.Should().Contain(x => x.To.Path.Equals($"Mods/{modName}/foo"));
+        var (_, modFiles) = await GetModWithFilesFromInstaller(path);
+        modFiles.Should().HaveCount(2);
+        modFiles.Should().Contain(x => x.To.Path.Equals($"Mods/{modName}/manifest.json"));
+        modFiles.Should().Contain(x => x.To.Path.Equals($"Mods/{modName}/foo"));
     }
 
     [Fact]
@@ -68,10 +68,10 @@ public class SMAPIModInstallerTests : AModInstallerTest<StardewValley, SMAPIModI
 
         await using var path = await CreateTestArchive(testFiles);
 
-        var filesToExtract = await GetFilesToExtractFromInstaller(path);
-        filesToExtract.Should().HaveCount(2);
-        filesToExtract.Should().Contain(x => x.To.Path.Equals($"Mods/{modName}/manifest.json"));
-        filesToExtract.Should().Contain(x => x.To.Path.Equals($"Mods/{modName}/baz"));
+        var (_, modFiles) = await GetModWithFilesFromInstaller(path);
+        modFiles.Should().HaveCount(2);
+        modFiles.Should().Contain(x => x.To.Path.Equals($"Mods/{modName}/manifest.json"));
+        modFiles.Should().Contain(x => x.To.Path.Equals($"Mods/{modName}/baz"));
     }
 
     [Fact]
@@ -86,7 +86,7 @@ public class SMAPIModInstallerTests : AModInstallerTest<StardewValley, SMAPIModI
         {
             hash.Should().Be(Hash.From(0x59112FD2E58BD042));
 
-            var mod = await InstallModWithInstaller(loadout, path.Path);
+            var mod = await InstallModFromArchiveIntoLoadout(loadout, path);
             mod.Files.Should().NotBeEmpty();
             mod.Files.Should().AllSatisfy(kv => kv.Value.To.Path.StartsWith("Mods/NPCMapLocations"));
         }

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/Installers/SMAPIModInstallerTests.cs
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/Installers/SMAPIModInstallerTests.cs
@@ -2,11 +2,13 @@ using System.Diagnostics.CodeAnalysis;
 using FluentAssertions;
 using NexusMods.Common;
 using NexusMods.DataModel;
+using NexusMods.DataModel.Loadouts;
 using NexusMods.Games.StardewValley.Installers;
 using NexusMods.Games.TestFramework;
 using NexusMods.Hashing.xxHash64;
 using NexusMods.Networking.NexusWebApi.Types;
 using NexusMods.Paths;
+using ModId = NexusMods.Networking.NexusWebApi.Types.ModId;
 
 namespace NexusMods.Games.StardewValley.Tests.Installers;
 
@@ -111,7 +113,7 @@ public class SMAPIModInstallerTests : AModInstallerTest<StardewValley, SMAPIModI
                 .Should().HaveCount(3)
                 .And.AllSatisfy(x =>
                 {
-                    // x.Metadata.Should().BeOfType<GroupMetadata>();
+                    x.Metadata.Should().BeOfType<GroupMetadata>();
                     x.Version.Should().Be("1.0.5");
                 })
                 .And.Satisfy(

--- a/tests/Games/NexusMods.Games.TestFramework/AGameTest.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/AGameTest.cs
@@ -112,16 +112,47 @@ public abstract class AGameTest<TGame> where TGame : AGame
     }
 
     /// <summary>
-    /// Installs a mod into the loadout and returns the <see cref="Mod"/> of it.
+    /// Installs the mods from the archive into the loadout.
     /// </summary>
     /// <param name="loadout"></param>
-    /// <param name="path"></param>
-    /// <param name="modName"></param>
+    /// <param name="archivePath"></param>
+    /// <param name="defaultModName"></param>
+    /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    protected async Task<Mod> InstallModIntoLoadout(LoadoutMarker loadout, AbsolutePath path, string? modName = null)
+    protected async Task<Mod[]> InstallModsFromArchiveIntoLoadout(
+        LoadoutMarker loadout,
+        AbsolutePath archivePath,
+        string? defaultModName = null,
+        CancellationToken cancellationToken = default)
     {
-        var modId = await loadout.InstallModAsync(path, modName ?? Guid.NewGuid().ToString("N"));
-        return loadout.Value.Mods[modId];
+        var modIds = await loadout.InstallModsFromArchiveAsync(archivePath, default, cancellationToken);
+        return modIds.Select(id => loadout.Value.Mods[id]).ToArray();
+    }
+
+    /// <summary>
+    /// Installs a single mod from the archive into the loadout. This calls
+    /// <see cref="InstallModsFromArchiveIntoLoadout"/> and asserts only one mod
+    /// exists in the archive.
+    /// </summary>
+    /// <param name="loadout"></param>
+    /// <param name="archivePath"></param>
+    /// <param name="defaultModName"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    protected async Task<Mod> InstallModFromArchiveIntoLoadout(
+        LoadoutMarker loadout,
+        AbsolutePath archivePath,
+        string? defaultModName = null,
+        CancellationToken cancellationToken = default)
+    {
+        var mods = await InstallModsFromArchiveIntoLoadout(
+            loadout,
+            archivePath,
+            defaultModName,
+            cancellationToken);
+
+        mods.Should().ContainSingle();
+        return mods.First();
     }
 
     /// <summary>

--- a/tests/Games/NexusMods.Games.TestFramework/AModInstallerTest.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/AModInstallerTest.cs
@@ -40,7 +40,7 @@ public abstract class AModInstallerTest<TGame, TModInstaller> : AGameTest<TGame>
     {
         var analyzedArchive = await AnalyzeArchive(path);
 
-        var priority = ModInstaller.Priority(
+        var priority = ModInstaller.GetPriority(
             GameInstallation,
             analyzedArchive.Contents);
 
@@ -228,7 +228,7 @@ public abstract class AModInstallerTest<TGame, TModInstaller> : AGameTest<TGame>
     {
         var description = BuildArchiveDescription(files);
         
-        var priority = ModInstaller.Priority(GameInstallation, description);
+        var priority = ModInstaller.GetPriority(GameInstallation, description);
 
         if (expectedPriority == Priority.None)
         {

--- a/tests/Games/NexusMods.Games.TestFramework/AModInstallerTest.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/AModInstallerTest.cs
@@ -1,15 +1,11 @@
 using System.Collections.Immutable;
 using FluentAssertions;
 using JetBrains.Annotations;
-using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Common;
-using NexusMods.DataModel;
 using NexusMods.DataModel.Abstractions;
-using NexusMods.DataModel.Abstractions.Ids;
 using NexusMods.DataModel.ArchiveContents;
 using NexusMods.DataModel.Games;
 using NexusMods.DataModel.Loadouts;
-using NexusMods.DataModel.Loadouts.Markers;
 using NexusMods.DataModel.Loadouts.ModFiles;
 using NexusMods.DataModel.ModInstallers;
 using NexusMods.FileExtractor.FileSignatures;
@@ -51,22 +47,86 @@ public abstract class AModInstallerTest<TGame, TModInstaller> : AGameTest<TGame>
         return priority;
     }
 
+
     /// <summary>
-    /// Runs the <typeparamref name="TModInstaller"/> and returns a list of files
-    /// to extract from the provided archive.
+    /// Runs <typeparamref name="TModInstaller"/> and returns all mods to be installed.
     /// </summary>
-    /// <param name="path">Path to the archive to extract.</param>
+    /// <param name="archivePath"></param>
+    /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    protected async Task<AModFile[]> GetFilesToExtractFromInstaller(AbsolutePath path)
+    protected async Task<Mod[]> GetModsFromInstaller(
+        AbsolutePath archivePath,
+        CancellationToken cancellationToken = default)
     {
-        var analyzedArchive = await AnalyzeArchive(path);
+        var analyzedArchive = await AnalyzeArchive(archivePath);
 
-        var contents = await ModInstaller.GetFilesToExtractAsync(
+        var baseMod = new Mod
+        {
+            Name = archivePath.FileName,
+            Files = new EntityDictionary<ModFileId, AModFile>(),
+            Id = ModId.New()
+        };
+
+        var mods = (await ModInstaller.GetModsAsync(
             GameInstallation,
+            baseMod,
             analyzedArchive.Hash,
-            analyzedArchive.Contents);
+            analyzedArchive.Contents,
+            cancellationToken)).ToArray();
 
-        return contents.WithPersist(DataStore).ToArray();
+        mods.Should().NotBeEmpty();
+        return mods;
+    }
+
+    /// <summary>
+    /// Runs <typeparamref name="TModInstaller"/> and returns the single mod
+    /// from the archive. This calls <see cref="GetModsFromInstaller"/> and
+    /// asserts that the installer only returns 1 mod.
+    /// </summary>
+    /// <param name="archivePath"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    protected async Task<Mod> GetModFromInstaller(
+        AbsolutePath archivePath,
+        CancellationToken cancellationToken = default)
+    {
+        var mods = await GetModsFromInstaller(archivePath, cancellationToken);
+        mods.Should().ContainSingle();
+        return mods.First();
+    }
+
+    /// <summary>
+    /// Runs <typeparamref name="TModInstaller"/> and returns all mods and files
+    /// from the archive in a dictionary. This uses <see cref="GetModsFromInstaller"/>.
+    /// </summary>
+    /// <param name="archivePath"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    protected async Task<Dictionary<Mod, AModFile[]>> GetModsWithFilesFromInstaller(
+        AbsolutePath archivePath,
+        CancellationToken cancellationToken = default)
+    {
+        var mods = await GetModsFromInstaller(archivePath, cancellationToken);
+        return mods.ToDictionary(mod => mod, mod => mod.Files.Values.ToArray());
+    }
+
+    /// <summary>
+    /// Runs <typeparamref name="TModInstaller"/> and returns the single mod and its
+    /// files from the archive. This uses <see cref="GetModsFromInstaller"/> and
+    /// asserts the installer only returned a single mod.
+    /// </summary>
+    /// <param name="archivePath"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    protected async Task<(Mod mod, AModFile[] modFiles)> GetModWithFilesFromInstaller(
+        AbsolutePath archivePath,
+        CancellationToken cancellationToken = default)
+    {
+        var mods = await GetModsFromInstaller(archivePath, cancellationToken);
+        mods.Should().ContainSingle();
+
+        var mod = mods.First();
+        return (mod, mod.Files.Values.ToArray());
     }
 
     /// <summary>
@@ -170,39 +230,27 @@ public abstract class AModInstallerTest<TGame, TModInstaller> : AGameTest<TGame>
 
         if (expectedPriority == Priority.None)
         {
-            priority.Should().Be(expectedPriority,
-                "because the installer doesn't support these files");
-            return Array
-                .Empty<(ulong Hash, GameFolderType FolderType, string Path)>();
-
+            priority.Should().Be(expectedPriority, "because the installer doesn't support these files");
+            return Array.Empty<(ulong Hash, GameFolderType FolderType, string Path)>();
         }
 
         priority.Should().Be(expectedPriority, "because the priority should be correct");
 
-        var contents =
-            await ModInstaller.GetFilesToExtractAsync(GameInstallation, Hash.From(0xDEADBEEF), description);
-        return contents.OfType<AStaticModFile>().Select(m => (m.Hash.Value, m.To.Type, m.To.Path.ToString().Replace("\\", "/")));
-    }
-
-    /// <summary>
-    /// Installs the archive at the provided path with the <typeparamref name="TModInstaller"/>
-    /// and returns the <see cref="Mod"/> of it.
-    /// </summary>
-    /// <param name="loadout"></param>
-    /// <param name="path"></param>
-    /// <returns></returns>
-    protected async Task<Mod> InstallModWithInstaller(LoadoutMarker loadout, AbsolutePath path)
-    {
-        var contents = await GetFilesToExtractFromInstaller(path);
-
-        var newMod = new Mod
+        var baseMod = new Mod
         {
+            Name = string.Empty,
             Id = ModId.New(),
-            Name = path.FileName,
-            Files = new EntityDictionary<ModFileId, AModFile>(DataStore, contents.Select(c => new KeyValuePair<ModFileId, IId>(c.Id, c.DataStoreId)))
+            Files = new EntityDictionary<ModFileId, AModFile>()
         };
 
-        loadout.Add(newMod);
-        return newMod;
+        var mods = (await ModInstaller.GetModsAsync(
+            GameInstallation,
+            baseMod,
+            Hash.From(0xDEADBEEF),
+            description)).ToArray();
+
+        mods.Should().ContainSingle();
+        var contents = mods.First().Files.Values;
+        return contents.OfType<AStaticModFile>().Select(m => (m.Hash.Value, m.To.Type, m.To.Path.ToString().Replace("\\", "/")));
     }
 }

--- a/tests/Games/NexusMods.Games.TestFramework/AModInstallerTest.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/AModInstallerTest.cs
@@ -72,7 +72,9 @@ public abstract class AModInstallerTest<TGame, TModInstaller> : AGameTest<TGame>
             baseMod,
             analyzedArchive.Hash,
             analyzedArchive.Contents,
-            cancellationToken)).ToArray();
+            cancellationToken))
+            .WithPersist(DataStore)
+            .ToArray();
 
         mods.Should().NotBeEmpty();
         return mods;

--- a/tests/NexusMods.DataModel.Tests/ApplicationTests.cs
+++ b/tests/NexusMods.DataModel.Tests/ApplicationTests.cs
@@ -20,7 +20,7 @@ public class ApplicationTests : ADataModelTest<ApplicationTests>
     public async Task CanApplyGame()
     {
         var mainList = await LoadoutManager.ManageGameAsync(Install, "MainList", CancellationToken.None);
-        await mainList.InstallModAsync(DataZipLzma, "First Mod", CancellationToken.None);
+        await mainList.InstallModsFromArchiveAsync(DataZipLzma, "First Mod", CancellationToken.None);
 
         var plan = await mainList.MakeApplyPlanAsync();
         plan.Steps.OfType<CopyFile>().Count().Should().Be(3);
@@ -43,8 +43,8 @@ public class ApplicationTests : ADataModelTest<ApplicationTests>
     public async Task CanIntegrateChanges()
     {
         var mainList = await LoadoutManager.ManageGameAsync(Install, "MainList", Token);
-        await mainList.InstallModAsync(DataZipLzma, "First Mod", Token);
-        await mainList.InstallModAsync(Data7ZLzma2, "Second Mod", Token);
+        await mainList.InstallModsFromArchiveAsync(DataZipLzma, "First Mod", Token);
+        await mainList.InstallModsFromArchiveAsync(Data7ZLzma2, "Second Mod", Token);
 
         var originalPlan = await mainList.MakeApplyPlanAsync();
         originalPlan.Steps.OfType<CopyFile>().Count().Should().Be(3, "Files override each other");

--- a/tests/NexusMods.DataModel.Tests/ModSortingTests.cs
+++ b/tests/NexusMods.DataModel.Tests/ModSortingTests.cs
@@ -17,8 +17,8 @@ public class ModSortingTests : ADataModelTest<ModSortingTests>
     public async Task ModSortingRulesArePreserved()
     {
         var loadout = await LoadoutManager.ManageGameAsync(Install, Guid.NewGuid().ToString());
-        await loadout.InstallModAsync(Data7ZLzma2, "Mod1", CancellationToken.None);
-        await loadout.InstallModAsync(DataZipLzma, "Mod2", CancellationToken.None);
+        await loadout.InstallModsFromArchiveAsync(Data7ZLzma2, "Mod1", CancellationToken.None);
+        await loadout.InstallModsFromArchiveAsync(DataZipLzma, "Mod2", CancellationToken.None);
 
         loadout.Value.Mods.Values.First(m => m.Files.Values.OfType<GameFile>().Any())
             .SortRules.Should().Contain(new First<Mod, ModId>(), "game files are loaded first");

--- a/tests/NexusMods.DataModel.Tests/ModelTests.cs
+++ b/tests/NexusMods.DataModel.Tests/ModelTests.cs
@@ -42,8 +42,8 @@ public class ModelTests : ADataModelTest<ModelTests>
     {
         var name = Guid.NewGuid().ToString();
         var loadout = await LoadoutManager.ManageGameAsync(Install, name);
-        await loadout.InstallModAsync(Data7ZLzma2, "Mod1", CancellationToken.None);
-        await loadout.InstallModAsync(DataZipLzma, "", CancellationToken.None);
+        await loadout.InstallModsFromArchiveAsync(Data7ZLzma2, "Mod1", CancellationToken.None);
+        await loadout.InstallModsFromArchiveAsync(DataZipLzma, "", CancellationToken.None);
 
         loadout.Value.Mods.Count.Should().Be(3);
         loadout.Value.Mods.Values.Sum(m => m.Files.Count).Should().Be(DataNames.Length * 2 + StubbedGame.DATA_NAMES.Length);
@@ -54,8 +54,8 @@ public class ModelTests : ADataModelTest<ModelTests>
     public async Task RenamingAListDoesntChangeOldIds()
     {
         var loadout = await LoadoutManager.ManageGameAsync(Install, Guid.NewGuid().ToString());
-        var id1 = await loadout.InstallModAsync(Data7ZLzma2, "Mod1", CancellationToken.None);
-        var id2 = await loadout.InstallModAsync(DataZipLzma, "Mod2", CancellationToken.None);
+        var id1 = (await loadout.InstallModsFromArchiveAsync(Data7ZLzma2, "Mod1", CancellationToken.None)).First();
+        var id2 = (await loadout.InstallModsFromArchiveAsync(DataZipLzma, "Mod2", CancellationToken.None)).First();
 
         id1.Should().NotBe(id2);
         id1.Should().BeEquivalentTo(id1);
@@ -79,8 +79,8 @@ public class ModelTests : ADataModelTest<ModelTests>
     public async Task CanExportAndImportLoadouts()
     {
         var loadout = await LoadoutManager.ManageGameAsync(Install, Guid.NewGuid().ToString());
-        await loadout.InstallModAsync(Data7ZLzma2, "Mod1", CancellationToken.None);
-        await loadout.InstallModAsync(DataZipLzma, "Mod2", CancellationToken.None);
+        await loadout.InstallModsFromArchiveAsync(Data7ZLzma2, "Mod1", CancellationToken.None);
+        await loadout.InstallModsFromArchiveAsync(DataZipLzma, "Mod2", CancellationToken.None);
 
         await using var tempFile = TemporaryFileManager.CreateFile(KnownExtensions.Zip);
         await loadout.ExportToAsync(tempFile, CancellationToken.None);

--- a/tests/NexusMods.DataModel.Tests/ToolTests.cs
+++ b/tests/NexusMods.DataModel.Tests/ToolTests.cs
@@ -22,7 +22,7 @@ public class ToolTests : ADataModelTest<ToolTests>
     {
         var name = Guid.NewGuid().ToString();
         var loadout = await LoadoutManager.ManageGameAsync(Install, name);
-        await loadout.InstallModAsync(Data7ZLzma2, "Mod1", CancellationToken.None);
+        await loadout.InstallModsFromArchiveAsync(Data7ZLzma2, "Mod1", CancellationToken.None);
         var gameFolder = loadout.Value.Installation.Locations[GameFolderType.Game];
 
         gameFolder.CombineUnchecked("files.txt").FileExists.Should().BeFalse("tool should not have run yet");

--- a/tests/NexusMods.StandardGameLocators.TestHelpers/StubbedGames/StubbedGameInstaller.cs
+++ b/tests/NexusMods.StandardGameLocators.TestHelpers/StubbedGames/StubbedGameInstaller.cs
@@ -23,7 +23,7 @@ public class StubbedGameInstaller : IModInstaller
 
     public Priority GetPriority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
-        return installation.Game is StubbedGame ? Common.Priority.Normal : Common.Priority.None;
+        return installation.Game is StubbedGame ? Priority.Normal : Priority.None;
     }
 
     public ValueTask<IEnumerable<Mod>> GetModsAsync(

--- a/tests/NexusMods.StandardGameLocators.TestHelpers/StubbedGames/StubbedGameInstaller.cs
+++ b/tests/NexusMods.StandardGameLocators.TestHelpers/StubbedGames/StubbedGameInstaller.cs
@@ -21,7 +21,7 @@ public class StubbedGameInstaller : IModInstaller
         _dataStore = store;
     }
 
-    public Priority Priority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> files)
+    public Priority GetPriority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
         return installation.Game is StubbedGame ? Common.Priority.Normal : Common.Priority.None;
     }

--- a/tests/NexusMods.StandardGameLocators.TestHelpers/StubbedGames/StubbedGameInstaller.cs
+++ b/tests/NexusMods.StandardGameLocators.TestHelpers/StubbedGames/StubbedGameInstaller.cs
@@ -26,18 +26,18 @@ public class StubbedGameInstaller : IModInstaller
         return installation.Game is StubbedGame ? Priority.Normal : Priority.None;
     }
 
-    public ValueTask<IEnumerable<Mod>> GetModsAsync(
+    public ValueTask<IEnumerable<ModInstallerResult>> GetModsAsync(
         GameInstallation gameInstallation,
-        Mod baseMod,
+        ModId baseModId,
         Hash srcArchiveHash,
         EntityDictionary<RelativePath, AnalyzedFile> archiveFiles,
         CancellationToken cancellationToken = default)
     {
-        return ValueTask.FromResult(GetMods(baseMod, srcArchiveHash, archiveFiles));
+        return ValueTask.FromResult(GetMods(baseModId, srcArchiveHash, archiveFiles));
     }
 
-    private IEnumerable<Mod> GetMods(
-        Mod baseMod,
+    private IEnumerable<ModInstallerResult> GetMods(
+        ModId baseModId,
         Hash srcArchiveHash,
         EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
@@ -56,9 +56,10 @@ public class StubbedGameInstaller : IModInstaller
                 };
             });
 
-        yield return baseMod with
+        yield return new ModInstallerResult
         {
-            Files = modFiles.ToEntityDictionary(_dataStore)
+            Id = baseModId,
+            Files = modFiles
         };
     }
 }

--- a/tests/NexusMods.StandardGameLocators.TestHelpers/StubbedGames/StubbedGameInstaller.cs
+++ b/tests/NexusMods.StandardGameLocators.TestHelpers/StubbedGames/StubbedGameInstaller.cs
@@ -1,6 +1,7 @@
 using NexusMods.Common;
 using NexusMods.DataModel.Abstractions;
 using NexusMods.DataModel.ArchiveContents;
+using NexusMods.DataModel.Extensions;
 using NexusMods.DataModel.Games;
 using NexusMods.DataModel.Loadouts;
 using NexusMods.DataModel.Loadouts.ModFiles;
@@ -13,12 +14,11 @@ namespace NexusMods.StandardGameLocators.TestHelpers.StubbedGames;
 
 public class StubbedGameInstaller : IModInstaller
 {
-    // ReSharper disable once NotAccessedField.Local
-    private readonly IDataStore _store;
+    private readonly IDataStore _dataStore;
 
     public StubbedGameInstaller(IDataStore store)
     {
-        _store = store;
+        _dataStore = store;
     }
 
     public Priority Priority(GameInstallation installation, EntityDictionary<RelativePath, AnalyzedFile> files)
@@ -26,23 +26,39 @@ public class StubbedGameInstaller : IModInstaller
         return installation.Game is StubbedGame ? Common.Priority.Normal : Common.Priority.None;
     }
 
-    public ValueTask<IEnumerable<AModFile>> GetFilesToExtractAsync(GameInstallation installation, Hash srcArchive, EntityDictionary<RelativePath, AnalyzedFile> files, CancellationToken ct = default)
+    public ValueTask<IEnumerable<Mod>> GetModsAsync(
+        GameInstallation gameInstallation,
+        Mod baseMod,
+        Hash srcArchiveHash,
+        EntityDictionary<RelativePath, AnalyzedFile> archiveFiles,
+        CancellationToken cancellationToken = default)
     {
-        return ValueTask.FromResult(GetFilesToExtractImpl(srcArchive, files));
+        return ValueTask.FromResult(GetMods(baseMod, srcArchiveHash, archiveFiles));
     }
 
-    private IEnumerable<AModFile> GetFilesToExtractImpl(Hash srcArchive, EntityDictionary<RelativePath, AnalyzedFile> files)
+    private IEnumerable<Mod> GetMods(
+        Mod baseMod,
+        Hash srcArchiveHash,
+        EntityDictionary<RelativePath, AnalyzedFile> archiveFiles)
     {
-        foreach (var (key, value) in files)
-        {
-            yield return new FromArchive
+        var modFiles = archiveFiles
+            .Select(kv =>
             {
-                Id = ModFileId.New(),
-                From = new HashRelativePath(srcArchive, key),
-                To = new GamePath(GameFolderType.Game, key),
-                Hash = value.Hash,
-                Size = value.Size
-            };
-        }
+                var (path, file) = kv;
+
+                return new FromArchive
+                {
+                    Id = ModFileId.New(),
+                    From = new HashRelativePath(srcArchiveHash, path),
+                    To = new GamePath(GameFolderType.Game, path),
+                    Hash = file.Hash,
+                    Size = file.Size
+                };
+            });
+
+        yield return baseMod with
+        {
+            Files = modFiles.ToEntityDictionary(_dataStore)
+        };
     }
 }


### PR DESCRIPTION
Fixes #266.

Changes:

- Renamed `IModInstaller.Priority` to `IModInstaller.GetPriority`.
- Replaced `IModInstaller.GetFilesToExtractAsync` with `IModInstaller.GetModsAsync`. Instead of returning `IEnumerable<AModFile>`, the return type is now `IEnumerable<Mod>`.
- Updated `LoadoutManager` and related to support this change.
- Adds `AModMetadata` abstract class and `GroupMetadata` implementation, which is set by the `LoadoutManager`.
- Updated the SMAPI mod installer to support returning multiple mods.

https://user-images.githubusercontent.com/16577545/233375529-2821dc56-7aef-49ec-9bab-227433462c6e.mp4

The changed made to `LoadoutManager` added some complexity to account for different possibilities. The indent implementation of `IModInstaller.GetModsAsync` can be found in `StubbedGameInstaller`:

https://github.com/erri120/NexusMods.App/blob/f1595db7b9d5a493788cc365512f89c786d55d2b/tests/NexusMods.StandardGameLocators.TestHelpers/StubbedGames/StubbedGameInstaller.cs#L29-L63

The method `GetModsAsync` has a `Mod baseMod` parameter which should be copied. In this simple example, where only one mod is returned, the `LoadoutManager` sees that the mod identifier didn't change, and alters the registry by updating the existing mod in the loadout.

However, if multiple mods are returned, the installer has to assign new identifiers as seen in the `SMAPIModInstaller`:

https://github.com/erri120/NexusMods.App/blob/f1595db7b9d5a493788cc365512f89c786d55d2b/src/Games/NexusMods.Games.StardewValley/Installers/SMAPIModInstaller.cs#L103-L109

If multiple mods are returned, the original base mod, assigned to the archive, must be removed. The video shows this happening in real time:

1) the user clicks `Add Mod` and selects an archive
2) `LoadoutManager` adds a new `Mod` with `id=foo` and `status=Installing` to the loadout
3) the UI reflects this loadout change by displaying a new entry in the table and an installation spinner
4) `SMAPIModInstaller` returns three new instances of `Mod`, all with new ids
5) `LoadoutManager` adds those new mods to the loadout
6) `LoadoutManager` removes `Mod` with `id=foo` because it wasn't returned by the installer
7) the UI updates and shows the three new mods