### PR TITLE
Added: A bunch of .nx related fixes. (fixes #410)

### DIFF
--- a/src/ArchiveManagement/NexusMods.FileExtractor/NexusMods.FileExtractor.csproj
+++ b/src/ArchiveManagement/NexusMods.FileExtractor/NexusMods.FileExtractor.csproj
@@ -12,7 +12,6 @@
     <ItemGroup>
         <PackageReference Include="CliWrap" Version="3.6.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
-        <PackageReference Include="NexusMods.Archives.Nx" Version="0.3.2-preview" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NexusMods.Common/NexusMods.Common.csproj
+++ b/src/NexusMods.Common/NexusMods.Common.csproj
@@ -9,7 +9,6 @@
     <ItemGroup>
         <PackageReference Include="CliWrap" Version="3.6.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-        <PackageReference Include="NexusMods.Archives.Nx" Version="0.3.2-preview" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NexusMods.DataModel/NexusMods.DataModel.csproj
+++ b/src/NexusMods.DataModel/NexusMods.DataModel.csproj
@@ -3,6 +3,7 @@
     <Import Project="$([MSBuild]::GetPathOfFileAbove('NuGet.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
     <ItemGroup>
+        <ProjectReference Include="..\..\NexusMods.Archives.Nx\NexusMods.Archives.Nx\NexusMods.Archives.Nx.csproj" />
         <ProjectReference Include="..\ArchiveManagement\NexusMods.FileExtractor\NexusMods.FileExtractor.csproj" />
         <ProjectReference Include="..\NexusMods.Hashing.xxHash64\NexusMods.Hashing.xxHash64.csproj" />
         <ProjectReference Include="..\NexusMods.Paths\NexusMods.Paths.csproj" />
@@ -16,7 +17,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="7.0.5" />
         <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.2" />
-        <PackageReference Include="NexusMods.Archives.Nx" Version="0.3.2-preview" />
+        <PackageReference Include="NexusMods.Archives.Nx" Version="0.3.3-preview" />
         <PackageReference Include="Sewer56.BitStream" Version="1.3.0" />
         <PackageReference Include="System.Reactive" Version="6.0.0" />
         <PackageReference Include="Vogen" Version="3.0.15" />

--- a/src/NexusMods.DataModel/NxArchiveManager.cs
+++ b/src/NexusMods.DataModel/NxArchiveManager.cs
@@ -81,8 +81,6 @@ public class NxArchiveManager : IArchiveManager
         await using var os = finalPath.Read();
         var unpacker = new NxUnpacker(new FromStreamProvider(os));
         UpdateIndexes(unpacker, distinct, guid, finalPath);
-        
-
     }
 
     private unsafe void UpdateIndexes(NxUnpacker unpacker, (IStreamFactory, Hash, Size)[] distinct, Guid guid,
@@ -139,8 +137,7 @@ public class NxArchiveManager : IArchiveManager
             await using var file = group.Key.Read();
             var provider = new FromStreamProvider(file);
             var unpacker = new NxUnpacker(provider);
-
-
+            
             var toExtract = group
                 .Select(entry =>
                     (IOutputDataProvider)new OutputFileProvider(entry.Dest.Parent.GetFullPath(), entry.Dest.FileName, entry.FileEntry))
@@ -171,19 +168,16 @@ public class NxArchiveManager : IArchiveManager
             throw new Exception($"Missing archive for {grouped[default].First().Hash.ToHex()}");
 
         var settings = new UnpackerSettings();
-
+        settings.MaxNumThreads = 1;
         foreach (var group in grouped)
         {
-            var byHash = group.ToLookup(f => f);
             var file = group.Key.Read();
             var provider = new FromStreamProvider(file);
             var unpacker = new NxUnpacker(provider);
 
             var infos = group.Select(entry => (entry.Hash, new OutputArrayProvider("", entry.FileEntry))).ToList();
-
-
+            
             unpacker.ExtractFiles(infos.Select(o => (IOutputDataProvider)o.Item2).ToArray(), settings);
-
             foreach (var info in infos)
             {
                 results.Add(info.Hash, info.Item2.Data);

--- a/src/NexusMods.DataModel/Services.cs
+++ b/src/NexusMods.DataModel/Services.cs
@@ -51,7 +51,7 @@ public static class Services
         coll.AddSingleton(typeof(EntityLinkConverter<>));
 
         coll.AddSingleton<IDataStore, SqliteDataStore>();
-        coll.AddAllSingleton<IArchiveManager, ZipArchiveManager>();
+        coll.AddAllSingleton<IArchiveManager, NxArchiveManager>();
         coll.AddAllSingleton<IResource, IResource<FileHashCache, Size>>(s =>
             new Resource<FileHashCache, Size>("File Hashing",
                 Settings(s).MaxHashingJobs,

--- a/src/NexusMods.DataModel/ZipArchiveManager.cs
+++ b/src/NexusMods.DataModel/ZipArchiveManager.cs
@@ -149,8 +149,7 @@ public class ZipArchiveManager : IArchiveManager
 
         if (grouped[default].Any())
             throw new Exception($"Missing archive for {grouped[default].First().ToHex()}");
-
-
+        
         foreach (var group in grouped)
         {
             var byHash = group.ToDictionary(f => f.ToHex());


### PR DESCRIPTION
# Fixes

- Multiple bug fixes in .nx Archive library (updated to `0.3.3-preview`).  
- Removed unnecessary `.nx` dependencies in projects that don't depend on it.  
- Reduced `stackalloc` from 64-bytes to just needed amount in `UpdateIndexes`.  

# Breaking Changes

- Changed to using `V1` instead of `V0` file entry format.
  - This will allow for 4GB+ files to be used in stored mods.
  - Delete your DataStore after merging, due to incompatibility of changed format.
  - We could potentially save some space, here, 