### PR TITLE
Add release pipeline

### DIFF
--- a/.github/workflows/build-linux-pupnet.yaml
+++ b/.github/workflows/build-linux-pupnet.yaml
@@ -1,0 +1,109 @@
+name: Build Linux (PupNet)
+
+on:
+  workflow_call:
+    inputs:
+      AppVersion:
+        type: string
+        required: false
+        description: "The version of the application to build"
+        default: "1.0.0"
+      PupNetVersion:
+        type: string
+        required: false
+        description: "The PupNet version to use"
+        default: "1.6.0"
+      ProjectFile:
+        type: string
+        required: true
+        description: "The relative path to the project to build"
+      RetentionDays:
+        type: number
+        required: false
+        default: 1
+        description: "The amount of days for the artifact to persist"
+      BuildAppImage:
+        type: boolean
+        description: "Build an AppImage?"
+        required: false
+        default: true
+      BuildArchive:
+        type: boolean
+        description: "Build an Archive?"
+        required: false
+        default: true
+    outputs:
+      ArtifactNameLinuxArchive:
+        description: "Name of the Artifact that contains the Linux Archive"
+        value: ${{ jobs.build.outputs.artifactNameLinuxArchive }}
+      ArtifactNameLinuxAppImage:
+        description: "Name of the Artifact that contains the Linux AppImage"
+        value: ${{ jobs.build.outputs.artifactNameLinuxAppImage }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      artifactNameLinuxArchive: ${{ steps.setOutputs.outputs.artifactNameLinuxArchive }}
+      artifactNameLinuxAppImage: ${{ steps.setOutputs.outputs.artifactNameLinuxAppImage }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: "recursive"
+
+      - name: Transform inputs
+        id: transformInputs
+        shell: pwsh
+        env:
+          ProjectFile: ${{ inputs.ProjectFile }}
+        run: |
+          $projectDir = [System.IO.Path]::GetDirectoryName("$env:ProjectFile")
+          $projectName = [System.IO.Path]::GetFileNameWithoutExtension("$env:ProjectFile")
+          echo "projectDir=$projectDir" >> $env:GITHUB_OUTPUT
+          echo "projectName=$projectName" >> $env:GITHUB_OUTPUT
+
+      - name: Print debug info
+        run: dotnet --info
+
+      # https://github.com/AppImage/AppImageKit/wiki/FUSE#install-fuse
+      - name: Install FUSE
+        run: sudo add-apt-repository universe && sudo apt install libfuse2
+
+      - name: Get PupNet
+        run: dotnet tool install -g KuiperZone.PupNet --version ${{ inputs.PupNetVersion }}
+
+      - name: Create Archive
+        if: ${{ inputs.BuildArchive }}
+        working-directory: ${{ steps.transformInputs.outputs.projectDir }}
+        run: pupnet -y -v ${{ inputs.AppVersion }} -k zip -p DefineConstants=INSTALLATION_METHOD_ARCHIVE
+
+      - name: Create AppImage
+        if: ${{ inputs.BuildAppImage }}
+        working-directory: ${{ steps.transformInputs.outputs.projectDir }}
+        run: pupnet -y -v ${{ inputs.AppVersion }} -k AppImage -p DefineConstants=INSTALLATION_METHOD_APPIMAGE
+
+      - name: Set outputs
+        id: setOutputs
+        shell: pwsh
+        run: |
+          echo "artifactNameLinuxArchive=${{ steps.transformInputs.outputs.projectName }}-${{ github.sha }}-Linux-Archive" >> $env:GITHUB_OUTPUT
+          echo "artifactNameLinuxAppImage=${{ steps.transformInputs.outputs.projectName }}-${{ github.sha }}-Linux-AppImage" >> $env:GITHUB_OUTPUT
+
+      - name: Upload Archive
+        if: ${{ inputs.BuildArchive }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.setOutputs.outputs.artifactNameLinuxArchive }}
+          path: ${{ steps.transformInputs.outputs.projectDir }}/Deploy/OUT/*.zip
+          if-no-files-found: error
+          retention-days: ${{ inputs.RetentionDays }}
+
+      - name: Upload AppImage
+        if: ${{ inputs.BuildAppImage }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.setOutputs.outputs.artifactNameLinuxAppImage }}
+          path: ${{ steps.transformInputs.outputs.projectDir }}/Deploy/OUT/*.AppImage
+          if-no-files-found: error
+          retention-days: ${{ inputs.RetentionDays }}

--- a/.github/workflows/build-windows-pupnet.yaml
+++ b/.github/workflows/build-windows-pupnet.yaml
@@ -1,0 +1,105 @@
+name: Build Windows (PupNet)
+
+on:
+  workflow_call:
+    inputs:
+      AppVersion:
+        type: string
+        required: false
+        description: "The version of the application to build"
+        default: "1.0.0"
+      PupNetVersion:
+        type: string
+        required: false
+        description: "The PupNet version to use"
+        default: "1.6.0"
+      ProjectFile:
+        type: string
+        required: true
+        description: "The relative path to the project to build"
+      RetentionDays:
+        type: number
+        required: false
+        default: 1
+        description: "The amount of days for the artifact to persist"
+      BuildInnoSetup:
+        type: boolean
+        description: "Build an Inno Setup?"
+        required: false
+        default: true
+      BuildArchive:
+        type: boolean
+        description: "Build an Archive?"
+        required: false
+        default: true
+    outputs:
+      ArtifactNameWindowsArchive:
+        description: "Name of the Artifact that contains the Windows Archive"
+        value: ${{ jobs.build.outputs.artifactNameWindowsArchive }}
+      ArtifactNameWindowsInnoSetup:
+        description: "Name of the Artifact that contains the Windows Inno Setup"
+        value: ${{ jobs.build.outputs.artifactNameWindowsInnoSetup }}
+
+jobs:
+  build:
+    runs-on: windows-latest
+    outputs:
+      artifactNameWindowsArchive: ${{ steps.setOutputs.outputs.artifactNameWindowsArchive }}
+      artifactNameWindowsInnoSetup: ${{ steps.setOutputs.outputs.artifactNameWindowsInnoSetup }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: "recursive"
+
+      - name: Transform inputs
+        id: transformInputs
+        shell: pwsh
+        env:
+          ProjectFile: ${{ inputs.ProjectFile }}
+        run: |
+          $projectDir = [System.IO.Path]::GetDirectoryName("$env:ProjectFile")
+          $projectName = [System.IO.Path]::GetFileNameWithoutExtension("$env:ProjectFile")
+          echo "projectDir=$projectDir" >> $env:GITHUB_OUTPUT
+          echo "projectName=$projectName" >> $env:GITHUB_OUTPUT
+
+      - name: Print debug info
+        run: dotnet --info
+
+      - name: Get PupNet
+        run: dotnet tool install -g KuiperZone.PupNet --version ${{ inputs.PupNetVersion }}
+
+      - name: Create Archive
+        if: ${{ inputs.BuildArchive }}
+        working-directory: ${{ steps.transformInputs.outputs.projectDir }}
+        run: pupnet -y -v ${{ inputs.AppVersion }} -k zip -p DefineConstants=INSTALLATION_METHOD_ARCHIVE
+
+      - name: Create Setup
+        if: ${{ inputs.BuildInnoSetup }}
+        working-directory: ${{ steps.transformInputs.outputs.projectDir }}
+        run: pupnet -y -v ${{ inputs.AppVersion }} -k Setup -p DefineConstants=INSTALLATION_METHOD_INNO_SETUP
+
+      - name: Set outputs
+        id: setOutputs
+        shell: pwsh
+        run: |
+          echo "artifactNameWindowsArchive=${{ steps.transformInputs.outputs.projectName }}-${{ github.sha }}-Windows-Archive" >> $env:GITHUB_OUTPUT
+          echo "artifactNameWindowsInnoSetup=${{ steps.transformInputs.outputs.projectName }}-${{ github.sha }}-Windows-Setup" >> $env:GITHUB_OUTPUT
+
+      - name: Upload Archive
+        if: ${{ inputs.BuildArchive }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.setOutputs.outputs.artifactNameWindowsArchive }}
+          path: ${{ steps.transformInputs.outputs.projectDir }}/Deploy/OUT/*.zip
+          if-no-files-found: error
+          retention-days: ${{ inputs.RetentionDays }}
+
+      - name: Upload Setup
+        if: ${{ inputs.BuildInnoSetup }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.setOutputs.outputs.artifactNameWindowsInnoSetup }}
+          path: ${{ steps.transformInputs.outputs.projectDir }}/Deploy/OUT/*.exe
+          if-no-files-found: error
+          retention-days: ${{ inputs.RetentionDays }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,162 @@
+name: Release
+run-name: Release ${{ inputs.version }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "The version to release (eg: 'v1.0.0')"
+        required: true
+        type: string
+      draft:
+        description: "Create a draft release?"
+        required: false
+        type: boolean
+        default: true
+      prerelease:
+        description: "Create a prerelease?"
+        required: false
+        type: boolean
+        default: true
+      release-nexus-mods:
+        description: "Release on Nexus Mods?"
+        required: false
+        type: boolean
+        default: false
+      notify-discord:
+        description: "Notify on Discord?"
+        required: false
+        type: boolean
+        default: false
+      notify-slack:
+        description: "Notify on Slack?"
+        required: false
+        type: boolean
+        default: false
+
+env:
+  ProjectFile: "src/NexusMods.App/NexusMods.App.csproj"
+
+jobs:
+  transformInputs:
+    runs-on: ubuntu-latest
+    outputs:
+      TagVersion: ${{ steps.setOutputs.outputs.tagVersion }}
+      RawVersion: ${{ steps.setOutputs.outputs.rawVersion }}
+      ProjectFile: ${{ steps.setOutputs.outputs.projectFile }}
+
+    steps:
+      - name: Set Outputs
+        id: setOutputs
+        shell: pwsh
+        env:
+          InputVersion: ${{ inputs.version }}
+        run: |
+          $tagVersion = $env:InputVersion.StartsWith('v') ? $env:InputVersion : "v" + $env:InputVersion
+          $rawVersion = $env:InputVersion.StartsWith('v') ? $env:InputVersion.Substring(1) : $env:InputVersion
+          $validation = [System.Version]::Parse($rawVersion)
+          echo "tagVersion=$tagVersion" >> $env:GITHUB_OUTPUT
+          echo "rawVersion=$rawVersion" >> $env:GITHUB_OUTPUT
+          echo "projectFile=${{ env.ProjectFile }}" >> $env:GITHUB_OUTPUT
+
+  build-linux:
+    needs: [ transformInputs ]
+    uses: ./.github/workflows/build-linux-pupnet.yaml
+    with:
+      AppVersion: ${{ needs.transformInputs.outputs.RawVersion }}
+      # this is a bit of a hack, you can't use environment variables here
+      # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
+      ProjectFile: ${{ needs.transformInputs.outputs.ProjectFile }}
+      RetentionDays: 1
+
+  build-windows:
+    needs: [ transformInputs ]
+    uses: ./.github/workflows/build-windows-pupnet.yaml
+    with:
+      AppVersion: ${{ needs.transformInputs.outputs.RawVersion }}
+      # this is a bit of a hack, you can't use environment variables here
+      # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
+      ProjectFile: ${{ needs.transformInputs.outputs.ProjectFile }}
+      RetentionDays: 1
+
+  release-github:
+    runs-on: ubuntu-latest
+    needs: [ transformInputs, build-linux, build-windows ]
+    outputs:
+      GitHubReleaseUrl: ${{ steps.create-gh-release.outputs.url }}
+
+    permissions:
+      contents: write
+      discussions: write
+
+    steps:
+      - name: Get Linux Archive
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.build-linux.outputs.ArtifactNameLinuxArchive }}
+          path: bin/LinuxArchive
+
+      - name: Get Linux AppImage
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.build-linux.outputs.ArtifactNameLinuxAppImage }}
+          path: bin/LinuxAppImage
+
+      - name: Get Windows Archive
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.build-windows.outputs.ArtifactNameWindowsArchive }}
+          path: bin/WindowsArchive
+
+      - name: Get Windows Inno Setup
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.build-windows.outputs.ArtifactNameWindowsInnoSetup }}
+          path: bin/WindowsInnoSetup
+
+      - name: List Artifacts
+        shell: bash
+        run: tree bin
+
+      - name: Create Release
+        id: create-gh-release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: ${{ needs.transformInputs.outputs.RawVersion }}
+          tag_name: ${{ needs.transformInputs.outputs.TagVersion }}
+          draft: ${{ inputs.draft }}
+          prerelease: ${{ inputs.prerelease }}
+          files: bin/**/*
+          fail_on_unmatched_files: true
+
+  release-nexus-mods:
+    runs-on: ubuntu-latest
+    needs: [ transformInputs, build-linux, build-windows ]
+
+    steps:
+      - name: Empty
+        if: inputs.release-nexus-mods == true
+        run: exit 0
+
+  notify-discord:
+    runs-on: ubuntu-latest
+    needs: [ release-github, release-nexus-mods ]
+
+    steps:
+      - name: Send Discord notification
+        if: inputs.notify-discord == true
+        uses: appleboy/discord-action@0.0.3
+        with:
+          webhook_id: ${{ secrets.DISCORD_WEBHOOK_ID }}
+          webhook_token: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}
+          message: "New release is available at ${{ needs.release-github.outputs.GitHubReleaseUrl }}"
+          username: "Release Bot"
+
+  notify-slack:
+    runs-on: ubuntu-latest
+    needs: [ release-github, release-nexus-mods ]
+
+    steps:
+      - name: Empty
+        if: inputs.notify-slack == true
+        run: exit 0

