### PR TITLE
Use GitHubActionsTestLogger

### DIFF
--- a/.github/workflows/clean_environment_tests.yaml
+++ b/.github/workflows/clean_environment_tests.yaml
@@ -37,7 +37,7 @@ jobs:
         run: dotnet build
 
       - name: Tests
-        run: dotnet test --no-build --filter "RequiresNetworking!=True" --collect:"XPlat Code Coverage;Format=opencover"
+        run: dotnet test --no-build --logger "GitHubActions" --filter "RequiresNetworking!=True" --collect:"XPlat Code Coverage;Format=opencover"
 
       - uses: codecov/codecov-action@v3
         with:

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -46,5 +46,9 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="GitHubActionsTestLogger" Version="2.1.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
This is a custom test logger that outputs to GitHub and creates summaries and annotations: https://github.com/Nexus-Mods/NexusMods.App/actions/runs/4989909959?pr=322

![2023-05-16_10-39-36](https://github.com/Nexus-Mods/NexusMods.App/assets/16577545/28a8cf2d-1f0f-4a2e-a753-6357523e8c46)
![2023-05-16_10-50-46](https://github.com/Nexus-Mods/NexusMods.App/assets/16577545/c1a03d11-aac7-464f-b6b9-e840a6b196d5)
![2023-05-16_10-50-59](https://github.com/Nexus-Mods/NexusMods.App/assets/16577545/2891135f-d4c4-4cb0-a8e9-f38cd1d36989)
