### PR TITLE
Various small cleanups

### DIFF
--- a/src/Networking/NexusMods.Networking.NexusWebApi/Types/CDNName.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/Types/CDNName.cs
@@ -7,7 +7,4 @@ namespace NexusMods.Networking.NexusWebApi.Types;
 /// </summary>
 [ValueObject<string>]
 // ReSharper disable once InconsistentNaming
-public partial struct CDNName
-{
-
-}
+public readonly partial struct CDNName { }

--- a/src/Networking/NexusMods.Networking.NexusWebApi/Types/CollectionSlug.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/Types/CollectionSlug.cs
@@ -6,7 +6,4 @@ namespace NexusMods.Networking.NexusWebApi.Types;
 /// Unique identifier for a collection hosted on Nexus.
 /// </summary>
 [ValueObject<string>]
-public partial struct CollectionSlug
-{
-
-}
+public readonly partial struct CollectionSlug { }

--- a/src/Networking/NexusMods.Networking.NexusWebApi/Types/FileId.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/Types/FileId.cs
@@ -9,7 +9,4 @@ namespace NexusMods.Networking.NexusWebApi.Types;
 /// i.e. This ID might be used for another mod if you search for mods for another game.
 /// </summary>
 [ValueObject<ulong>]
-public partial struct FileId
-{
-
-}
+public readonly partial struct FileId { }

--- a/src/Networking/NexusMods.Networking.NexusWebApi/Types/GameId.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/Types/GameId.cs
@@ -6,7 +6,4 @@ namespace NexusMods.Networking.NexusWebApi.Types;
 /// Unique identifier for an individual game hosted on Nexus.
 /// </summary>
 [ValueObject<int>]
-public partial struct GameId
-{
-
-}
+public readonly partial struct GameId { }

--- a/src/Networking/NexusMods.Networking.NexusWebApi/Types/ModId.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/Types/ModId.cs
@@ -7,7 +7,4 @@ namespace NexusMods.Networking.NexusWebApi.Types;
 /// i.e. Each game has its own set of IDs and starts with 0.
 /// </summary>
 [ValueObject<ulong>]
-public partial struct ModId
-{
-
-}
+public readonly partial struct ModId { }

--- a/src/Networking/NexusMods.Networking.NexusWebApi/Types/NXMKey.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/Types/NXMKey.cs
@@ -8,7 +8,4 @@ namespace NexusMods.Networking.NexusWebApi.Types;
 [ValueObject<string>]
 // ReSharper disable once InconsistentNaming
 // ReSharper disable once StructCanBeMadeReadOnly
-public partial struct NXMKey
-{
-
-}
+public readonly partial struct NXMKey { }

--- a/src/Networking/NexusMods.Networking.NexusWebApi/Types/RevisionId.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/Types/RevisionId.cs
@@ -6,7 +6,4 @@ namespace NexusMods.Networking.NexusWebApi.Types;
 /// globally unique id identifying a specific revision of a collection
 /// </summary>
 [ValueObject<ulong>]
-public partial struct RevisionId
-{
-
-}
+public readonly partial struct RevisionId { }

--- a/src/Networking/NexusMods.Networking.NexusWebApi/Types/RevisionNumber.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/Types/RevisionNumber.cs
@@ -6,7 +6,4 @@ namespace NexusMods.Networking.NexusWebApi.Types;
 /// revision number (aka "version") of a revision. Only unique within one collection
 /// </summary>
 [ValueObject<ulong>]
-public partial struct RevisionNumber
-{
-
-}
+public readonly partial struct RevisionNumber { }

--- a/src/Networking/NexusMods.Networking.NexusWebApi/Types/UserId.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/Types/UserId.cs
@@ -6,7 +6,4 @@ namespace NexusMods.Networking.NexusWebApi.Types;
 /// Unique identifier for a given site user.
 /// </summary>
 [ValueObject<ulong>]
