### PR TITLE
Add missing GenerateFile case in apply table summary

### DIFF
--- a/src/NexusMods.CLI/Verbs/Apply.cs
+++ b/src/NexusMods.CLI/Verbs/Apply.cs
@@ -67,6 +67,9 @@ public class Apply : AVerb<LoadoutMarker, bool, bool>
                     case DeleteFile df:
                         rows.Add(new object[] { df, df.To, df.Hash, df.Size });
                         break;
+                    case GenerateFile gf:
+                        rows.Add(new object[] { gf, gf.To, gf.Fingerprint, "-"});
+                        break;
                     default:
                         throw new InvalidOperationException($"Unknown step type ({step.GetType()}) encountered, this should never happen.");
                 }


### PR DESCRIPTION
The missing case would generate an exception when running the `apply -run` command.
The switch is used to populate a summary of the apply steps, just visual data.