### PR TITLE
Sqlite IPC Rework

### DIFF
--- a/src/NexusMods.CLI/Types/IpcHandlers/NxmIpcProtocolHandler.cs
+++ b/src/NexusMods.CLI/Types/IpcHandlers/NxmIpcProtocolHandler.cs
@@ -13,7 +13,7 @@ public class NxmIpcProtocolHandler : IIpcProtocolHandler
     /// <inheritdoc/>
     public string Protocol => "nxm";
 
-    private IMessageProducer<NXMUrlMessage> _messages;
+    private readonly IMessageProducer<NXMUrlMessage> _messages;
 
     /// <summary>
     /// constructor
@@ -27,6 +27,7 @@ public class NxmIpcProtocolHandler : IIpcProtocolHandler
     public async Task Handle(string url, CancellationToken cancel)
     {
         await _messages.Write(new NXMUrlMessage { Value = NXMUrl.Parse(url) }, cancel);
+        _messages.EnsureWrite(cancel);
     }
 }
 

--- a/src/NexusMods.DataModel/Interprocess/IMessageProducer.cs
+++ b/src/NexusMods.DataModel/Interprocess/IMessageProducer.cs
@@ -4,7 +4,7 @@ namespace NexusMods.DataModel.Interprocess;
 /// A message producer for sending messages to other processes.
 /// </summary>
 /// <typeparam name="T">Message type to send, each message type gets its own queue</typeparam>
-public interface IMessageProducer<T> where T : IMessage
+public interface IMessageProducer<in T> where T : IMessage
 {
     /// <summary>
     /// Sends a message to the queue.
@@ -12,4 +12,11 @@ public interface IMessageProducer<T> where T : IMessage
     /// <param name="message">The message to write.</param>
     /// <param name="token">Can be used to cancel this operation.</param>
     public ValueTask Write(T message, CancellationToken token);
+
+    /// <summary>
+    /// Ensures all messages in-flight have been saved to the database.
+    /// This is done using an <see cref="EventWaitHandle"/> and this call
+    /// will block the entire thread.
+    /// </summary>
+    public void EnsureWrite(CancellationToken cancellationToken);
 }

--- a/src/NexusMods.DataModel/Interprocess/SemaphoreSlimWaiter.cs
+++ b/src/NexusMods.DataModel/Interprocess/SemaphoreSlimWaiter.cs
@@ -1,0 +1,32 @@
+namespace NexusMods.DataModel.Interprocess;
+
+internal readonly struct SemaphoreSlimWaiter : IDisposable
+{
+    private readonly SemaphoreSlim _semaphoreSlim;
+
+    public bool HasEntered { get; }
+
+    internal SemaphoreSlimWaiter(SemaphoreSlim semaphoreSlim, bool entered)
+    {
+        _semaphoreSlim = semaphoreSlim;
+        HasEntered = entered;
+    }
+
+    public void Dispose()
+    {
+        if (!HasEntered) return;
+        _semaphoreSlim.Release();
+    }
+}
+
+internal static class SemaphoreExtensions
+{
+    public static SemaphoreSlimWaiter CustomWait(
+        this SemaphoreSlim semaphoreSlim,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+    {
+        var entered = semaphoreSlim.Wait(timeout, cancellationToken);
+        return new SemaphoreSlimWaiter(semaphoreSlim, entered);
+    }
+}

--- a/src/NexusMods.DataModel/Interprocess/SqliteIPC.cs
+++ b/src/NexusMods.DataModel/Interprocess/SqliteIPC.cs
@@ -228,7 +228,7 @@ public class SqliteIPC : IDisposable, IInterprocessJobManager
         }
 
         using var cmd = conn.Value.CreateCommand();
