### PR TITLE
Upgrade to GameFinder 3

### DIFF
--- a/src/Games/NexusMods.Games.BethesdaGameStudios/SkyrimSpecialEdition.cs
+++ b/src/Games/NexusMods.Games.BethesdaGameStudios/SkyrimSpecialEdition.cs
@@ -30,15 +30,22 @@ public class SkyrimSpecialEdition : AGame, ISteamGame, IGogGame, IXboxGame
         _fileSystem = fileSystem;
     }
 
-    protected override IEnumerable<KeyValuePair<GameFolderType, AbsolutePath>> GetLocations(IGameLocator locator, GameLocatorResult installation)
+    protected override IEnumerable<KeyValuePair<GameFolderType, AbsolutePath>> GetLocations(
+        IFileSystem fileSystem,
+        IGameLocator locator,
+        GameLocatorResult installation)
     {
-        yield return new(GameFolderType.Game, installation.Path);
-        var appData = locator switch
-        {
-            GogLocator => _fileSystem.GetKnownPath(KnownPath.MyGamesDirectory).CombineUnchecked("Skyrim Special Edition GOG"),
-            _ => _fileSystem.GetKnownPath(KnownPath.MyGamesDirectory).CombineUnchecked("Skyrim Special Edition"),
-        };
-        yield return new(GameFolderType.AppData, appData);
+        yield return new KeyValuePair<GameFolderType, AbsolutePath>(GameFolderType.Game, installation.Path);
+
+        var appData = installation.Store == GameStore.GOG
+            ? fileSystem
+                .GetKnownPath(KnownPath.MyGamesDirectory)
+                .CombineUnchecked("Skyrim Special Edition GOG")
+            : fileSystem
+                .GetKnownPath(KnownPath.MyGamesDirectory)
+                .CombineUnchecked("Skyrim Special Edition");
+
+        yield return new KeyValuePair<GameFolderType, AbsolutePath>(GameFolderType.AppData, appData);
     }
 
     public override IEnumerable<AModFile> GetGameFiles(GameInstallation installation, IDataStore store)

--- a/src/Games/NexusMods.Games.BethesdaGameStudios/SkyrimSpecialEdition.cs
+++ b/src/Games/NexusMods.Games.BethesdaGameStudios/SkyrimSpecialEdition.cs
@@ -9,7 +9,7 @@ using NexusMods.StandardGameLocators;
 
 namespace NexusMods.Games.BethesdaGameStudios;
 
-public class SkyrimSpecialEdition : AGame, ISteamGame, IGogGame
+public class SkyrimSpecialEdition : AGame, ISteamGame, IGogGame, IXboxGame
 {
     private readonly IFileSystem _fileSystem;
 
@@ -60,6 +60,8 @@ public class SkyrimSpecialEdition : AGame, ISteamGame, IGogGame
         1801825368, // The Elder Scrolls V: Skyrim Anniversary Edition AKA The Store Bundle
         1162721350 // Upgrade DLC
     };
+
+    public IEnumerable<string> XboxIds => new[] { "BethesdaSoftworks.SkyrimSE-PC" };
 
     public override IStreamFactory Icon =>
         new EmbededResourceStreamFactory<SkyrimSpecialEdition>("NexusMods.Games.BethesdaGameStudios.Resources.SkyrimSpecialEdition.icon.jpg");

--- a/src/Games/NexusMods.Games.DarkestDungeon/DarkestDungeon.cs
+++ b/src/Games/NexusMods.Games.DarkestDungeon/DarkestDungeon.cs
@@ -30,7 +30,10 @@ public class DarkestDungeon : AGame, ISteamGame, IGogGame
         );
     }
 
-    protected override IEnumerable<KeyValuePair<GameFolderType, AbsolutePath>> GetLocations(IGameLocator locator, GameLocatorResult installation)
+    protected override IEnumerable<KeyValuePair<GameFolderType, AbsolutePath>> GetLocations(
+        IFileSystem fileSystem,
+        IGameLocator locator,
+        GameLocatorResult installation)
     {
         yield return new KeyValuePair<GameFolderType, AbsolutePath>(GameFolderType.Game, installation.Path);
     }

--- a/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077.cs
+++ b/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077.cs
@@ -19,13 +19,24 @@ public class Cyberpunk2077 : AGame, ISteamGame, IGogGame, IEpicGame
     public override string Name => "Cyberpunk 2077";
     public override GameDomain Domain => StaticDomain;
     public override GamePath GetPrimaryFile(GameStore store) => new(GameFolderType.Game, @"bin\x64\Cyberpunk2077.exe");
-    protected override IEnumerable<KeyValuePair<GameFolderType, AbsolutePath>> GetLocations(IGameLocator locator, GameLocatorResult installation)
+    protected override IEnumerable<KeyValuePair<GameFolderType, AbsolutePath>> GetLocations(IFileSystem fileSystem, IGameLocator locator, GameLocatorResult installation)
     {
         yield return new KeyValuePair<GameFolderType, AbsolutePath>(GameFolderType.Game, installation.Path);
+
         yield return new KeyValuePair<GameFolderType, AbsolutePath>(GameFolderType.Saves,
-            _fileSystem.GetKnownPath(KnownPath.HomeDirectory).CombineUnchecked(@"Saved Games\CD Projekt Red\Cyberpunk 2077"));
+            fileSystem
+                .GetKnownPath(KnownPath.HomeDirectory)
+                .CombineUnchecked("Saved Games")
+                .CombineChecked("CD Projekt Red")
+                .CombineChecked("Cyberpunk 2077")
+            );
+
         yield return new KeyValuePair<GameFolderType, AbsolutePath>(GameFolderType.AppData,
-            _fileSystem.GetKnownPath(KnownPath.HomeDirectory).CombineUnchecked(@"AppData\Local\CD Projekt Red\Cyberpunk 2077"));
+            fileSystem
+                .GetKnownPath(KnownPath.LocalApplicationDataDirectory)
+                .CombineUnchecked("CD Projekt Red")
+                .CombineChecked("Cyberpunk 2077")
+        );
     }
 
     public IEnumerable<int> SteamIds => new[] { 1091500 };

--- a/src/Games/NexusMods.Games.Sifu/Sifu.cs
+++ b/src/Games/NexusMods.Games.Sifu/Sifu.cs
@@ -26,7 +26,10 @@ public class Sifu : AGame, ISteamGame, IEpicGame
     {
     }
 
-    protected override IEnumerable<KeyValuePair<GameFolderType, AbsolutePath>> GetLocations(IGameLocator locator, GameLocatorResult installation)
+    protected override IEnumerable<KeyValuePair<GameFolderType, AbsolutePath>> GetLocations(
+        IFileSystem fileSystem,
+        IGameLocator locator,
+        GameLocatorResult installation)
     {
         yield return new KeyValuePair<GameFolderType, AbsolutePath>(GameFolderType.Game, installation.Path);
     }

--- a/src/Games/NexusMods.Games.StardewValley/StardewValley.cs
+++ b/src/Games/NexusMods.Games.StardewValley/StardewValley.cs
@@ -8,14 +8,14 @@ using NexusMods.Paths;
 namespace NexusMods.Games.StardewValley;
 
 [UsedImplicitly]
-public class StardewValley : AGame, ISteamGame, IGogGame
+public class StardewValley : AGame, ISteamGame, IGogGame, IXboxGame
 {
     private readonly IOSInformation _osInformation;
     private readonly IFileSystem _fileSystem;
 
     public IEnumerable<int> SteamIds => new[] { 413150 };
     public IEnumerable<long> GogIds => new long[] { 1453375253 };
-    // TODO: XboxId = "ConcernedApe.StardewValleyPC"
+    public IEnumerable<string> XboxIds => new[] { "ConcernedApe.StardewValleyPC" };
 
     public override string Name => "Stardew Valley";
 

--- a/src/Games/NexusMods.Games.StardewValley/StardewValley.cs
+++ b/src/Games/NexusMods.Games.StardewValley/StardewValley.cs
@@ -47,7 +47,10 @@ public class StardewValley : AGame, ISteamGame, IGogGame, IXboxGame
         );
     }
 
-    protected override IEnumerable<KeyValuePair<GameFolderType, AbsolutePath>> GetLocations(IGameLocator locator, GameLocatorResult installation)
+    protected override IEnumerable<KeyValuePair<GameFolderType, AbsolutePath>> GetLocations(
+        IFileSystem fileSystem,
+        IGameLocator locator,
+        GameLocatorResult installation)
     {
         if (installation.Store == GameStore.XboxGamePass)
         {
@@ -58,7 +61,7 @@ public class StardewValley : AGame, ISteamGame, IGogGame, IXboxGame
             yield return new KeyValuePair<GameFolderType, AbsolutePath>(GameFolderType.Game, installation.Path);
         }
 
-        var stardewValleyAppDataPath = _fileSystem
+        var stardewValleyAppDataPath = fileSystem
             .GetKnownPath(KnownPath.ApplicationDataDirectory)
             .CombineUnchecked("StardewValley");
 

--- a/src/NexusMods.Common/Services.cs
+++ b/src/NexusMods.Common/Services.cs
@@ -35,6 +35,11 @@ public static class Services
         return services;
     }
 
