### PR TITLE
In memory datastore

### DIFF
--- a/src/Networking/NexusMods.Networking.HttpDownloader/LocalFileDownloader.cs
+++ b/src/Networking/NexusMods.Networking.HttpDownloader/LocalFileDownloader.cs
@@ -29,7 +29,7 @@ internal static class LocalFileDownloader
         var filePath = Uri.UnescapeDataString(uri.AbsolutePath);
         var fullPath = Path.GetFullPath(filePath);
 
-        await using var stream = fullPath.ToAbsolutePath(FileSystem.Shared).Create();
+        await using var stream = fullPath.ToAbsolutePath(FileSystem.Shared).Read();
         job.Size = Size.FromLong(stream.Length);
         await using var file = destination.Create();
         return await stream.HashingCopyAsync(file, default, job);

--- a/src/NexusMods.CLI/Types/DownloadHandlers/NxmDownloadProtocolHandler.cs
+++ b/src/NexusMods.CLI/Types/DownloadHandlers/NxmDownloadProtocolHandler.cs
@@ -1,4 +1,5 @@
 ﻿using NexusMods.DataModel;
+using NexusMods.DataModel.Abstractions;
 using NexusMods.DataModel.Loadouts.Markers;
 using NexusMods.Networking.HttpDownloader;
 using NexusMods.Networking.NexusWebApi;
@@ -16,13 +17,13 @@ public class NxmDownloadProtocolHandler : IDownloadProtocolHandler
     private readonly Client _client;
     private readonly IHttpDownloader _downloader;
     private readonly TemporaryFileManager _temp;