-public partial struct UserId
-{
-
-}
+public readonly partial struct UserId { }

--- a/src/NexusMods.Common/UserInput/AssetUrl.cs
+++ b/src/NexusMods.Common/UserInput/AssetUrl.cs
@@ -7,7 +7,4 @@ namespace NexusMods.Common.UserInput;
 /// a URL to a remote resource.
 /// </summary>
 [ValueObject<string>]
-public partial class AssetUrl
-{
-
-}
+public readonly partial struct AssetUrl { }

--- a/src/NexusMods.DataModel/Games/GameDomain.cs
+++ b/src/NexusMods.DataModel/Games/GameDomain.cs
@@ -14,4 +14,4 @@ namespace NexusMods.DataModel.Games;
 [ValueObject<string>]
 [Instance("Cyberpunk2077", "cyberpunk2077")]
 // ReSharper disable once PartialTypeWithSinglePart
-public partial struct GameDomain { }
+public readonly partial struct GameDomain { }

--- a/src/NexusMods.DataModel/Loadouts/ModFileId.cs
+++ b/src/NexusMods.DataModel/Loadouts/ModFileId.cs
@@ -11,7 +11,7 @@ namespace NexusMods.DataModel.Loadouts;
 /// </summary>
 [ValueObject<Guid>(conversions: Conversions.None)]
 [JsonConverter(typeof(ModFileIdConverter))]
-public partial struct ModFileId
+public readonly partial struct ModFileId
 {
     /// <summary>
     /// Creates a new <see cref="ModFileId"/> with a unique GUID.

--- a/src/NexusMods.DataModel/Loadouts/ModId.cs
+++ b/src/NexusMods.DataModel/Loadouts/ModId.cs
@@ -11,7 +11,7 @@ namespace NexusMods.DataModel.Loadouts;
 /// </summary>
 [ValueObject<Guid>(conversions: Conversions.None)]
 [JsonConverter(typeof(ModIdConverter))]
-public partial struct ModId
+public readonly partial struct ModId
 {
     /// <summary>
     /// Creates a new <see cref="ModId"/> with a unique GUID.

--- a/src/NexusMods.Paths/Bandwidth.cs
+++ b/src/NexusMods.Paths/Bandwidth.cs
@@ -7,7 +7,7 @@ namespace NexusMods.Paths;
 /// Represents bandwidth in bytes per second.
 /// </summary>
 [ValueObject<ulong>]
-public partial struct Bandwidth
+public readonly partial struct Bandwidth
 {
     /// <inheritdoc />
     public override string ToString() => _value.ToFileSizeString("/sec");

--- a/tests/Games/NexusMods.Games.TestFramework/AGameTest.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/AGameTest.cs
@@ -43,8 +43,14 @@ public abstract class AGameTest<TGame> where TGame : AGame
     protected AGameTest(IServiceProvider serviceProvider)
     {
         ServiceProvider = serviceProvider;
+
         Game = serviceProvider.FindImplementationInContainer<TGame, IGame>();
-        GameInstallation = Game.Installations.First();
+
+        var gameInstallations = Game.Installations.ToArray();
+        gameInstallations.Should().NotBeEmpty("because the game has to be installed");
+
+        GameInstallation = gameInstallations.First();
+        GameInstallation.Game.Should().BeOfType<TGame>("because the game installation should be for the game we're testing");
 
         FileSystem = serviceProvider.GetRequiredService<IFileSystem>();
         ArchiveManager = serviceProvider.GetRequiredService<ArchiveManager>();


### PR DESCRIPTION
This PR is a collection of smaller fixes and changes, that don't need to be in separate PRs.

Changes:
- `AGameTest` has more assertions regarding the game installation. We sometimes get tests that fail in some mod installer testing code, and this ensures the issue is not related to a missing game installation.
- all value objects created using `Vogen` are now marked as `readonly struct`. This is a very small performance win in very special situations to prevent defensive copies.