### PR TITLE
Push to NuGet

### DIFF
--- a/.github/workflows/clean_environment_tests.yaml
+++ b/.github/workflows/clean_environment_tests.yaml
@@ -32,9 +32,12 @@ jobs:
 
       # - name: Clean
       #  run: dotnet clean
-      
+
+      - name: Build
+        run: dotnet build
+
       - name: Tests
-        run: dotnet test --filter "RequiresNetworking!=True" --collect:"XPlat Code Coverage;Format=opencover"
+        run: dotnet test --no-build --filter "RequiresNetworking!=True" --collect:"XPlat Code Coverage;Format=opencover"
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/publish-nuget-packages.yaml
+++ b/.github/workflows/publish-nuget-packages.yaml
@@ -1,0 +1,34 @@
+name: Publish NuGet Packages
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Get Version
+      id: get-version
+      shell: pwsh
+      run: |
+        $version = [System.Version]::Parse("${{ github.ref_name }}".Replace('v', '')).ToString()
+        echo "version=$version" >> $env:GITHUB_OUTPUT
+        echo $version
+
+    - name: Print Debug Info
+      run: dotnet --info
+
+    - name: Pack
+      run: dotnet --pack -p:Version="${{ steps.get-version.outputs.version }}" -p:RepositoryCommit="${{ github.sha }}"
+
+    - name: Validate
+      shell: pwsh
+      run: ./scripts/validate-nupkgs.ps1
+
+    - name: Push to NuGet
+      run: dotnet nuget push **/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,6 +6,10 @@
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
+    <PropertyGroup>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
     <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
         <!-- https://github.com/dotnet/sourcelink/tree/main/docs#continuousintegrationbuild -->
         <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>

--- a/NuGet.Build.props
+++ b/NuGet.Build.props
@@ -1,5 +1,10 @@
 <Project>
     <PropertyGroup>
+        <!-- Overwrites IsPackable from global Directory.Build.props -->
+        <IsPackable>true</IsPackable>
+    </PropertyGroup>
+
+    <PropertyGroup>
         <Authors>Nexus Mods</Authors>
 
         <PackageIcon>Nexus-Icon.png</PackageIcon>

--- a/scripts/validate-nupkgs.ps1
+++ b/scripts/validate-nupkgs.ps1
@@ -1,0 +1,56 @@
+# This script extracts all "*.nupkg" files and parses the ".nuspec" file.
+# It looks at the dependencies of that package and alerts if some dependencies
+# of this organization are not available.
+
+$Organization = "NexusMods"
+
+$nupkgs = Get-ChildItem -Path "*" -Recurse -Include "*.nupkg"
+
+$allPackages = [System.Collections.Generic.HashSet[string]]::new()
+$allDependencies = [System.Collections.Generic.HashSet[string]]::new()
+
+foreach ($item in $nupkgs)
+{
+    $packageName = [System.IO.Path]::GetFileName(
+            [System.IO.Path]::GetDirectoryName(
+                    [System.IO.Path]::GetDirectoryName(
+                            [System.IO.Path]::GetDirectoryName($item))))
+
+    $allPackages.Add($packageName)
+    $extractedPath = [System.IO.Path]::Combine([System.IO.Path]::GetDirectoryName($item.FullName), "extracted")
+
+    Expand-Archive -Path $item.FullName -DestinationPath $extractedPath -Force
+
+    $nuspecFilePath = [System.IO.Path]::Combine($extractedPath, $packageName + ".nuspec")
+
+    if (![System.IO.File]::Exists($nuspecFilePath)) {
+        echo "File $nuspecFilePath does not exist!"
+        exit 1
+    }
+
+    # Select-Xml doesn't want to work for whatever reason
+    #$dependencies = Select-Xml -Path $nuspecFilePath -XPath "//dependency"
+
+    $xml = ([xml](Get-Content -Path $nuspecFilePath))
+    $dependencies = $xml.ChildNodes[1].ChildNodes.dependencies.group.dependency.id
+
+    foreach ($dep in $dependencies) {
+        if (!$dep.StartsWith($Organization)) {
+            continue
+        }
+
+        $allDependencies.Add($dep)
+    }
+}
+
+$allDependencies.ExceptWith($allPackages)
+
+foreach ($missing in $allDependencies) {
+    echo "The following package wasn't packed: $missing"
+}
+
+if ($allDependencies.Count -ne 0) {
+    exit 1
+} else {
+    echo "All packages are correct"
+}

