### PR TITLE
FOMOD validation for CLI

### DIFF
--- a/src/Games/NexusMods.Games.FOMOD/FomodXmlInstaller.cs
+++ b/src/Games/NexusMods.Games.FOMOD/FomodXmlInstaller.cs
@@ -36,7 +36,8 @@ public class FomodXmlInstaller : IModInstaller
             fomodInstallationPath);
     }
 
-    public FomodXmlInstaller(ILogger<FomodXmlInstaller> logger, ICoreDelegates coreDelegates, GamePath fomodInstallationPath)
+    public FomodXmlInstaller(ILogger<FomodXmlInstaller> logger, ICoreDelegates coreDelegates,
+        GamePath fomodInstallationPath)
     {
         _delegates = coreDelegates;
         _fomodInstallationPath = fomodInstallationPath;
@@ -57,7 +58,6 @@ public class FomodXmlInstaller : IModInstaller
         EntityDictionary<RelativePath, AnalyzedFile> archiveFiles,
         CancellationToken cancellationToken = default)
     {
-
         // the component dealing with FOMODs is built to support all kinds of mods, including those without a script.
         // for those cases, stop patterns can be way more complex to deduce the intended installation structure. In our case, where
         // we only intend to support xml scripted FOMODs, this should be good enough
@@ -156,7 +156,8 @@ public class FomodXmlInstaller : IModInstaller
             return new FromArchive
             {
                 Id = ModFileId.New(),
-                To = new GamePath(gameTargetPath.Type, gameTargetPath.Path.Join(instruction.destination)),
+                To = new GamePath(gameTargetPath.Type,
+                    gameTargetPath.Path.Join(RelativePath.FromUnsanitizedInput(instruction.destination))),
                 Hash = file.Value.Hash,
                 Size = file.Value.Size
             };
@@ -169,7 +170,7 @@ public class FomodXmlInstaller : IModInstaller
         return instructions.Select(instruction => new EmptyDirectory
         {
             Id = ModFileId.New(),
-            Directory = new GamePath(gameTargetPath.Type, gameTargetPath.Path.Join(instruction.destination))
+            Directory = new GamePath(gameTargetPath.Type, gameTargetPath.Path.Join(RelativePath.FromUnsanitizedInput(instruction.destination)))
         });
     }
 }

--- a/src/NexusMods.CLI/CliGuidedInstaller.cs
+++ b/src/NexusMods.CLI/CliGuidedInstaller.cs
@@ -114,8 +114,10 @@ public class CliGuidedInstaller : IGuidedInstaller
                         if (invalidGroups.Any())
                         {
                             _logger.LogError(
-                                "Some groups have invalid selection, please correct them. Invalid groups: {InvalidGroups}",
-                                invalidGroups);
+                                "Some groups have invalid selection, please correct them. Invalid groups:\n {InvalidGroups} \n",
+                                installationStep.Groups.Select((group, index) => new { group, index })
+                                    .Where(x => invalidGroups.Contains(x.group.Id))
+                                    .Select(x => $"{x.index + 1} - {x.group.Description} \n"));
                             continue;
                         }
 
@@ -151,8 +153,8 @@ public class CliGuidedInstaller : IGuidedInstaller
                         if (!GuidedInstallerValidation.IsValidGroupSelection(currentGroup, selectedOptions))
                         {
                             _logger.LogError(
-                                "Selection is invalid for group {GroupId}",
-                                currentGroup.Id);
+                                "Selection is invalid for group {GroupIndex} \n",
+                                Array.IndexOf(installationStep.Groups, currentGroup) + 1);
                             continue;
                         }
 

--- a/src/NexusMods.Common/GuidedInstaller/GuidedInstallationStepValidator.cs
+++ b/src/NexusMods.Common/GuidedInstaller/GuidedInstallationStepValidator.cs
@@ -17,17 +17,14 @@ public static class GuidedInstallerValidation
     /// <param name="installationStep">The installation step containing all the groups</param>
     /// <param name="selectedOptions">A collection of <see cref="SelectedOption"/> for all the groups.</param>
     /// <returns>
-    /// A collection of <see cref="GroupId"/>s that have invalid selections.
-    /// An empty collection means all groups have valid selections.
+    /// An array of <see cref="GroupId"/>s that have invalid selections.
+    /// An empty array means all groups have valid selections.
     /// </returns>
-    public static IEnumerable<GroupId> ValidateStepSelections(GuidedInstallationStep installationStep,
-        IEnumerable<SelectedOption> selectedOptions)
+    public static GroupId[] ValidateStepSelections(GuidedInstallationStep installationStep,
+        IReadOnlyCollection<SelectedOption> selectedOptions)
     {
-        var selectedOptionsList = selectedOptions.ToArray();
-
-        return (from @group in installationStep.Groups
-            where !IsValidGroupSelection(@group, selectedOptionsList)
-            select @group.Id).ToList();
+        return installationStep.Groups.Where(group => !IsValidGroupSelection(group, selectedOptions))
+            .Select(group => group.Id).ToArray();
     }
 
     /// <summary>
