### PR TITLE
Refactored content sending method and updated tests

### DIFF
--- a/.github/workflows/clean_environment_tests.yaml
+++ b/.github/workflows/clean_environment_tests.yaml
@@ -29,7 +29,7 @@ jobs:
 
   build-and-test:
     if: github.event_name == 'push' || github.event.pull_request.draft == false
-    uses: Nexus-Mods/NexusMods.App.Meta/.github/workflows/dotnet-build-and-test.yaml@2b734d6bd0ca3925cd009872e7cb00a7c2c72627
+    uses: Nexus-Mods/NexusMods.App.Meta/.github/workflows/dotnet-build-and-test.yaml@780d2001be902a9523de8331da2c77c687abbddb
     with:
       test-filter: "RequiresNetworking!=True"
       codecov-flags: ",clean_environment_tests"

--- a/src/Networking/NexusMods.Networking.HttpDownloader/AdvancedHttpDownloader.cs
+++ b/src/Networking/NexusMods.Networking.HttpDownloader/AdvancedHttpDownloader.cs
@@ -324,6 +324,7 @@ namespace NexusMods.Networking.HttpDownloader
                     if (retries >= MaxRetries)
                         throw;
                     retries += 1;
+                    request = request.Copy();
                     continue;
                 }
             }

--- a/src/NexusMods.CLI/Services.cs
+++ b/src/NexusMods.CLI/Services.cs
@@ -42,11 +42,6 @@ public static class Services
         services.AddSingleton<IOptionParser<ITool>, ToolParser>();
         services.AddSingleton<IOptionSelector, CliOptionSelector>();
 
