### PR TITLE
Fix broken version parsing for SMAPI Manifests

### DIFF
--- a/src/Games/NexusMods.Games.StardewValley/Analyzers/SMAPIManifestAnalyzer.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Analyzers/SMAPIManifestAnalyzer.cs
@@ -1,13 +1,11 @@
 using System.Runtime.CompilerServices;
 using System.Text.Json;
-using JetBrains.Annotations;
 using Microsoft.Extensions.Logging;
 using NexusMods.DataModel.Abstractions;
 using NexusMods.DataModel.Abstractions.Ids;
-using NexusMods.DataModel.JsonConverters;
 using NexusMods.FileExtractor.FileSignatures;
-// ReSharper disable StringLiteralTypo
-// ReSharper disable IdentifierTypo
+using NexusMods.Games.StardewValley.Models;
+
 // ReSharper disable InconsistentNaming
 
 namespace NexusMods.Games.StardewValley.Analyzers;
@@ -24,7 +22,8 @@ public class SMAPIManifestAnalyzer : IFileAnalyzer
 
     private static readonly JsonSerializerOptions JsonSerializerOptions = new()
     {
-        AllowTrailingCommas = true
+        AllowTrailingCommas = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
     };
 
     private readonly ILogger<SMAPIManifestAnalyzer> _logger;
@@ -52,64 +51,4 @@ public class SMAPIManifestAnalyzer : IFileAnalyzer
         if (result is null) yield break;
         yield return result;
     }
-}
-
-// TODO: SMAPI uses ISemanticVersion instead of Version (https://github.com/Pathoschild/SMAPI/blob/develop/src/SMAPI.Toolkit.CoreInterfaces/ISemanticVersion.cs#L7)
-
-/// <summary>
-/// https://github.com/Pathoschild/SMAPI/blob/9763bc7484e29cbc9e7f37c61121d794e6720e75/src/SMAPI.Toolkit/Serialization/Models/Manifest.cs#L11
-/// </summary>
-[PublicAPI]
-[JsonName("NexusMods.Games.StardewValley.SMAPIManifest")]
-public record SMAPIManifest : IFileAnalysisData
-{
-    /// <summary>
-    /// The mod name.
-    /// </summary>
-    public required string Name { get; init; }
-
-    /// <summary>
-    /// The unique mod ID.
-    /// </summary>
-    public required string UniqueID { get; init; }
-
-    /// <summary>
-    /// The mod version.
-    /// </summary>
-    public required Version Version { get; init; }
-
-    /// <summary>
-    /// The minimum SMAPI version required by this mod (if any).
-    /// </summary>
-    public Version? MinimumApiVersion { get; init; }
-
-    /// <summary>
-    /// The other mods that must be loaded before this mod.
-    /// </summary>
-    public SMAPIManifestDependency[]? Dependencies { get; init; }
-}
-
-/// <summary>
-/// https://github.com/Pathoschild/SMAPI/blob/9763bc7484e29cbc9e7f37c61121d794e6720e75/src/SMAPI.Toolkit.CoreInterfaces/IManifestDependency.cs
-/// https://github.com/Pathoschild/SMAPI/blob/9763bc7484e29cbc9e7f37c61121d794e6720e75/src/SMAPI.Toolkit/Serialization/Models/ManifestDependency.cs
-/// </summary>
-[PublicAPI]
-[JsonName("NexusMods.Games.StardewValley.SMAPIManifestDependency")]
-public record SMAPIManifestDependency
-{
-    /// <summary>
-    /// The unique mod ID to require.
-    /// </summary>
-    public required string UniqueID { get; init; }
-
-    /// <summary>
-    /// The minimum required version. This property is optional.
-    /// </summary>
-    public Version? MinimumVersion { get; init; }
-
-    /// <summary>
-    /// Whether the dependency must be installed to use the mod. This property is
-    /// optional and set to <c>true</c> by default (https://github.com/Pathoschild/SMAPI/blob/9763bc7484e29cbc9e7f37c61121d794e6720e75/src/SMAPI.Toolkit/Serialization/Models/ManifestDependency.cs#L29)
-    /// </summary>
-    public bool IsRequired { get; init; } = true;
 }

--- a/src/Games/NexusMods.Games.StardewValley/Emitters/001_MissingDependencies.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/001_MissingDependencies.cs
@@ -3,6 +3,7 @@ using NexusMods.DataModel.Diagnostics.Emitters;
 using NexusMods.DataModel.Loadouts;
 using NexusMods.DataModel.Loadouts.Mods;
 using NexusMods.Games.StardewValley.Analyzers;