--- a/src/NexusMods.App/app.desktop
+++ b/src/NexusMods.App/app.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Type=Application
+Name=${APP_FRIENDLY_NAME}
+Icon=${APP_ID}
+Comment=${APP_SHORT_SUMMARY}
+Exec=${INSTALL_EXEC}
+TryExec=${INSTALL_EXEC}
+NoDisplay=${DESKTOP_NODISPLAY}
+X-AppImage-Integrate=${DESKTOP_INTEGRATE}
+Terminal=${DESKTOP_TERMINAL}
+Categories=${PRIME_CATEGORY}
+MimeType=
+Keywords=

--- a/src/NexusMods.App/app.metainfo.xml
+++ b/src/NexusMods.App/app.metainfo.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+    <!-- See https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#spec-component-filespec -->
+
+    <!-- This license is not the project license but the license for this singular file. -->
+    <metadata_license>MIT</metadata_license>
+
+    <!-- Note the use of macros to automate most (but not all) content below -->
+    <id>${APP_ID}</id>
+    <name>${APP_FRIENDLY_NAME}</name>
+    <summary>${APP_SHORT_SUMMARY}</summary>
+    <developer_name>${PUBLISHER_NAME}</developer_name>
+    <url type="homepage">${PUBLISHER_LINK_URL}</url>
+    <project_license>${APP_LICENSE_ID}</project_license>
+    <content_rating type="oars-1.1" />
+
+    <launchable type="desktop-id">${APP_ID}.desktop</launchable>
+
+    <description>
+        ${APPSTREAM_DESCRIPTION_XML}
+    </description>
+
+    <!-- Freedesktop Categories -->
+    <categories>
+        <category>${PRIME_CATEGORY}</category>
+    </categories>
+
+    <!-- Uncomment to provide keywords
+    <keywords>
+        <keyword translate="no">IDE</keyword>
+        <keyword>development</keyword>
+        <keyword>programming</keyword>
+        <keyword xml:lang="de">entwicklung</keyword>
+        <keyword xml:lang="de">programmierung</keyword>
+    </keywords>
+    -->
+
+    <!-- Uncomment to provide screenshots
+    <screenshots>
+        <screenshot type="default">
+            <image>https://i.postimg.cc/0jc8xxxC/Hello-Computer.png</image>
+        </screenshot>
+    </screenshots>
+    -->
+
+    <releases>
+        <!-- See AppChangeFile in configuration -->
+        ${APPSTREAM_CHANGELOG_XML}
+    </releases>
+
+</component>