-        var prefix = FileSystem.Shared
-            .GetKnownPath(KnownPath.CurrentDirectory)
-            .Combine($"NexusMods.App-{Guid.NewGuid().ToString("D", CultureInfo.InvariantCulture)}");
-        services.AddSingleton(new TemporaryFileManager(FileSystem.Shared, prefix));
-
         OSInformation.Shared.SwitchPlatform(
             ref services,
 #pragma warning disable CA1416

--- a/src/NexusMods.CLI/Services.cs
+++ b/src/NexusMods.CLI/Services.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.Extensions.DependencyInjection;
 using NexusMods.CLI.OptionParsers;
 using NexusMods.CLI.Verbs;
@@ -40,7 +41,11 @@ public static class Services
         services.AddSingleton<IOptionParser<Loadout>, LoadoutParser>();
         services.AddSingleton<IOptionParser<ITool>, ToolParser>();
         services.AddSingleton<IOptionSelector, CliOptionSelector>();
-        services.AddSingleton<TemporaryFileManager>();
+
+        var prefix = FileSystem.Shared
+            .GetKnownPath(KnownPath.TempDirectory)
+            .Combine($"NexusMods.App-{Guid.NewGuid().ToString("D", CultureInfo.InvariantCulture)}");
+        services.AddSingleton(new TemporaryFileManager(FileSystem.Shared, prefix));
 
         OSInformation.Shared.SwitchPlatform(
             ref services,

--- a/src/NexusMods.CLI/Services.cs
+++ b/src/NexusMods.CLI/Services.cs
@@ -43,7 +43,7 @@ public static class Services
         services.AddSingleton<IOptionSelector, CliOptionSelector>();
 
         var prefix = FileSystem.Shared
-            .GetKnownPath(KnownPath.TempDirectory)
+            .GetKnownPath(KnownPath.CurrentDirectory)
             .Combine($"NexusMods.App-{Guid.NewGuid().ToString("D", CultureInfo.InvariantCulture)}");
         services.AddSingleton(new TemporaryFileManager(FileSystem.Shared, prefix));
 

--- a/tests/Games/NexusMods.Games.TestFramework/DependencyInjectionHelper.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/DependencyInjectionHelper.cs
@@ -42,7 +42,7 @@ public static class DependencyInjectionHelper
     {
         var prefix = FileSystem.Shared
             .GetKnownPath(KnownPath.EntryDirectory)
-            .Combine($"NexusMods.App-{Guid.NewGuid().ToString("D", CultureInfo.InvariantCulture)}");
+            .Combine($"NexusMods.Games.TestFramework-{Guid.NewGuid()}");
 
         return serviceCollection
             .AddLogging(builder => builder.SetMinimumLevel(LogLevel.Debug))

--- a/tests/Games/NexusMods.Games.TestFramework/DependencyInjectionHelper.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/DependencyInjectionHelper.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -39,11 +40,15 @@ public static class DependencyInjectionHelper
     /// <returns></returns>
     public static IServiceCollection AddDefaultServicesForTesting(this IServiceCollection serviceCollection)
     {
+        var prefix = FileSystem.Shared
+            .GetKnownPath(KnownPath.TempDirectory)
+            .Combine($"NexusMods.App-{Guid.NewGuid().ToString("D", CultureInfo.InvariantCulture)}");
+
         return serviceCollection
             .AddLogging(builder => builder.SetMinimumLevel(LogLevel.Debug))
             .AddOSInformation()
             .AddFileSystem()
-            .AddSingleton<TemporaryFileManager>()
+            .AddSingleton<TemporaryFileManager>(_ => new TemporaryFileManager(FileSystem.Shared, prefix))
             .AddSingleton<HttpClient>()
             .AddSingleton<TestModDownloader>()
             .AddNexusWebApi()

--- a/tests/Games/NexusMods.Games.TestFramework/DependencyInjectionHelper.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/DependencyInjectionHelper.cs
@@ -41,7 +41,7 @@ public static class DependencyInjectionHelper
     public static IServiceCollection AddDefaultServicesForTesting(this IServiceCollection serviceCollection)
     {
         var prefix = FileSystem.Shared
-            .GetKnownPath(KnownPath.TempDirectory)
+            .GetKnownPath(KnownPath.EntryDirectory)
             .Combine($"NexusMods.App-{Guid.NewGuid().ToString("D", CultureInfo.InvariantCulture)}");
 
         return serviceCollection

--- a/tests/Games/NexusMods.Games.TestFramework/TestModDownloader.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/TestModDownloader.cs
@@ -18,9 +18,11 @@ public class TestModDownloader
     private readonly ILogger<TestModDownloader> _logger;
     private readonly IHttpDownloader _httpDownloader;
     private readonly Client _nexusClient;
+    private readonly TemporaryFileManager _manager;
 
-    public TestModDownloader(IHttpDownloader httpDownloader, ILogger<TestModDownloader> logger, Client nexusClient)
+    public TestModDownloader(IHttpDownloader httpDownloader, ILogger<TestModDownloader> logger, Client nexusClient, TemporaryFileManager manager)
     {
+        _manager = manager;
         _httpDownloader = httpDownloader;
         _logger = logger;
         _nexusClient = nexusClient;
@@ -49,10 +51,9 @@ public class TestModDownloader
     /// <returns>Downloaded item inside the provided FileSystem.</returns>
     public async Task<DownloadedItem> DownloadAsync(RemoteModMetadataBase meta, IFileSystem targetFs, CancellationToken token = default)
     {
-        var manager = new TemporaryFileManager(targetFs);
-        var tempFile = manager.CreateFile();
+        var tempFile = _manager.CreateFile();
         await DownloadAsync(meta, targetFs, tempFile.Path, token);
-        return new DownloadedItem(manager, tempFile, targetFs, meta);
+        return new DownloadedItem(_manager, tempFile, targetFs, meta);
     }
 
     /// <summary>

--- a/tests/Networking/NexusMods.Networking.HttpDownloader.Tests/AdvancedHttpDownloaderTests.cs
+++ b/tests/Networking/NexusMods.Networking.HttpDownloader.Tests/AdvancedHttpDownloaderTests.cs
@@ -121,6 +121,7 @@ public class AdvancedHttpDownloaderTests
             new HttpRequestMessage(HttpMethod.Get, _localHttpServer.Uri + "unreliable")
         }, path);
 
+        path.Path.FileInfo.Size.Value.Should().Be((ulong)_localHttpServer.LargeData.Length);
         resultHash.Should().Be(_localHttpServer.LargeDataHash);
     }
 }

--- a/tests/Networking/NexusMods.Networking.HttpDownloader.Tests/Startup.cs
+++ b/tests/Networking/NexusMods.Networking.HttpDownloader.Tests/Startup.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NexusMods.Common;
@@ -11,11 +12,15 @@ public class Startup
 {
     public void ConfigureServices(IServiceCollection container)
     {
+        var prefix = FileSystem.Shared
+            .GetKnownPath(KnownPath.EntryDirectory)
+            .Combine($"NexusMods.App-{Guid.NewGuid().ToString("D", CultureInfo.InvariantCulture)}");
+
         container.AddAdvancedHttpDownloader()
                  .AddSingleton<SimpleHttpDownloader>()
                  .AddSingleton<AdvancedHttpDownloader>()
                  .AddFileSystem()
-                 .AddSingleton<TemporaryFileManager>()
+                 .AddSingleton(new TemporaryFileManager(FileSystem.Shared, prefix))
                  .AddSingleton<HttpClient>()
                  .AddSingleton<LocalHttpServer>()
                  .Validate();

--- a/tests/Networking/NexusMods.Networking.HttpDownloader.Tests/Startup.cs
+++ b/tests/Networking/NexusMods.Networking.HttpDownloader.Tests/Startup.cs
@@ -14,7 +14,7 @@ public class Startup
     {
         var prefix = FileSystem.Shared
             .GetKnownPath(KnownPath.EntryDirectory)
-            .Combine($"NexusMods.App-{Guid.NewGuid().ToString("D", CultureInfo.InvariantCulture)}");
+            .Combine($"NexusMods.Networking.HttpDownloader.Tests-{Guid.NewGuid()}");
 
         container.AddAdvancedHttpDownloader()
                  .AddSingleton<SimpleHttpDownloader>()

--- a/tests/NexusMods.DataModel.Tests/Startup.cs
+++ b/tests/NexusMods.DataModel.Tests/Startup.cs
@@ -19,14 +19,14 @@ public class Startup
 {
     public void ConfigureServices(IServiceCollection container)
     {
-        var prefix = FileSystem.Shared.GetKnownPath(KnownPath.EntryDirectory)
-            .Combine(typeof(Startup).FullName ?? "NexusMods.DataModel.Tests")
-            .Combine(Guid.NewGuid().ToString());
+        var prefix = FileSystem.Shared
+            .GetKnownPath(KnownPath.EntryDirectory)
+            .Combine($"NexusMods.DataModel.Tests-{Guid.NewGuid()}");
 
         container
             .AddLogging(builder => builder.SetMinimumLevel(LogLevel.Debug))
             .AddFileSystem()
-            .AddSingleton(new TemporaryFileManager(FileSystem.Shared, prefix.Combine("Temp")))
+            .AddSingleton(new TemporaryFileManager(FileSystem.Shared, prefix))
             .AddDataModel(new DataModelSettings(prefix))
             .AddStandardGameLocators(false)
             .AddFileExtractors()

--- a/tests/NexusMods.DataModel.Tests/Startup.cs
+++ b/tests/NexusMods.DataModel.Tests/Startup.cs
@@ -19,14 +19,14 @@ public class Startup
 {
     public void ConfigureServices(IServiceCollection container)
     {
-        var prefix = FileSystem.Shared.GetKnownPath(KnownPath.TempDirectory)
+        var prefix = FileSystem.Shared.GetKnownPath(KnownPath.EntryDirectory)
             .Combine(typeof(Startup).FullName ?? "NexusMods.DataModel.Tests")
             .Combine(Guid.NewGuid().ToString());
 
         container
             .AddLogging(builder => builder.SetMinimumLevel(LogLevel.Debug))
             .AddFileSystem()
-            .AddSingleton<TemporaryFileManager>()
+            .AddSingleton(new TemporaryFileManager(FileSystem.Shared, prefix.Combine("Temp")))
             .AddDataModel(new DataModelSettings(prefix))
             .AddStandardGameLocators(false)
             .AddFileExtractors()


### PR DESCRIPTION
The content sending logic has been refactored into a separate method called "SendContent" for better maintainability. This simplifies the HTTP response handling section in the "LocalHttpServer.cs" file, as the responsibility to position the stream, create a buffer, and write to the response output stream has been moved to this new helper method. The range of data to be sent is now calculated within this method itself.  Also, included Debug.Assert statement in "AdvancedHttpDownloader.cs" for debugging purpose.