### PR TITLE
Fix how we handle generated file metadata during applying. 

### DIFF
--- a/src/NexusMods.DataModel/Loadouts/LoadoutSyncronizer.cs
+++ b/src/NexusMods.DataModel/Loadouts/LoadoutSyncronizer.cs
@@ -167,11 +167,23 @@ public class LoadoutSynchronizer
 
             if (flattenedLoadout.TryGetValue(gamePath, out var planned))
             {
-                var planMetadata = await GetMetaData(planned.File, existing.Path);
-                if (planMetadata is null || planMetadata.Hash != existing.Hash || planMetadata.Size != existing.Size)
+                switch (planned.File)
                 {
-                    await EmitReplacePlan(plan, existing, tmpPlan, planned);
+                    case IFromArchive fa when fa.Hash == existing.Hash && fa.Size == existing.Size:
+                        continue;
+                    case IGeneratedFile generatedFile:
+                    {
+                        var fingerprint = generatedFile.TriggerFilter.GetFingerprint(planned, tmpPlan);
+                        if (_generatedFileFingerprintCache.TryGet(fingerprint, out var cached) && cached.Hash == existing.Hash && cached.Size == existing.Size)
+                        {
+                            continue;
+                        }
+
+                        break;
+                    }
                 }
+
+                await EmitReplacePlan(plan, existing, tmpPlan, planned);
             }
             else
             {


### PR DESCRIPTION
Fixes #411 - in a somewhat temporary way. Fixes how we get metadata for generated files. This fixes how generated files work during applying but not during ingesting. Ingesting generated files is part of a future task