--- a/src/Networking/NexusMods.Networking.NexusWebApi/NexusMods.Networking.NexusWebApi.csproj
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/NexusMods.Networking.NexusWebApi.csproj
@@ -3,6 +3,7 @@
     <Import Project="$([MSBuild]::GetPathOfFileAbove('NuGet.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
     <ItemGroup>
+        <PackageReference Include="System.Linq.Async" Version="6.0.1" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.29.0" />
     </ItemGroup>
 

--- a/src/NexusMods.App.UI/RightContent/LoadoutGrid/Columns/IDataGridColumnFactory.cs
+++ b/src/NexusMods.App.UI/RightContent/LoadoutGrid/Columns/IDataGridColumnFactory.cs
@@ -1,5 +1,4 @@
 ﻿using Avalonia.Controls;
-using Mutagen.Bethesda.Skyrim;
 
 namespace NexusMods.App.UI.RightContent.LoadoutGrid.Columns;
 

--- a/src/NexusMods.App.UI/RightContent/LoadoutGrid/Columns/ModInstalledViewModel.cs
+++ b/src/NexusMods.App.UI/RightContent/LoadoutGrid/Columns/ModInstalledViewModel.cs
@@ -3,7 +3,6 @@ using System.Reactive.Linq;
 using NexusMods.DataModel.Abstractions;
 using NexusMods.DataModel.Loadouts;
 using NexusMods.DataModel.Loadouts.Cursors;
-using Noggog;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
 

--- a/src/NexusMods.App/NexusMods.App.csproj
+++ b/src/NexusMods.App/NexusMods.App.csproj
@@ -5,6 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\Games\NexusMods.Games.BethesdaGameStudios\NexusMods.Games.BethesdaGameStudios.csproj" />
         <ProjectReference Include="..\Games\NexusMods.Games.DarkestDungeon\NexusMods.Games.DarkestDungeon.csproj" />
         <ProjectReference Include="..\Games\NexusMods.Games.StardewValley\NexusMods.Games.StardewValley.csproj" />
         <ProjectReference Include="..\Games\NexusMods.Games.FOMOD\NexusMods.Games.FOMOD.csproj" />

--- a/src/NexusMods.CLI/NexusMods.CLI.csproj
+++ b/src/NexusMods.CLI/NexusMods.CLI.csproj
@@ -1,4 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
+    <!-- NuGet Package Shared Details -->
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('NuGet.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
     <ItemGroup>
         <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
         <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
@@ -6,7 +9,6 @@
 
     <ItemGroup>
         <ProjectReference Include="..\ArchiveManagement\NexusMods.FileExtractor\NexusMods.FileExtractor.csproj" />
-        <ProjectReference Include="..\Games\NexusMods.Games.BethesdaGameStudios\NexusMods.Games.BethesdaGameStudios.csproj" />
         <ProjectReference Include="..\NexusMods.DataModel\NexusMods.DataModel.csproj" />
         <ProjectReference Include="..\NexusMods.Paths\NexusMods.Paths.csproj" />
         <ProjectReference Include="..\NexusMods.StandardGameLocators\NexusMods.StandardGameLocators.csproj" />


### PR DESCRIPTION
Resolves #104 

- adds a GitHub workflow for pushing packages to NuGet when a new tag is pushed to the repository
- uses a whitelist to manage which projects are being packaged
- fixes some dependencies
- adds a validation script that makes sure we're exporting every required local project
- adds a build step to the CI, this cleans up the logs and allows for better debugging