### PR TITLE
Try and fix flakey tests

### DIFF
--- a/src/Networking/NexusMods.Networking.HttpDownloader/AdvancedHttpDownloader.cs
+++ b/src/Networking/NexusMods.Networking.HttpDownloader/AdvancedHttpDownloader.cs
@@ -46,7 +46,7 @@ namespace NexusMods.Networking.HttpDownloader
         /// </summary>
         private readonly Size _chunkSize = Size.MB * 128;
 
-        private const int MaxRetries = 4;
+        private const int MaxRetries = 16;
 
         /// <summary>
         /// The size of the buffer used to read from the network stream, no need to make this too large as
@@ -409,6 +409,7 @@ namespace NexusMods.Networking.HttpDownloader
             {
                 var rented = _memoryPool.Rent((int)_readBlockSize.Value);
                 var filledBuffer = await FillBuffer(stream, rented.Memory, chunk.RemainingToRead, cancel);
+
                 var lastRead = Size.FromLong(filledBuffer.Length);
                 if (lastRead == Size.Zero) break;
 

--- a/tests/Games/NexusMods.Games.TestFramework/AGameTest.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/AGameTest.cs
@@ -245,6 +245,7 @@ public abstract class AGameTest<TGame> where TGame : AGame
             await using var entryStream = entry.Open();
             await using var ms = new MemoryStream(contents);
             await ms.CopyToAsync(entryStream);
+            await entryStream.FlushAsync();
         }
 
         await stream.FlushAsync();


### PR DESCRIPTION
Two fixes

* Flush .ZIP files before returning from a test function, this might help with cases were we get ".zip is not an archive"
* Move the number of socket retries from 4 -> 16, because the network for the test runners on GH seem super flakey at times