### PR TITLE
Fix "File is not an archive"

### DIFF
--- a/tests/Games/NexusMods.Games.TestFramework/AGameTest.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/AGameTest.cs
@@ -239,6 +239,8 @@ public abstract class AGameTest<TGame> where TGame : AGame
         // Don't put this in Create mode, because for some reason it will create broken Zips that are not prefixed
         // with the ZIP magic number. Not sure why and I can't reproduce it in a simple test case, but if you open
         // in create mode all your zip archives will be prefixed with 0x0000FFFF04034B50 instead of 0x04034B50.
+        // See https://github.com/dotnet/runtime/blob/23886f158cf925e13c72e661b9891df704806746/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs#L949-L956
+        // for where this bug occurs 
         using var zipArchive = new ZipArchive(stream, ZipArchiveMode.Update);
 
         foreach (var kv in filesToZip)

--- a/tests/Games/NexusMods.Games.TestFramework/AGameTest.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/AGameTest.cs
@@ -234,8 +234,12 @@ public abstract class AGameTest<TGame> where TGame : AGame
     {
         var file = TemporaryFileManager.CreateFile();
 
-        await using var stream = FileSystem.OpenFile(file.Path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read);
-        using var zipArchive = new ZipArchive(stream, ZipArchiveMode.Create);
+        await using var stream = file.Path.Create();
+
+        // Don't put this in Create mode, because for some reason it will create broken Zips that are not prefixed
+        // with the ZIP magic number. Not sure why and I can't reproduce it in a simple test case, but if you open
+        // in create mode all your zip archives will be prefixed with 0x0000FFFF04034B50 instead of 0x04034B50.
+        using var zipArchive = new ZipArchive(stream, ZipArchiveMode.Update);
 
         foreach (var kv in filesToZip)
         {

--- a/xunit.runner.json
+++ b/xunit.runner.json
@@ -1,4 +1,4 @@
 ﻿{
-  "parallelizeAssembly": true,
+  "parallelizeAssembly": false,
   "parallelizeTestCollections": false
 }


### PR DESCRIPTION
Resolves #436 for the Darkest dungeon tests and likely others. We were creating zip archives in Create mode which for some reason was resulting in bad ZIP data. Added a comment and fixed the behavior. We could also pull in sharp compress, but this seems to do the trick just as well.