### PR TITLE
Fix crash when adding mods from cli

### DIFF
--- a/src/Games/NexusMods.Games.FOMOD/FomodAnalyzer.cs
+++ b/src/Games/NexusMods.Games.FOMOD/FomodAnalyzer.cs
@@ -49,7 +49,7 @@ public class FomodAnalyzer : IFileAnalyzer
 
         try
         {
-            using var streamReader = new StreamReader(info.Stream);
+            using var streamReader = new StreamReader(info.Stream, leaveOpen:true);
             data = await streamReader.ReadToEndAsync(ct);
             var xmlScript = new XmlScriptType();
             var script = (XmlScript)xmlScript.LoadScript(data, true);


### PR DESCRIPTION
fix #413 
The FomodAnalyzer was closing a stream that was still in use causing an exception later.