--- a/src/NexusMods.App/app.pupnet.conf
+++ b/src/NexusMods.App/app.pupnet.conf
@@ -1,0 +1,86 @@
+# PUPNET DEPLOY: 1.6.0
+
+# APP PREAMBLE
+AppBaseName = NexusMods.App
+AppFriendlyName = Nexus Mods App
+AppId = com.nexusmods.app
+AppVersionRelease = 1.0.0[1]
+AppShortSummary = The Nexus Mods App.
+AppDescription = """"""
+AppLicenseId =  GPL-3.0-only
+AppLicenseFile =
+AppChangeFile =
+
+# PUBLISHER
+PublisherName = Nexus Mods
+PublisherCopyright = Copyright (C) Nexus Mods 2023
+PublisherLinkName = Home Page
+PublisherLinkUrl = https://nexusmods.com
+PublisherEmail =
+
+# DESKTOP INTEGRATION
+DesktopNoDisplay = false
+DesktopTerminal = false
+DesktopFile = app.desktop
+StartCommand =
+PrimeCategory =
+MetaFile = app.metainfo.xml
+IconFiles =
+
+# DOTNET PUBLISH
+DotnetProjectPath =
+DotnetPublishArgs = -p:Version=${APP_VERSION} --self-contained true -c Release -p:TieredCompilation=true -p:PublishReadyToRun=true -p:PublishSingleFile=true
+DotnetPostPublish =
+DotnetPostPublishOnWindows =
+
+# PACKAGE OUTPUT
+PackageName = NexusMods.App
+OutputDirectory = Deploy/OUT
+
+# APPIMAGE OPTIONS
+AppImageArgs =
+AppImageVersionOutput = false
+
+# FLATPAK OPTIONS
+FlatpakPlatformRuntime = org.freedesktop.Platform
+FlatpakPlatformSdk = org.freedesktop.Sdk
+FlatpakPlatformVersion = 22.08
+FlatpakFinishArgs = """
+    --socket=wayland
+    --socket=x11
+    --filesystem=host
+    --share=network
+"""
+FlatpakBuilderArgs =
+
+# RPM OPTIONS
+RpmAutoReq = false
+RpmAutoProv = true
+RpmRequires = """
+    krb5-libs
+    libicu
+    openssl-libs
+    zlib
+"""
+
+# DEBIAN OPTIONS
+DebianRecommends = """
+    libc6
+    libgcc1
+    libgcc-s1
+    libgssapi-krb5-2
+    libicu
+    libssl
+    libstdc++6
+    libunwind
+    zlib1g
+"""
+
+# WINDOWS SETUP OPTIONS
+SetupAdminInstall = false
+SetupCommandPrompt =
+SetupMinWindowsVersion = 10
+# TODO: signing
+SetupSignTool =
+SetupSuffixOutput =
+SetupVersionOutput = false

