### PR TITLE
SSE: Add `*` in front of entries of plugins.txt to make them enabled

### DIFF
--- a/src/Games/NexusMods.Games.BethesdaGameStudios/PluginFile.cs
+++ b/src/Games/NexusMods.Games.BethesdaGameStudios/PluginFile.cs
@@ -127,7 +127,7 @@ public record PluginFile : AModFile, IGeneratedFile, IToFile, ITriggerFilter<Mod
             i => i.Rules, //GenerateRules(pluginFiles, i),
             RelativePath.Comparer);
 
-        await stream.WriteAllLinesAsync(results.Select(i => i.Mod.To.FileName.ToString()), token: token);
+        await stream.WriteAllLinesAsync(results.Select(i => '*' + i.Mod.To.FileName.ToString()), token: token);
         stream.Position = 0;
         return await stream.XxHash64Async(token);
     }

--- a/tests/Games/NexusMods.Games.BethesdaGameStudios.Tests/SkyrimSpecialEditionTests/SkyrimSpecialEditionTests.cs
+++ b/tests/Games/NexusMods.Games.BethesdaGameStudios.Tests/SkyrimSpecialEditionTests/SkyrimSpecialEditionTests.cs
@@ -83,14 +83,14 @@ public class SkyrimSpecialEditionTests : AGameTest<SkyrimSpecialEdition>
 
         ms.Position = 0;
 
-        (await ms.XxHash64Async()).Should().Be(Hash.From(0x7F10458731B543D4));
+        (await ms.XxHash64Async()).Should().Be(Hash.From(0x68B821EEFD98523C));
         var results = Encoding.UTF8.GetString(ms.ToArray()).Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
 
         // CC = Creation Club
         if (results.Length == 9)
         {
             // Skyrim SE without CC downloads
-            results.Should()
+            results.Select(t=> t.TrimStart('*')).Should()
                 .BeEquivalentTo(new[]
                 {
                     "Skyrim.esm",
@@ -108,7 +108,7 @@ public class SkyrimSpecialEditionTests : AGameTest<SkyrimSpecialEdition>
         {
             // Skyrim SE with CC downloads
             results
-                .Select(t => t.ToLowerInvariant())
+                .Select(t => t.TrimStart('*').ToLowerInvariant())
                 .Should()
                 .BeEquivalentTo(new[]
                 {


### PR DESCRIPTION
Plugins.txt was missing '*' in front of plugins to enable. 
This is required for Skyrim SE and FO4 for example, while SLE and older games only had enabled files in plugins.txt and loadorder.txt was created by modders to keep track of position of disabled plugins.
fix #412 