+using NexusMods.Games.StardewValley.Models;
 
 namespace NexusMods.Games.StardewValley.Emitters;
 

--- a/src/Games/NexusMods.Games.StardewValley/Installers/SMAPIModInstaller.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Installers/SMAPIModInstaller.cs
@@ -8,6 +8,7 @@ using NexusMods.DataModel.Loadouts;
 using NexusMods.DataModel.Loadouts.ModFiles;
 using NexusMods.DataModel.ModInstallers;
 using NexusMods.Games.StardewValley.Analyzers;
+using NexusMods.Games.StardewValley.Models;
 using NexusMods.Hashing.xxHash64;
 using NexusMods.Paths;
 using NexusMods.Paths.Extensions;

--- a/src/Games/NexusMods.Games.StardewValley/Models/SMAPIManifest.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Models/SMAPIManifest.cs
@@ -1,0 +1,40 @@
+using JetBrains.Annotations;
+using NexusMods.DataModel.Abstractions;
+using NexusMods.DataModel.JsonConverters;
+
+namespace NexusMods.Games.StardewValley.Models;
+
+// ReSharper disable InconsistentNaming
+
+/// <summary>
+/// https://github.com/Pathoschild/SMAPI/blob/9763bc7484e29cbc9e7f37c61121d794e6720e75/src/SMAPI.Toolkit/Serialization/Models/Manifest.cs#L11
+/// </summary>
+[PublicAPI]
+[JsonName("NexusMods.Games.StardewValley.SMAPIManifest")]
+public record SMAPIManifest : IFileAnalysisData
+{
+    /// <summary>
+    /// The mod name.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// The unique mod ID.
+    /// </summary>
+    public required string UniqueID { get; init; }
+
+    /// <summary>
+    /// The mod version.
+    /// </summary>
+    public required SMAPIVersion Version { get; init; }
+
+    /// <summary>
+    /// The minimum SMAPI version required by this mod (if any).
+    /// </summary>
+    public SMAPIVersion? MinimumApiVersion { get; init; }
+
+    /// <summary>
+    /// The other mods that must be loaded before this mod.
+    /// </summary>
+    public SMAPIManifestDependency[]? Dependencies { get; init; }
+}

--- a/src/Games/NexusMods.Games.StardewValley/Models/SMAPIManifestDependency.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Models/SMAPIManifestDependency.cs
@@ -1,0 +1,31 @@
+using JetBrains.Annotations;
+using NexusMods.DataModel.JsonConverters;
+
+namespace NexusMods.Games.StardewValley.Models;
+
+// ReSharper disable InconsistentNaming
+
+/// <summary>
+/// https://github.com/Pathoschild/SMAPI/blob/9763bc7484e29cbc9e7f37c61121d794e6720e75/src/SMAPI.Toolkit.CoreInterfaces/IManifestDependency.cs
+/// https://github.com/Pathoschild/SMAPI/blob/9763bc7484e29cbc9e7f37c61121d794e6720e75/src/SMAPI.Toolkit/Serialization/Models/ManifestDependency.cs
+/// </summary>
+[PublicAPI]
+[JsonName("NexusMods.Games.StardewValley.SMAPIManifestDependency")]
+public record SMAPIManifestDependency
+{
+    /// <summary>
+    /// The unique mod ID to require.
+    /// </summary>
+    public required string UniqueID { get; init; }
+
+    /// <summary>
+    /// The minimum required version. This property is optional.
+    /// </summary>
+    public SMAPIVersion? MinimumVersion { get; init; }
+
+    /// <summary>
+    /// Whether the dependency must be installed to use the mod. This property is
+    /// optional and set to <c>true</c> by default (https://github.com/Pathoschild/SMAPI/blob/9763bc7484e29cbc9e7f37c61121d794e6720e75/src/SMAPI.Toolkit/Serialization/Models/ManifestDependency.cs#L29)
+    /// </summary>
+    public bool IsRequired { get; init; } = true;
+}

