### PR TITLE
High performance logging

### DIFF
--- a/benchmarks/NexusMods.Benchmarks/Benchmarks/HighPerformanceLogging.cs
+++ b/benchmarks/NexusMods.Benchmarks/Benchmarks/HighPerformanceLogging.cs
@@ -1,0 +1,98 @@
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.Logging;
+using NexusMods.Benchmarks.Interfaces;
+
+namespace NexusMods.Benchmarks.Benchmarks;
+
+[MemoryDiagnoser]
+[BenchmarkInfo("High Performance Logging", "Compares the different methods of logging")]
+public class HighPerformanceLogging : IBenchmark
+{
+    public const string LoggingMessageWithReferenceTypes = "This uses reference types: {a} and {b}";
+    public const string LoggingMessageWithValueTypes = "This uses value types: {a} and {b}";
+
+    [Params(LogLevel.Trace, LogLevel.Information)]
+    public LogLevel MinimumLogLevel { get; set; }
+
+    private ILogger _logger;
+    private string _referenceA;
+    private string _referenceB;
+    private Guid _valueA;
+    private Guid _valueB;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _logger = new DummyLogger(MinimumLogLevel);
+        _valueA = Guid.NewGuid();
+        _valueB = Guid.NewGuid();
+        _referenceA = _valueA.ToString();
+        _referenceB = _valueB.ToString();
+    }
+
+    [Benchmark]
+    public void Default_ReferenceTypes()
+    {
+        _logger.LogTrace(LoggingMessageWithReferenceTypes, _referenceA, _referenceB);
+    }
+
+    [Benchmark]
+    public void Default_ValueTypes()
+    {
+        _logger.LogTrace(LoggingMessageWithValueTypes, _valueA, _valueB);
+    }
+
+    [Benchmark]
+    public void LoggerMessage_ReferenceTypes()
+    {
+        _logger.WithReferenceTypes(_referenceA, _referenceB);
+    }
+
+    [Benchmark]
+    public void LoggerMessage_ValueTypes()
+    {
+        _logger.WithValueTypes(_valueA, _valueB);
+    }
+
+    private class DummyLogger : ILogger
+    {
+        private readonly LogLevel _minLogLevel;
+
+        public DummyLogger(LogLevel minLogLevel)
+        {
+            _minLogLevel = minLogLevel;
+        }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+            Exception? exception, Func<TState, Exception?, string> formatter) { }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return _minLogLevel <= logLevel;
+        }
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
+    }
+}
+
+internal static partial class LoggingExtensions
+{
+    [LoggerMessage(
+        EventId = 0,
+        Level = LogLevel.Trace,
+        Message = HighPerformanceLogging.LoggingMessageWithReferenceTypes)]
+    public static partial void WithReferenceTypes(
+        this ILogger logger,
+        string a,
+        string b);
+
+    [LoggerMessage(
+        EventId = 0,
+        Level = LogLevel.Trace,
+        Message = HighPerformanceLogging.LoggingMessageWithValueTypes)]
+    public static partial void WithValueTypes(
+        this ILogger logger,
+        Guid a,
+        Guid b);
+}

--- a/benchmarks/NexusMods.Benchmarks/Benchmarks/IdToString.cs
+++ b/benchmarks/NexusMods.Benchmarks/Benchmarks/IdToString.cs
@@ -1,0 +1,29 @@
+using BenchmarkDotNet.Attributes;
+using NexusMods.Benchmarks.Interfaces;
+using NexusMods.DataModel.Abstractions;
+using NexusMods.DataModel.Abstractions.Ids;
+
+namespace NexusMods.Benchmarks.Benchmarks;
+
+[MemoryDiagnoser]
+[BenchmarkInfo("Id.ToString", "Benchmarking the Id.ToString methods of our IId implementations")]
+public class IdToString : IBenchmark
+{
+    private readonly AId _id = new Id64(EntityCategory.Loadouts, ulong.MaxValue);
+
+    [Benchmark(Baseline = true)]
+    public string Old()
+    {
+        Span<byte> span = stackalloc byte[_id.SpanSize];
+        _id.ToSpan(span);
+        return $"{_id.Category}-{Convert.ToHexString(span)}";
+    }
+
+    [Benchmark]
+    public string New_WithEnumExtensions()
+    {
+        Span<byte> span = stackalloc byte[_id.SpanSize];
+        _id.ToSpan(span);
+        return $"{_id.Category.ToStringFast()}-{Convert.ToHexString(span)}";
+    }
+}

