### PR TITLE
Add banner for development builds (#567)

### DIFF
--- a/src/NexusMods.App.UI/Controls/DevelopmentBuildBanner/DevelopmentBuildBannerView.axaml
+++ b/src/NexusMods.App.UI/Controls/DevelopmentBuildBanner/DevelopmentBuildBannerView.axaml
@@ -1,0 +1,25 @@
+﻿<reactiveUi:ReactiveUserControl
+    d:DesignHeight="48"
+    d:DesignWidth="800"
+    mc:Ignorable="d"
+    x:Class="NexusMods.App.UI.Controls.DevelopmentBuildBanner.DevelopmentBuildBannerView"
+    x:TypeArguments="developmentBuildBanner:IDevelopmentBuildBannerViewModel"
+    xmlns:avalonia="clr-namespace:Projektanker.Icons.Avalonia;assembly=Projektanker.Icons.Avalonia"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:reactiveUi="http://reactiveui.net"
+    xmlns:developmentBuildBanner="clr-namespace:NexusMods.App.UI.Controls.DevelopmentBuildBanner">
+    <Design.DataContext>
+        <developmentBuildBanner:DevelopmentBuildBannerViewModel />
+    </Design.DataContext>
+    <StackPanel Orientation="Horizontal" Background="#A30000" >
+        <avalonia:Icon Classes="Alert" Foreground="{DynamicResource BrandWhite}" FontSize="20" Margin="30 2 8 2" VerticalAlignment="Center" />
+        <TextBlock
+            Foreground="{DynamicResource BrandWhite}"
+            FontFamily="{DynamicResource FontPrimaryBold}"
+            Text="{Binding Text, RelativeSource={RelativeSource AncestorType={x:Type developmentBuildBanner:DevelopmentBuildBannerView}}}"
+            VerticalAlignment="Center" />
+    </StackPanel>
+</reactiveUi:ReactiveUserControl>

--- a/src/NexusMods.App.UI/Controls/DevelopmentBuildBanner/DevelopmentBuildBannerView.axaml.cs
+++ b/src/NexusMods.App.UI/Controls/DevelopmentBuildBanner/DevelopmentBuildBannerView.axaml.cs
@@ -1,0 +1,33 @@
+﻿using System.Diagnostics;
+using Avalonia;
+using Avalonia.ReactiveUI;
+using ReactiveUI;
+
+namespace NexusMods.App.UI.Controls.DevelopmentBuildBanner;
+
+public partial class DevelopmentBuildBannerView : ReactiveUserControl<IDevelopmentBuildBannerViewModel>
+{
+    private static readonly StyledProperty<string> TextProperty =
+        AvaloniaProperty.Register<DevelopmentBuildBannerView, string>(nameof(Text), "vX.X - DEVELOPMENT USE ONLY");
+
+    public string Text
+    {
+        get => GetValue(TextProperty);
+        set => SetValue(TextProperty, value);
+    }
+
+    public DevelopmentBuildBannerView()
+    {
+        InitializeComponent();
+        var appVersion = GetAppVersion();
+        this.WhenActivated(_ => Text = $"{appVersion} - DEVELOPMENT USE ONLY");
+    }
+
+    private static string GetAppVersion()
+    {
+        #if DEBUG
+            return "Debug build";
+        #endif
+        return $"v{Process.GetCurrentProcess().MainModule!.FileVersionInfo.FileVersion}";
+    }
+}

--- a/src/NexusMods.App.UI/Controls/DevelopmentBuildBanner/DevelopmentBuildBannerViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/DevelopmentBuildBanner/DevelopmentBuildBannerViewModel.cs
@@ -1,0 +1,5 @@
+﻿namespace NexusMods.App.UI.Controls.DevelopmentBuildBanner;
+
+public class DevelopmentBuildBannerViewModel : AViewModel<IDevelopmentBuildBannerViewModel>, IDevelopmentBuildBannerViewModel
+{
+}

--- a/src/NexusMods.App.UI/Controls/DevelopmentBuildBanner/IDevelopmentBuildBannerViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/DevelopmentBuildBanner/IDevelopmentBuildBannerViewModel.cs
@@ -1,0 +1,5 @@
+﻿namespace NexusMods.App.UI.Controls.DevelopmentBuildBanner;
+
+public interface IDevelopmentBuildBannerViewModel : IViewModelInterface
+{
+}

--- a/src/NexusMods.App.UI/NexusMods.App.UI.csproj
+++ b/src/NexusMods.App.UI/NexusMods.App.UI.csproj
@@ -294,6 +294,12 @@
           <AutoGen>True</AutoGen>
           <DependentUpon>Language.resx</DependentUpon>
         </Compile>
+        <Compile Update="Controls\DevelopmentBuildBanner\DevelopmentBuildBannerViewModel.cs">
+          <DependentUpon>IDevelopmentBuildBannerViewModel.cs</DependentUpon>
+        </Compile>
+        <Compile Update="Controls\DevelopmentBuildBanner\DevelopmentBuildBannerView.axaml.cs">
+          <DependentUpon>DevelopmentBuildBannerView.axaml</DependentUpon>
+        </Compile>
     </ItemGroup>
 
     <ItemGroup>
@@ -314,6 +320,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <AdditionalFiles Include="Controls\DevelopmentBuildBanner\DevelopmentBuildBannerView.axaml" />
       <AdditionalFiles Include="RightContent\DownloadGrid\Columns\DownloadGameName\DownloadGameNameView.axaml" />
       <AdditionalFiles Include="RightContent\DownloadGrid\Columns\DownloadName\DownloadNameView.axaml" />
       <AdditionalFiles Include="RightContent\DownloadGrid\Columns\DownloadSize\DownloadSizeView.axaml" />

--- a/src/NexusMods.App.UI/Services.cs
+++ b/src/NexusMods.App.UI/Services.cs
@@ -1,6 +1,7 @@
 
 using Microsoft.Extensions.DependencyInjection;
 using NexusMods.App.UI.Controls.DataGrid;
+using NexusMods.App.UI.Controls.DevelopmentBuildBanner;
 using NexusMods.App.UI.Controls.GameWidget;
 using NexusMods.App.UI.Controls.Spine;
 using NexusMods.App.UI.Controls.Spine.Buttons.Download;
@@ -72,6 +73,7 @@ public static class Services
             .AddSingleton<IViewLocator, InjectedViewLocator>()
 
             .AddViewModel<CompletedViewModel, ICompletedViewModel>()
+            .AddViewModel<DevelopmentBuildBannerViewModel, IDevelopmentBuildBannerViewModel>()
             .AddViewModel<DownloadsViewModel, IDownloadsViewModel>()
             .AddViewModel<FoundGamesViewModel, IFoundGamesViewModel>()
             .AddViewModel<GameLeftMenuViewModel, IGameLeftMenuViewModel>()
@@ -107,6 +109,7 @@ public static class Services
 
             // Views
             .AddView<CompletedView, ICompletedViewModel>()
+            .AddView<DevelopmentBuildBannerView, IDevelopmentBuildBannerViewModel>()
             .AddView<DownloadsView, IDownloadsViewModel>()
             .AddView<FoundGamesView, IFoundGamesViewModel>()
             .AddView<GameLeftMenuView, IGameLeftMenuViewModel>()

--- a/src/NexusMods.App.UI/Theme/IconStyles.xaml
+++ b/src/NexusMods.App.UI/Theme/IconStyles.xaml
@@ -1,8 +1,8 @@
-﻿<Styles
+<Styles
     xmlns="https://github.com/avaloniaui"
     xmlns:icons="clr-namespace:Projektanker.Icons.Avalonia;assembly=Projektanker.Icons.Avalonia"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    
+
     <Design.PreviewWith>
         <WrapPanel>
             <WrapPanel.Styles>
@@ -12,6 +12,7 @@
                     <Setter Property="Margin" Value="2"></Setter>
                 </Style>
             </WrapPanel.Styles>
+            <icons:Icon Classes="Alert"></icons:Icon>
             <icons:Icon Classes="Bell"></icons:Icon>
             <icons:Icon Classes="CheckUnderline"></icons:Icon>
             <icons:Icon Classes="ClearAll"></icons:Icon>
@@ -30,13 +31,16 @@
             <icons:Icon Classes="PlayCircleOutline"></icons:Icon>
         </WrapPanel>
     </Design.PreviewWith>
-    
-    <!-- 
+
+    <!--
     NOTE:
        Material icon names are not standardized well, use this site to look them up:
-       https://pictogrammers.com/library/mdi/       
+       https://pictogrammers.com/library/mdi/
      -->
-    
+    <Style Selector="icons|Icon.Alert">
+        <Setter Property="Value" Value="mdi-alert"></Setter>
+    </Style>
+
     <Style Selector="icons|Icon.Bell">
         <Setter Property="Value" Value="mdi-bell"></Setter>
     </Style>
@@ -44,11 +48,11 @@
     <Style Selector="icons|Icon.CheckUnderline">
         <Setter Property="Value" Value="mdi-check-underline" />
     </Style>
-    
+
     <Style Selector="icons|Icon.Cog">
         <Setter Property="Value" Value="mdi-cog" />
     </Style>
-    
+
     <Style Selector="icons|Icon.Download">
         <Setter Property="Value" Value="mdi-download" />
     </Style>
@@ -56,47 +60,47 @@
     <Style Selector="icons|Icon.ClearAll">
         <Setter Property="Value" Value="mdi-notification-clear-all" />
     </Style>
-    
+
     <Style Selector="icons|Icon.Help">
         <Setter Property="Value" Value="mdi-help-circle-outline" />
     </Style>
-    
+
     <Style Selector="icons|Icon.History">
         <Setter Property="Value" Value="mdi-history" />
     </Style>
-    
+
     <Style Selector="icons|Icon.Play">
         <Setter Property="Value" Value="mdi-play"></Setter>
     </Style>
-    
+
     <Style Selector="icons|Icon.PlusCircleOutline">
         <Setter Property="Value" Value="mdi-plus-circle-outline"></Setter>
     </Style>
-    
+
     <Style Selector="icons|Icon.ProgressDownload">
         <Setter Property="Value" Value="mdi-progress-download"></Setter>
     </Style>
-    
+
     <Style Selector="icons|Icon.PauseCircleOutline">
         <Setter Property="Value" Value="mdi-pause-circle-outline"></Setter>
     </Style>
-    
+
     <Style Selector="icons|Icon.PauseCircleFilled">
         <Setter Property="Value" Value="mdi-pause-circle"></Setter>
     </Style>
-    
+
     <Style Selector="icons|Icon.RemoveCircleOutline">
         <Setter Property="Value" Value="mdi-minus-circle-outline"></Setter>
     </Style>
-    
+
     <Style Selector="icons|Icon.Star">
         <Setter Property="Value" Value="mdi-star"></Setter>
     </Style>
-    
+
     <Style Selector="icons|Icon.TrashCanOutline">
         <Setter Property="Value" Value="mdi-trash-can-outline"></Setter>
     </Style>
-    
+
     <Style Selector="icons|Icon.PlayCircleOutline">
         <Setter Property="Value" Value="mdi-play-circle-outline"/>
     </Style>

--- a/src/NexusMods.App.UI/Windows/MainWindow.axaml
+++ b/src/NexusMods.App.UI/Windows/MainWindow.axaml
@@ -23,7 +23,7 @@
         <windows:MainWindowViewModel />
     </Design.DataContext>
 
-    <Grid ColumnDefinitions="72, 216, *" RowDefinitions="62, *">
+    <Grid ColumnDefinitions="72, 216, *" RowDefinitions="62, *, 48">
         <Border
             Background="#CC2A2C2B"
             Grid.Column="0"
@@ -69,6 +69,12 @@
             x:Name="LeftMenuViewModelHost" />
 
         <reactiveUi:ViewModelViewHost Grid.Column="2" Grid.Row="1" x:Name="RightContent" />
+
+        <reactiveUi:ViewModelViewHost
+            Grid.Column="0"
+            Grid.ColumnSpan="3"
+            Grid.Row="2"
+            x:Name="DevelopmentBuildBanner" />
     </Grid>
 
 

--- a/src/NexusMods.App.UI/Windows/MainWindow.axaml.cs
+++ b/src/NexusMods.App.UI/Windows/MainWindow.axaml.cs
@@ -26,6 +26,9 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
             this.OneWayBind(ViewModel, vm => vm.Spine, v => v.Spine.ViewModel)
                 .DisposeWith(disposables);
 
+            this.OneWayBind(ViewModel, vm => vm.DevelopmentBuildBanner, v => v.DevelopmentBuildBanner.ViewModel)
+                .DisposeWith(disposables);
+
             this.OneWayBind(ViewModel, vm => vm.RightContent, v => v.RightContent.ViewModel)
                 .DisposeWith(disposables);
 

--- a/src/NexusMods.App.UI/Windows/MainWindowViewModel.cs
+++ b/src/NexusMods.App.UI/Windows/MainWindowViewModel.cs
@@ -1,6 +1,7 @@
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using Microsoft.Extensions.Logging;
+using NexusMods.App.UI.Controls.DevelopmentBuildBanner;
 using NexusMods.App.UI.Controls.Spine;
 using NexusMods.App.UI.Controls.TopBar;
 using NexusMods.App.UI.LeftMenu;
@@ -28,6 +29,7 @@ public class MainWindowViewModel : AViewModel<IMainWindowViewModel>
         IOSInformation osInformation,
         ISpineViewModel spineViewModel,
         ITopBarViewModel topBarViewModel,
+        IDevelopmentBuildBannerViewModel developmentBuildBannerViewModel,
         IOverlayController controller,
         IDownloadService downloadService,
         IArchiveInstaller archiveInstaller,
@@ -36,6 +38,7 @@ public class MainWindowViewModel : AViewModel<IMainWindowViewModel>
     {
         TopBar = topBarViewModel;
         Spine = spineViewModel;
+        DevelopmentBuildBanner = developmentBuildBannerViewModel;
         _overlayController = controller;
         _archiveInstaller = archiveInstaller;
         _registry = registry;
@@ -144,6 +147,9 @@ public class MainWindowViewModel : AViewModel<IMainWindowViewModel>
 
     [Reactive]
     public ITopBarViewModel TopBar { get; set; }
+
+    [Reactive]
+    public IDevelopmentBuildBannerViewModel DevelopmentBuildBanner { get; set; }
 
     [Reactive]
     public IOverlayViewModel? OverlayContent { get; set; }


### PR DESCRIPTION
This adds a banner at the bottom of the screen to show that the current build is a development/debug build as described in #567. In case of a debug build, it looks like this:

![Screenshot 2023-08-24 231037](https://github.com/Nexus-Mods/NexusMods.App/assets/26406078/f2621df4-c15f-4e41-ae16-92e5d5e81f17)

In case of an official (pre-)release, it shows the product version instead of the "Debug build" text.

For now, the banner is hard-coded into the MainWindow as discussed on Discord. This means the code needs to be removed before making a stable release, or updated to only display the banner if a stable release version is detected. The text is also hard-coded an not localised.

I noticed that Rider automatically made some whitespace changes in IconStyles.xaml. Let me know if I should remove those from the commit.