### PR TITLE
End-to-End testing framework

### DIFF
--- a/src/NexusMods.App.UI/Windows/MainWindow.axaml
+++ b/src/NexusMods.App.UI/Windows/MainWindow.axaml
@@ -23,7 +23,7 @@
         <windows:MainWindowViewModel />
     </Design.DataContext>
 
-    <Grid ColumnDefinitions="72, 216, *" RowDefinitions="62, *">
+    <Grid ColumnDefinitions="72, 216, *" RowDefinitions="62, *" x:Name="MainContent" x:FieldModifier="public">
         <Border
             Background="#CC2A2C2B"
             Grid.Column="0"

--- a/src/NexusMods.App.UI/Windows/MainWindow.axaml
+++ b/src/NexusMods.App.UI/Windows/MainWindow.axaml
@@ -23,7 +23,7 @@
         <windows:MainWindowViewModel />
     </Design.DataContext>
 
-    <Grid ColumnDefinitions="72, 216, *" RowDefinitions="62, *" x:Name="MainContent" x:FieldModifier="public">
+    <Grid ColumnDefinitions="72, 216, *" RowDefinitions="62, *">
         <Border
             Background="#CC2A2C2B"
             Grid.Column="0"

--- a/tests/NexusMods.UI.Tests/AEndToEndTest.cs
+++ b/tests/NexusMods.UI.Tests/AEndToEndTest.cs
@@ -1,0 +1,29 @@
+﻿using NexusMods.UI.Tests.Framework;
+
+namespace NexusMods.UI.Tests;
+
+/// <summary>
+/// A base test class for a test that needs the entire app, the MainWindow and a full View Model
+/// </summary>
+public class AEndToEndTest : IAsyncLifetime
+{
+    private readonly AvaloniaApp _app;
+    
+    protected WindowHost? Host { get; private set; }
+
+    public AEndToEndTest(AvaloniaApp app)
+    {
+        _app = app;
+
+    }
+
+    public async Task InitializeAsync()
+    {
+        Host = await _app.GetMainWindow();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await Host!.DisposeAsync();
+    }
+}

--- a/tests/NexusMods.UI.Tests/AEndToEndTest.cs
+++ b/tests/NexusMods.UI.Tests/AEndToEndTest.cs
@@ -8,10 +8,11 @@ namespace NexusMods.UI.Tests;
 public class AEndToEndTest : IAsyncLifetime
 {
     private readonly AvaloniaApp _app;
-    
-    protected WindowHost? Host { get; private set; }
 
-    public AEndToEndTest(AvaloniaApp app)
+    protected WindowHost Host => _host!;
+    private WindowHost? _host;
+
+    protected AEndToEndTest(AvaloniaApp app)
     {
         _app = app;
 
@@ -19,11 +20,11 @@ public class AEndToEndTest : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        Host = await _app.GetMainWindow();
+        _host = await _app.GetMainWindow();
     }
 
     public async Task DisposeAsync()
     {
-        await Host!.DisposeAsync();
+        await Host.DisposeAsync();
     }
 }

--- a/tests/NexusMods.UI.Tests/EndToEndSanityTest.cs
+++ b/tests/NexusMods.UI.Tests/EndToEndSanityTest.cs
@@ -12,8 +12,8 @@ public class EndToEndSanityTest : AEndToEndTest
     [Fact]
     public async Task CanGetControlsInTheMainWindow()
     {
-        await Host!.SnapShot();
-        var found = await Host!.Select<Button>("Button#LoginButton");
-        found.Count().Should().BeGreaterOrEqualTo(1);
+        await Host.SnapShot();
+        var found = await Host.Select<Button>("Button#LoginButton");
+        found.Should().HaveCountGreaterOrEqualTo(1);
     }
 }

--- a/tests/NexusMods.UI.Tests/EndToEndSanityTest.cs
+++ b/tests/NexusMods.UI.Tests/EndToEndSanityTest.cs
@@ -1,0 +1,19 @@
+﻿using Avalonia.Controls;
+using Avalonia.Markup.Parsers;
+using FluentAssertions;
+using NexusMods.UI.Tests.Framework;
+
+namespace NexusMods.UI.Tests;
+
+public class EndToEndSanityTest : AEndToEndTest
+{
+    public EndToEndSanityTest(AvaloniaApp app) : base(app) { }
+
+    [Fact]
+    public async Task CanGetControlsInTheMainWindow()
+    {
+        await Host!.SnapShot();
+        var found = await Host!.Select<Button>("Button#LoginButton");
+        found.Count().Should().BeGreaterOrEqualTo(1);
+    }
+}