--- a/src/NexusMods.App.UI/HighPerformanceLogging.cs
+++ b/src/NexusMods.App.UI/HighPerformanceLogging.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.Logging;
+
+namespace NexusMods.App.UI;
+
+internal static partial class HighPerformanceLogging
+{
+    [LoggerMessage(
+        EventId = 0,
+        Level = LogLevel.Debug,
+        Message = "Finding View for {viewModel}")]
+    public static partial void FindingView(
+        this ILogger logger,
+        string viewModel);
+}

--- a/src/NexusMods.App.UI/InjectedViewLocator.cs
+++ b/src/NexusMods.App.UI/InjectedViewLocator.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -18,12 +19,13 @@ public class InjectedViewLocator : IViewLocator
         _method = GetType().GetMethod("ResolveViewInner", BindingFlags.NonPublic | BindingFlags.Instance)!;
     }
 
+    [SuppressMessage("ReSharper", "HeapView.PossibleBoxingAllocation", Justification = "Our ViewModels are always reference types.")]
     public IViewFor? ResolveView<T>(T? viewModel, string? contract = null)
     {
-        if (viewModel == null)
+        if (viewModel is null)
             return null;
 
-        _logger.LogDebug("Finding View for {ViewModel}", viewModel.GetType().FullName);
+        _logger.FindingView(viewModel.GetType().FullName ?? viewModel.GetType().ToString());
         try
         {
             if (viewModel is IViewModel vm)

--- a/src/NexusMods.DataModel/Abstractions/EntityCategory.cs
+++ b/src/NexusMods.DataModel/Abstractions/EntityCategory.cs
@@ -1,5 +1,5 @@
+using NetEscapades.EnumGenerators;
 using NexusMods.DataModel.Attributes;
-
 using NexusMods.FileExtractor.FileSignatures;
 using NexusMods.Hashing.xxHash64;
 using NexusMods.Paths;
@@ -15,6 +15,7 @@ namespace NexusMods.DataModel.Abstractions;
 /// <remarks>
 ///    Limited to 255 in our current implementation due to how we create IDs.
 /// </remarks>
+[EnumExtensions]
 public enum EntityCategory
 {
     /// <summary>

--- a/src/NexusMods.DataModel/Abstractions/Ids/AId.cs
+++ b/src/NexusMods.DataModel/Abstractions/Ids/AId.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 namespace NexusMods.DataModel.Abstractions.Ids;
 
 /// <summary>
@@ -29,7 +31,7 @@ public abstract class AId : IId
     {
         Span<byte> span = stackalloc byte[SpanSize];
         ToSpan(span);
-        return $"{Category}-{Convert.ToHexString(span)}";
+        return $"{Category.ToStringFast()}-{Convert.ToHexString(span)}";
     }
 
     /// <summary>

--- a/src/NexusMods.DataModel/HighPerformanceLogging.cs
+++ b/src/NexusMods.DataModel/HighPerformanceLogging.cs
@@ -1,0 +1,81 @@
+using Microsoft.Extensions.Logging;
+using NexusMods.DataModel.Interprocess.Jobs;
+using NexusMods.DataModel.RateLimiting;
+using NexusMods.Paths;
+
+namespace NexusMods.DataModel;
+
+internal static partial class HighPerformanceLogging
+{
+    [LoggerMessage(
+        EventId = 0,
+        Level = LogLevel.Trace,
+        Message = "Processing jobs")]
+    public static partial void ProcessingJobs(this ILogger logger);
+
+    [LoggerMessage(
+        EventId = 0,
+        Level = LogLevel.Trace,
+        Message = "Job {jobId} progress is {percent}")]
+    public static partial void JobProgress(
+        this ILogger logger,
+        JobId jobId,
+        Percent percent);
+
+    [LoggerMessage(
+        EventId = 0,
+        Level = LogLevel.Trace,
+        Message = "Found new job {jobId}")]
+    public static partial void NewJob(
+        this ILogger logger,
+        JobId jobId);
+
+    [LoggerMessage(
+        EventId = 0,
+        Level = LogLevel.Trace,
+        Message = "Removing job {jobId}")]
+    public static partial void RemovingJob(
+        this ILogger logger,
+        JobId jobId);
+
+    [LoggerMessage(
+        EventId = 0,
+        Level = LogLevel.Trace,
+        Message = "Done processing")]
+    public static partial void DoneProcessing(this ILogger logger);
+
+    [LoggerMessage(
+        EventId = 0,
+        Level = LogLevel.Trace,
+        Message = "Sending {bytes} byte message to queue {queue}")]
+    public static partial void SendingByteMessageToQueue(
+        this ILogger logger,
+        Size bytes,
+        string queue);
+
+    [LoggerMessage(
+        EventId = 0,
+        Level = LogLevel.Trace,
+        Message = "Creating job {jobId} of type {jobType}")]
+    public static partial void CreatingJob(
+        this ILogger logger,
+        JobId jobId,
+        JobType jobType);
+
+    [LoggerMessage(
+        EventId = 0,
+        Level = LogLevel.Trace,
+        Message = "Deleting job {jobId}")]
+    public static partial void DeletingJob(
+        this ILogger logger,
+        JobId jobId);
+
+    [LoggerMessage(
+        EventId = 0,
+        Level = LogLevel.Trace,
+        Message = "Updating job {jobId} progress to {percent}")]
+    public static partial void UpdatingJobProgress(
+        this ILogger logger,
+        JobId jobId,
+        Percent percent);
+}

--- a/src/NexusMods.DataModel/HighPerformanceLogging.cs
+++ b/src/NexusMods.DataModel/HighPerformanceLogging.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using NexusMods.DataModel.Abstractions.Ids;
 using NexusMods.DataModel.Interprocess.Jobs;
 using NexusMods.DataModel.RateLimiting;
 using NexusMods.Paths;
@@ -78,4 +79,29 @@ internal static partial class HighPerformanceLogging
         this ILogger logger,
         JobId jobId,
         Percent percent);
+
+    [LoggerMessage(
+        EventId = 0,
+        Level = LogLevel.Trace,
+        Message = "Getting {id} of type {type}")]
+    public static partial void GetIdOfType(
+        this ILogger logger,
+        IId id,
+        string type);
+
+    [LoggerMessage(
+        EventId = 0,
+        Level = LogLevel.Debug,
+        Message = "Waiting for write to {id} to complete")]
+    public static partial void WaitingForWriteToId(
+        this ILogger logger,
+        IId id);
+
+    [LoggerMessage(
+        EventId = 0,
+        Level = LogLevel.Trace,
+        Message = "Id {id} is updated")]
+    public static partial void IdIsUpdated(
+        this ILogger logger,
+        IId id);
 }

--- a/src/NexusMods.DataModel/NexusMods.DataModel.csproj
+++ b/src/NexusMods.DataModel/NexusMods.DataModel.csproj
@@ -24,6 +24,15 @@
         <PackageReference Include="Vogen" Version="3.0.12" />
     </ItemGroup>
 
+    <PropertyGroup>
+        <!-- https://github.com/andrewlock/NetEscapades.EnumGenerators#embedding-the-attributes-in-your-project -->
+        <DefineConstants>$(DefineConstants);NETESCAPADES_ENUMGENERATORS_EMBED_ATTRIBUTES</DefineConstants>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="NetEscapades.EnumGenerators" Version="1.0.0-beta07" PrivateAssets="all" ExcludeAssets="compile;runtime" />
+    </ItemGroup>
+
     <ItemGroup>
       <Folder Include="Loadouts\Extensions" />
     </ItemGroup>

--- a/src/NexusMods.DataModel/NexusMods.DataModel.csproj
+++ b/src/NexusMods.DataModel/NexusMods.DataModel.csproj
@@ -16,7 +16,7 @@
         <PackageReference Include="DynamicData" Version="7.13.1" />
         <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.4" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="7.0.4" />
         <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.1" />
         <PackageReference Include="Sewer56.BitStream" Version="1.3.0" />

--- a/src/NexusMods.DataModel/SqliteDataStore.cs
+++ b/src/NexusMods.DataModel/SqliteDataStore.cs
@@ -185,7 +185,7 @@ public class SqliteDataStore : IDataStore, IDisposable
         if (canCache && _cache.TryGet(id, out var cached))
             return (T)cached;
 
-        _logger.LogTrace("Getting {Id} of type {Type}", id, typeof(T).Name);
+        _logger.GetIdOfType(id, typeof(T).Name);
         using var conn = _pool.RentDisposable();
         using var cmd = conn.Value.CreateCommand();
         cmd.CommandText = _getStatements[id.Category];
@@ -364,11 +364,12 @@ public class SqliteDataStore : IDataStore, IDisposable
         var maxCycles = 0;
         while (change.Type != IdUpdated.UpdateType.Delete && GetRaw(change.Id) == null && maxCycles < 10)
         {
-            _logger.LogDebug("Waiting for write to {Id} to complete", change.Id);
+            _logger.WaitingForWriteToId(change.Id);
             await Task.Delay(100);
             maxCycles++;
         }
-        _logger.LogTrace("Id {Id} is updated", change.Id);
+
+        _logger.IdIsUpdated(change.Id);
         return change.Id;
     }
 


