### PR TITLE
Add Working Directory to .nxm Handler & Remove Default Host Builder (fixes #513)

### DIFF
--- a/src/NexusMods.App/Program.cs
+++ b/src/NexusMods.App/Program.cs
@@ -68,8 +68,7 @@ public class Program
         // I'm not 100% sure how to wire this up to cleanly pass settings
         // to ConfigureLogging; since the DI container isn't built until the host is.
         var config = new AppConfig();
-
-        var host = Host.CreateDefaultBuilder(Environment.GetCommandLineArgs())
+        var host = new HostBuilder()
             .ConfigureServices(services =>
             {
                 // Bind the AppSettings class to the configuration and register it as a singleton service

--- a/src/NexusMods.App/Program.cs
+++ b/src/NexusMods.App/Program.cs
@@ -68,6 +68,7 @@ public class Program
         // I'm not 100% sure how to wire this up to cleanly pass settings
         // to ConfigureLogging; since the DI container isn't built until the host is.
         var config = new AppConfig();
+
         var host = Host.CreateDefaultBuilder(Environment.GetCommandLineArgs())
             .ConfigureServices(services =>
             {
@@ -80,7 +81,7 @@ public class Program
                 config = JsonSerializer.Deserialize<AppConfig>(configJson)!;
                 config.Sanitize();
                 services.AddSingleton(config);
-                services.AddApp(new AppConfig()).Validate();
+                services.AddApp(config).Validate();
             })
             .ConfigureLogging((_, builder) => AddLogging(builder, config.LoggingSettings))
             .Build();

--- a/src/NexusMods.Common/ProtocolRegistration/IProtocolRegistration.cs
+++ b/src/NexusMods.Common/ProtocolRegistration/IProtocolRegistration.cs
@@ -24,9 +24,10 @@ public interface IProtocolRegistration
     /// </summary>
     /// <param name="protocol">The protocol to register for</param>
     /// <param name="friendlyName">Arbitrary friendly name for the protocol</param>
-    /// <param name="commandLine"></param>
+    /// <param name="workingDirectory">The directory inside which the program is executed</param>
+    /// <param name="commandLine">The full commandline</param>
     /// <returns>the previous handler, if any</returns>
-    Task<string?> Register(string protocol, string friendlyName, string commandLine);
+    Task<string?> Register(string protocol, string friendlyName, string workingDirectory, string commandLine);
 
     /// <summary>
     /// determine if this application is the handler for a protocol. This is based on the full url

--- a/src/NexusMods.Common/ProtocolRegistration/ProtocolRegistrationLinux.cs
+++ b/src/NexusMods.Common/ProtocolRegistration/ProtocolRegistrationLinux.cs
@@ -36,11 +36,12 @@ public class ProtocolRegistrationLinux : IProtocolRegistration
         return await Register(
             protocol,
             $"{BaseId}-{protocol}.desktop",
+            Path.GetDirectoryName(executable)!,
             $"{executable} protocol-invoke --url %u");
     }
 
     /// <inheritdoc/>
-    public async Task<string?> Register(string protocol, string friendlyName, string commandLine)
+    public async Task<string?> Register(string protocol, string friendlyName, string workingDirectory, string commandLine)
     {
         var applicationsFolder = _fileSystem.GetKnownPath(KnownPath.HomeDirectory)
             .Combine(".local/share/applications");
@@ -54,6 +55,7 @@ public class ProtocolRegistrationLinux : IProtocolRegistration
         sb.AppendLine($"Name=NexusMods.App {protocol.ToUpper()} Handler");
         sb.AppendLine("Terminal=false");
         sb.AppendLine("Type=Application");
+        sb.AppendLine($"Path={workingDirectory}");
         sb.AppendLine($"Exec={commandLine}");
         sb.AppendLine($"MimeType=x-scheme-handler/{protocol}");
 

--- a/src/NexusMods.Common/ProtocolRegistration/ProtocolRegistrationWindows.cs
+++ b/src/NexusMods.Common/ProtocolRegistration/ProtocolRegistrationWindows.cs
@@ -26,7 +26,7 @@ public class ProtocolRegistrationWindows : IProtocolRegistration
     }
 
     /// <inheritdoc/>
-    public Task<string?> Register(string protocol, string friendlyName, string commandLine)
+    public Task<string?> Register(string protocol, string friendlyName, string workingDirectory, string commandLine)
     {
         using var key = GetClassKey(protocol);
         key.SetValue("", "URL:" + friendlyName);
@@ -36,6 +36,7 @@ public class ProtocolRegistrationWindows : IProtocolRegistration
 
         var res = (string?)commandKey.GetValue("");
         commandKey.SetValue("", commandLine);
+        commandKey.SetValue("WorkingDirectory", workingDirectory);
 
         return Task.FromResult(res);
     }
@@ -43,7 +44,8 @@ public class ProtocolRegistrationWindows : IProtocolRegistration
     /// <inheritdoc/>
     public Task<string?> RegisterSelf(string protocol)
     {
-        return Register(protocol, "NMA", GetOwnExe() + " protocol-invoke --url \"%1\"");
+        var exePath = GetOwnExe();
+        return Register(protocol, "NMA", Path.GetDirectoryName(exePath)!, exePath + " protocol-invoke --url \"%1\"");
     }
 
     private static string GetOwnExe()

--- a/tests/NexusMods.DataModel.Tests/Harness/ADataModelTest.cs
+++ b/tests/NexusMods.DataModel.Tests/Harness/ADataModelTest.cs
@@ -57,7 +57,7 @@ public abstract class ADataModelTest<T> : IDisposable, IAsyncLifetime
     protected ADataModelTest(IServiceProvider provider)
     {
         var startup = new Startup();
-        _host = Host.CreateDefaultBuilder(Environment.GetCommandLineArgs())
+        _host = new HostBuilder()
             .ConfigureServices((_, service) => startup.ConfigureServices(service))
             .Build();
         var provider1 = _host.Services;


### PR DESCRIPTION
## [Change] Added Working Directory to Protocol Registration

On Linux, this involved setting the `Path=` field inside the `.desktop` file as specified in the original PR.  

On Windows, it was a matter of adding an additional value named `WorkingDirectory`, under the same registry key as the default commandline itself. 

## Investigation: Folder Scanning

Original issue (#513) mentions, that the Default Host Builder is scanning the current working directory recursively.

I had a look into its code; and found out that it was searching for `appconfig.json` and its possible variants (e.g. `appconfig.Development.json`; which are part of the default MSFT configuration system.

It was searching up from what it set as the default `Content Root`, which defaults to current working directory in `Host.CreateDefaultBuilder`. It is possible to replace this after the fact before calling `Build()`, however...

In the case of the App, we switched from using the default config system to a custom solution a while back; the reasoning being that the default implementation does not have a means of customizing how the data is deserialized; and we needed to deserialize types that are dependent on our custom serialization system in the DataModel.

## [Change] Removed `Host.CreateDefaultBuilder` Outright

At first I considered just fixing the content root, however I've done a quick investigation into the functionality of `Host.CreateDefaultBuilder` to see how much we use from it; as I was curious, especially given that we usually roll our own stuff in the app.

| Action | Used By App | Notes |
|-|-|-|  
| Set the ContentRootPath to the result of GetCurrentDirectory(). | No | We use our own Paths library for fetching content. |
| Load host IConfiguration from "DOTNET_" prefixed environment variables. | No | We roll our own config. |
| Load app IConfiguration from 'appsettings.json' and 'appsettings.[EnvironmentName].json'. | No | We roll our own config. |
| Load app IConfiguration from User Secrets when EnvironmentName is 'Development' using the entry assembly. | No | We roll our own config. |
| Load app IConfiguration from environment variables. | No | We roll our own config. |
| Configure the ILoggerFactory to log to the console, debug, and event source output. | No | We configure all logging that we actively use in-app manually. |
| Enable scope validation on the dependency injection container when EnvironmentName is 'Development'. | No | In Rider, there is no by default environment override; you need to create a custom launch profile and add it as an environment variable; so most likely none of us have actually used this before. |

Given that we don't use any of its functionality, I removed the default host builder from App & Unit Tests, then verified that basic functionality works.