--- a/tests/NexusMods.UI.Tests/Framework/WindowHost.cs
+++ b/tests/NexusMods.UI.Tests/Framework/WindowHost.cs
@@ -1,0 +1,127 @@
+﻿using System.Runtime.CompilerServices;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Markup.Parsers;
+using Avalonia.Styling;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using NexusMods.App.UI.Windows;
+using NexusMods.Paths;
+
+namespace NexusMods.UI.Tests.Framework;
+
+public class WindowHost : IAsyncDisposable
+{
+    private readonly MainWindow _window;
+    private readonly MainWindowViewModel _viewModel;
+    private readonly SelectorParser _parser;
+
+    public WindowHost(MainWindow window, MainWindowViewModel viewModel)
+    {
+        _window = window;
+        _viewModel = viewModel;
+        var types = new Lazy<Dictionary<string, Type>>(GetTypes);
+        _parser = new SelectorParser((_, name) => types.Value[name]);
+    }
+
+    private Dictionary<string,Type> GetTypes()
+    {
+        var types = new Dictionary<string, Type>();
+        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            if (assembly.IsDynamic)
+                continue;
+            if (!assembly.FullName!.StartsWith("Avalonia."))
+                continue;
+            foreach (var type in assembly.GetTypes())
+            {
+                if (type.IsSubclassOf(typeof(Control)))
+                {
+                    types.Add(type.Name, type);
+                }
+            }
+        }
+
+        return types;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            // If we close here, the app hangs when using the headless renderer.
+            // so either we can use the platform renderer (and have flashing windows during testing)
+            // or we hide the window instead :|
+            _window.Hide();
+        });
+    }
+
+    /// <summary>
+    /// Executes an action on the UI thread and waits for it to complete.
+    /// </summary>
+    /// <param name="action"></param>
+    public async Task OnUi(Func<Task> action)
+    {
+        await Dispatcher.UIThread.InvokeAsync(action);
+        await Flush();
+    }
+
+    /// <summary>
+    /// Insures that all pending UI actions have been completed.
+    /// </summary>
+    public async Task Flush()
+    {
+        await Dispatcher.UIThread.InvokeAsync(() => { });
+    }
+
+    /// <summary>
+    /// Use Avalonia selectors to find controls in the current Window. For now the only
+    /// types supported are those found in the Avalonia.* namespace.
+    /// </summary>
+    /// <param name="selector"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    /// <exception cref="ArgumentException"></exception>
+    public async Task<IEnumerable<T>> Select<T>(string selector) where T : IStyleable
+    {
+        var parsed = _parser.Parse(selector);
+        if (parsed == null)
+            throw new ArgumentException("Invalid selector", nameof(selector));
+        
+        return await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            return _window.GetVisualDescendants()
+                .OfType<StyledElement>()
+                .Where(x => parsed.Match(x).IsMatch)
+                .OfType<T>()
+                .ToArray();
+        });
+    }
+
+    /// <summary>
+    /// Take a snapshot of the current window state and save it to the screenshots folder which is located in the entry directory.
+    /// </summary>
+    /// <param name="name">Injected by the compiler, the name of the calling method</param>
+    /// <param name="line">Injected by the compiler, the line of the calling method's invocation</param>
+    /// <param name="wait">Wait for one second, while forcing a UI refresh every 100ms</param>
+    public async Task SnapShot([CallerMemberName] string name = "", [CallerLineNumber] int line = 0, bool wait = true)
+    {
+        if (wait)
+        {
+            // 10 fps refresh for one sec to allow the UI to settle
+            for (int i = 0; i < 10; i++)
+            {
+                await Task.Delay(100);
+                AvaloniaHeadlessPlatform.ForceRenderTimerTick(1);
+            }
+        }
+
+        using var frame = (_window.PlatformImpl as IHeadlessWindow)?.GetLastRenderedFrame();
+        var path = FileSystem.Shared.GetKnownPath(KnownPath.EntryDirectory).CombineUnchecked("screenshots")
+            .CombineUnchecked($"{name}_{line}.png");
+        path.Parent.CreateDirectory();
+        frame?.Item.Save(path.ToString());
+    }
+}
+ 

--- a/tests/NexusMods.UI.Tests/Startup.cs
+++ b/tests/NexusMods.UI.Tests/Startup.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using NexusMods.App;
 using NexusMods.Common;
 using NexusMods.Games.RedEngine;
+using NexusMods.Paths;
 using NexusMods.StandardGameLocators.TestHelpers;
 using NexusMods.UI.Tests.Framework;
 using Xunit.DependencyInjection;
@@ -14,8 +15,20 @@ public class Startup
 {
     public void ConfigureServices(IServiceCollection services)
     {
+        var path = FileSystem.Shared.GetKnownPath(KnownPath.EntryDirectory).CombineUnchecked("temp").CombineUnchecked(Guid.NewGuid().ToString());
+        path.CreateDirectory();
+        var config = new AppConfig
+        {
+            DataModelSettings =
+            {
+                ArchiveLocations = new[] { new ConfigurationPath(path.CombineUnchecked("Archives"))},
+                DataStoreFilePath = new ConfigurationPath(path.CombineUnchecked("DataModel.sqlite")),
+                IpcDataStoreFilePath = new ConfigurationPath(path.CombineUnchecked("DataModel.IPC.sqlite"))
+            }
+        };
+        
         services.AddUniversalGameLocator<Cyberpunk2077>(new Version("1.61"))
-                .AddApp(addStandardGameLocators: false)
+                .AddApp(addStandardGameLocators: false, config: config)
                 .AddSingleton<AvaloniaApp>()
                 .Validate();
     }


### PR DESCRIPTION
For #221, implements a full-app testing system for end to end testing. The created window uses a real MainWindow, real MainWindowViewModel and all the associated services. Routes the datamodel folders to a temporary location so tests start clean every time, and also implements a way to save screenshots of the headless renderer the window runs in. 

In the future we may want to upload these screenshots as part of the tests so we can verify that the code looks as expected. But this is beyond the scope of this ticket. 