### PR DESCRIPTION
## Logging

### Problem

We're using `Microsoft.Extensions.Abstractions.Logging` for all of our logging. We're also producing a lot of _trace_ logs in hot paths of our app. I fixed the issue of always logging traces in #280, which indirectly helped with performance (because the code no longer writes to console), however there is still performance to be gained.

The `ILogger` extension methods `LogTrace`, `LogDebug` and so on, all use `param object[]`, which **always** allocates a new array, even if we disabled trace logging. Furthermore, value types, which we use everywhere, get boxed to `object`.

### Solution

Microsoft provides [guidelines](https://learn.microsoft.com/en-us/dotnet/core/extensions/high-performance-logging) for high performance logging using the [`LoggerMessage`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.loggermessage) class, which exposes functionality to create cacheable delegates that require fewer object allocations and reduced computational overhead compared:

```csharp
private static readonly Action<ILogger, WorkItem, Exception> s_processingPriorityItem = LoggerMessage.Define<WorkItem>(
    LogLevel.Information,
    new EventId(1, nameof(PriorityItemProcessed)),
    "Processing priority item: {Item}");

public static void PriorityItemProcessed(this ILogger logger, WorkItem workItem)
{
    if (logger.IsEnabled(LogLevel.Information)
    {
        s_processingPriorityItem(logger, workItem, default!)
    }
}
```

This prevents an array allocation for `params object[]`, removes boxing allocation since it's using generics, and doesn't do additional work, if the log level isn't even enabled.

Instead of writing this by hand, we can also make use of [source generators](https://learn.microsoft.com/en-us/dotnet/core/extensions/logger-message-generator):

```csharp
    [LoggerMessage(
        EventId = 0,
        Level = LogLevel.Trace,
        Message = "Job {jobId} progress is {percent}")]
    public static partial void JobProgress(
        this ILogger logger,
        JobId jobId,
        Percent percent);
```

This generates the same code as before:

```csharp
        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Logging.Generators", "7.0.7.1805")]
        private static readonly global::System.Action<global::Microsoft.Extensions.Logging.ILogger, global::NexusMods.DataModel.Interprocess.Jobs.JobId, global::NexusMods.DataModel.RateLimiting.Percent, global::System.Exception?> __JobProgressCallback =
            global::Microsoft.Extensions.Logging.LoggerMessage.Define<global::NexusMods.DataModel.Interprocess.Jobs.JobId, global::NexusMods.DataModel.RateLimiting.Percent>(global::Microsoft.Extensions.Logging.LogLevel.Trace, new global::Microsoft.Extensions.Logging.EventId(0, nameof(JobProgress)), "Job {jobId} progress is {percent}", new global::Microsoft.Extensions.Logging.LogDefineOptions() { SkipEnabledCheck = true }); 

        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Logging.Generators", "7.0.7.1805")]
        public static partial void JobProgress(this global::Microsoft.Extensions.Logging.ILogger logger, global::NexusMods.DataModel.Interprocess.Jobs.JobId jobId, global::NexusMods.DataModel.RateLimiting.Percent percent)
        {
            if (logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Trace))
            {
                __JobProgressCallback(logger, jobId, percent, null);
            }
        }
```

### Benchmarks

I've written a benchmark to showcase the difference in performance:

|                       Method | MinimumLogLevel |      Mean |     Error |    StdDev |   Gen0 | Allocated |
|----------------------------- |---------------- |----------:|----------:|----------:|-------:|----------:|
|       Default_ReferenceTypes |           Trace | 43.057 ns | 0.0488 ns | 0.0408 ns | 0.0005 |      40 B |
|           Default_ValueTypes |           Trace | 49.025 ns | 0.1098 ns | 0.0973 ns | 0.0012 |     104 B |
| LoggerMessage_ReferenceTypes |           Trace | 11.080 ns | 0.1052 ns | 0.0984 ns |      - |         - |
|     LoggerMessage_ValueTypes |           Trace | 11.493 ns | 0.0898 ns | 0.0840 ns |      - |         - |
|       Default_ReferenceTypes |     Information | 42.167 ns | 0.1096 ns | 0.1025 ns | 0.0005 |      40 B |
|           Default_ValueTypes |     Information | 48.945 ns | 0.0987 ns | 0.0923 ns | 0.0012 |     104 B |
| LoggerMessage_ReferenceTypes |     Information |  1.728 ns | 0.0025 ns | 0.0021 ns |      - |         - |
|     LoggerMessage_ValueTypes |     Information |  1.562 ns | 0.0150 ns | 0.0140 ns |      - |         - |

The `Default_*` benchmarks used the `LogTrace` extension methods, while the `LoggerMessage_*` benchmarks use the compiled custom logging methods. The minimum logging level was set to `Trace` for the first run, and `Information` in the second run.

The table shows a ~4x speed improvement and no memory allocations, if the message should be logged. If the minimum logging level is higher than `Trace`, the compiled logging methods don't do anything and exit early, resulting in a ~43x speed improvement.

### Conclusion

Compiled logging methods using `LoggerMessage` should be used in critical hot paths, where we do a lot of trace and debug logging. I've updated the `InjectedViewLocator`, `SqliteIPC` and `SqliteDataStore` classes to use this kind of logging, because they produce 99% of all logs.

## `Id.ToString`

### Problem

On the topic of logging, `SqliteIPC` logs massive amounts of `IId` values. The `ToString` implementation of `AId` does the following:

```csharp
Span<byte> span = stackalloc byte[SpanSize];
ToSpan(span);
return $"{Category}-{Convert.ToHexString(span)}";
```

The `ToSpan` implementations are already optimized, however the string creation is not. C# enums are very weird sometimes and have massive performance issues when calling stringifying them. They are using reflection behind the scenes and have to account for "missing" enum values. In our case, we know the values and we know the string values.

### Solution

[`NetEscapades.EnumGenerators`](https://github.com/andrewlock/NetEscapades.EnumGenerators) is a source generator that produces `ToStringFast` extension methods for enums with the `EnumExtension` attribute:

```csharp
        public static string ToStringFast(this NexusMods.DataModel.Abstractions.EntityCategory value)
            => value switch
            {
                NexusMods.DataModel.Abstractions.EntityCategory.Loadouts => nameof(NexusMods.DataModel.Abstractions.EntityCategory.Loadouts),
                NexusMods.DataModel.Abstractions.EntityCategory.FileAnalysis => nameof(NexusMods.DataModel.Abstractions.EntityCategory.FileAnalysis),
                NexusMods.DataModel.Abstractions.EntityCategory.LoadoutRoots => nameof(NexusMods.DataModel.Abstractions.EntityCategory.LoadoutRoots),
                NexusMods.DataModel.Abstractions.EntityCategory.FileHashes => nameof(NexusMods.DataModel.Abstractions.EntityCategory.FileHashes),
                NexusMods.DataModel.Abstractions.EntityCategory.FileContainedIn => nameof(NexusMods.DataModel.Abstractions.EntityCategory.FileContainedIn),
                NexusMods.DataModel.Abstractions.EntityCategory.AuthData => nameof(NexusMods.DataModel.Abstractions.EntityCategory.AuthData),
                NexusMods.DataModel.Abstractions.EntityCategory.TestData => nameof(NexusMods.DataModel.Abstractions.EntityCategory.TestData),
                _ => value.ToString(),
            };
```

### Benchmarks

|                 Method |     Mean |    Error |   StdDev | Ratio |   Gen0 | Allocated | Alloc Ratio |
|----------------------- |---------:|---------:|---------:|------:|-------:|----------:|------------:|
|                    Old | 76.17 ns | 0.132 ns | 0.117 ns |  1.00 | 0.0018 |     152 B |        1.00 |
| New_WithEnumExtensions | 32.81 ns | 0.575 ns | 0.538 ns |  0.43 | 0.0015 |     128 B |        0.84 |

The `New_WithEnumExtensions` benchmark uses `Category.ToStringFast` instead of `Category.ToString`. This single change basically doubles the performance and also reduces memory allocations.

### Conclusion

The default implementation of `ToString` for enums is horrible and should not be used in hot paths. I believe we can further improve the `ToString` method of `AId` by using `string.Create` or changing how we represent the ids in general.