### PR TITLE
Avoid exception on nxm protocol that doesn't match managed game

### DIFF
--- a/src/ArchiveManagement/NexusMods.FileExtractor/Extractors/SevenZipExtractor.cs
+++ b/src/ArchiveManagement/NexusMods.FileExtractor/Extractors/SevenZipExtractor.cs
@@ -138,7 +138,7 @@ public class SevenZipExtractor : IExtractor
                 .WithStandardOutputPipe(PipeTarget.ToDelegate(line =>
                 {
                     if (string.IsNullOrWhiteSpace(line)) return;
-                    _logger.LogDebug("[7z.exe] {Line}", line);
+                    _logger.ExecutingSevenZip(line);
                     
                     if (line.Length <= 4 || line[3] != '%') return;
                     if (!int.TryParse(line.AsSpan()[..3], out var percentInt)) return;

--- a/src/ArchiveManagement/NexusMods.FileExtractor/Extractors/SevenZipExtractor.cs
+++ b/src/ArchiveManagement/NexusMods.FileExtractor/Extractors/SevenZipExtractor.cs
@@ -137,6 +137,9 @@ public class SevenZipExtractor : IExtractor
                     }, true)
                 .WithStandardOutputPipe(PipeTarget.ToDelegate(line =>
                 {
+                    if (string.IsNullOrWhiteSpace(line)) return;
+                    _logger.LogDebug("[7z.exe] {Line}", line);
+                    
                     if (line.Length <= 4 || line[3] != '%') return;
                     if (!int.TryParse(line.AsSpan()[..3], out var percentInt)) return;
 

--- a/src/ArchiveManagement/NexusMods.FileExtractor/HighPerformanceLogging.cs
+++ b/src/ArchiveManagement/NexusMods.FileExtractor/HighPerformanceLogging.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace NexusMods.FileExtractor;
+
+internal static partial class HighPerformanceLogging
+{
+    [LoggerMessage(
+        EventId = 0,
+        Level = LogLevel.Debug,
+        Message = "[7z.exe] {line}")]
+    public static partial void ExecutingSevenZip(
+        this ILogger logger,
+        string line);
+}


### PR DESCRIPTION
Also added some logging for 7z.exe extraction for CI debugging in case of errors.