### PR TITLE
Use VSTest integration instead of MSBuild

### DIFF
--- a/.github/workflows/clean_environment_tests.yaml
+++ b/.github/workflows/clean_environment_tests.yaml
@@ -34,8 +34,8 @@ jobs:
       #  run: dotnet clean
       
       - name: Tests
-        run: dotnet test --filter "RequiresNetworking!=True" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
-      
+        run: dotnet test --filter "RequiresNetworking!=True" --collect:"XPlat Code Coverage;Format=opencover"
+
       - uses: codecov/codecov-action@v3
         with:
           flags: clean_environment_tests, ${{runner.os}}

--- a/.github/workflows/networking_tests.yaml
+++ b/.github/workflows/networking_tests.yaml
@@ -40,7 +40,7 @@ jobs:
         run: dotnet clean
 
       - name: Tests
-        run: dotnet test --filter RequiresNetworking=True /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
+        run: dotnet test --filter RequiresNetworking=True --collect:"XPlat Code Coverage;Format=opencover"
 
       - uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
VSTest integration is [preferred](https://github.com/coverlet-coverage/coverlet#vstest-integration-preferred-due-to-known-issue) over MSBuild. This might help stabilize the CI tests a bit.