### PR TITLE
Update clean_environment_tests.yaml

### DIFF
--- a/.github/workflows/clean_environment_tests.yaml
+++ b/.github/workflows/clean_environment_tests.yaml
@@ -40,6 +40,7 @@ jobs:
         run: dotnet test --no-build --logger "GitHubActions" --filter "RequiresNetworking!=True" --collect:"XPlat Code Coverage;Format=opencover"
 
       - uses: codecov/codecov-action@v3
+        if: always()
         with:
           flags: clean_environment_tests, ${{runner.os}}
           verbose: true


### PR DESCRIPTION
Upload coverage info even when the tests fail, so we get better test feedback on failed builds