### PR TITLE
Hide remaining time in UI when paused

### DIFF
--- a/src/NexusMods.App.UI/RightContent/Downloads/InProgressCommonViewModel.cs
+++ b/src/NexusMods.App.UI/RightContent/Downloads/InProgressCommonViewModel.cs
@@ -176,7 +176,7 @@ public class InProgressCommonViewModel : AViewModel<IInProgressViewModel>, IInPr
         // Calculate Remaining Time.
         var throughput = Tasks.Sum(x => x.Throughput);
         var remainingBytes = totalSizeBytes - totalDownloadedBytes;
-        SecondsRemaining = (int)(remainingBytes / Math.Max(throughput, 1));
+        SecondsRemaining = throughput < 1.0 ? 0 : (int)(remainingBytes / Math.Max(throughput, 1));
     }
 
     private void UpdateWindowInfoInternal(object? sender, object? state) => UpdateWindowInfo();

--- a/src/NexusMods.App.UI/RightContent/Downloads/InProgressView.axaml.cs
+++ b/src/NexusMods.App.UI/RightContent/Downloads/InProgressView.axaml.cs
@@ -1,4 +1,4 @@
-﻿using System.Reactive.Disposables;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using Avalonia.ReactiveUI;
 using DynamicData.Binding;
@@ -78,7 +78,16 @@ public partial class InProgressView : ReactiveUserControl<IInProgressViewModel>
                 .Subscribe(_ =>
                 {
                     var vm = ViewModel!;
-                    BoldMinutesRemainingTextBlock.Text = StringFormatters.ToTimeRemainingShort(vm.SecondsRemaining);
+                    if (vm.SecondsRemaining == 0)
+                    {
+                        BoldMinutesRemainingTextBlock.Text = "";
+                        MinutesRemainingTextBlock.Text = "";
+                    }
+                    else
+                    {
+                        BoldMinutesRemainingTextBlock.Text = StringFormatters.ToTimeRemainingShort(vm.SecondsRemaining);
+                        MinutesRemainingTextBlock.Text = "Remaining";
+                    }
                 })
                 .DisposeWith(d);
 

--- a/tests/NexusMods.UI.Tests/RightContent/Downloads/InProgressViewModelTests.cs
+++ b/tests/NexusMods.UI.Tests/RightContent/Downloads/InProgressViewModelTests.cs
@@ -203,7 +203,8 @@ public class InProgressViewModelTests : AViewTest<InProgressView, InProgressDesi
         
             // Check the total completion is correct with 0 elements.
             var originalTimeRemaining = StringFormatters.ToTimeRemainingShort(ViewModel.SecondsRemaining);
-            View.BoldMinutesRemainingTextBlock.Text.Should().Be(originalTimeRemaining);
+            // Time remaining text is empty when no downloads occuring
+            View.BoldMinutesRemainingTextBlock.Text.Should().Be("");
             
             // Check the total completion is correct with 1 element.
             ViewModel.AddDownload(new DownloadTaskDesignViewModel()

--- a/tests/NexusMods.UI.Tests/RightContent/Downloads/InProgressViewModelTests.cs
+++ b/tests/NexusMods.UI.Tests/RightContent/Downloads/InProgressViewModelTests.cs
@@ -200,11 +200,18 @@ public class InProgressViewModelTests : AViewTest<InProgressView, InProgressDesi
         {
             ViewModel.ClearDownloads();
             ViewModel.IsRunning.Should().BeFalse();
-        
+
             // Check the total completion is correct with 0 elements.
             var originalTimeRemaining = StringFormatters.ToTimeRemainingShort(ViewModel.SecondsRemaining);
-            // Time remaining text is empty when no downloads occuring
-            View.BoldMinutesRemainingTextBlock.Text.Should().Be("");
+            // If 0 seconds remaining, then no download is occuring, and the text block is empty string
+            if (ViewModel.SecondsRemaining == 0)
+            {
+                View.BoldMinutesRemainingTextBlock.Text.Should().Be("");
+            }
+            else
+            {
+                View.BoldMinutesRemainingTextBlock.Text.Should().Be(originalTimeRemaining);
+            }
             
             // Check the total completion is correct with 1 element.
             ViewModel.AddDownload(new DownloadTaskDesignViewModel()


### PR DESCRIPTION
closes #510 

Hides the UI element text for time remaining when throughput is effectively zero (paused)

Thought it was better hidden rather than saying "0 seconds remaining" which might be a bit misleading.

Normal:

![unpaused](https://github.com/Nexus-Mods/NexusMods.App/assets/85711747/78759acb-4bbe-49db-b37c-4beef1a763db)

Paused:

![paused](https://github.com/Nexus-Mods/NexusMods.App/assets/85711747/8046a685-fc05-4e46-b25b-a2e8663b8da6)

