### PR TITLE
Publish Job updates via the IPC

### DIFF
--- a/src/NexusMods.DataModel/Interprocess/SqliteIPC.cs
+++ b/src/NexusMods.DataModel/Interprocess/SqliteIPC.cs
@@ -259,10 +259,14 @@ public class SqliteIPC : IDisposable, IInterprocessJobManager
                     var item = editable.Lookup(jobId);
                     if (item.HasValue)
                     {
-                        if (item.Value.Progress != progress)
-                            item.Value.Progress = progress;
+                        var prev = item.Value;
+
+                        if (prev.Progress == progress) continue;
+                        prev.Progress = progress;
 
                         _logger.JobProgress(jobId, progress);
+                        editable.AddOrUpdate(prev);
+
                         continue;
                     }
 

--- a/tests/NexusMods.DataModel.Tests/InterprocessTests.cs
+++ b/tests/NexusMods.DataModel.Tests/InterprocessTests.cs
@@ -189,9 +189,8 @@ public class InterprocessTests : IDisposable
         Thread.Sleep(timeout);
 
         // The IPC should have picked up every addition, update and removal
-        totalAdds.Should().Be(numThreads);
-        totalRemoves.Should().Be(totalAdds);
-        totalUpdates.Should().Be(totalAdds * 10);
+        var combined = (totalAdds, totalUpdates, totalRemoves);
+        combined.Should().Be((numThreads, numThreads * 10, numThreads));
     }
 
     [Fact]

--- a/tests/NexusMods.DataModel.Tests/InterprocessTests.cs
+++ b/tests/NexusMods.DataModel.Tests/InterprocessTests.cs
@@ -91,7 +91,7 @@ public class InterprocessTests : IDisposable
         var magic = Random.Shared.Next();
         var updates = new List<(int Adds, int Updates, int Removes)>();
 
-        // SqliteIPC pools every 100ms
+        // SqliteIPC polls every 100ms
         var timeout = TimeSpan.FromMilliseconds(300);
 
         _jobManager.Jobs


### PR DESCRIPTION
Related to #372.

Job updates via the IPC were never published. We only added new jobs or removed completed ones. This PR allows job updates to be observed. I've added some tests for a single-thread and multi-thread scenario. These tests have a high enough timeout for the IPC reader loop to pick up the changes and notify the subscribers.