--- a/src/Games/NexusMods.Games.StardewValley/Models/SMAPIVersion.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Models/SMAPIVersion.cs
@@ -1,0 +1,209 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using JetBrains.Annotations;
+using Microsoft.Extensions.Primitives;
+using NexusMods.Paths.Extensions;
+
+namespace NexusMods.Games.StardewValley.Models;
+
+// ReSharper disable InconsistentNaming
+
+/// <summary>
+/// https://github.com/Pathoschild/SMAPI/blob/3dc45bb85ed4399edfe170fb26aa4ddb2f53d66c/src/SMAPI.Toolkit.CoreInterfaces/ISemanticVersion.cs#L7
+/// https://github.com/Pathoschild/SMAPI/blob/3dc45bb85ed4399edfe170fb26aa4ddb2f53d66c/src/SMAPI.Toolkit/SemanticVersion.cs#L17
+/// </summary>
+[PublicAPI]
+[JsonConverter(typeof(SMAPIVersionConverter))]
+public sealed record SMAPIVersion
+{
+    public required int MajorVersion { get; init; }
+
+    public required int MinorVersion { get; init; }
+
+    public int PatchVersion { get; init; }
+
+    public int PlatformRelease { get; init; }
+
+    public string? PrereleaseTag { get; init; }
+
+    public string? BuildMetadata { get; init; }
+
+    public override string ToString()
+    {
+        var sb = new StringBuilder();
+
+        sb.Append(MajorVersion);
+        sb.Append('.');
+        sb.Append(MinorVersion);
+
+        if (PatchVersion != 0)
+        {
+            sb.Append('.');
+            sb.Append(PatchVersion);
+        }
+
+        if (PrereleaseTag is not null)
+        {
+            sb.Append('-');
+            sb.Append(PrereleaseTag);
+        }
+
+        if (BuildMetadata is not null)
+        {
+            sb.Append('+');
+            sb.Append(BuildMetadata);
+        }
+
+        return sb.ToString();
+    }
+
+    public static SMAPIVersion From(Version version)
+    {
+        return new SMAPIVersion
+        {
+            MajorVersion = version.Major,
+            MinorVersion = version.Minor,
+            PatchVersion = version.Build == -1 ? 0 : version.Build
+        };
+    }
+
+    public static bool TryParse(ReadOnlySpan<char> input, [NotNullWhen(true)] out SMAPIVersion? version)
+    {
+        if (!TryParseParts(
+                input,
+                out var majorVersion,
+                out var minorVersion,
+                out var patchVersion,
+                out var platformRelease,
+                out var prereleaseTag,
+                out var buildMetadata))
+        {
+            version = null;
+            return false;
+        }
+
+        version = new SMAPIVersion
+        {
+            MajorVersion = majorVersion,
+            MinorVersion = minorVersion,
+            PatchVersion = patchVersion,
+            PlatformRelease = platformRelease,
+            PrereleaseTag = prereleaseTag,
+            BuildMetadata = buildMetadata
+        };
+
+        return true;
+    }
+
+    private static bool TryParseParts(
+        ReadOnlySpan<char> input,
+        out int majorVersion,
+        out int minorVersion,
+        out int patchVersion,
+        out int platformRelease,
+        out string? prereleaseTag,
+        out string? buildMetadata)
+    {
+        majorVersion = 0;
+        minorVersion = 0;
+        patchVersion = 0;
+        platformRelease = 0;
+        prereleaseTag = null;
+        buildMetadata = null;
+
+        var i = 0;
+
+        // complete example: "12.34.56-beta434+debug93"
+
+        // required major and minor version
+        if (!TryParseVersionPart(input, ref i, out majorVersion)) return false;
+        if (!TryParseLiteral(input, ref i, '.')) return false;
+        if (!TryParseVersionPart(input, ref i, out minorVersion)) return false;
+
+        // optional patch version
+        if (TryParseLiteral(input, ref i, '.') && !TryParseVersionPart(input, ref i, out patchVersion))
+            return false;
+
+        // // optional non-standard platform release version
+        // if (TryParseLiteral(input, ref i, '.') && !TryParseVersionPart(input, ref i, out platformRelease))
+        //     return false;
+
+        // optional prerelease tag
+        if (TryParseLiteral(input, ref i, '-') && !TryParseTag(input, ref i, out prereleaseTag))
+            return false;
+
+        // optional build tag
+        if (TryParseLiteral(input, ref i, '+') && !TryParseTag(input, ref i, out buildMetadata))
+            return false;
+
+        return i == input.Length;
+    }
+
+    private static bool TryParseVersionPart(ReadOnlySpan<char> input, ref int index, out int part)
+    {
+        part = 0;
+        var start = index;
+
+        int i;
+        for (i = index; i < input.Length && char.IsDigit(input[i]); i++) { }
+
+        if (i == 0) return false;
+        var slice = input.SliceFast(start, i - start);
+
+        // no leading zeroes
+        if (slice.Length > 1 && slice[0] == '0') return false;
+
+        index += slice.Length;
+        return int.TryParse(slice, CultureInfo.InvariantCulture, out part);
+    }
+
+    private static bool TryParseLiteral(ReadOnlySpan<char> input, ref int index, char literal)
+    {
+        if (index >= input.Length || input[index] != literal) return false;
+        index++;
+        return true;
+    }
+
+    private static bool TryParseTag(ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out string? tag)
+    {
+        var length = 0;
+        for (var i = index; i < input.Length && (char.IsLetterOrDigit(input[i]) || input[i] == '-' || input[i] == '.'); i++)
+        {
+            length++;
+        }
+
+        if (length == 0)
+        {
+            tag = null;
+            return false;
+        }
+
+        tag = input.SliceFast(index, length).ToString();
+        index += length;
+        return true;
+    }
+}
+
+public class SMAPIVersionConverter : JsonConverter<SMAPIVersion>
+{
+    public override SMAPIVersion? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.String)
+            throw new JsonException($"Expected {JsonTokenType.String}, found {reader.TokenType}");
+
+        var s = reader.GetString();
+
+        if (s is null) return null;
+
+        if (SMAPIVersion.TryParse(s, out var version)) return version;
+        throw new JsonException($"Unable to parse \"{s}\"!");
+    }
+
+    public override void Write(Utf8JsonWriter writer, SMAPIVersion value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToString());
+    }
+}

