### PR TITLE
Allow trailing comma in SMAPI Manifest

### DIFF
--- a/src/NexusMods.DataModel/Abstractions/IFileAnalyzer.cs
+++ b/src/NexusMods.DataModel/Abstractions/IFileAnalyzer.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using NexusMods.DataModel.Abstractions.Ids;
 using NexusMods.FileExtractor.FileSignatures;
 using NexusMods.Paths;
@@ -36,6 +37,7 @@ public interface IFileAnalyzer
 /// <summary>
 /// Extra info for file analyzer. Passed as a struct to avoid having to update all callees.
 /// </summary>
+[DebuggerDisplay("{FileName}")]
 public struct FileAnalyzerInfo
 {
     /// <summary>

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/Analyzers/SMAPIManifestAnalyzerTests.cs
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/Analyzers/SMAPIManifestAnalyzerTests.cs
@@ -73,7 +73,7 @@ public class SMAPIManifestAnalyzerTests : AFileAnalyzerTest<StardewValley, SMAPI
     ""UpdateKeys"": [""Nexus:0""],
     ""Dependencies"": [
         {
-            ""UniqueID"": ""bar""
+            ""UniqueID"": ""bar"",
         }
     ]
 }


### PR DESCRIPTION
Fixes #435.
Changes:

- adds exception logging when JSON Serialization fails
- allows trailing commas in `manifest.json` files