### PR TITLE
Show product version instead of file version in development build banner

### DIFF
--- a/src/NexusMods.App.UI/Controls/DevelopmentBuildBanner/DevelopmentBuildBannerView.axaml.cs
+++ b/src/NexusMods.App.UI/Controls/DevelopmentBuildBanner/DevelopmentBuildBannerView.axaml.cs
@@ -28,6 +28,6 @@ public partial class DevelopmentBuildBannerView : ReactiveUserControl<IDevelopme
         #if DEBUG
             return "Debug build";
         #endif
-        return $"v{Process.GetCurrentProcess().MainModule!.FileVersionInfo.FileVersion}";
+        return $"v{Process.GetCurrentProcess().MainModule!.FileVersionInfo.ProductVersion}";
     }
 }


### PR DESCRIPTION
In PR #574 I forgot to change `FileVersion` to `ProductVersion`. In the design in #567 the product version is shown, so this PR fixes that. The difference is shown here ("v0.1" instead of "v0.1.0.0"):

![Screenshot 2023-08-24 230107](https://github.com/Nexus-Mods/NexusMods.App/assets/26406078/ef73dbdb-4329-4a58-aded-03b62b4e69e1)