-    private readonly ArchiveAnalyzer _archiveAnalyzer;
-    private readonly ArchiveInstaller _archiveInstaller;
+    private readonly IArchiveAnalyzer _archiveAnalyzer;
+    private readonly IArchiveInstaller _archiveInstaller;
 
     /// <summary/>
     public NxmDownloadProtocolHandler(Client client, 
         IHttpDownloader downloader, TemporaryFileManager temp, 
-        ArchiveInstaller archiveInstaller, ArchiveAnalyzer archiveAnalyzer)
+        IArchiveInstaller archiveInstaller, IArchiveAnalyzer archiveAnalyzer)
     {
         _archiveAnalyzer = archiveAnalyzer;
         _archiveInstaller = archiveInstaller;

--- a/src/NexusMods.DataModel/ArchiveInstaller.cs
+++ b/src/NexusMods.DataModel/ArchiveInstaller.cs
@@ -50,7 +50,7 @@ public class ArchiveInstaller : IArchiveInstaller
     {
         if (_archiveAnalyzer.GetAnalysisData(archiveHash) is not AnalyzedArchive analysisData)
         {
-            _logger.LogError("Could not find analysis data for archive {ArchiveHash}", archiveHash);
+            _logger.LogError("Could not find analysis data for archive {ArchiveHash} or file is not an archive", archiveHash);
             throw new InvalidOperationException("Could not find analysis data for archive");
         }
         

--- a/src/NexusMods.DataModel/IDataModelSettings.cs
+++ b/src/NexusMods.DataModel/IDataModelSettings.cs
@@ -12,6 +12,11 @@ namespace NexusMods.DataModel;
 public interface IDataModelSettings
 {
     /// <summary>
+    /// If true, data model will be stored in memory only and the paths will be ignored.
+    /// </summary>
+    public bool UseInMemoryDataModel { get; }
+    
+    /// <summary>
     /// Path of the file which contains the backing data store or database.
     /// </summary>
     public ConfigurationPath DataStoreFilePath { get; }
@@ -57,7 +62,10 @@ public class DataModelSettings : IDataModelSettings
     private const string DataModelFileName = "DataModel.sqlite";
     private const string DataModelIpcFileName = "DataModel_IPC.sqlite";
     private const string ArchivesFileName = "Archives";
-
+    
+    /// <inheritdoc />
+    public bool UseInMemoryDataModel { get; set; }
+    
     /// <inheritdoc />
     public ConfigurationPath DataStoreFilePath { get; set; }
 

--- a/src/NexusMods.DataModel/Interprocess/ISharedArray.cs
+++ b/src/NexusMods.DataModel/Interprocess/ISharedArray.cs
@@ -1,0 +1,25 @@
+﻿namespace NexusMods.DataModel.Interprocess;
+
+/// <summary>
+/// A shared (multiprocess) array of 64-bit unsigned integers, supports atomic operations via a CAS operation
+/// </summary>
+public interface ISharedArray : IDisposable
+{
+
+    /// <summary>
+    /// Get the ulong at the specified index
+    /// </summary>
+    /// <param name="idx"></param>
+    /// <returns></returns>
+    public ulong Get(int idx);
+
+    /// <summary>
+    /// Set the value at the given index to the given value if the current value is the expected value.
+    /// Returns true if the value was set, false otherwise.
+    /// </summary>
+    /// <param name="idx">item index into the array</param>
+    /// <param name="expected">the expected value</param>
+    /// <param name="value">the value to replace it with</param>
+    /// <returns></returns>
+    public bool CompareAndSwap(int idx, ulong expected, ulong value);
+}

--- a/src/NexusMods.DataModel/Interprocess/MultiprocessSharedArray.cs
+++ b/src/NexusMods.DataModel/Interprocess/MultiprocessSharedArray.cs
@@ -8,7 +8,7 @@ namespace NexusMods.DataModel.Interprocess;
 /// A shared array of 64-bit unsigned integers, supports atomic operations via
 /// a CAS operation on a mmaped file.
 /// </summary>
-public unsafe class SharedArray : IDisposable
+public unsafe class MultiProcessSharedArray : ISharedArray
 {
     private readonly int _totalSize;
     private readonly Stream _stream;
@@ -17,7 +17,12 @@ public unsafe class SharedArray : IDisposable
 
     private bool _isDisposed;
 
-    public SharedArray(AbsolutePath path, int itemCount)
+    /// <summary>
+    /// Create a new shared array with the given number of items at the given path
+    /// </summary>
+    /// <param name="path"></param>
+    /// <param name="itemCount"></param>
+    public MultiProcessSharedArray(AbsolutePath path, int itemCount)
     {
         _totalSize = itemCount * sizeof(ulong);
 
@@ -76,7 +81,7 @@ public unsafe class SharedArray : IDisposable
     public ulong Get(int idx)
     {
         if (_isDisposed)
-            throw new ObjectDisposedException(nameof(SharedArray));
+            throw new ObjectDisposedException(nameof(MultiProcessSharedArray));
 
 #if DEBUG
         if (idx < 0 || idx >= _totalSize / sizeof(ulong))
@@ -99,7 +104,7 @@ public unsafe class SharedArray : IDisposable
     public bool CompareAndSwap(int idx, ulong expected, ulong value)
     {
         if (_isDisposed)
-            throw new ObjectDisposedException(nameof(SharedArray));
+            throw new ObjectDisposedException(nameof(MultiProcessSharedArray));
 
 #if DEBUG
         if (idx < 0 || idx >= _totalSize / sizeof(ulong))

--- a/src/NexusMods.DataModel/Interprocess/SingleProcessSharedArray.cs
+++ b/src/NexusMods.DataModel/Interprocess/SingleProcessSharedArray.cs
@@ -1,0 +1,40 @@
+﻿using System.Runtime.InteropServices;
+
+namespace NexusMods.DataModel.Interprocess;
+
+/// <summary>
+/// A shared array of 64-bit unsigned integers, supports atomic operations via a CAS operation, for use in a single process
+/// and mostly for testing purposes.
+/// </summary>
+public class SingleProcessSharedArray : ISharedArray
+{
+    private readonly ulong[] _slots;
+
+    /// <summary>
+    /// Create a new shared array with the given number of items
+    /// </summary>
+    /// <param name="slots"></param>
+    public SingleProcessSharedArray(int slots)
+    {
+        _slots = new ulong[slots];
+    }
+    
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        // Nothing to do
+    }
+
+    /// <inheritdoc />
+    public ulong Get(int idx)
+    {
+        return _slots[idx];
+    }
+    
+    /// <inheritdoc />
+    public bool CompareAndSwap(int idx, ulong expected, ulong value)
+    {
+        var span = _slots.AsSpan();
+        return Interlocked.CompareExchange(ref span[idx], value, expected) == expected;
+    }
+}

--- a/src/NexusMods.Paths/Extensions/SpanExtensions.cs
+++ b/src/NexusMods.Paths/Extensions/SpanExtensions.cs
@@ -60,6 +60,7 @@ public static class SpanExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ReadOnlySpan<T> SliceFast<T>(this ReadOnlySpan<T> data, int start)
     {
+        return data.Slice(start);
         return MemoryMarshal.CreateSpan(ref Unsafe.Add(ref MemoryMarshal.GetReference(data), start), data.Length - start);
     }
 
@@ -69,6 +70,7 @@ public static class SpanExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ReadOnlySpan<T> SliceFast<T>(this ReadOnlySpan<T> data, int start, int length)
     {
+        return data.Slice(start, length);
         return MemoryMarshal.CreateSpan(ref Unsafe.Add(ref MemoryMarshal.GetReference(data), start), length);
     }
 
@@ -78,6 +80,7 @@ public static class SpanExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Span<T> SliceFast<T>(this Span<T> data, int start)
     {
+        return data.Slice(start);
         return MemoryMarshal.CreateSpan(ref Unsafe.Add(ref MemoryMarshal.GetReference(data), start), data.Length - start);
     }
 
@@ -87,6 +90,7 @@ public static class SpanExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Span<T> SliceFast<T>(this Span<T> data, int start, int length)
     {
+        return data.Slice(start, length);
         return MemoryMarshal.CreateSpan(ref Unsafe.Add(ref MemoryMarshal.GetReference(data), start), length);
     }
 

--- a/tests/Games/NexusMods.Games.TestFramework/DependencyInjectionHelper.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/DependencyInjectionHelper.cs
@@ -49,7 +49,10 @@ public static class DependencyInjectionHelper
             .AddNexusWebApi()
             .AddNexusWebApiNmaIntegration(true)
             .AddHttpDownloader()
-            .AddDataModel()
+            .AddDataModel(new DataModelSettings
+            {
+                UseInMemoryDataModel = true
+            })
             .AddAllSingleton<IResource, IResource<ArchiveAnalyzer, Size>>(_ => new Resource<ArchiveAnalyzer, Size>("File Analysis for tests"))
             .AddAllSingleton<IResource, IResource<IExtractor, Size>>(_ => new Resource<IExtractor, Size>("File Extraction for tests"))
             .AddAllSingleton<IResource, IResource<FileHashCache, Size>>(_ => new Resource<FileHashCache, Size>("Hash Cache for tests"))

--- a/tests/Networking/NexusMods.Networking.NexusWebApi.Tests/Startup.cs
+++ b/tests/Networking/NexusMods.Networking.NexusWebApi.Tests/Startup.cs
@@ -30,7 +30,10 @@ public class Startup
             .AddSingleton<LocalHttpServer>()
             .AddNexusWebApi()
             .AddNexusWebApiNmaIntegration(true)
-            .AddDataModel()
+            .AddDataModel(new DataModelSettings()
+            {
+                UseInMemoryDataModel = true
+            })
             .Validate();
     }
 

--- a/tests/NexusMods.CLI.Tests/Startup.cs
+++ b/tests/NexusMods.CLI.Tests/Startup.cs
@@ -19,7 +19,10 @@ public class Startup
         services.AddStandardGameLocators(false)
                 .AddStubbedGameLocators()
                 .AddFileSystem()
-                .AddDataModel()
+                .AddDataModel(new DataModelSettings
+                {
+                    UseInMemoryDataModel = true
+                })
                 .AddFileExtractors()
                 .AddCLI()
                 .AddSingleton<HttpClient>()

--- a/tests/NexusMods.DataModel.Tests/SharedArrayTests.cs
+++ b/tests/NexusMods.DataModel.Tests/SharedArrayTests.cs
@@ -20,7 +20,7 @@ public class SharedArrayTests : IDisposable
     {
         var arraySize = 16;
         ulong iterations = 1024 * 16;
-        using var array = new SharedArray(_file, arraySize);
+        using var array = new MultiProcessSharedArray(_file, arraySize);
         var threads = new Thread[ThreadCount];
 
         // Brute force CAS operations and make sure the final value is correct
@@ -28,7 +28,7 @@ public class SharedArrayTests : IDisposable
         {
             threads[i] = new Thread(() =>
             {
-                using var innerArray = new SharedArray(_file, arraySize);
+                using var innerArray = new MultiProcessSharedArray(_file, arraySize);
                 for (ulong loop = 0; loop < iterations; loop++)
                 {
                     for (var idx = 0; idx < arraySize; idx++)

--- a/tests/NexusMods.UI.Tests/Startup.cs
+++ b/tests/NexusMods.UI.Tests/Startup.cs
@@ -21,9 +21,7 @@ public class Startup
         {
             DataModelSettings =
             {
-                ArchiveLocations = new[] { new ConfigurationPath(path.CombineUnchecked("Archives"))},
-                DataStoreFilePath = new ConfigurationPath(path.CombineUnchecked("DataModel.sqlite")),
-                IpcDataStoreFilePath = new ConfigurationPath(path.CombineUnchecked("DataModel.IPC.sqlite"))
+                UseInMemoryDataModel = true
             }
         };
         


### PR DESCRIPTION
Adds `UseInMemoryDataModel` to `IDataModelSettings` which will switch the datamodel over to using a in-memory version of Sqlite, and a single process sync array. 

There's two major issues with this approach: normally every connection to a in-memory database gets a new database, and we need multithreaded access to the DB, so we have to generate a unique name for the store. In addition the DB is deleted once the last connection closes, so we now open a connection to the DB and keep it live for the lifetime of the app. This should also stop someone from deleting/moving the db in the middle of the app running.

In order to get the tests to pass I also had to fix a few issues in the existing tests. Not sure how the download url tests ever passed as the files were getting truncated on every test run. In addition the FOMOD tests were using a version of the datastore that didn't come from the DI system, so I fixed that as well. 