--- a/src/Games/NexusMods.Games.StardewValley/NexusMods.Games.StardewValley.csproj
+++ b/src/Games/NexusMods.Games.StardewValley/NexusMods.Games.StardewValley.csproj
@@ -16,4 +16,6 @@
         <InternalsVisibleTo Include="NexusMods.Games.StardewValley.Tests" />
     </ItemGroup>
 
+
+
 </Project>

--- a/src/Games/NexusMods.Games.StardewValley/TypeFinder.cs
+++ b/src/Games/NexusMods.Games.StardewValley/TypeFinder.cs
@@ -1,5 +1,6 @@
 using NexusMods.DataModel.JsonConverters.ExpressionGenerator;
 using NexusMods.Games.StardewValley.Analyzers;
+using NexusMods.Games.StardewValley.Models;
 
 namespace NexusMods.Games.StardewValley;
 
@@ -14,5 +15,6 @@ public class TypeFinder : ITypeFinder
     {
         typeof(SMAPIManifest),
         typeof(SMAPIManifestDependency),
+        typeof(SMAPIVersion)
     };
 }

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/Analyzers/SMAPIManifestAnalyzerTests.cs
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/Analyzers/SMAPIManifestAnalyzerTests.cs
@@ -1,11 +1,10 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using FluentAssertions;
-using NexusMods.DataModel.Abstractions;
 using NexusMods.FileExtractor.FileSignatures;
 using NexusMods.Games.StardewValley.Analyzers;
+using NexusMods.Games.StardewValley.Models;
 using NexusMods.Games.TestFramework;
-using NexusMods.Paths;
 
 namespace NexusMods.Games.StardewValley.Tests.Analyzers;
 
@@ -26,9 +25,17 @@ public class SMAPIManifestAnalyzerTests : AFileAnalyzerTest<StardewValley, SMAPI
         var expected = new SMAPIManifest
         {
             Name = Guid.NewGuid().ToString("N"),
-            Version = new Version(1, 2, 3),
+            Version = new SMAPIVersion
+            {
+                MajorVersion = 1,
+                MinorVersion = 2,
+            },
             UniqueID = Guid.NewGuid().ToString("N"),
-            MinimumApiVersion = new Version(3, 12, 0),
+            MinimumApiVersion = new SMAPIVersion
+            {
+                MajorVersion = 3,
+                MinorVersion = 12
+            }
         };
 
         var bytes = JsonSerializer.SerializeToUtf8Bytes(expected);
