### PR TITLE
Prevent database locking in reader loop

### DIFF
--- a/src/NexusMods.DataModel/Interprocess/SqliteIPC.cs
+++ b/src/NexusMods.DataModel/Interprocess/SqliteIPC.cs
@@ -250,14 +250,9 @@ public class SqliteIPC : IDisposable, IInterprocessJobManager
 
             _jobs.Edit(editable =>
             {
-                var idBytes = new byte[16];
                 while (reader.Read())
                 {
-                    var count = reader.GetBytes(0, 0, idBytes, 0, idBytes.Length);
-                    Debug.Assert(count == 16);
-
-                    var jobId = JobId.From(new Guid(idBytes));
-
+                    var jobId = JobId.From(new Guid(reader.GetBlob(0)));
                     var progress = new Percent(reader.GetDouble(2));
 
                     seen.Add(jobId);

--- a/src/NexusMods.DataModel/Interprocess/SqliteIPC.cs
+++ b/src/NexusMods.DataModel/Interprocess/SqliteIPC.cs
@@ -247,13 +247,14 @@ public class SqliteIPC : IDisposable, IInterprocessJobManager
             var reader = cmd.ExecuteReader();
 
             var seen = new HashSet<JobId>();
+
             _jobs.Edit(editable =>
             {
+                var idBytes = new byte[16];
                 while (reader.Read())
                 {
-                    var idSize = reader.GetBytes(0, 0, null, 0, 0);
-                    var idBytes = new byte[idSize];
-                    reader.GetBytes(0, 0, idBytes, 0, idBytes.Length);
+                    var count = reader.GetBytes(0, 0, idBytes, 0, idBytes.Length);
+                    Debug.Assert(count == 16);
 
                     var jobId = JobId.From(new Guid(idBytes));
 

--- a/src/NexusMods.DataModel/Interprocess/SqliteIPC.cs
+++ b/src/NexusMods.DataModel/Interprocess/SqliteIPC.cs
@@ -271,13 +271,10 @@ public class SqliteIPC : IDisposable, IInterprocessJobManager
                     }
 
                     _logger.NewJob(jobId);
-                    var processId = Interprocess.Jobs.ProcessId.From((uint)reader.GetInt64(1));
-                    var startTime =
-                        DateTime.FromFileTimeUtc(reader.GetInt64(3));
+                    var processId = ProcessId.From((uint)reader.GetInt64(1));
+                    var startTime = DateTime.FromFileTimeUtc(reader.GetInt64(3));
 
-                    var entity =
-                        JsonSerializer.Deserialize<Entity>(reader.GetBlob(4),
-                            _jsonSettings)!;
+                    var entity = JsonSerializer.Deserialize<Entity>(reader.GetBlob(4), _jsonSettings)!;
 
                     var newJob = new InterprocessJob(jobId, this, processId, startTime, progress, entity);
                     editable.AddOrUpdate(newJob);


### PR DESCRIPTION
Part 1 of #372.

Inside the `SqliteIPC.ReaderLoop` method, we're calling [`ProcessJobs`](https://github.com/Nexus-Mods/NexusMods.App/blob/e1455ec7aaef2faf3c8225cdbd3c158052496524/src/NexusMods.DataModel/Interprocess/SqliteIPC.cs#L239) which gets every job from the IPC DB and then updates or inserts the jobs into the `_jobs` `SourceCache`. The issue is this section:

https://github.com/Nexus-Mods/NexusMods.App/blob/e1455ec7aaef2faf3c8225cdbd3c158052496524/src/NexusMods.DataModel/Interprocess/SqliteIPC.cs#L263-L271

While reading from the database, we're updating the progress of the job, which will try to update the progress in the database:

https://github.com/Nexus-Mods/NexusMods.App/blob/e1455ec7aaef2faf3c8225cdbd3c158052496524/src/NexusMods.DataModel/Interprocess/Jobs/InterprocessJob.cs#L72-L81

However, this is unintended behavior. The fix is to add a check and only update the DB if we actually own the job.

I also a small performance issue:

https://github.com/Nexus-Mods/NexusMods.App/blob/e1455ec7aaef2faf3c8225cdbd3c158052496524/src/NexusMods.DataModel/Interprocess/SqliteIPC.cs#L254-L256

We're using `GetBytes` to get the amount of bytes the ID takes up, then we allocate a new array with the required length and read the bytes into the array. However, Job IDs are always 16-bytes long and we can simply use `GetBlob`, which returns a `ReadOnlySpan<byte>`, and pass that directly to the `Guid` constructor. This completely removes all allocations.