+    /// <summary>
+    /// Adds a shared implementation of <see cref="IOSInformation"/> to the service collection.
+    /// </summary>
+    /// <param name="serviceCollection"></param>
+    /// <returns></returns>
     public static IServiceCollection AddOSInformation(this IServiceCollection serviceCollection)
     {
         return serviceCollection.AddSingleton(OSInformation.Shared);

--- a/src/NexusMods.DataModel/Games/AGame.cs
+++ b/src/NexusMods.DataModel/Games/AGame.cs
@@ -71,7 +71,7 @@ public abstract class AGame : IGame
                 select new GameInstallation
                 {
                     Game = this,
-                    Locations = new Dictionary<GameFolderType, AbsolutePath>(GetLocations(locator, installation)),
+                    Locations = new Dictionary<GameFolderType, AbsolutePath>(GetLocations(installation.Path.FileSystem, locator, installation)),
                     Version = installation.Version ?? GetVersion(installation),
                     Store = installation.Store
                 })
@@ -82,10 +82,14 @@ public abstract class AGame : IGame
     /// <summary>
     /// Returns the locations of known game elements, such as save folder, etc.
     /// </summary>
+    /// <param name="fileSystem">The file system where the game was found in. This comes from <paramref name="installation"/>.</param>
     /// <param name="locator">The locator used to find this game installation.</param>
     /// <param name="installation">An installation of the game found by the <paramref name="locator"/>.</param>
     /// <returns></returns>
-    protected abstract IEnumerable<KeyValuePair<GameFolderType, AbsolutePath>> GetLocations(IGameLocator locator, GameLocatorResult installation);
+    protected abstract IEnumerable<KeyValuePair<GameFolderType, AbsolutePath>> GetLocations(
+        IFileSystem fileSystem,
+        IGameLocator locator,
+        GameLocatorResult installation);
 
     /// <inheritdoc />
     public override string ToString() => Name;

--- a/src/NexusMods.DataModel/Games/IXboxGame.cs
+++ b/src/NexusMods.DataModel/Games/IXboxGame.cs
@@ -1,0 +1,17 @@
+namespace NexusMods.DataModel.Games;
+
+/// <summary>
+/// When implemented, enables support for detecting installations of your
+/// <see cref="AGame"/> managed by Xbox Game Pass.
+/// </summary>
+/// <remarks>
+/// Game detection is automatic provided the correct <see cref="XboxIds"/>
+/// is applied.
+/// </remarks>
+public interface IXboxGame : IGame
+{
+    /// <summary>
+    /// Returns one ore more Xbox IDs for the game.
+    /// </summary>
+    IEnumerable<string> XboxIds { get; }
+}

--- a/src/NexusMods.Paths/AbsolutePath.cs
+++ b/src/NexusMods.Paths/AbsolutePath.cs
@@ -12,7 +12,7 @@ namespace NexusMods.Paths;
 /// A path that represents a full path to a file or directory.
 /// </summary>
 [PublicAPI]
-[DebuggerDisplay("{Directory}{DirectorySeparatorCharStr}{FileName}")]
+[DebuggerDisplay("{DebugDisplay()}")]
 public readonly partial struct AbsolutePath : IEquatable<AbsolutePath>, IPath
 {
     private static readonly char PathSeparatorForInternalOperations = Path.DirectorySeparatorChar;
@@ -485,4 +485,13 @@ public readonly partial struct AbsolutePath : IEquatable<AbsolutePath>, IPath
 
         return fileName;
     }
+
+#if DEBUG
+    private string DebugDisplay()
+    {
+        return IsRootDirectory(Directory)
+            ? $"{Directory}{FileName}"
+            : $"{Directory}{DirectorySeparatorCharStr}{FileName}";
+    }
+#endif
 }

--- a/src/NexusMods.Paths/FileSystemAbstraction/InMemoryFileSystem/InMemoryFileSystem.cs
+++ b/src/NexusMods.Paths/FileSystemAbstraction/InMemoryFileSystem/InMemoryFileSystem.cs
@@ -260,7 +260,7 @@ public partial class InMemoryFileSystem : BaseFileSystem
         }
 
         if (inMemoryFileEntry is null)