-        cmd.CommandText = "CREATE TABLE IF NOT EXISTS Ipc (Id INTEGER PRIMARY KEY AUTOINCREMENT, Queue TEXT, Data BLOB, TimeStamp INTEGER)";
+        cmd.CommandText = "CREATE TABLE IF NOT EXISTS Ipc (Id INTEGER PRIMARY KEY ASC AUTOINCREMENT, Queue TEXT, Data BLOB, TimeStamp INTEGER)";
         cmd.ExecuteNonQuery();
 
         using var cmd2 = conn.Value.CreateCommand();

--- a/src/NexusMods.DataModel/Interprocess/SqliteIPC.cs
+++ b/src/NexusMods.DataModel/Interprocess/SqliteIPC.cs
@@ -228,7 +228,7 @@ public class SqliteIPC : IDisposable, IInterprocessJobManager
         }
 
         using var cmd = conn.Value.CreateCommand();
-        cmd.CommandText = "CREATE TABLE IF NOT EXISTS Ipc (Id INTEGER PRIMARY KEY AUTOINCREMENT, Queue VARCHAR, Data BLOB, TimeStamp INTEGER)";
+        cmd.CommandText = "CREATE TABLE IF NOT EXISTS Ipc (Id INTEGER PRIMARY KEY AUTOINCREMENT, Queue TEXT, Data BLOB, TimeStamp INTEGER)";
         cmd.ExecuteNonQuery();
 
         using var cmd2 = conn.Value.CreateCommand();

--- a/tests/NexusMods.DataModel.Tests/InterprocessTests.cs
+++ b/tests/NexusMods.DataModel.Tests/InterprocessTests.cs
@@ -63,9 +63,6 @@ public sealed class InterprocessTests : IDisposable
             await _producer.Write(new Message { Value = i }, CancellationToken.None);
         }
 
-        // Wait for the IPC reader loop to finish
-        await Task.Delay(TimeSpan.FromMilliseconds(500));
-
         dest.Should().BeEquivalentTo(src);
     }
 

--- a/tests/NexusMods.DataModel.Tests/InterprocessTests.cs
+++ b/tests/NexusMods.DataModel.Tests/InterprocessTests.cs
@@ -188,9 +188,9 @@ public class InterprocessTests : IDisposable
     }
 
     [Fact]
-    public async Task CanCleanup()
+    public void CanCleanup()
     {
-        await _ipc.CleanupOnce(CancellationToken.None);
+        _ipc.CleanupOnce();
     }
 
     public void Dispose()


### PR DESCRIPTION
Fixes #372. This is a follow-up to #501.

**Important Changes**:

- Use in-built connection pool, instead of our custom one for the IPC.
- Add `WriterLoop` and batching.
- Notify subscribers in-process about immediate changes of in-process jobs and messages.
- Optimize the hell out of the IPC.

Previously, sending a message, creating, update or deleting a job would always write to the database immediately. This caused a lot of lock contention in the database and slowed things down, as threads had to wait for the database to be available again.

This PR changes how we write to the IPC database. Instead of writing to it immediately, the job/message will be put into a queue. The `WriterLoop` will run periodically and batch insert/update/delete the items from the queue into the database. This solves the database locking issue.

The second issue is updates being skipped (#372). This was also caused by locking. The `ReaderLoop` could wait multiple seconds before it was able to read the database again. During this time, inserts/updates/deletes could occur, which the `ReaderLoop` would be unable to pick up. Thus, we skipped updates.

While the locking issue was resolved using batching, this introduced another issue. If a job gets created, updated and deleted within the sleep period of the `WaiterLoop`, all those changes will be batch inserted at once into the database. The `ReaderLoop` would only see the final flattened result, which is either going to be the last update or the last delete. With our current data model, this issue can't be resolved completely. However, it can be resolved for the _current_ process only.

Jobs and messages that are created in the current process will be broadcasted to all subscribers in the current process. This means that only jobs that come from another process are affected by the "update skipping" behavior.

**Misc Changes**:

- Updated the table definitions:
  - Using `TEXT` instead of `VARCHAR` (`VARCHAR` doesn't exist in Sqlite)
  - Force ascending aliased row ID values for message IDs.