@@ -41,19 +38,18 @@ public static class GuidedInstallerValidation
     /// A collection of <see cref="SelectedOption"/>, could contain selections for other groups as well
     /// </param>
     /// <returns>True if the group has a valid selection, false otherwise</returns>
-    public static bool IsValidGroupSelection(OptionGroup group, IEnumerable<SelectedOption> selectedOptions)
+    public static bool IsValidGroupSelection(OptionGroup group, IReadOnlyCollection<SelectedOption> selectedOptions)
     {
-        var selectedOptionsList = selectedOptions.ToArray();
         return group.Type switch
         {
-            OptionGroupType.ExactlyOne => selectedOptionsList.Count(
+            OptionGroupType.ExactlyOne => selectedOptions.Count(
                 selectedOption => selectedOption.GroupId == group.Id) == 1,
 
             OptionGroupType.AtMostOne =>
-                selectedOptionsList.Count(selectedOption => selectedOption.GroupId == group.Id) <= 1,
+                selectedOptions.Count(selectedOption => selectedOption.GroupId == group.Id) <= 1,
 
             OptionGroupType.AtLeastOne =>
-                selectedOptionsList.Any(selectedOption => selectedOption.GroupId == group.Id),
+                selectedOptions.Any(selectedOption => selectedOption.GroupId == group.Id),
 
             _ => true
         };

--- a/src/NexusMods.Common/GuidedInstaller/GuidedInstallationStepValidator.cs
+++ b/src/NexusMods.Common/GuidedInstaller/GuidedInstallationStepValidator.cs
@@ -1,0 +1,61 @@
+﻿using System.Collections;
+using NexusMods.Common.GuidedInstaller.ValueObjects;
+
+namespace NexusMods.Common.GuidedInstaller;
+
+/// <summary>
+/// Validation utilities for <see cref="GuidedInstallationStep"/>.
+/// </summary>
+public static class GuidedInstallerValidation
+{
+    /// <summary>
+    /// Checks if the <see cref="OptionGroup"/>s in the <see cref="GuidedInstallationStep"/> have a valid selection.
+    /// </summary>
+    /// <remarks>
+    /// A group is valid if its selection satisfies the <see cref="OptionGroup.Type"/> requirements.
+    /// </remarks>
+    /// <param name="installationStep">The installation step containing all the groups</param>
+    /// <param name="selectedOptions">A collection of <see cref="SelectedOption"/> for all the groups.</param>
+    /// <returns>
+    /// A collection of <see cref="GroupId"/>s that have invalid selections.
+    /// An empty collection means all groups have valid selections.
+    /// </returns>
+    public static IEnumerable<GroupId> ValidateStepSelections(GuidedInstallationStep installationStep,
+        IEnumerable<SelectedOption> selectedOptions)
+    {
+        var selectedOptionsList = selectedOptions.ToArray();
+
+        return (from @group in installationStep.Groups
+            where !IsValidGroupSelection(@group, selectedOptionsList)
+            select @group.Id).ToList();
+    }
+
+    /// <summary>
+    /// Checks if the <see cref="OptionGroup"/> has a valid selection.
+    /// </summary>
+    /// <remarks>
+    /// A selection is valid if it satisfies the group's <see cref="OptionGroup.Type"/> requirements.
+    /// </remarks>
+    /// <param name="group"></param>
+    /// <param name="selectedOptions">
+    /// A collection of <see cref="SelectedOption"/>, could contain selections for other groups as well
+    /// </param>
+    /// <returns>True if the group has a valid selection, false otherwise</returns>
+    public static bool IsValidGroupSelection(OptionGroup group, IEnumerable<SelectedOption> selectedOptions)
+    {
+        var selectedOptionsList = selectedOptions.ToArray();
+        return group.Type switch
+        {
+            OptionGroupType.ExactlyOne => selectedOptionsList.Count(
+                selectedOption => selectedOption.GroupId == group.Id) == 1,
+
+            OptionGroupType.AtMostOne =>
+                selectedOptionsList.Count(selectedOption => selectedOption.GroupId == group.Id) <= 1,
+
+            OptionGroupType.AtLeastOne =>
+                selectedOptionsList.Any(selectedOption => selectedOption.GroupId == group.Id),
+
+            _ => true
+        };
+    }
+}

--- a/tests/NexusMods.Common.Tests/GuidedInstaller/GuidedInstallationStepValidatorTests.cs
+++ b/tests/NexusMods.Common.Tests/GuidedInstaller/GuidedInstallationStepValidatorTests.cs
@@ -1,0 +1,118 @@
+﻿using System.Text.RegularExpressions;
+using FluentAssertions;
+using NexusMods.Common.GuidedInstaller;
+using NexusMods.Common.GuidedInstaller.ValueObjects;
+
+namespace NexusMods.Common.Tests.GuidedInstaller;
+
+public class GuidedInstallationStepValidatorTests
+{
+
+    [Theory]
+    [InlineData(OptionGroupType.Any, new int[0], true)]
+    [InlineData(OptionGroupType.Any, new[] { 0, 1 }, true)]
+    [InlineData(OptionGroupType.ExactlyOne, new[] { 2 }, true)]
+    [InlineData(OptionGroupType.ExactlyOne, new int[0], false)]
+    [InlineData(OptionGroupType.ExactlyOne, new[] { 0, 1 }, false)]
+    [InlineData(OptionGroupType.AtMostOne, new[] { 0 }, true)]
+    [InlineData(OptionGroupType.AtMostOne, new int[0], true)]
+    [InlineData(OptionGroupType.AtMostOne, new[] { 0, 1 }, false)]
+    [InlineData(OptionGroupType.AtLeastOne, new[] { 0 }, true)]
+    [InlineData(OptionGroupType.AtLeastOne, new[] { 0, 1 }, true)]
+    [InlineData(OptionGroupType.AtLeastOne, new int[0], false)]
+    public void IsValidGroupSelectionTest(OptionGroupType groupType, int[] selectionIndexes, bool isValid)
+    {
+        var installStep = CreateInstallationStep(groupType);
+        var group = installStep.Groups.First();
+        var selectedOptions = selectionIndexes.Select(index => new SelectedOption(group.Id, group.Options[index].Id)).ToList();
+
+        // add a couple of extra options to the selected options, to simulate other group selections being present
+        selectedOptions.AddRange(new[]
+        {
+            new SelectedOption(GroupId.From(new Guid("513C6470-639B-44E1-AB0B-DE410871E15D")), OptionId.From(new Guid("4D1F7EBE-010C-49DF-972B-91EEF093F432"))),
+            new SelectedOption(GroupId.From(new Guid("513C6470-639B-44E1-AB0B-DE410871E15D")), OptionId.From(new Guid("23955466-1AA8-4339-8004-FA5A5F3EA10A")))
+        });
+
+        // test if validation works
+        GuidedInstallerValidation.IsValidGroupSelection(group, selectedOptions).Should().Be(isValid);
+
+        // test if the validation method works
+        GuidedInstallerValidation.ValidateStepSelections(installStep, selectedOptions).Should().BeEquivalentTo(isValid ? Array.Empty<GroupId>() : new[] { group.Id });
+    }
+
+    private GuidedInstallationStep CreateInstallationStep(OptionGroupType groupType)
+    {
+        return new()
+        {
+            Id = StepId.From(new Guid("E0B0B0A0-0A0A-0A0A-0A0A-0A0A0A0A0A0A")),
+            Groups = new[]
+            {
+                CreateOptionGroup(groupType),
+                new OptionGroup()
+                {
+                    Id = GroupId.From(new Guid("513C6470-639B-44E1-AB0B-DE410871E15D")),
+                    Description = "Other Group",
+                    Type = OptionGroupType.Any,
+                    Options = new []
+                    {
+                        new Option
+                        {
+                            Id = OptionId.From(new Guid("4D1F7EBE-010C-49DF-972B-91EEF093F432")),
+                            Name = "Some other option 0",
+                            Description = "Some other option 0",
+                            Type = OptionType.Available
+                        },
+                        new Option
+                        {
+                            Id = OptionId.From(new Guid("23955466-1AA8-4339-8004-FA5A5F3EA10A")),
+                            Name = "Some other option 1",
+                            Description = "Some other option 1",
+                            Type = OptionType.Available
+                        }
+                    }
+                }
+
+            }
+        };
+    }
+    private OptionGroup CreateOptionGroup(OptionGroupType groupType)
+    {
+        return new()
+        {
+            Id = GroupId.From(new Guid("54DDF485-124A-4E6E-B4B8-1A9B94533EC0")),
+            Description = "Test group",
+            Type = groupType,
+            Options = new[]
+            {
+                new Option
+                {
+                    Id = OptionId.From(new Guid("C12F8029-4E73-4175-A0A3-8840DFA9416D")),
+                    Name = "Test option 0",
+                    Description = "Test option 0",
+                    Type = OptionType.Available
+                },
+                new Option
+                {
+                    Id = OptionId.From(new Guid("6A2CAB8B-CFA3-4962-856B-36092E89914D")),
+                    Name = "Test option 1",
+                    Description = "Test option 1",
+                    Type = OptionType.Available
+                },
+                new Option
+                {
+                    Id = OptionId.From(new Guid("1E59BD9A-9A88-4753-ADDE-07E625C911D8")),
+                    Name = "Test option 2",
+                    Description = "Test option 2",
+                    Type = OptionType.Available
+                },
+                new Option
+                {
+                    Id = OptionId.From(new Guid("83BF090A-1D65-4CC7-BFAF-6157CBC986C6")),
+                    Name = "Test option 3",
+                    Description = "Test option 3",
+                    Type = OptionType.Available
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
- Added static GuidedInstallerValidation class containing two static validation methods, one for a single group, one for an entire step.

- Adds checks before proceeding with steps to make sure each group selection respects the requirements of the group (At least one, at most one, exactly one).

- Fixed Fomod installer creating GamePaths using unsanitized paths.