-            throw new FileNotFoundException("File does not exist!", path.FileName);
+            throw new FileNotFoundException($"File \"{path.GetFullPath()}\" does not exist");
 
         return access switch
         {

--- a/src/NexusMods.StandardGameLocators/AGameLocator.cs
+++ b/src/NexusMods.StandardGameLocators/AGameLocator.cs
@@ -14,6 +14,7 @@ namespace NexusMods.StandardGameLocators;
 /// <typeparam name="TGameType">The underlying game type library which maps to the <see cref="GameFinder"/> library. e.g. <see cref="SteamGame"/>.</typeparam>
 /// <typeparam name="TId">Unique identifier used by the store for the games.</typeparam>
 /// <typeparam name="TGame">Implementation of <see cref="IGame"/> such as <see cref="ISteamGame"/> that allows us to retrieve info about the game.</typeparam>
+/// <typeparam name="TParent"></typeparam>
 public abstract class AGameLocator<TGameType, TId, TGame, TParent> : IGameLocator
     where TGame : IGame
     where TParent : AGameLocator<TGameType, TId, TGame, TParent>
@@ -25,6 +26,10 @@ public abstract class AGameLocator<TGameType, TId, TGame, TParent> : IGameLocato
     private readonly AHandler<TGameType, TId> _handler;
     private IReadOnlyDictionary<TId, TGameType>? _cachedGames;
 
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    /// <param name="provider"></param>
     protected AGameLocator(IServiceProvider provider)
     {
         _logger = provider.GetRequiredService<ILogger<TParent>>();

--- a/src/NexusMods.StandardGameLocators/AGameLocator.cs
+++ b/src/NexusMods.StandardGameLocators/AGameLocator.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NexusMods.DataModel.Games;
 using NexusMods.Paths;
+using IGame = NexusMods.DataModel.Games.IGame;
 
 namespace NexusMods.StandardGameLocators;
 
@@ -13,23 +14,21 @@ namespace NexusMods.StandardGameLocators;
 /// <typeparam name="TGameType">The underlying game type library which maps to the <see cref="GameFinder"/> library. e.g. <see cref="SteamGame"/>.</typeparam>
 /// <typeparam name="TId">Unique identifier used by the store for the games.</typeparam>
 /// <typeparam name="TGame">Implementation of <see cref="IGame"/> such as <see cref="ISteamGame"/> that allows us to retrieve info about the game.</typeparam>
-public abstract class AGameLocator<TGameType, TId, TGame, TParent> : IGameLocator where TGameType : class
-    where TGame : IGame 
+public abstract class AGameLocator<TGameType, TId, TGame, TParent> : IGameLocator
+    where TGame : IGame
     where TParent : AGameLocator<TGameType, TId, TGame, TParent>
+    where TGameType : class, GameFinder.Common.IGame
+    where TId : notnull
 {
     private readonly ILogger _logger;
-    private readonly AHandler<TGameType, TId> _handler;
-    private IDictionary<TId, TGameType>? _cachedGames;
-    protected readonly IFileSystem FileSystem;
 
-    /// <summary/>
-    /// <param name="logger">Allows you to log results.</param>
-    /// <param name="handler">Common interface for store handlers.</param>
+    private readonly AHandler<TGameType, TId> _handler;
+    private IReadOnlyDictionary<TId, TGameType>? _cachedGames;
+
     protected AGameLocator(IServiceProvider provider)
     {
         _logger = provider.GetRequiredService<ILogger<TParent>>();
         _handler = provider.GetRequiredService<AHandler<TGameType, TId>>();
-        FileSystem = provider.GetRequiredService<IFileSystem>();
     }
 
     /// <summary>

--- a/src/NexusMods.StandardGameLocators/AWineGameLocator.cs
+++ b/src/NexusMods.StandardGameLocators/AWineGameLocator.cs
@@ -1,0 +1,69 @@
+using GameFinder.Wine;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NexusMods.DataModel.Games;
+using IGame = NexusMods.DataModel.Games.IGame;
+
+namespace NexusMods.StandardGameLocators;
+
+/// <summary>
+/// <see cref="IGameLocator"/> implementation that looks for games inside
+/// wine prefixes.
+/// </summary>
+/// <typeparam name="TPrefix"></typeparam>
+public abstract class AWineGameLocator<TPrefix> : IGameLocator
+    where TPrefix : AWinePrefix
+{
+    private readonly ILogger _logger;
+    private readonly IWinePrefixManager<TPrefix> _winePrefixManager;
+    private readonly WineStoreHandlerWrapper _storeHandlerWrapper;
+
+    private IReadOnlyList<GameFinder.Common.IGame>? _cachedGames;
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    /// <param name="serviceProvider"></param>
+    protected AWineGameLocator(IServiceProvider serviceProvider)
+    {
+        _logger = serviceProvider.GetRequiredService<ILogger<AWineGameLocator<TPrefix>>>();
+        _winePrefixManager = serviceProvider.GetRequiredService<IWinePrefixManager<TPrefix>>();
+        _storeHandlerWrapper = serviceProvider.GetRequiredService<WineStoreHandlerWrapper>();
+    }
+
+    /// <inheritdoc/>
+    public IEnumerable<GameLocatorResult> Find(IGame game)
+    {
+        _cachedGames ??= FindAllGames();
+
+        var foundGame = _storeHandlerWrapper.FindMatchingGame(_cachedGames, game);
+        if (foundGame is not null) yield return foundGame;
+    }
+
+    private IReadOnlyList<GameFinder.Common.IGame> FindAllGames()
+    {
+        var results = new List<GameFinder.Common.IGame>();
+
+        foreach (var res in _winePrefixManager.FindPrefixes())
+        {
+            if (!res.TryPickT0(out var prefix, out var error))
+            {
+                _logger.LogError("While looking for a Wine prefix: {Error}", error.Message);
+                continue;
+            }
+
+            foreach (var handlerRes in _storeHandlerWrapper.FindAllGamesInPrefix(prefix))
+            {
+                if (!handlerRes.TryPickT0(out var game, out error))
+                {
+                    _logger.LogError("While looking for a game inside a Wine Prefix {Prefix}: {Error}", prefix, error.Message);
+                    continue;
+                }
+
+                results.Add(game);
+            }
+        }
+
+        return results;
+    }
+}

--- a/src/NexusMods.StandardGameLocators/BottlesWineGameLocator.cs
+++ b/src/NexusMods.StandardGameLocators/BottlesWineGameLocator.cs
@@ -1,0 +1,12 @@
+using GameFinder.Wine.Bottles;
+
+namespace NexusMods.StandardGameLocators;
+
+/// <summary>
+/// <see cref="AWineGameLocator{TPrefix}"/> for <see cref="BottlesWinePrefix"/>.
+/// </summary>
+public class BottlesWineGameLocator : AWineGameLocator<BottlesWinePrefix>
+{
+    /// <inheritdoc/>
+    public BottlesWineGameLocator(IServiceProvider serviceProvider) : base(serviceProvider) { }
+}

--- a/src/NexusMods.StandardGameLocators/DefaultWineGameLocator.cs
+++ b/src/NexusMods.StandardGameLocators/DefaultWineGameLocator.cs
@@ -1,0 +1,12 @@
+using GameFinder.Wine;
+
+namespace NexusMods.StandardGameLocators;
+
+/// <summary>
+/// <see cref="AWineGameLocator{TPrefix}"/> for <see cref="WinePrefix"/>.
+/// </summary>
+public class DefaultWineGameLocator : AWineGameLocator<WinePrefix>
+{
+    /// <inheritdoc/>
+    public DefaultWineGameLocator(IServiceProvider serviceProvider) : base(serviceProvider) { }
+}

--- a/src/NexusMods.StandardGameLocators/EADesktopLocator.cs
+++ b/src/NexusMods.StandardGameLocators/EADesktopLocator.cs
@@ -1,9 +1,6 @@
-using GameFinder.Common;
 using GameFinder.StoreHandlers.EADesktop;
-using Microsoft.Extensions.Logging;
 using NexusMods.DataModel.Games;
 using NexusMods.Paths;
-using NexusMods.Paths.Extensions;
 
 namespace NexusMods.StandardGameLocators;
 
@@ -11,19 +8,17 @@ namespace NexusMods.StandardGameLocators;
 /// Finds games managed by the 'EA Desktop' application, the successor to Origin.
 /// </summary>
 // ReSharper disable once InconsistentNaming
-public class EADesktopLocator : AGameLocator<EADesktopGame, string, IEADesktopGame, EADesktopLocator>
+public class EADesktopLocator : AGameLocator<EADesktopGame, EADesktopGameId, IEADesktopGame, EADesktopLocator>
 {
     /// <summary/>
-    public EADesktopLocator(IServiceProvider provider) : base(provider)
-    {
-    }
+    public EADesktopLocator(IServiceProvider provider) : base(provider) { }
 
     /// <inheritdoc />
     protected override GameStore Store => GameStore.EADesktop;
 
     /// <inheritdoc />
-    protected override IEnumerable<string> Ids(IEADesktopGame game) => game.EADesktopSoftwareIDs;
+    protected override IEnumerable<EADesktopGameId> Ids(IEADesktopGame game) => game.EADesktopSoftwareIDs.Select(EADesktopGameId.From);
 
     /// <inheritdoc />
-    protected override AbsolutePath Path(EADesktopGame record) => record.BaseInstallPath.ToAbsolutePath(FileSystem);
+    protected override AbsolutePath Path(EADesktopGame record) => record.BaseInstallPath;
 }

--- a/src/NexusMods.StandardGameLocators/EpicLocator.cs
+++ b/src/NexusMods.StandardGameLocators/EpicLocator.cs
@@ -1,28 +1,23 @@
-using GameFinder.Common;
 using GameFinder.StoreHandlers.EGS;
-using Microsoft.Extensions.Logging;
 using NexusMods.DataModel.Games;
 using NexusMods.Paths;
-using NexusMods.Paths.Extensions;
 
 namespace NexusMods.StandardGameLocators;
 
 /// <summary>
 /// Finds games managed by the Epic Games Launcher.
 /// </summary>
-public class EpicLocator : AGameLocator<EGSGame, string, IEpicGame, EpicLocator>
+public class EpicLocator : AGameLocator<EGSGame, EGSGameId, IEpicGame, EpicLocator>
 {
     /// <inheritdoc />
-    public EpicLocator(IServiceProvider provider) : base(provider)
-    {
-    }
+    public EpicLocator(IServiceProvider provider) : base(provider) { }
 
     /// <inheritdoc />
     protected override GameStore Store => GameStore.EGS;
 
     /// <inheritdoc />
-    protected override IEnumerable<string> Ids(IEpicGame game) => game.EpicCatalogItemId;
+    protected override IEnumerable<EGSGameId> Ids(IEpicGame game) => game.EpicCatalogItemId.Select(EGSGameId.From);
 
     /// <inheritdoc />
-    protected override AbsolutePath Path(EGSGame record) => record.InstallLocation.ToAbsolutePath(FileSystem);
+    protected override AbsolutePath Path(EGSGame record) => record.InstallLocation;
 }

--- a/src/NexusMods.StandardGameLocators/GogLocator.cs
+++ b/src/NexusMods.StandardGameLocators/GogLocator.cs
@@ -1,28 +1,23 @@
-using GameFinder.Common;
 using GameFinder.StoreHandlers.GOG;
-using Microsoft.Extensions.Logging;
 using NexusMods.DataModel.Games;
 using NexusMods.Paths;
-using NexusMods.Paths.Extensions;
 
 namespace NexusMods.StandardGameLocators;
 
 /// <summary>
 /// Finds games managed by 'Good Old Games Galaxy' (GOG Galaxy) application.
 /// </summary>
-public class GogLocator : AGameLocator<GOGGame, long, IGogGame, GogLocator>
+public class GogLocator : AGameLocator<GOGGame, GOGGameId, IGogGame, GogLocator>
 {
     /// <inheritdoc />
-    public GogLocator(IServiceProvider provider) : base(provider)
-    {
-    }
+    public GogLocator(IServiceProvider provider) : base(provider) { }
 
     /// <inheritdoc />
     protected override GameStore Store => GameStore.GOG;
 
     /// <inheritdoc />
-    protected override IEnumerable<long> Ids(IGogGame game) => game.GogIds;
+    protected override IEnumerable<GOGGameId> Ids(IGogGame game) => game.GogIds.Select(GOGGameId.From);
 
     /// <inheritdoc />
-    protected override AbsolutePath Path(GOGGame record) => record.Path.ToAbsolutePath(FileSystem);
+    protected override AbsolutePath Path(GOGGame record) => record.Path;
 }

--- a/src/NexusMods.StandardGameLocators/NexusMods.StandardGameLocators.csproj
+++ b/src/NexusMods.StandardGameLocators/NexusMods.StandardGameLocators.csproj
@@ -3,7 +3,7 @@
     <Import Project="$([MSBuild]::GetPathOfFileAbove('NuGet.Build.props', '$(MSBuildThisFileDirectory)../'))" />
     
     <ItemGroup>
-        <PackageReference Include="GameFinder" Version="3.0.1" />
+        <PackageReference Include="GameFinder" Version="3.0.2" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
     </ItemGroup>

--- a/src/NexusMods.StandardGameLocators/NexusMods.StandardGameLocators.csproj
+++ b/src/NexusMods.StandardGameLocators/NexusMods.StandardGameLocators.csproj
@@ -3,7 +3,7 @@
     <Import Project="$([MSBuild]::GetPathOfFileAbove('NuGet.Build.props', '$(MSBuildThisFileDirectory)../'))" />
     
     <ItemGroup>
-        <PackageReference Include="GameFinder" Version="3.0.0" />
+        <PackageReference Include="GameFinder" Version="3.0.1" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
     </ItemGroup>

--- a/src/NexusMods.StandardGameLocators/NexusMods.StandardGameLocators.csproj
+++ b/src/NexusMods.StandardGameLocators/NexusMods.StandardGameLocators.csproj
@@ -3,15 +3,11 @@
     <Import Project="$([MSBuild]::GetPathOfFileAbove('NuGet.Build.props', '$(MSBuildThisFileDirectory)../'))" />
     
     <ItemGroup>
-        <PackageReference Include="GameFinder.StoreHandlers.EADesktop" Version="2.5.0" />
-        <PackageReference Include="GameFinder.StoreHandlers.EGS" Version="2.5.0" />
-        <PackageReference Include="GameFinder.StoreHandlers.GOG" Version="2.5.0" />
-        <PackageReference Include="GameFinder.StoreHandlers.Origin" Version="2.5.0" />
-        <PackageReference Include="GameFinder.StoreHandlers.Steam" Version="2.5.0" />
+        <PackageReference Include="GameFinder" Version="3.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
     </ItemGroup>
-    
+
     <ItemGroup>
         <ProjectReference Include="..\NexusMods.DataModel\NexusMods.DataModel.csproj" />
         <ProjectReference Include="..\NexusMods.Paths\NexusMods.Paths.csproj" />

--- a/src/NexusMods.StandardGameLocators/OriginLocator.cs
+++ b/src/NexusMods.StandardGameLocators/OriginLocator.cs
@@ -1,28 +1,23 @@
-using GameFinder.Common;
 using GameFinder.StoreHandlers.Origin;
-using Microsoft.Extensions.Logging;
 using NexusMods.DataModel.Games;
 using NexusMods.Paths;
-using NexusMods.Paths.Extensions;
 
 namespace NexusMods.StandardGameLocators;
 
 /// <summary>
 /// Finds games managed by 'Origin', EA's previous launcher.
 /// </summary>
-public class OriginLocator : AGameLocator<OriginGame, string, IOriginGame, OriginLocator>
+public class OriginLocator : AGameLocator<OriginGame, OriginGameId, IOriginGame, OriginLocator>
 {
     /// <inheritdoc />
-    public OriginLocator(IServiceProvider provider) : base(provider)
-    {
-    }
+    public OriginLocator(IServiceProvider provider) : base(provider) { }
 
     /// <inheritdoc />
     protected override GameStore Store => GameStore.Origin;
 
     /// <inheritdoc />
-    protected override IEnumerable<string> Ids(IOriginGame game) => game.OriginGameIds;
+    protected override IEnumerable<OriginGameId> Ids(IOriginGame game) => game.OriginGameIds.Select(OriginGameId.From);
 
     /// <inheritdoc />
-    protected override AbsolutePath Path(OriginGame record) => record.InstallPath.ToAbsolutePath(FileSystem);
+    protected override AbsolutePath Path(OriginGame record) => record.InstallPath;
 }

--- a/src/NexusMods.StandardGameLocators/Services.cs
+++ b/src/NexusMods.StandardGameLocators/Services.cs
@@ -7,6 +7,7 @@ using GameFinder.StoreHandlers.EGS;
 using GameFinder.StoreHandlers.GOG;
 using GameFinder.StoreHandlers.Origin;
 using GameFinder.StoreHandlers.Steam;
+using GameFinder.StoreHandlers.Xbox;
 using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Common;
 using NexusMods.DataModel.Games;
@@ -29,15 +30,20 @@ public static class Services
     public static IServiceCollection AddStandardGameLocators(this IServiceCollection services,
         bool registerConcreteLocators = true)
     {
-        services.AddSingleton<IGameLocator, SteamLocator>();
-
-        if (OSInformation.Shared.IsWindows)
-        {
-            services.AddSingleton<IGameLocator, EADesktopLocator>();
-            services.AddSingleton<IGameLocator, EpicLocator>();
-            services.AddSingleton<IGameLocator, GogLocator>();
-            services.AddSingleton<IGameLocator, OriginLocator>();
-        }
+        OSInformation.Shared.SwitchPlatform(
+            onWindows: () =>
+            {
+                services.AddSingleton<IGameLocator, SteamLocator>();
+                services.AddSingleton<IGameLocator, EADesktopLocator>();
+                services.AddSingleton<IGameLocator, EpicLocator>();
+                services.AddSingleton<IGameLocator, GogLocator>();
+                services.AddSingleton<IGameLocator, OriginLocator>();
+                services.AddSingleton<IGameLocator, XboxLocator>();
+            },
+            onLinux: () =>
+            {
+                services.AddSingleton<IGameLocator, SteamLocator>();
+            });
 
         if (!registerConcreteLocators) return services;
 
@@ -51,6 +57,7 @@ public static class Services
                 services.AddSingleton<AHandler<EGSGame, EGSGameId>>(provider => new EGSHandler(provider.GetRequiredService<IRegistry>(), provider.GetRequiredService<IFileSystem>()));
                 services.AddSingleton<AHandler<GOGGame, GOGGameId>>(provider => new GOGHandler(provider.GetRequiredService<IRegistry>(), provider.GetRequiredService<IFileSystem>()));
                 services.AddSingleton<AHandler<OriginGame, OriginGameId>>(provider => new OriginHandler(provider.GetRequiredService<IFileSystem>()));
+                services.AddSingleton<AHandler<XboxGame, XboxGameId>>(provider => new XboxHandler(provider.GetRequiredService<IFileSystem>()));
             },
             onLinux: () =>
             {

--- a/src/NexusMods.StandardGameLocators/Services.cs
+++ b/src/NexusMods.StandardGameLocators/Services.cs
@@ -8,6 +8,8 @@ using GameFinder.StoreHandlers.GOG;
 using GameFinder.StoreHandlers.Origin;
 using GameFinder.StoreHandlers.Steam;
 using GameFinder.StoreHandlers.Xbox;
+using GameFinder.Wine;
+using GameFinder.Wine.Bottles;
 using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Common;
 using NexusMods.DataModel.Games;
@@ -30,6 +32,8 @@ public static class Services
     public static IServiceCollection AddStandardGameLocators(this IServiceCollection services,
         bool registerConcreteLocators = true)
     {
+        // TODO: figure out the Proton-Wine situation
+
         OSInformation.Shared.SwitchPlatform(
             onWindows: () =>
             {
@@ -43,6 +47,9 @@ public static class Services
             onLinux: () =>
             {
                 services.AddSingleton<IGameLocator, SteamLocator>();
+
+                services.AddSingleton<IGameLocator, DefaultWineGameLocator>();
+                services.AddSingleton<IGameLocator, BottlesWineGameLocator>();
             });
 
         if (!registerConcreteLocators) return services;
@@ -50,8 +57,10 @@ public static class Services
         OSInformation.Shared.SwitchPlatform(
             onWindows: () =>
             {
+#pragma warning disable CA1416
                 services.AddSingleton(WindowsRegistry.Shared);
                 services.AddSingleton<IHardwareInfoProvider, HardwareInfoProvider>();
+#pragma warning restore CA1416
                 services.AddSingleton<AHandler<SteamGame, SteamGameId>>(provider => new SteamHandler(provider.GetRequiredService<IFileSystem>(), provider.GetRequiredService<IRegistry>()));
                 services.AddSingleton<AHandler<EADesktopGame, EADesktopGameId>>(provider => new EADesktopHandler(provider.GetRequiredService<IFileSystem>(), provider.GetRequiredService<IHardwareInfoProvider>()));
                 services.AddSingleton<AHandler<EGSGame, EGSGameId>>(provider => new EGSHandler(provider.GetRequiredService<IRegistry>(), provider.GetRequiredService<IFileSystem>()));
@@ -62,8 +71,51 @@ public static class Services
             onLinux: () =>
             {
                 services.AddSingleton<AHandler<SteamGame, SteamGameId>>(provider => new SteamHandler(provider.GetRequiredService<IFileSystem>(), registry: null));
+
+                services.AddSingleton<IWinePrefixManager<WinePrefix>>(provider => new DefaultWinePrefixManager(provider.GetRequiredService<IFileSystem>()));
+                services.AddSingleton<IWinePrefixManager<BottlesWinePrefix>>(provider => new BottlesWinePrefixManager(provider.GetRequiredService<IFileSystem>()));
+
+                services.AddSingleton(provider => new WineStoreHandlerWrapper(
+                    provider.GetRequiredService<IFileSystem>(),
+                    new WineStoreHandlerWrapper.CreateHandler[]
+                    {
+                        (_, wineRegistry, wineFileSystem) => new GOGHandler(wineRegistry, wineFileSystem),
+                        (_, wineRegistry, wineFileSystem) => new EGSHandler(wineRegistry, wineFileSystem),
+                        (_, _, wineFileSystem) => new OriginHandler(wineFileSystem),
+                    },
+                    new[]
+                    {
+                        CreateDelegateFor<GOGGame, IGogGame>(
+                            (foundGame, requestedGame) => requestedGame.GogIds.Any(x => foundGame.Id.Equals(x)),
+                            game => new GameLocatorResult(game.Path, GameStore.GOG)
+                        ),
+                        CreateDelegateFor<EGSGame, IEpicGame>(
+                            (foundGame, requestedGame) => requestedGame.EpicCatalogItemId.Any(x => foundGame.CatalogItemId.Equals(x)),
+                            game => new GameLocatorResult(game.InstallLocation, GameStore.EGS)
+                        ),
+                        CreateDelegateFor<OriginGame, IOriginGame>(
+                            (foundGame, requestedGame) => requestedGame.OriginGameIds.Any(x => foundGame.Id.Equals(x)),
+                            game => new GameLocatorResult(game.InstallPath, GameStore.Origin)
+                        ),
+                    }
+                ));
             });
 
         return services;
+    }
+
+    private static WineStoreHandlerWrapper.Matches CreateDelegateFor<TFoundGame, TRequestedGame>(
+        Func<TFoundGame, TRequestedGame, bool> matches,
+        Func<TFoundGame, GameLocatorResult> createResult)
+        where TFoundGame : GameFinder.Common.IGame
+        where TRequestedGame : DataModel.Games.IGame
+    {
+        return (foundGame, requestedGame) =>
+        {
+            if (foundGame is not TFoundGame typedFoundGame) return null;
+            if (requestedGame is not TRequestedGame typedRequestedGame) return null;
+            if (!matches(typedFoundGame, typedRequestedGame)) return null;
+            return createResult(typedFoundGame);
+        };
     }
 }

--- a/src/NexusMods.StandardGameLocators/SteamLocator.cs
+++ b/src/NexusMods.StandardGameLocators/SteamLocator.cs
@@ -1,28 +1,23 @@
-using GameFinder.Common;
 using GameFinder.StoreHandlers.Steam;
-using Microsoft.Extensions.Logging;
 using NexusMods.DataModel.Games;
 using NexusMods.Paths;
-using NexusMods.Paths.Extensions;
 
 namespace NexusMods.StandardGameLocators;
 
 /// <summary>
 /// Finds games managed by 'Steam'.
 /// </summary>
-public class SteamLocator : AGameLocator<SteamGame, int, ISteamGame, SteamLocator>
+public class SteamLocator : AGameLocator<SteamGame, SteamGameId, ISteamGame, SteamLocator>
 {
     /// <inheritdoc />
-    public SteamLocator(IServiceProvider provider) : base(provider)
-    {
-    }
+    public SteamLocator(IServiceProvider provider) : base(provider) { }
 
     /// <inheritdoc />
     protected override GameStore Store => GameStore.Steam;
 
     /// <inheritdoc />
-    protected override IEnumerable<int> Ids(ISteamGame game) => game.SteamIds;
+    protected override IEnumerable<SteamGameId> Ids(ISteamGame game) => game.SteamIds.Select(SteamGameId.From);
 
     /// <inheritdoc />
-    protected override AbsolutePath Path(SteamGame record) => record.Path.ToAbsolutePath(FileSystem);
+    protected override AbsolutePath Path(SteamGame record) => record.Path;
 }

--- a/src/NexusMods.StandardGameLocators/WineStoreHandlerWrapper.cs
+++ b/src/NexusMods.StandardGameLocators/WineStoreHandlerWrapper.cs
@@ -1,0 +1,88 @@
+using GameFinder.Common;
+using GameFinder.RegistryUtils;
+using GameFinder.Wine;
+using NexusMods.DataModel.Games;
+using NexusMods.Paths;
+using OneOf;
+using IGame = GameFinder.Common.IGame;
+
+namespace NexusMods.StandardGameLocators;
+
+/// <summary>
+/// Helper class that uses all registered store handlers to find games inside wine prefixes.
+/// </summary>
+public class WineStoreHandlerWrapper
+{
+    /// <summary>
+    /// Delegate for creating a <see cref="AHandler"/> given a <see cref="AWinePrefix"/>, an implementation
+    /// of <see cref="IRegistry"/> and an implementation of <see cref="IFileSystem"/>. The registry and
+    /// file system are overlays and created from the wine prefix.
+    /// </summary>
+    public delegate AHandler CreateHandler(AWinePrefix winePrefix, IRegistry wineRegistry, IFileSystem wineFileSystem);
+
+    /// <summary>
+    /// Delegate for trying to match the requested game with a found game.
+    /// </summary>
+    public delegate GameLocatorResult? Matches(IGame foundGame, DataModel.Games.IGame requestedGame);
+
+    private readonly IFileSystem _fileSystem;
+    private readonly CreateHandler[] _factories;
+    private readonly Matches[] _matchers;
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    /// <param name="fileSystem"></param>
+    /// <param name="factories"></param>
+    /// <param name="matchers"></param>
+    public WineStoreHandlerWrapper(IFileSystem fileSystem,
+        CreateHandler[] factories,
+        Matches[] matchers)
+    {
+        _fileSystem = fileSystem;
+        _factories = factories;
+        _matchers = matchers;
+    }
+
+    /// <summary>
+    /// Tries to match the requested game with one of the found games and returns
+    /// a non-null <see cref="GameLocatorResult"/> on success, else <c>null</c>.
+    /// </summary>
+    /// <param name="foundGames"></param>
+    /// <param name="requestedGame"></param>
+    /// <returns></returns>
+    public GameLocatorResult? FindMatchingGame(IEnumerable<IGame> foundGames, DataModel.Games.IGame requestedGame)
+    {
+        foreach (var foundGame in foundGames)
+        {
+            foreach (var matcher in _matchers)
+            {
+                var res = matcher(foundGame, requestedGame);
+                if (res is not null) return res;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Finds all games inside the given prefix using the registered store handlers.
+    /// </summary>
+    /// <param name="winePrefix"></param>
+    /// <returns></returns>
+    public IEnumerable<OneOf<IGame, ErrorMessage>> FindAllGamesInPrefix(AWinePrefix winePrefix)
+    {
+        var wineRegistry = winePrefix.CreateRegistry(_fileSystem);
+        var wineFileSystem = winePrefix.CreateOverlayFileSystem(_fileSystem);
+
+        foreach (var factory in _factories)
+        {
+            var handler = factory(winePrefix, wineRegistry, wineFileSystem);
+
+            foreach (var res in handler.FindAllInterfaceGames())
+            {
+                yield return res;
+            }
+        }
+    }
+}

--- a/src/NexusMods.StandardGameLocators/WineStoreHandlerWrapper.cs
+++ b/src/NexusMods.StandardGameLocators/WineStoreHandlerWrapper.cs
@@ -72,7 +72,16 @@ public class WineStoreHandlerWrapper
     /// <returns></returns>
     public IEnumerable<OneOf<IGame, ErrorMessage>> FindAllGamesInPrefix(AWinePrefix winePrefix)
     {
-        var wineRegistry = winePrefix.CreateRegistry(_fileSystem);
+        IRegistry wineRegistry;
+        try
+        {
+            wineRegistry = winePrefix.CreateRegistry(_fileSystem);
+        }
+        catch (Exception)
+        {
+            wineRegistry = new InMemoryRegistry();
+        }
+
         var wineFileSystem = winePrefix.CreateOverlayFileSystem(_fileSystem);
 
         foreach (var factory in _factories)

--- a/src/NexusMods.StandardGameLocators/XboxLocator.cs
+++ b/src/NexusMods.StandardGameLocators/XboxLocator.cs
@@ -1,0 +1,23 @@
+using GameFinder.StoreHandlers.Xbox;
+using NexusMods.DataModel.Games;
+using NexusMods.Paths;
+
+namespace NexusMods.StandardGameLocators;
+
+/// <summary>
+/// Finds games managed by Xbox Game Pass.
+/// </summary>
+public class XboxLocator : AGameLocator<XboxGame, XboxGameId, IXboxGame, XboxLocator>
+{
+    /// <inheritdoc />
+    public XboxLocator(IServiceProvider provider) : base(provider) { }
+
+    /// <inheritdoc />
+    protected override GameStore Store => GameStore.XboxGamePass;
+
+    /// <inheritdoc />
+    protected override IEnumerable<XboxGameId> Ids(IXboxGame game) => game.XboxIds.Select(XboxGameId.From);
+
+    /// <inheritdoc />
+    protected override AbsolutePath Path(XboxGame record) => record.Path;
+}

--- a/tests/NexusMods.Paths.Tests/FileSystem/BaseFileSystemTests.cs
+++ b/tests/NexusMods.Paths.Tests/FileSystem/BaseFileSystemTests.cs
@@ -35,6 +35,23 @@ public class BaseFileSystemTests
     }
 
     [SkippableTheory, AutoFileSystem]
+    public void Test_PathMappings_SpecialCases(InMemoryFileSystem fs)
+    {
+        Skip.IfNot(OperatingSystem.IsLinux());
+
+        var overlayFileSystem = (BaseFileSystem)fs.CreateOverlayFileSystem(
+            new Dictionary<AbsolutePath, AbsolutePath>
+            {
+                { fs.FromFullPath("/c"), fs.FromFullPath("/foo") },
+                { fs.FromFullPath("/z"), fs.FromFullPath("/") },
+            },
+            new Dictionary<KnownPath, AbsolutePath>());
+
+        overlayFileSystem.GetMappedPath(fs.FromFullPath("/c/a")).Should().Be(fs.FromFullPath("/foo/a"));
+        overlayFileSystem.GetMappedPath(fs.FromFullPath("/z/a")).Should().Be(fs.FromFullPath("/a"));
+    }
+
+    [SkippableTheory, AutoFileSystem]
     public async Task Test_ReadAllBytesAsync(InMemoryFileSystem fs, AbsolutePath path, byte[] contents)
     {
         fs.AddFile(path, contents);

--- a/tests/NexusMods.Paths.Tests/New/AbsolutePathTests/FromFullPathTests.cs
+++ b/tests/NexusMods.Paths.Tests/New/AbsolutePathTests/FromFullPathTests.cs
@@ -22,8 +22,12 @@ public class FromFullPathTests
     [InlineData("C:\\foo\\bar", "C:\\foo\\bar", "C:\\foo", "bar", false)]
     [InlineData("C:\\foo\\bar\\", "C:\\foo\\bar", "C:\\foo", "bar", false)]
     [InlineData("C:\\foo\\bar\\baz", "C:\\foo\\bar\\baz", "C:\\foo\\bar", "baz", false)]
-    public void Test_FromFullPath(string input, string expectedFullPath,
-        string? expectedDirectory, string expectedFileName, bool linux)
+    public void Test_FromFullPath(
+        string input,
+        string expectedFullPath,
+        string expectedDirectory,
+        string expectedFileName,
+        bool linux)
     {
         Skip.If(linux != OperatingSystem.IsLinux());
         var path = AbsolutePath.FromFullPath(input, _fileSystem);

--- a/tests/NexusMods.Paths.Tests/New/AbsolutePathTests/UtilityTests.cs
+++ b/tests/NexusMods.Paths.Tests/New/AbsolutePathTests/UtilityTests.cs
@@ -51,6 +51,7 @@ public class UtilityTests
     }
 
     [SkippableTheory]
+    [InlineData("/", "/", true)]
     [InlineData("/", "/foo", true)]
     [InlineData("/", "/foo/bar", true)]
     [InlineData("C:\\", "C:\\foo", false)]

--- a/tests/NexusMods.StandardGameLocators.TestHelpers/Services.cs
+++ b/tests/NexusMods.StandardGameLocators.TestHelpers/Services.cs
@@ -10,6 +10,7 @@ using NexusMods.DataModel.Games;
 using NexusMods.DataModel.ModInstallers;
 using NexusMods.Paths;
 using NexusMods.StandardGameLocators.TestHelpers.StubbedGames;
+using IGame = NexusMods.DataModel.Games.IGame;
 
 namespace NexusMods.StandardGameLocators.TestHelpers;
 
@@ -20,29 +21,29 @@ public static class Services
         coll.AddAllSingleton<IGame, StubbedGame>();
         coll.AddAllSingleton<IModInstaller, StubbedGameInstaller>();
         coll.AddAllSingleton<ITool, ListFilesTool>();
-        coll.AddSingleton<AHandler<EADesktopGame, string>>(s =>
-            new StubbedGameLocator<EADesktopGame, string>(s.GetRequiredService<TemporaryFileManager>(),
-                tfm => new EADesktopGame("ea-game-id", "Stubbed Game", tfm.CreateFolder("ea_game").Path.ToString()),
-                game => game.SoftwareID));
+        coll.AddSingleton<AHandler<EADesktopGame, EADesktopGameId>>(s =>
+            new StubbedGameLocator<EADesktopGame, EADesktopGameId>(s.GetRequiredService<TemporaryFileManager>(),
+                tfm => new EADesktopGame(EADesktopGameId.From("ea-game-id"), "Stubbed Game", tfm.CreateFolder("ea_game").Path),
+                game => game.EADesktopGameId));
 
-        coll.AddSingleton<AHandler<EGSGame, string>>(s =>
-            new StubbedGameLocator<EGSGame, string>(s.GetRequiredService<TemporaryFileManager>(),
-                tfm => new EGSGame("epic-game-id", "Stubbed Game", tfm.CreateFolder("epic_game").Path.ToString()),
+        coll.AddSingleton<AHandler<EGSGame, EGSGameId>>(s =>
+            new StubbedGameLocator<EGSGame, EGSGameId>(s.GetRequiredService<TemporaryFileManager>(),
+                tfm => new EGSGame(EGSGameId.From("epic-game-id"), "Stubbed Game", tfm.CreateFolder("epic_game").Path),
                 game => game.CatalogItemId));
 
-        coll.AddSingleton<AHandler<OriginGame, string>>(s =>
-            new StubbedGameLocator<OriginGame, string>(s.GetRequiredService<TemporaryFileManager>(),
-                tfm => new OriginGame("origin-game-id", tfm.CreateFolder("origin_game").Path.ToString()),
+        coll.AddSingleton<AHandler<OriginGame, OriginGameId>>(s =>
+            new StubbedGameLocator<OriginGame, OriginGameId>(s.GetRequiredService<TemporaryFileManager>(),
+                tfm => new OriginGame(OriginGameId.From("origin-game-id"), tfm.CreateFolder("origin_game").Path),
                 game => game.Id));
 
-        coll.AddSingleton<AHandler<GOGGame, long>>(s =>
-            new StubbedGameLocator<GOGGame, long>(s.GetRequiredService<TemporaryFileManager>(),
-                tfm => new GOGGame(42, "Stubbed Game", tfm.CreateFolder("gog_game").Path.ToString()),
+        coll.AddSingleton<AHandler<GOGGame, GOGGameId>>(s =>
+            new StubbedGameLocator<GOGGame, GOGGameId>(s.GetRequiredService<TemporaryFileManager>(),
+                tfm => new GOGGame(GOGGameId.From(42), "Stubbed Game", tfm.CreateFolder("gog_game").Path),
                 game => game.Id));
 
-        coll.AddSingleton<AHandler<SteamGame, int>>(s =>
-            new StubbedGameLocator<SteamGame, int>(s.GetRequiredService<TemporaryFileManager>(),
-                tfm => new SteamGame(42, "Stubbed Game", tfm.CreateFolder("steam_game").Path.ToString()),
+        coll.AddSingleton<AHandler<SteamGame, SteamGameId>>(s =>
+            new StubbedGameLocator<SteamGame, SteamGameId>(s.GetRequiredService<TemporaryFileManager>(),
+                tfm => new SteamGame(SteamGameId.From( 42), "Stubbed Game", tfm.CreateFolder("steam_game").Path),
                 game => game.AppId));
         return coll;
     }

--- a/tests/NexusMods.StandardGameLocators.TestHelpers/Services.cs
+++ b/tests/NexusMods.StandardGameLocators.TestHelpers/Services.cs
@@ -4,6 +4,7 @@ using GameFinder.StoreHandlers.EGS;
 using GameFinder.StoreHandlers.GOG;
 using GameFinder.StoreHandlers.Origin;
 using GameFinder.StoreHandlers.Steam;
+using GameFinder.StoreHandlers.Xbox;
 using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Common;
 using NexusMods.DataModel.Games;
@@ -45,6 +46,11 @@ public static class Services
             new StubbedGameLocator<SteamGame, SteamGameId>(s.GetRequiredService<TemporaryFileManager>(),
                 tfm => new SteamGame(SteamGameId.From( 42), "Stubbed Game", tfm.CreateFolder("steam_game").Path),
                 game => game.AppId));
+
+        coll.AddSingleton<AHandler<XboxGame, XboxGameId>>(s =>
+            new StubbedGameLocator<XboxGame, XboxGameId>(s.GetRequiredService<TemporaryFileManager>(),
+                tfm => new XboxGame(XboxGameId.From("xbox-game-id"), "Stubbed Game", tfm.CreateFolder("xbox_game").Path),
+                game => game.Id));
         return coll;
     }
 }

--- a/tests/NexusMods.StandardGameLocators.TestHelpers/Services.cs
+++ b/tests/NexusMods.StandardGameLocators.TestHelpers/Services.cs
@@ -5,6 +5,8 @@ using GameFinder.StoreHandlers.GOG;
 using GameFinder.StoreHandlers.Origin;
 using GameFinder.StoreHandlers.Steam;
 using GameFinder.StoreHandlers.Xbox;
+using GameFinder.Wine;
+using GameFinder.Wine.Bottles;
 using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Common;
 using NexusMods.DataModel.Games;
@@ -51,6 +53,29 @@ public static class Services
             new StubbedGameLocator<XboxGame, XboxGameId>(s.GetRequiredService<TemporaryFileManager>(),
                 tfm => new XboxGame(XboxGameId.From("xbox-game-id"), "Stubbed Game", tfm.CreateFolder("xbox_game").Path),
                 game => game.Id));
+
+        if (OSInformation.Shared.IsLinux)
+        {
+            coll.AddSingleton<IWinePrefixManager<WinePrefix>>(s =>
+                new StubbedWinePrefixManager<WinePrefix>(s.GetRequiredService<TemporaryFileManager>(),
+                    tfm => new WinePrefix
+                    {
+                        ConfigurationDirectory = tfm.CreateFolder("wine-prefix").Path,
+                    }));
+
+            coll.AddSingleton<IWinePrefixManager<BottlesWinePrefix>>(s =>
+                new StubbedWinePrefixManager<BottlesWinePrefix>(s.GetRequiredService<TemporaryFileManager>(),
+                    tfm => new BottlesWinePrefix
+                    {
+                        ConfigurationDirectory = tfm.CreateFolder("bottles-prefix").Path,
+                    }));
+
+            coll.AddSingleton<WineStoreHandlerWrapper>(s => new WineStoreHandlerWrapper(
+                s.GetRequiredService<IFileSystem>(),
+                new WineStoreHandlerWrapper.CreateHandler[] { },
+                new WineStoreHandlerWrapper.Matches[] { }));
+        }
+
         return coll;
     }
 }

--- a/tests/NexusMods.StandardGameLocators.TestHelpers/StubbedGames/StubbedGame.cs
+++ b/tests/NexusMods.StandardGameLocators.TestHelpers/StubbedGames/StubbedGame.cs
@@ -11,7 +11,7 @@ using NexusMods.Paths.Extensions;
 
 namespace NexusMods.StandardGameLocators.TestHelpers.StubbedGames;
 
-public class StubbedGame : IEADesktopGame, IEpicGame, IOriginGame, ISteamGame, IGogGame
+public class StubbedGame : IEADesktopGame, IEpicGame, IOriginGame, ISteamGame, IGogGame, IXboxGame
 {
     private readonly ILogger<StubbedGame> _logger;
     private readonly IEnumerable<IGameLocator> _locators;
@@ -93,4 +93,5 @@ public class StubbedGame : IEADesktopGame, IEpicGame, IOriginGame, ISteamGame, I
     public IEnumerable<string> EADesktopSoftwareIDs => new[] { "ea-game-id" };
     public IEnumerable<string> EpicCatalogItemId => new[] { "epic-game-id" };
     public IEnumerable<string> OriginGameIds => new[] { "origin-game-id" };
+    public IEnumerable<string> XboxIds => new[] { "xbox-game-id" };
 }

--- a/tests/NexusMods.StandardGameLocators.TestHelpers/StubbedWinePrefixManager.cs
+++ b/tests/NexusMods.StandardGameLocators.TestHelpers/StubbedWinePrefixManager.cs
@@ -1,0 +1,24 @@
+using GameFinder.Common;
+using GameFinder.Wine;
+using NexusMods.Paths;
+using OneOf;
+
+namespace NexusMods.StandardGameLocators.TestHelpers;
+
+public class StubbedWinePrefixManager<TPrefix> : IWinePrefixManager<TPrefix>
+    where TPrefix : AWinePrefix
+{
+    private readonly TPrefix _prefix;
+
+    public StubbedWinePrefixManager(
+        TemporaryFileManager manager,
+        Func<TemporaryFileManager, TPrefix> factory)
+    {
+        _prefix = factory(manager);
+    }
+
+    public IEnumerable<OneOf<TPrefix, ErrorMessage>> FindPrefixes()
+    {
+        yield return _prefix;
+    }
+}

--- a/tests/NexusMods.StandardGameLocators.Tests/BasicTests.cs
+++ b/tests/NexusMods.StandardGameLocators.Tests/BasicTests.cs
@@ -13,10 +13,10 @@ public class BasicTests
         _game = game;
     }
 
-    [SkippableFact]
+    [Fact]
     public void Test_Locators_Linux()
     {
-        Skip.If(!OperatingSystem.IsLinux());
+        if (!OperatingSystem.IsLinux()) return;
 
         _game.Installations.Should().SatisfyRespectively(
             steamInstallation =>
@@ -26,10 +26,10 @@ public class BasicTests
             });
     }
 
-    [SkippableFact]
+    [Fact]
     public void Test_Locators_Windows()
     {
-        Skip.If(!OperatingSystem.IsWindows());
+        if (!OperatingSystem.IsWindows()) return;
 
         _game.Installations.Should().SatisfyRespectively(
             eaInstallation =>

--- a/tests/NexusMods.StandardGameLocators.Tests/BasicTests.cs
+++ b/tests/NexusMods.StandardGameLocators.Tests/BasicTests.cs
@@ -36,12 +36,12 @@ public class BasicTests
         _game.Installations
             .Should().HaveCount(6)
             .And.Satisfy(
-                eaInstallation => eaInstallation.Locations.Should().ContainSingle().Which.Value.ToString().Contains("ea_game"),
-                epicInstallation => epicInstallation.Locations.Should().ContainSingle().Which.Value.ToString().Contains("epic_game"),
-                originInstallation => originInstallation.Locations.Should().ContainSingle().Which.Value.ToString().Contains("origin_game"),
-                gogInstallation => gogInstallation.Locations.Should().ContainSingle().Which.Value.ToString().Contains("gog_game"),
-                steamInstallation => steamInstallation.Locations.Should().ContainSingle().Which.Value.ToString().Contains("steam_game"),
-                xboxInstallation => xboxInstallation.Locations.Should().ContainSingle().Which.Value.ToString().Contains("xbox_game")
+                eaInstallation => eaInstallation.Locations.First().Value.ToString().Contains("ea_game"),
+                epicInstallation => epicInstallation.Locations.First().Value.ToString().Contains("epic_game"),
+                originInstallation => originInstallation.Locations.First().Value.ToString().Contains("origin_game"),
+                gogInstallation => gogInstallation.Locations.First().Value.ToString().Contains("gog_game"),
+                steamInstallation => steamInstallation.Locations.First().Value.ToString().Contains("steam_game"),
+                xboxInstallation => xboxInstallation.Locations.First().Value.ToString().Contains("xbox_game")
             );
     }
 

--- a/tests/NexusMods.StandardGameLocators.Tests/BasicTests.cs
+++ b/tests/NexusMods.StandardGameLocators.Tests/BasicTests.cs
@@ -33,49 +33,16 @@ public class BasicTests
     {
         if (!OperatingSystem.IsWindows()) return;
 
-        _game.Installations.Should().SatisfyRespectively(
-            eaInstallation =>
-            {
-                eaInstallation.Locations
-                    .Should().ContainSingle()
-                    .Which.Value
-                    .ToString().Should().Contain("ea_game");
-            },
-            epicInstallation =>
-            {
-                epicInstallation.Locations
-                    .Should().ContainSingle()
-                    .Which.Value
-                    .ToString().Should().Contain("epic_game");
-            },
-            originInstallation =>
-            {
-                originInstallation.Locations
-                    .Should().ContainSingle()
-                    .Which.Value
-                    .ToString().Should().Contain("origin_game");
-            },
-            gogInstallation =>
-            {
-                gogInstallation.Locations
-                    .Should().ContainSingle()
-                    .Which.Value
-                    .ToString().Should().Contain("gog_game");
-            },
-            steamInstallation =>
-            {
-                steamInstallation.Locations
-                    .Should().ContainSingle()
-                    .Which.Value
-                    .ToString().Should().Contain("steam_game");
-            },
-            xboxInstallation =>
-            {
-                xboxInstallation.Locations
-                    .Should().ContainSingle()
-                    .Which.Value
-                    .ToString().Should().Contain("xbox_game");
-            });
+        _game.Installations
+            .Should().HaveCount(6)
+            .And.Satisfy(
+                eaInstallation => eaInstallation.Locations.Should().ContainSingle().Which.Value.ToString().Contains("ea_game"),
+                epicInstallation => epicInstallation.Locations.Should().ContainSingle().Which.Value.ToString().Contains("epic_game"),
+                originInstallation => originInstallation.Locations.Should().ContainSingle().Which.Value.ToString().Contains("origin_game"),
+                gogInstallation => gogInstallation.Locations.Should().ContainSingle().Which.Value.ToString().Contains("gog_game"),
+                steamInstallation => steamInstallation.Locations.Should().ContainSingle().Which.Value.ToString().Contains("steam_game"),
+                xboxInstallation => xboxInstallation.Locations.Should().ContainSingle().Which.Value.ToString().Contains("xbox_game")
+            );
     }
 
     [Fact]

--- a/tests/NexusMods.StandardGameLocators.Tests/BasicTests.cs
+++ b/tests/NexusMods.StandardGameLocators.Tests/BasicTests.cs
@@ -21,8 +21,10 @@ public class BasicTests
         _game.Installations.Should().SatisfyRespectively(
             steamInstallation =>
             {
-                steamInstallation.Locations.Should().ContainSingle(kv =>
-                    kv.Key == GameFolderType.Game && kv.Value.ToString().Contains("steam_game"));
+                steamInstallation.Locations
+                    .Should().ContainSingle()
+                    .Which.Value
+                    .ToString().Should().Contain("steam_game");
             });
     }
 
@@ -34,33 +36,45 @@ public class BasicTests
         _game.Installations.Should().SatisfyRespectively(
             eaInstallation =>
             {
-                eaInstallation.Locations.Should().ContainSingle(kv =>
-                    kv.Key == GameFolderType.Game && kv.Value.ToString().Contains("ea_game"));
+                eaInstallation.Locations
+                    .Should().ContainSingle()
+                    .Which.Value
+                    .ToString().Should().Contain("ea_game");
             },
             epicInstallation =>
             {
-                epicInstallation.Locations.Should().ContainSingle(kv =>
-                    kv.Key == GameFolderType.Game && kv.Value.ToString().Contains("epic_game"));
+                epicInstallation.Locations
+                    .Should().ContainSingle()
+                    .Which.Value
+                    .ToString().Should().Contain("epic_game");
             },
             originInstallation =>
             {
-                originInstallation.Locations.Should().ContainSingle(kv =>
-                    kv.Key == GameFolderType.Game && kv.Value.ToString().Contains("origin_game"));
+                originInstallation.Locations
+                    .Should().ContainSingle()
+                    .Which.Value
+                    .ToString().Should().Contain("origin_game");
             },
             gogInstallation =>
             {
-                gogInstallation.Locations.Should().ContainSingle(kv =>
-                    kv.Key == GameFolderType.Game && kv.Value.ToString().Contains("gog_game"));
+                gogInstallation.Locations
+                    .Should().ContainSingle()
+                    .Which.Value
+                    .ToString().Should().Contain("gog_game");
             },
             steamInstallation =>
             {
-                steamInstallation.Locations.Should().ContainSingle(kv =>
-                    kv.Key == GameFolderType.Game && kv.Value.ToString().Contains("steam_game"));
+                steamInstallation.Locations
+                    .Should().ContainSingle()
+                    .Which.Value
+                    .ToString().Should().Contain("steam_game");
             },
             xboxInstallation =>
             {
-                xboxInstallation.Locations.Should().ContainSingle(kv =>
-                    kv.Key == GameFolderType.Game && kv.Value.ToString().Contains("xbox_game"));
+                xboxInstallation.Locations
+                    .Should().ContainSingle()
+                    .Which.Value
+                    .ToString().Should().Contain("xbox_game");
             });
     }
 

--- a/tests/NexusMods.StandardGameLocators.Tests/BasicTests.cs
+++ b/tests/NexusMods.StandardGameLocators.Tests/BasicTests.cs
@@ -1,46 +1,72 @@
-using System.Runtime.InteropServices;
 using FluentAssertions;
 using NexusMods.DataModel.Games;
 using NexusMods.Paths;
-using NexusMods.StandardGameLocators.TestHelpers.StubbedGames;
 
 namespace NexusMods.StandardGameLocators.Tests;
 
 public class BasicTests
 {
     private readonly IGame _game;
-    private readonly GameInstallation _steamInstall;
-    private readonly GameInstallation? _gogInstall;
 
-    public BasicTests(StubbedGame game)
+    public BasicTests(IGame game)
     {
         _game = game;
-        _steamInstall = _game.Installations.First(g => g.Locations.Any(l => l.ToString().Contains("steam_game")));
+    }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            _gogInstall = _game.Installations.First(g => g.Locations.Any(l => l.ToString().Contains("gog_game")));
+    [SkippableFact]
+    public void Test_Locators_Linux()
+    {
+        Skip.If(!OperatingSystem.IsLinux());
 
+        _game.Installations.Should().SatisfyRespectively(
+            steamInstallation =>
+            {
+                steamInstallation.Locations.Should().ContainSingle(kv =>
+                    kv.Key == GameFolderType.Game && kv.Value.ToString().Contains("steam_game"));
+            });
+    }
+
+    [SkippableFact]
+    public void Test_Locators_Windows()
+    {
+        Skip.If(!OperatingSystem.IsWindows());
+
+        _game.Installations.Should().SatisfyRespectively(
+            eaInstallation =>
+            {
+                eaInstallation.Locations.Should().ContainSingle(kv =>
+                    kv.Key == GameFolderType.Game && kv.Value.ToString().Contains("ea_game"));
+            },
+            epicInstallation =>
+            {
+                epicInstallation.Locations.Should().ContainSingle(kv =>
+                    kv.Key == GameFolderType.Game && kv.Value.ToString().Contains("epic_game"));
+            },
+            originInstallation =>
+            {
+                originInstallation.Locations.Should().ContainSingle(kv =>
+                    kv.Key == GameFolderType.Game && kv.Value.ToString().Contains("origin_game"));
+            },
+            gogInstallation =>
+            {
+                gogInstallation.Locations.Should().ContainSingle(kv =>
+                    kv.Key == GameFolderType.Game && kv.Value.ToString().Contains("gog_game"));
+            },
+            steamInstallation =>
+            {
+                steamInstallation.Locations.Should().ContainSingle(kv =>
+                    kv.Key == GameFolderType.Game && kv.Value.ToString().Contains("steam_game"));
+            },
+            xboxInstallation =>
+            {
+                xboxInstallation.Locations.Should().ContainSingle(kv =>
+                    kv.Key == GameFolderType.Game && kv.Value.ToString().Contains("xbox_game"));
+            });
     }
 
     [Fact]
     public void CanFindGames()
     {
-        Assert.NotEmpty(_game.Installations);
-    }
-
-    [Fact]
-    public void CanGetInstallLocations()
-    {
-        _steamInstall.Locations[GameFolderType.Game].CombineUnchecked("StubbedGame.exe").FileExists.Should().BeTrue();
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            _gogInstall!.Locations[GameFolderType.Game].CombineUnchecked("StubbedGame.exe").FileExists.Should().BeTrue();
-        }
-    }
-
-    [Fact]
-    public void CanConvertToString()
-    {
-        Assert.Equal("Stubbed Game v0.0.0.0 (Unknown)", _steamInstall.ToString());
+        _game.Installations.Should().NotBeEmpty();
     }
 }


### PR DESCRIPTION
Resolves #285

Changes:

- Upgrades GameFinder to the most recent version.
- Adds support for finding Xbox Game Pass games by implementing `XboxLocator` and adding `IXboxGame`.
- Updated Stardew Valley and Skyrim Special Edition to use the new `IXboxGame` interface, thanks @Pickysaurus for the IDs.
- Adds support for Wine:
  - Adds new abstract class `AWineGameLocator<TPrefix>` that implements `IGameLocator`.
  - Adds `DefaultWineGameLocator` and `BottlesWineGameLocator` inheritors of `AWineGameLocator<TPrefix>`.
  - Adds `WineStoreHandlerWrapper` that uses factory methods to create different `AHandler<TGame, TId>` instances for each found Wine prefix.
  - Updates `AGame.GetLocations`, which now provides an `IFileSystem` implementation that is now used in the implementations of this method.
  - Fixes an issue related to path mappings when mapping from `Z:` to `/`.

The difficult part was figuring out how to find games inside Wine prefixes. I ended up creating a `WineStoreHandlerWrapper` that uses factory methods to create store handlers and `GameLocatorResult` instances. The resulting code is a bit of a mess, especially since both `GameFinder.Common` and `NexusMods.DataModel.Games` have an `IGame` interface.