### PR TITLE
Add PR Maintenance workflow

### DIFF
--- a/.github/workflows/pr-maintenance.yaml
+++ b/.github/workflows/pr-maintenance.yaml
@@ -1,0 +1,22 @@
+name: "PR Maintenance"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request_target:
+    branches: [ main ]
+    types: [ synchronize ]
+
+jobs:
+  check-dirty:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Check if PRs are dirty"
+        uses: eps1lon/actions-label-merge-conflict@releases/2.x
+        with:
+          dirtyLabel: "status-needs-rebase"
+          removeOnDirtyLabel: "status-ready"
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          commentOnDirty: "This PR conflicts with `main`. You need to rebase the PR before it can be merged."
+          commentOnClean: "This PR doesn't conflict with `main` anymore. It can be merged after all status checks have passed and it has been reviewed."


### PR DESCRIPTION
Adds a PR maintenance workflow using https://github.com/eps1lon/actions-label-merge-conflict to prevent PRs from going stale for too long.