--- a/src/NexusMods.Common/CompileConstants.cs
+++ b/src/NexusMods.Common/CompileConstants.cs
@@ -1,0 +1,58 @@
+using JetBrains.Annotations;
+
+namespace NexusMods.Common;
+
+/// <summary>
+/// Constants supplied during compile time.
+/// </summary>
+[PublicAPI]
+public static class CompileConstants
+{
+    /// <summary>
+    /// The method used to install the app. This is set at compile time.
+    /// </summary>
+    public static readonly InstallationMethod InstallationMethod =
+#if INSTALLATION_METHOD_ARCHIVE
+        InstallationMethod.Archive;
+#elif INSTALLATION_METHOD_APPIMAGE
+        InstallationMethod.AppImage;
+#elif INSTALLATION_METHOD_FLATPAK
+        InstallationMethod.Flatpak;
+#elif INSTALLATION_METHOD_INNO_SETUP
+        InstallationMethod.InnoSetup;
+#else
+        InstallationMethod.Manually;
+#endif
+}
+
+/// <summary>
+/// Method used to install the app.
+/// </summary>
+[PublicAPI]
+public enum InstallationMethod
+{
+    /// <summary>
+    /// Manual.
+    /// </summary>
+    Manually = 0,
+
+    /// <summary>
+    /// Via the archive.
+    /// </summary>
+    Archive,
+
+    /// <summary>
+    /// Via the AppImage.
+    /// </summary>
+    AppImage,
+
+    /// <summary>
+    /// Via the Flatpak.
+    /// </summary>
+    Flatpak,
+
+    /// <summary>
+    /// Via the Inno Setup.
+    /// </summary>
+    InnoSetup
+}


### PR DESCRIPTION
Resolves #376 
Resolves #454 
Resolves #444

**Features**:

- Release on GitHub:
  - "normal" release
  - prerelease
  - draft release (essentially a private release)
- Notify on Discord (requires `DISCORD_WEBHOOK_ID` and `DISCORD_WEBHOOK_TOKEN` secrets)
- Windows:
  - Archive
  - Inno Setup
- Linux:
  - Archive
  - AppImage

**Missing**:

- Signing (#455) waiting on https://github.com/kuiperzone/PupNet-Deploy/issues/25
- Assets (icons, logos)
- Slack notifications
- Release on Nexus Mods