@@ -50,9 +57,18 @@ public class SMAPIManifestAnalyzerTests : AFileAnalyzerTest<StardewValley, SMAPI
         var expected = new SMAPIManifest
         {
             Name = "foo",
-            Version = new Version(1, 0, 5),
+            Version = new SMAPIVersion
+            {
+                MajorVersion = 1,
+                MinorVersion = 0,
+                PatchVersion = 5
+            },
             UniqueID = "foo",
-            MinimumApiVersion = new Version(3, 12, 0),
+            MinimumApiVersion = new SMAPIVersion
+            {
+                MajorVersion = 3,
+                MinorVersion = 12
+            },
             Dependencies = new SMAPIManifestDependency[]
             {
                 new()
@@ -73,6 +89,7 @@ public class SMAPIManifestAnalyzerTests : AFileAnalyzerTest<StardewValley, SMAPI
     ""UpdateKeys"": [""Nexus:0""],
     ""Dependencies"": [
         {
+            /* this is a comment */
             ""UniqueID"": ""bar"",
         }
     ]

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/Emitters/001_MissingDependencyTests.cs
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/Emitters/001_MissingDependencyTests.cs
@@ -3,6 +3,7 @@ using NexusMods.DataModel.Diagnostics;
 using NexusMods.DataModel.Diagnostics.References;
 using NexusMods.Games.StardewValley.Analyzers;
 using NexusMods.Games.StardewValley.Emitters;
+using NexusMods.Games.StardewValley.Models;
 using NexusMods.Games.TestFramework;
 
 namespace NexusMods.Games.StardewValley.Tests.Emitters;
@@ -20,7 +21,11 @@ public class MissingDependenciesEmitterTests : ALoadoutDiagnosticEmitterTest<Sta
         {
             Name = "ModA",
             UniqueID = "ModA",
-            Version = new Version(1, 0, 0),
+            Version = new SMAPIVersion
+            {
+                MajorVersion = 1,
+                MinorVersion = 0
+            },
             Dependencies = new[]
             {
                 new SMAPIManifestDependency
@@ -48,7 +53,11 @@ public class MissingDependenciesEmitterTests : ALoadoutDiagnosticEmitterTest<Sta
         {
             Name = "ModB",
             UniqueID = "ModB",
-            Version = new Version(1, 0, 0)
+            Version = new SMAPIVersion
+            {
+                MajorVersion = 1,
+                MinorVersion = 0
+            },
         };
 
         var modBFiles = TestHelper.CreateTestFiles(modBManifest);

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/Models/SMAPIVersionTests.cs
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/Models/SMAPIVersionTests.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+using FluentAssertions;
+using NexusMods.Games.StardewValley.Models;
+
+namespace NexusMods.Games.StardewValley.Tests.Models;
+
+// ReSharper disable InconsistentNaming
+
+public class SMAPIVersionTests
+{
+    [Theory]
+    [InlineData("1.2", 1, 2, 0, 0, null, null)]
+    [InlineData("123.456", 123, 456, 0, 0, null, null)]
+    [InlineData("1.0.2", 1, 0, 2, 0, null, null)]
+    [InlineData("1.2.3", 1, 2, 3, 0, null, null)]
+    [InlineData("12.34.56", 12, 34, 56, 0, null, null)]
+    [InlineData("1.2-beta123", 1, 2, 0, 0, "beta123", null)]
+    [InlineData("1.2-beta123+debug5", 1, 2, 0, 0, "beta123", "debug5")]
+    [InlineData("1.2+debug4", 1, 2, 0, 0, null, "debug4")]
+    public void Test_TryParse_Success(
+        string input,
+        int expectedMajorVersion,
+        int expectedMinorVersion,
+        int expectedPatchVersion,
+        int expectedPlatformRelease,
+        string? expectedPrereleaseTag,
+        string? expectedBuildMetadata)
+    {
+        var res = SMAPIVersion.TryParse(input, out var version);
+        res.Should().BeTrue();
+        version.Should().NotBeNull();
+        version!.MajorVersion.Should().Be(expectedMajorVersion);
+        version.MinorVersion.Should().Be(expectedMinorVersion);
+        version.PatchVersion.Should().Be(expectedPatchVersion);
+        version.PlatformRelease.Should().Be(expectedPlatformRelease);
+        version.PrereleaseTag.Should().Be(expectedPrereleaseTag);
+        version.BuildMetadata.Should().Be(expectedBuildMetadata);
+
+        version.ToString().Should().Be(input);
+
+        var json = JsonSerializer.Serialize(version);
+        var deserialized = JsonSerializer.Deserialize<SMAPIVersion>(json);
+        deserialized.Should().Be(version);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("1")]
+    [InlineData("1.2:debug")]
+    [InlineData("01.02")]
+    public void Test_Try_Parse_Failure(string input)
+    {
+        var res = SMAPIVersion.TryParse(input, out var version);
+        version.Should().BeNull();
+        res.Should().BeFalse();
+    }
+}

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/TestHelper.cs
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/TestHelper.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.Json;
 using NexusMods.Games.StardewValley.Analyzers;
+using NexusMods.Games.StardewValley.Models;
 using NexusMods.Paths;
 
 namespace NexusMods.Games.StardewValley.Tests;


### PR DESCRIPTION
Changes:
- fixes comments breaking JSON serialization for SMAPI manifests
- adds `SMAPIVersion` that correctly parses version numbers in SMAPI manifests