### PR TITLE
Fix mod Enabling / Disabling functionality

### DIFF
--- a/src/NexusMods.App.UI/RightContent/LoadoutGrid/Columns/ModEnabled/ModEnabledViewModel.cs
+++ b/src/NexusMods.App.UI/RightContent/LoadoutGrid/Columns/ModEnabled/ModEnabledViewModel.cs
@@ -59,7 +59,7 @@ public class ModEnabledViewModel : AViewModel<IModEnabledViewModel>, IModEnabled
                 $"Setting {mod.Name} from {oldState} to {newState}",
                 mod =>
                 {
-                    if (mod?.Enabled == Enabled) return mod;
+                    if (mod?.Enabled == enabled) return mod;
                     return mod! with { Enabled = enabled };
                 });
             return Unit.Default;

--- a/src/NexusMods.DataModel/Loadouts/LoadoutSyncronizer.cs
+++ b/src/NexusMods.DataModel/Loadouts/LoadoutSyncronizer.cs
@@ -69,7 +69,7 @@ public class LoadoutSynchronizer
 
         foreach (var mod in sorted)
         {
-            if (! mod.Enabled)
+            if (!mod.Enabled)
                 continue;
             
             foreach (var (_, file) in mod.Files)

--- a/src/NexusMods.DataModel/Loadouts/LoadoutSyncronizer.cs
+++ b/src/NexusMods.DataModel/Loadouts/LoadoutSyncronizer.cs
@@ -69,6 +69,9 @@ public class LoadoutSynchronizer
 
         foreach (var mod in sorted)
         {
+            if (! mod.Enabled)
+                continue;
+            
             foreach (var (_, file) in mod.Files)
             {
                 if (file is not IToFile toFile)

--- a/tests/NexusMods.DataModel.Tests/LoadoutSynchronizerTests/IngestChangesTest.cs
+++ b/tests/NexusMods.DataModel.Tests/LoadoutSynchronizerTests/IngestChangesTest.cs
@@ -44,7 +44,7 @@ public class IngestChangesTest : ALoadoutSynrchonizerTest<IngestChangesTest>
     public async Task RemovedFilesAreRemoved()
     {
         var loadout = await CreateApplyPlanTestLoadout();
-        var firstMod = loadout.Mods.Values.First();
+        var firstMod = loadout.Mods.Values.First(mod => mod.Enabled == true);
 
         var absPath = GetFirstModFile(loadout);
 
@@ -58,9 +58,10 @@ public class IngestChangesTest : ALoadoutSynrchonizerTest<IngestChangesTest>
             })
         });
 
-        loadout.Mods.Count.Should().Be(2);
+        loadout.Mods.Count.Should().Be(3);
 
         (from mod in loadout.Mods.Values
+            where mod.Enabled == true
             from file in mod.Files.Values
             select file).Count().Should().Be(2);
 
@@ -78,9 +79,10 @@ public class IngestChangesTest : ALoadoutSynrchonizerTest<IngestChangesTest>
             }
         });
 
-        loadout.Mods.Count.Should().Be(2);
+        loadout.Mods.Count.Should().Be(3);
 
         (from mod in loadout.Mods.Values
+            where mod.Enabled == true
             from file in mod.Files.Values
             select file).Count().Should().Be(0);
     }

--- a/tests/NexusMods.DataModel.Tests/LoadoutSynchronizerTests/MakeApplyPlanTests.cs
+++ b/tests/NexusMods.DataModel.Tests/LoadoutSynchronizerTests/MakeApplyPlanTests.cs
@@ -117,7 +117,7 @@ public class MakeApplyPlanTests : ALoadoutSynrchonizerTest<MakeApplyPlanTests>
     {
         var loadout = await CreateApplyPlanTestLoadout();
 
-        var fileOne = loadout.Mods.Values.First().Files.Values.OfType<IFromArchive>()
+        var fileOne = loadout.Mods.Values.First(mod => mod.Enabled == true).Files.Values.OfType<IFromArchive>()
             .First(f => f.Hash == Hash.From(0x00001));
 
         var absPath = loadout.Installation.Locations[GameFolderType.Game].Combine("0x00001.dat");
@@ -125,6 +125,8 @@ public class MakeApplyPlanTests : ALoadoutSynrchonizerTest<MakeApplyPlanTests>
             Size.From(0x33)));
 
         var plan = await TestSyncronizer.MakeApplySteps(loadout);
+        
+        
 
         plan.Steps.Should().ContainEquivalentOf(new DeleteFile
         {

--- a/tests/NexusMods.DataModel.Tests/LoadoutSynchronizerTests/MakeIngestPlanTests.cs
+++ b/tests/NexusMods.DataModel.Tests/LoadoutSynchronizerTests/MakeIngestPlanTests.cs
@@ -90,6 +90,7 @@ public class MakeIngestPlanTests : ALoadoutSynrchonizerTest<MakeIngestPlanTests>
         var absPath = loadout.Installation.Locations[GameFolderType.Game].Combine("0x00001.dat");
 
         var fileOne = (from mod in loadout.Mods
+            where mod.Value.Enabled == true
             from file in mod.Value.Files
             where file.Value is IFromArchive
             select (mod.Key, file.Key, file.Value)).First();


### PR DESCRIPTION
Fixes #427 

There were two separate issues: 
- The UI wasn't actually updating the sate of the mod as intended.
- The LoadoutSynchronizer wasn't excluding disabled mods during Apply step computations.