### PR TITLE
Fix crash on 7z file extraction to long paths on windows

### DIFF
--- a/src/ArchiveManagement/NexusMods.FileExtractor/Extractors/SevenZipExtractor.cs
+++ b/src/ArchiveManagement/NexusMods.FileExtractor/Extractors/SevenZipExtractor.cs
@@ -125,10 +125,15 @@ public class SevenZipExtractor : IExtractor
             var totalSize = source.FileInfo.Size;
             var lastPercent = 0;
             job.Size = totalSize;
+            
+            // NOTE: 7z.exe has a bug with long destination path with forwards `/` separators on windows,
+            // as a workaround we need to change the separators to backwards '\' on windows.
+            // See: https://sourceforge.net/p/sevenzip/discussion/45797/thread/a9a0f02618/
+            var fixedDestination = destination.ToNativeSeparators(OSInformation);
 
             var result = await process.WithArguments(new[]
                     {
-                        "x", "-bsp1", "-y", $"-o{destination}", source.ToString(), "-mmt=off"
+                        "x", "-bsp1", "-y", $"-o{fixedDestination}", source.ToString(), "-mmt=off"
                     }, true)
                 .WithStandardOutputPipe(PipeTarget.ToDelegate(line =>
                 {

--- a/src/NexusMods.Paths/AbsolutePath.cs
+++ b/src/NexusMods.Paths/AbsolutePath.cs
@@ -111,6 +111,14 @@ public readonly partial struct AbsolutePath : IEquatable<AbsolutePath>, IPath
     }
 
     /// <summary>
+    /// Returns the full path with directory separators matching the passed OS.
+    /// </summary>
+    public string ToNativeSeparators(IOSInformation os)
+    {
+        return PathHelpers.ToNativeSeparators(GetFullPath(), os);
+    }
+
+    /// <summary>
     /// Returns the file name of the specified path string without the extension.
     /// </summary>
     public string GetFileNameWithoutExtension()

--- a/src/NexusMods.Paths/RelativePath.cs
+++ b/src/NexusMods.Paths/RelativePath.cs
@@ -88,6 +88,14 @@ public readonly struct RelativePath : IEquatable<RelativePath>, IPath, IComparab
     {
         return new RelativePath(PathHelpers.Sanitize(path, OS));
     }
+    
+    /// <summary>
+    /// Returns the path with the directory separators native to the passed operating system.
+    /// </summary>
+    public string ToNativeSeparators(IOSInformation os)
+    {
+        return PathHelpers.ToNativeSeparators(Path, os);
+    }
 
     /// <summary>
     /// Returns a new path that is this path with the extension changed.

--- a/tests/NexusMods.FileExtractor.Tests/SevenZipExtractionTests.cs
+++ b/tests/NexusMods.FileExtractor.Tests/SevenZipExtractionTests.cs
@@ -1,4 +1,6 @@
 using FluentAssertions;
+using NexusMods.Common;
+using NexusMods.DataModel.Extensions;
 using NexusMods.FileExtractor.StreamFactories;
 using NexusMods.Hashing.xxHash64;
 using NexusMods.Paths;
@@ -10,10 +12,56 @@ namespace NexusMods.FileExtractor.Tests;
 public class SevenZipExtractionTests
 {
     private readonly FileExtractor _extractor;
+    
+    private readonly TemporaryFileManager _temporaryFileManager;
+    
+    private readonly IFileSystem _fileSystem;
 
-    public SevenZipExtractionTests(FileExtractor extractor)
+    public SevenZipExtractionTests(FileExtractor extractor, TemporaryFileManager temporaryFileManager, 
+        IFileSystem fileSystem)
     {
         _extractor = extractor;
+        _temporaryFileManager = temporaryFileManager;
+        _fileSystem = fileSystem;
+    }
+
+    [Fact]
+    public async Task CanExtractToLongPath()
+    {
+        await using var tempFolder = _temporaryFileManager.CreateFolder();
+        var dest = tempFolder.Path;
+        
+        // Create a long path
+        while (!(dest.GetFullPathLength() > 280))
+        {
+            dest = dest.Combine("subfolder");
+            _fileSystem.CreateDirectory(dest);
+        }
+        
+        dest.GetFullPathLength().Should().BeGreaterThan(280);
+        
+        _fileSystem.CreateDirectory(dest);
+
+        var file = FileSystem.Shared.GetKnownPath(KnownPath.CurrentDirectory)
+            .Combine("Resources/data_7zip_lzma2.7z");
+        
+        var act = async () => await _extractor.ExtractAllAsync(file, dest, CancellationToken.None);
+        
+        await act.Should().NotThrowAsync();
+
+
+        (await tempFolder.Path.EnumerateFiles()
+                .SelectAsync(async f => (f.RelativeTo(dest), await f.XxHash64Async()))
+                .ToArrayAsync())
+            .Should()
+            .BeEquivalentTo(new[]
+            {
+                ("deepFolder/deepFolder2/deepFolder3/deepFolder4/deepFile.txt".ToRelativePath(), (Hash)0xE405A7CFA6ABBDE3),
+                ("folder1/folder1file.txt".ToRelativePath(), (Hash)0xC9E47B1523162066),
+                ("rootFile.txt".ToRelativePath(), (Hash)0x33DDBF7930BA002A),
+            });
+        
+        
     }
 
     [Fact]

--- a/tests/NexusMods.Paths.Tests/AbsolutePathTests.cs
+++ b/tests/NexusMods.Paths.Tests/AbsolutePathTests.cs
@@ -42,6 +42,27 @@ public class AbsolutePathTests
         actualPath.FileName.Should().Be(expectedFileName);
         actualPath.GetFullPath().Should().Be(expectedFullPath);
     }
+    
+    [Theory]
+    [InlineData(true, "", "")]
+    [InlineData(false, "", "")]
+    [InlineData(true, "foo\\bar", "foo/bar")]
+    [InlineData(false, "foo\\bar", "foo\\bar")]
+    [InlineData(true, "foo\\bar\\", "foo/bar")]
+    [InlineData(false, "foo\\bar\\", "foo\\bar")]
+    [InlineData(true, "foo/bar\\", "foo/bar")]
+    [InlineData(false, "foo/bar\\", "foo\\bar")]
+    [InlineData(true, "foo/bar/", "foo/bar")]
+    [InlineData(false, "foo/bar/", "foo\\bar")]
+    public void Test_ToNativeSeparators(bool isUnix, string input, string expected)
+    {
+        var os = CreateOSInformation(isUnix);
+        var fs = new InMemoryFileSystem(os);
+        
+        var absolutePath = AbsolutePath.FromUnsanitizedFullPath(input, fs);
+        var actual = absolutePath.ToNativeSeparators(os);
+        actual.Should().Be(expected);
+    }
 
     [Theory]
     [InlineData("/", "")]

--- a/tests/NexusMods.Paths.Tests/AbsolutePathTests.cs
+++ b/tests/NexusMods.Paths.Tests/AbsolutePathTests.cs
@@ -46,14 +46,8 @@ public class AbsolutePathTests
     [Theory]
     [InlineData(true, "", "")]
     [InlineData(false, "", "")]
-    [InlineData(true, "foo\\bar", "foo/bar")]
-    [InlineData(false, "foo\\bar", "foo\\bar")]
-    [InlineData(true, "foo\\bar\\", "foo/bar")]
-    [InlineData(false, "foo\\bar\\", "foo\\bar")]
-    [InlineData(true, "foo/bar\\", "foo/bar")]
-    [InlineData(false, "foo/bar\\", "foo\\bar")]
-    [InlineData(true, "foo/bar/", "foo/bar")]
-    [InlineData(false, "foo/bar/", "foo\\bar")]
+    [InlineData(true, "foo/bar", "foo/bar")]
+    [InlineData(false, "foo/bar", "foo\\bar")]
     public void Test_ToNativeSeparators(bool isUnix, string input, string expected)
     {
         var os = CreateOSInformation(isUnix);

--- a/tests/NexusMods.Paths.Tests/PathHelperTests.cs
+++ b/tests/NexusMods.Paths.Tests/PathHelperTests.cs
@@ -78,19 +78,10 @@ public class PathHelperTests
     [Theory]
     [InlineData(true, "", "")]
     [InlineData(false, "", "")]
-    [InlineData(true, "/", "/")]
-    [InlineData(false, "/", "\\")]
-    [InlineData(true, "/foo/", "/foo/")]
-    [InlineData(false, "/foo/", "\\foo\\")]
-    [InlineData(true, "foo\\bar", "foo/bar")]
-    [InlineData(false, "foo\\bar", "foo\\bar")]
-    [InlineData(true, "foo\\bar\\", "foo/bar/")]
-    [InlineData(false, "foo\\bar\\", "foo\\bar\\")]
-    [InlineData(true, "/foo\\bar", "/foo/bar")]
-    [InlineData(false, "/foo\\bar", "\\foo\\bar")]
-    [InlineData(true, "foo/bar\\", "foo/bar/")]
-    [InlineData(false, "foo/bar\\", "foo\\bar\\")]
-
+    [InlineData(true, "/foo/bar", "/foo/bar")]
+    [InlineData(false, "/foo/bar", "\\foo\\bar")]
+    [InlineData(true, "foo/bar", "foo/bar")]
+    [InlineData(false, "foo/bar", "foo\\bar")]
     public void Test_ToNativeSeparators(bool isUnix, string input, string expectedOutput)
     {
         var actualOutput = PathHelpers.ToNativeSeparators(input, CreateOSInformation(isUnix));

--- a/tests/NexusMods.Paths.Tests/PathHelperTests.cs
+++ b/tests/NexusMods.Paths.Tests/PathHelperTests.cs
@@ -74,6 +74,28 @@ public class PathHelperTests
         var actualOutput = PathHelpers.Sanitize(input, CreateOSInformation(isUnix));
         actualOutput.Should().Be(expectedOutput);
     }
+    
+    [Theory]
+    [InlineData(true, "", "")]
+    [InlineData(false, "", "")]
+    [InlineData(true, "/", "/")]
+    [InlineData(false, "/", "\\")]
+    [InlineData(true, "/foo/", "/foo/")]
+    [InlineData(false, "/foo/", "\\foo\\")]
+    [InlineData(true, "foo\\bar", "foo/bar")]
+    [InlineData(false, "foo\\bar", "foo\\bar")]
+    [InlineData(true, "foo\\bar\\", "foo/bar/")]
+    [InlineData(false, "foo\\bar\\", "foo\\bar\\")]
+    [InlineData(true, "/foo\\bar", "/foo/bar")]
+    [InlineData(false, "/foo\\bar", "\\foo\\bar")]
+    [InlineData(true, "foo/bar\\", "foo/bar/")]
+    [InlineData(false, "foo/bar\\", "foo\\bar\\")]
+
+    public void Test_ToNativeSeparators(bool isUnix, string input, string expectedOutput)
+    {
+        var actualOutput = PathHelpers.ToNativeSeparators(input, CreateOSInformation(isUnix));
+        actualOutput.Should().Be(expectedOutput);
+    }
 
     [Theory]
     [InlineData(true, "", "", true)]

--- a/tests/NexusMods.Paths.Tests/RelativePathTests.cs
+++ b/tests/NexusMods.Paths.Tests/RelativePathTests.cs
@@ -4,6 +4,11 @@ namespace NexusMods.Paths.Tests;
 
 public class RelativePathTests
 {
+    private static IOSInformation CreateOSInformation(bool isUnix)
+    {
+        return isUnix ? OSInformation.FakeUnix : OSInformation.FakeWindows;
+    }
+    
     [Theory]
     [InlineData("a", "a")]
     [InlineData("a/b", "a/b")]
@@ -43,6 +48,29 @@ public class RelativePathTests
         
         var sanitizedPath = RelativePath.FromUnsanitizedInput(inputPath);
         sanitizedPath.Should().Be(expectedRelativePath);
+    }
+    
+    [Theory]
+    [InlineData(true, "", "")]
+    [InlineData(false, "", "")]
+    [InlineData(true, "/", "/")]
+    [InlineData(false, "/", "\\")]
+    [InlineData(true, "/foo/", "/foo/")]
+    [InlineData(false, "/foo/", "\\foo\\")]
+    [InlineData(true, "foo\\bar", "foo/bar")]
+    [InlineData(false, "foo\\bar", "foo\\bar")]
+    [InlineData(true, "foo\\bar\\", "foo/bar/")]
+    [InlineData(false, "foo\\bar\\", "foo\\bar\\")]
+    [InlineData(true, "/foo\\bar", "/foo/bar")]
+    [InlineData(false, "/foo\\bar", "\\foo\\bar")]
+    [InlineData(true, "foo/bar\\", "foo/bar/")]
+    [InlineData(false, "foo/bar\\", "foo\\bar\\")]
+    public void Test_ToNativeSeparators(bool isUnix, string input, string expected)
+    {
+        var os = CreateOSInformation(isUnix);
+        
+        var path = new RelativePath(input);
+        path.ToNativeSeparators(os).Should().Be(expected);
     }
 
     [Theory]

--- a/tests/NexusMods.Paths.Tests/RelativePathTests.cs
+++ b/tests/NexusMods.Paths.Tests/RelativePathTests.cs
@@ -53,18 +53,8 @@ public class RelativePathTests
     [Theory]
     [InlineData(true, "", "")]
     [InlineData(false, "", "")]
-    [InlineData(true, "/", "/")]
-    [InlineData(false, "/", "\\")]
-    [InlineData(true, "/foo/", "/foo/")]
-    [InlineData(false, "/foo/", "\\foo\\")]
-    [InlineData(true, "foo\\bar", "foo/bar")]
-    [InlineData(false, "foo\\bar", "foo\\bar")]
-    [InlineData(true, "foo\\bar\\", "foo/bar/")]
-    [InlineData(false, "foo\\bar\\", "foo\\bar\\")]
-    [InlineData(true, "/foo\\bar", "/foo/bar")]
-    [InlineData(false, "/foo\\bar", "\\foo\\bar")]
-    [InlineData(true, "foo/bar\\", "foo/bar/")]
-    [InlineData(false, "foo/bar\\", "foo\\bar\\")]
+    [InlineData(true, "foo/bar", "foo/bar")]
+    [InlineData(false, "foo/bar", "foo\\bar")]
     public void Test_ToNativeSeparators(bool isUnix, string input, string expected)
     {
         var os = CreateOSInformation(isUnix);


### PR DESCRIPTION
fixes #429 

This implements a workaround for a 7z.exe problem on windows in cases where the path is very long and uses forward slashes.
We normally always use forward slashes internally as windows file systems should support it, but apparently in this particular case 7z requires backwards slashes on windows.

To obtain the proper slashes, the ToNativeSeparators functions were added to the paths library.