### PR TITLE
Upgrade Avalonia to 11.0.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,14 +15,14 @@
 
     <ItemGroup>
         <!-- Avalonia -->
-        <PackageVersion Include="Avalonia" Version="11.0.0" />
-        <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.0.0" />
-        <PackageVersion Include="Avalonia.Desktop" Version="11.0.0" />
-        <PackageVersion Include="Avalonia.Diagnostics" Version="11.0.0" />
-        <PackageVersion Include="Avalonia.Headless" Version="11.0.0" />
-        <PackageVersion Include="Avalonia.ReactiveUI" Version="11.0.0" />
-        <PackageVersion Include="Avalonia.Svg.Skia" Version="11.0.0" />
-        <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.0.0" />
+        <PackageVersion Include="Avalonia" Version="11.0.1" />
+        <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.0.1" />
+        <PackageVersion Include="Avalonia.Desktop" Version="11.0.1" />
+        <PackageVersion Include="Avalonia.Diagnostics" Version="11.0.1" />
+        <PackageVersion Include="Avalonia.Headless" Version="11.0.1" />
+        <PackageVersion Include="Avalonia.ReactiveUI" Version="11.0.1" />
+        <PackageVersion Include="Avalonia.Svg.Skia" Version="11.0.1" />
+        <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.0.1" />
         <PackageVersion Include="Projektanker.Icons.Avalonia.MaterialDesign" Version="6.6.0-rc1.1" />
     </ItemGroup>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,9 +21,9 @@
         <PackageVersion Include="Avalonia.Diagnostics" Version="11.0.1" />
         <PackageVersion Include="Avalonia.Headless" Version="11.0.1" />
         <PackageVersion Include="Avalonia.ReactiveUI" Version="11.0.1" />
-        <PackageVersion Include="Avalonia.Svg.Skia" Version="11.0.1" />
         <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.0.1" />
         <PackageVersion Include="Projektanker.Icons.Avalonia.MaterialDesign" Version="6.6.0-rc1.1" />
+        <PackageVersion Include="Avalonia.Svg.Skia" Version="11.0.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This release only contains bug fixes: https://github.com/AvaloniaUI/Avalonia/releases/tag/11.0.1