### PR TITLE
Upgrade dependencies and use floating versions

### DIFF
--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -6,19 +6,19 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Moq" Version="4.18.4" />
+        <PackageReference Include="Moq" Version="4.*" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoFixture" Version="4.18.0" />
-        <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.0" />
-        <PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
+        <PackageReference Include="AutoFixture" Version="4.*" />
+        <PackageReference Include="AutoFixture.AutoMoq" Version="4.*" />
+        <PackageReference Include="AutoFixture.Xunit2" Version="4.*" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.11.0" />
+        <PackageReference Include="FluentAssertions" Version="6.*" />
         <PackageReference Include="FluentAssertions.OneOf" Version="0.0.5" />
-        <PackageReference Include="FluentAssertions.Analyzers" Version="0.17.2">
+        <PackageReference Include="FluentAssertions.Analyzers" Version="0.18.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
@@ -37,16 +37,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-        <PackageReference Include="coverlet.collector" Version="3.2.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.*" />
+        <PackageReference Include="coverlet.collector" Version="6.*">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.msbuild" Version="3.2.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.1.0">
+        <PackageReference Include="GitHubActionsTestLogger" Version="2.*">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
Floating versions are very useful for test dependencies, which frequent releases with almost no breaking changes.