### PR TITLE
Added: Base Implementation of AdvancedInstaller Core

### DIFF
--- a/NexusMods.App.sln
+++ b/NexusMods.App.sln
@@ -123,6 +123,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NexusMods.Games.Generic.Tes
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NexusMods.Games.FOMOD.UI", "src\Games\NexusMods.Games.FOMOD.UI\NexusMods.Games.FOMOD.UI.csproj", "{500CE772-93C3-4DA9-9AB3-E9E9EC0A9429}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NexusMods.Games.AdvancedInstaller.Tests", "tests\Games\NexusMods.Games.AdvancedInstaller.Tests\NexusMods.Games.AdvancedInstaller.Tests.csproj", "{63BC2EE7-18E5-4887-913A-4843DBBE2C8D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NexusMods.Games.AdvancedInstaller", "src\Games\NexusMods.Games.AdvancedInstaller\NexusMods.Games.AdvancedInstaller.csproj", "{E7E68E07-6732-4FA4-BC4D-6E4249B592FD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -301,6 +305,14 @@ Global
 		{500CE772-93C3-4DA9-9AB3-E9E9EC0A9429}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{500CE772-93C3-4DA9-9AB3-E9E9EC0A9429}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{500CE772-93C3-4DA9-9AB3-E9E9EC0A9429}.Release|Any CPU.Build.0 = Release|Any CPU
+		{63BC2EE7-18E5-4887-913A-4843DBBE2C8D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{63BC2EE7-18E5-4887-913A-4843DBBE2C8D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{63BC2EE7-18E5-4887-913A-4843DBBE2C8D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{63BC2EE7-18E5-4887-913A-4843DBBE2C8D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E7E68E07-6732-4FA4-BC4D-6E4249B592FD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E7E68E07-6732-4FA4-BC4D-6E4249B592FD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E7E68E07-6732-4FA4-BC4D-6E4249B592FD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E7E68E07-6732-4FA4-BC4D-6E4249B592FD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -354,6 +366,8 @@ Global
 		{1E20E979-5F04-44FD-BE07-54B6686ECB13} = {E7BAE287-D505-4D6D-A090-665A64309B2D}
 		{AA95B93F-23AC-46D5-83B3-2E7AE4BD309C} = {05B06AC1-7F2B-492F-983E-5BC63CDBF20D}
 		{500CE772-93C3-4DA9-9AB3-E9E9EC0A9429} = {70D38D24-79AE-4600-8E83-17F3C11BA81F}
+		{63BC2EE7-18E5-4887-913A-4843DBBE2C8D} = {05B06AC1-7F2B-492F-983E-5BC63CDBF20D}
+		{E7E68E07-6732-4FA4-BC4D-6E4249B592FD} = {70D38D24-79AE-4600-8E83-17F3C11BA81F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9F9F8352-34DD-42C0-8564-EE9AF34A3501}

--- a/src/Games/NexusMods.Games.AdvancedInstaller/AdvancedInstaller.cs
+++ b/src/Games/NexusMods.Games.AdvancedInstaller/AdvancedInstaller.cs
@@ -6,11 +6,33 @@ using NexusMods.Paths.FileTree;
 
 namespace NexusMods.Games.AdvancedInstaller;
 
+// Temporary.
+#pragma warning disable CS1998
+
+/// <summary>
+/// Provides the implementation of the 'Advanced Installer' functionality.
+/// </summary>
 public class AdvancedInstaller : IModInstaller
 {
-    public ValueTask<IEnumerable<ModInstallerResult>> GetModsAsync(GameInstallation gameInstallation, ModId baseModId, FileTreeNode<RelativePath, ModSourceFileEntry> archiveFiles,
+    public async ValueTask<IEnumerable<ModInstallerResult>> GetModsAsync(GameInstallation gameInstallation, ModId baseModId, FileTreeNode<RelativePath, ModSourceFileEntry> archiveFiles,
         CancellationToken cancellationToken = default)
     {
-        throw new NotImplementedException();
+        // Note: This code is effectively a stub.
+        var deploymentData = await GetDeploymentDataAsync(gameInstallation, baseModId, archiveFiles, cancellationToken);
+        return new[]
+        {
+            new ModInstallerResult
+            {
+                Id = baseModId,
+                Files = deploymentData.EmitOperations(archiveFiles)
+            }
+        };
+    }
+
+    private async Task<DeploymentData> GetDeploymentDataAsync(GameInstallation gameInstallation, ModId baseModId, FileTreeNode<RelativePath, ModSourceFileEntry> archiveFiles, CancellationToken cancellationToken)
+#pragma warning restore CS1998
+    {
+        // This is a stub, until we implement some UI logic to pull this data
+        return new DeploymentData();
     }
 }

--- a/src/Games/NexusMods.Games.AdvancedInstaller/AdvancedInstaller.cs
+++ b/src/Games/NexusMods.Games.AdvancedInstaller/AdvancedInstaller.cs
@@ -1,0 +1,16 @@
+﻿using NexusMods.DataModel.Games;
+using NexusMods.DataModel.Loadouts;
+using NexusMods.DataModel.ModInstallers;
+using NexusMods.Paths;
+using NexusMods.Paths.FileTree;
+
+namespace NexusMods.Games.AdvancedInstaller;
+
+public class AdvancedInstaller : IModInstaller
+{
+    public ValueTask<IEnumerable<ModInstallerResult>> GetModsAsync(GameInstallation gameInstallation, ModId baseModId, FileTreeNode<RelativePath, ModSourceFileEntry> archiveFiles,
+        CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Games/NexusMods.Games.AdvancedInstaller/DeploymentData.cs
+++ b/src/Games/NexusMods.Games.AdvancedInstaller/DeploymentData.cs
@@ -1,0 +1,109 @@
+using System.ComponentModel;
+using NexusMods.Paths;
+
+namespace NexusMods.Games.AdvancedInstaller;
+
+/// <summary>
+/// DeploymentData encapsulates all the data needed for a manual or advanced mod installation.
+/// It contains a mapping between the source files in the archive to the target paths in the game directory.
+/// </summary>
+public struct DeploymentData
+{
+    /// <summary>
+    /// This Dictionary maps relative paths of files in the mod archive to relative paths in the game directories.<br/>
+    ///
+    /// Key: The relative path of a file within the mod archive.
+    /// Value: The relative path where the file should be placed in the game directory.
+    /// </summary>
+    /// <example>
+    /// If a mod file 'texture.dds' in the archive should go to 'Game/Data/Textures/texture.dds',
+    /// then the KeyValuePair would be like ("texture.dds", "Game/Data/Textures/texture.dds").
+    /// </example>
+    /// <remarks>
+    /// Paths follow internal Nexus Mods App path standards: they use a "/" as a separator, trim whitespace, and do not alter "..".
+    /// </remarks>
+    internal Dictionary<RelativePath, GamePath> ArchiveToOutputMap { get; init; } = new();
+
+    /// <summary>
+    /// This is a reverse lookup for the _archiveToOutputMap.<br/>.
+    /// We use this lookup to ensure that a file has not already been mapped to a given location.
+    /// </summary>
+    internal Dictionary<GamePath, RelativePath> OutputToArchiveMap { get; init; } = new();
+
+    /// <summary>
+    /// Public/Default Constructor.
+    /// </summary>
+    public DeploymentData() { }
+
+    /// <summary>
+    /// Adds a new mapping from a source file in the archive to a target path in the game directory.
+    /// </summary>
+    /// <param name="archivePath">The relative path of the source file within the mod archive.</param>
+    /// <param name="outputPath">The relative path where the file should be placed in one of the game directories.</param>
+    /// <returns>True if the mapping was added successfully, false if the key already exists.</returns>
+    public void AddMapping(RelativePath archivePath, GamePath outputPath)
+    {
+        // Check if said location is already mapped.
+        if (OutputToArchiveMap.TryGetValue(outputPath, out var existing))
+        {
+            // Already mapped to same path, so it's a no-op.
+            if (existing.Equals(archivePath))
+                return;
+
+            // Otherwise we throw telling which path we're mapped to.
+            ThrowHelpers.MappingAlreadyExists(outputPath, existing, archivePath);
+        }
+
+        ArchiveToOutputMap[archivePath] = outputPath;
+        OutputToArchiveMap[outputPath] = archivePath;
+    }
+
+    /// <summary>
+    /// Removes a mapping based on the source file's relative path in the archive.
+    /// </summary>
+    /// <param name="archivePath">The relative path of the source file within the mod archive.</param>
+    /// <returns>True if the mapping was removed successfully, false if the key does not exist.</returns>
+    public bool RemoveMapping(RelativePath archivePath)
+    {
+        var result = ArchiveToOutputMap.Remove(archivePath, out var existing);
+        OutputToArchiveMap.Remove(existing);
+        return result;
+    }
+
+    /// <summary>
+    /// Clears all the existing mappings.
+    /// </summary>
+    public void ClearMappings()
+    {
+        ArchiveToOutputMap.Clear();
+        OutputToArchiveMap.Clear();
+    }
+
+    /*
+    /// <summary>
+    /// Emits a series of AModFile instructions based on the current mappings.
+    /// </summary>
+    /// <param name="gameTargetPath">Path to the game folder.</param>
+    /// <param name="archiveFiles">Files from the archive.</param>
+    /// <returns>An IEnumerable of AModFile, representing the files to be moved and their target paths.</returns>
+    public IEnumerable<AModFile> EmitOperations(FileTreeNode<RelativePath, ModSourceFileEntry> archiveFiles, GamePath gameTargetPath)
+    {
+        // Written like this for clarity, use array in actual code.
+        // Just an example, might not compile.
+        foreach (var mapping in _archiveToOutputMap)
+        {
+            // find file in `files` input.
+            var file = files.First(file => file.Key.Equals(RelativePath.FromUnsanitizedInput(mapping.Key)));
+
+            yield return new FromArchive
+            {
+                Id = ModId.New(),
+                To = new GamePath(gameTargetPath.Type,
+                    gameTargetPath.Path.Join(RelativePath.FromUnsanitizedInput(mapping.Value))),
+                Hash = file.Value.Hash,
+                Size = file.Value.Size
+            };
+        }
+    }
+    */
+}

--- a/src/Games/NexusMods.Games.AdvancedInstaller/DeploymentData.cs
+++ b/src/Games/NexusMods.Games.AdvancedInstaller/DeploymentData.cs
@@ -1,5 +1,9 @@
 using System.ComponentModel;
+using NexusMods.DataModel.Loadouts;
+using NexusMods.DataModel.Loadouts.ModFiles;
+using NexusMods.DataModel.ModInstallers;
 using NexusMods.Paths;
+using NexusMods.Paths.FileTree;
 
 namespace NexusMods.Games.AdvancedInstaller;
 
@@ -79,31 +83,28 @@ public struct DeploymentData
         OutputToArchiveMap.Clear();
     }
 
-    /*
     /// <summary>
     /// Emits a series of AModFile instructions based on the current mappings.
     /// </summary>
-    /// <param name="gameTargetPath">Path to the game folder.</param>
     /// <param name="archiveFiles">Files from the archive.</param>
     /// <returns>An IEnumerable of AModFile, representing the files to be moved and their target paths.</returns>
-    public IEnumerable<AModFile> EmitOperations(FileTreeNode<RelativePath, ModSourceFileEntry> archiveFiles, GamePath gameTargetPath)
+    public IEnumerable<AModFile> EmitOperations(FileTreeNode<RelativePath, ModSourceFileEntry> archiveFiles)
     {
         // Written like this for clarity, use array in actual code.
         // Just an example, might not compile.
-        foreach (var mapping in _archiveToOutputMap)
+        foreach (var mapping in ArchiveToOutputMap)
         {
             // find file in `files` input.
-            var file = files.First(file => file.Key.Equals(RelativePath.FromUnsanitizedInput(mapping.Key)));
+            var src = RelativePath.FromUnsanitizedInput(mapping.Key);
+            var file = archiveFiles.FindNode(src)!.Value;
 
             yield return new FromArchive
             {
-                Id = ModId.New(),
-                To = new GamePath(gameTargetPath.Type,
-                    gameTargetPath.Path.Join(RelativePath.FromUnsanitizedInput(mapping.Value))),
-                Hash = file.Value.Hash,
-                Size = file.Value.Size
+                Id = ModFileId.New(),
+                To = mapping.Value,
+                Hash = file!.Hash,
+                Size = file.Size
             };
         }
     }
-    */
 }

--- a/src/Games/NexusMods.Games.AdvancedInstaller/DeploymentDataExtensions.cs
+++ b/src/Games/NexusMods.Games.AdvancedInstaller/DeploymentDataExtensions.cs
@@ -1,0 +1,38 @@
+using NexusMods.DataModel.ModInstallers;
+using NexusMods.Paths;
+using NexusMods.Paths.FileTree;
+
+namespace NexusMods.Games.AdvancedInstaller;
+
+/// <summary>
+///     Extension methods for the <see cref="DeploymentData" /> class which involve external types.
+/// </summary>
+public static class DeploymentDataExtensions
+{
+    /// <summary>
+    ///     Maps all of the children of the given path onto the given output folder.
+    /// </summary>
+    /// <param name="data">The instance of <see cref="DeploymentData" />.</param>
+    /// <param name="folderNode">The relative path of the source file within the mod archive.</param>
+    /// <param name="outputFolder">The folder where the file should be placed in one of the game directories.</param>
+    /// <returns>True if the mapping was added successfully, false if the key already exists.</returns>
+    public static void AddFolderMapping<TValue>(this DeploymentData data,
+        FileTreeNode<RelativePath, TValue> folderNode, GamePath outputFolder)
+    {
+        // Check if said location is already mapped.
+        // Get all of the children of the folder node.
+        var substringLength = folderNode.Path.Path.Length;
+        substringLength = substringLength == 0 ? 0 : substringLength + 1;
+
+        // if this path is non-empty add 1 for the separator.
+        // this separator is guaranteed to exist if descendant files (GetAllDescendentFiles) exist.
+
+        // TODO: Change to `CollectionsMarshal.AsSpan` after this type returns list.
+        foreach (var child in folderNode.GetAllDescendentFiles())
+        {
+            var childPath = child.Path.Path.Substring(substringLength);
+            var newPath = new GamePath(outputFolder.Type, outputFolder.Path.Join(childPath));
+            data.AddMapping(child.Path, newPath);
+        }
+    }
+}

--- a/src/Games/NexusMods.Games.AdvancedInstaller/DeploymentDataExtensions.cs
+++ b/src/Games/NexusMods.Games.AdvancedInstaller/DeploymentDataExtensions.cs
@@ -21,6 +21,7 @@ public static class DeploymentDataExtensions
     {
         // Check if said location is already mapped.
         // Get all of the children of the folder node.
+        // Note: We assume paths in the file tree are already sanitized, e.g. use / as separator.
         var substringLength = folderNode.Path.Path.Length;
         substringLength = substringLength == 0 ? 0 : substringLength + 1;
 

--- a/src/Games/NexusMods.Games.AdvancedInstaller/Exceptions/MappingAlreadyExists.cs
+++ b/src/Games/NexusMods.Games.AdvancedInstaller/Exceptions/MappingAlreadyExists.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using NexusMods.Paths;
 
 namespace NexusMods.Games.AdvancedInstaller.Exceptions;
@@ -28,9 +29,4 @@ public class MappingAlreadyExistsException : Exception
         ExistingPath = existingPath;
         AttemptedPath = attemptedPath;
     }
-
-    /// <summary>
-    /// The path that was trying to be mapped.
-    /// </summary>
-    public RelativePath Path { get; private set; }
 }

--- a/src/Games/NexusMods.Games.AdvancedInstaller/Exceptions/MappingAlreadyExists.cs
+++ b/src/Games/NexusMods.Games.AdvancedInstaller/Exceptions/MappingAlreadyExists.cs
@@ -1,0 +1,36 @@
+using NexusMods.Paths;
+
+namespace NexusMods.Games.AdvancedInstaller.Exceptions;
+
+/// <summary>
+/// This is an exception thrown when trying to map an file to a location which is already mapped by another file.
+/// </summary>
+public class MappingAlreadyExistsException : Exception
+{
+    /// <summary>
+    /// Path where the file is to be stored in one of the game directories.
+    /// </summary>
+    public GamePath OutputPath { get; }
+
+    /// <summary>
+    /// The path that is currently mapped.
+    /// </summary>
+    public RelativePath ExistingPath { get; }
+
+    /// <summary>
+    /// The path the user attempted to map with.
+    /// </summary>
+    public RelativePath AttemptedPath { get; }
+
+    public MappingAlreadyExistsException(GamePath outputPath, RelativePath existingPath, RelativePath attemptedPath)
+    {
+        OutputPath = outputPath;
+        ExistingPath = existingPath;
+        AttemptedPath = attemptedPath;
+    }
+
+    /// <summary>
+    /// The path that was trying to be mapped.
+    /// </summary>
+    public RelativePath Path { get; private set; }
+}

--- a/src/Games/NexusMods.Games.AdvancedInstaller/NexusMods.Games.AdvancedInstaller.csproj
+++ b/src/Games/NexusMods.Games.AdvancedInstaller/NexusMods.Games.AdvancedInstaller.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\tests\Games\NexusMods.Games.TestFramework\NexusMods.Games.TestFramework.csproj"/>
+        <ProjectReference Include="..\..\NexusMods.DataModel\NexusMods.DataModel.csproj"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <InternalsVisibleTo Include="NexusMods.Games.AdvancedInstaller.Tests" />
+    </ItemGroup>
+</Project>

--- a/src/Games/NexusMods.Games.AdvancedInstaller/ThrowHelpers.cs
+++ b/src/Games/NexusMods.Games.AdvancedInstaller/ThrowHelpers.cs
@@ -1,0 +1,15 @@
+using NexusMods.Games.AdvancedInstaller.Exceptions;
+using NexusMods.Paths;
+
+namespace NexusMods.Games.AdvancedInstaller;
+
+/// <summary>
+/// Helpers for throwing methods with high performance.
+/// </summary>
+internal class ThrowHelpers
+{
+    public static void MappingAlreadyExists(GamePath outputPath, RelativePath existingPath, RelativePath attemptedPath)
+    {
+        throw new MappingAlreadyExistsException(outputPath, existingPath, attemptedPath);
+    }
+}

--- a/tests/Games/NexusMods.Games.AdvancedInstaller.Tests/DeploymentDataEmitTests.cs
+++ b/tests/Games/NexusMods.Games.AdvancedInstaller.Tests/DeploymentDataEmitTests.cs
@@ -1,0 +1,73 @@
+using FluentAssertions;
+using NexusMods.DataModel.Loadouts.ModFiles;
+using NexusMods.DataModel.ModInstallers;
+using NexusMods.Hashing.xxHash64;
+using NexusMods.Paths;
+using NexusMods.Paths.FileTree;
+
+namespace NexusMods.Games.AdvancedInstaller.Tests;
+
+public partial class DeploymentDataTests
+{
+    [Fact]
+    public void EmitOperations_ShouldEmitCorrectAModFileInstructions()
+    {
+        // Arrange
+        var data = new DeploymentData();
+
+        var fileEntries = CreateEmitTestFileTree();
+        var folderNode = FileTreeNode<RelativePath, ModSourceFileEntry>.CreateTree(fileEntries);
+        data.AddFolderMapping(folderNode, MakeGamePath(""));
+
+        // Act
+        var emittedOperations = data.EmitOperations(folderNode).ToList();
+
+        // Assert
+        emittedOperations.Should().NotBeEmpty();
+        var first = emittedOperations[0] as FromArchive;
+        first!.To.Should().Be(MakeGamePath("folder/file1.txt"));
+        first.Hash.Should().Be(Hash.From(1));
+        first.Size.Should().Be(Size.From(1));
+
+        var second = emittedOperations[1] as FromArchive;
+        second!.To.Should().Be(MakeGamePath("folder/file2.txt"));
+        second.Hash.Should().Be(Hash.From(2));
+        second.Size.Should().Be(Size.From(2));
+
+        var third = emittedOperations[2] as FromArchive;
+        third!.To.Should().Be(MakeGamePath("folder/subfolder/file3.txt"));
+        third.Hash.Should().Be(Hash.From(3));
+        third.Size.Should().Be(Size.From(3));
+    }
+
+    private static Dictionary<RelativePath, ModSourceFileEntry> CreateEmitTestFileTree()
+    {
+        return new Dictionary<RelativePath, ModSourceFileEntry>
+        {
+            {
+                new RelativePath("folder/file1.txt"), new ModSourceFileEntry
+                {
+                    Hash = Hash.From(1),
+                    Size = Size.From(1),
+                    StreamFactory = null!
+                }
+            },
+            {
+                new RelativePath("folder/file2.txt"), new ModSourceFileEntry
+                {
+                    Hash = Hash.From(2),
+                    Size = Size.From(2),
+                    StreamFactory = null!
+                }
+            },
+            {
+                new RelativePath("folder/subfolder/file3.txt"), new ModSourceFileEntry
+                {
+                    Hash = Hash.From(3),
+                    Size = Size.From(3),
+                    StreamFactory = null!
+                }
+            }
+        };
+    }
+}

--- a/tests/Games/NexusMods.Games.AdvancedInstaller.Tests/DeploymentDataExtensionTests.cs
+++ b/tests/Games/NexusMods.Games.AdvancedInstaller.Tests/DeploymentDataExtensionTests.cs
@@ -4,7 +4,7 @@ using NexusMods.Paths.FileTree;
 
 namespace NexusMods.Games.AdvancedInstaller.Tests;
 
-public class DeploymentDataExtensionTests
+public partial class DeploymentDataTests
 {
     [Fact]
     public void AddFolderMapping_Should_MapAllChildrenCorrectly_WhenMappingToSubfolderInGamePath()
@@ -13,7 +13,7 @@ public class DeploymentDataExtensionTests
         var data = new DeploymentData();
 
         // Create a File Tree
-        var fileEntries = CreateTestFileTree();
+        var fileEntries = CreateExtensionTestFileTree();
         var folderNode = FileTreeNode<RelativePath, int>.CreateTree(fileEntries);
 
         // Act
@@ -32,7 +32,7 @@ public class DeploymentDataExtensionTests
         var data = new DeploymentData();
 
         // Create a File Tree
-        var fileEntries = CreateTestFileTree();
+        var fileEntries = CreateExtensionTestFileTree();
         var folderNode = FileTreeNode<RelativePath, int>.CreateTree(fileEntries).FindNode("folder")!;
 
         // Act
@@ -46,7 +46,7 @@ public class DeploymentDataExtensionTests
 
     private static GamePath MakeGamePath(string path) => new(GameFolderType.Game, path);
 
-    private static Dictionary<RelativePath, int> CreateTestFileTree()
+    private static Dictionary<RelativePath, int> CreateExtensionTestFileTree()
     {
         var fileEntries = new Dictionary<RelativePath, int>
         {

--- a/tests/Games/NexusMods.Games.AdvancedInstaller.Tests/DeploymentDataExtensionTests.cs
+++ b/tests/Games/NexusMods.Games.AdvancedInstaller.Tests/DeploymentDataExtensionTests.cs
@@ -1,0 +1,66 @@
+using FluentAssertions;
+using NexusMods.Paths;
+using NexusMods.Paths.FileTree;
+
+namespace NexusMods.Games.AdvancedInstaller.Tests;
+
+public class DeploymentDataExtensionTests
+{
+    [Fact]
+    public void AddFolderMapping_Should_MapAllChildrenCorrectly_WhenMappingToSubfolderInGamePath()
+    {
+        // Arrange
+        var data = new DeploymentData();
+
+        // Create a File Tree
+        var fileEntries = CreateTestFileTree();
+        var folderNode = FileTreeNode<RelativePath, int>.CreateTree(fileEntries);
+
+        // Act
+        data.AddFolderMapping(folderNode, MakeGamePath("Data"));
+
+        // Assert
+        AssertMapping(data, "folder/file1.txt", MakeGamePath("Data/folder/file1.txt"));
+        AssertMapping(data, "folder/file2.txt", MakeGamePath("Data/folder/file2.txt"));
+        AssertMapping(data, "folder/subfolder/file3.txt", MakeGamePath("Data/folder/subfolder/file3.txt"));
+    }
+
+    [Fact]
+    public void AddFolderMapping_Should_MapAllChildrenCorrectly_WhenMappingASubfolderInArchive()
+    {
+        // Arrange
+        var data = new DeploymentData();
+
+        // Create a File Tree
+        var fileEntries = CreateTestFileTree();
+        var folderNode = FileTreeNode<RelativePath, int>.CreateTree(fileEntries).FindNode("folder")!;
+
+        // Act
+        data.AddFolderMapping(folderNode, MakeGamePath("Data"));
+
+        // Assert
+        AssertMapping(data, "folder/file1.txt", MakeGamePath("Data/file1.txt"));
+        AssertMapping(data, "folder/file2.txt", MakeGamePath("Data/file2.txt"));
+        AssertMapping(data, "folder/subfolder/file3.txt", MakeGamePath("Data/subfolder/file3.txt"));
+    }
+
+    private static GamePath MakeGamePath(string path) => new(GameFolderType.Game, path);
+
+    private static Dictionary<RelativePath, int> CreateTestFileTree()
+    {
+        var fileEntries = new Dictionary<RelativePath, int>
+        {
+            { new RelativePath("folder/file1.txt"), 1 },
+            { new RelativePath("folder/file2.txt"), 2 },
+            { new RelativePath("folder/subfolder/file3.txt"), 3 }
+        };
+        return fileEntries;
+    }
+
+    private void AssertMapping(DeploymentData data, string archivePath, GamePath expectedOutputPath)
+    {
+        var map = data.ArchiveToOutputMap;
+        map.Should().ContainKey(archivePath);
+        map[archivePath].Should().Be(expectedOutputPath);
+    }
+}

--- a/tests/Games/NexusMods.Games.AdvancedInstaller.Tests/DeploymentDataTests.cs
+++ b/tests/Games/NexusMods.Games.AdvancedInstaller.Tests/DeploymentDataTests.cs
@@ -1,0 +1,79 @@
+using FluentAssertions;
+using NexusMods.Games.AdvancedInstaller.Exceptions;
+using NexusMods.Paths;
+
+namespace NexusMods.Games.AdvancedInstaller.Tests;
+
+public class DeploymentDataTests
+{
+    // Note: Paths use / as separator on all platforms to ensure conformance with our backend decisions.
+    [Fact]
+    public void AddMapping_Should_AddCorrectMapping()
+    {
+        // Arrange
+        var data = new DeploymentData();
+        var archivePath = new RelativePath("archive/file1");
+        var outputPath = new GamePath(GameFolderType.Game, "Data/file1");
+
+        // Act
+        data.AddMapping(archivePath, outputPath);
+
+        // Assert
+        data.ArchiveToOutputMap.Should().ContainKey(archivePath);
+        data.ArchiveToOutputMap[archivePath].Should().Be(outputPath);
+
+        data.OutputToArchiveMap.Should().ContainKey(outputPath);
+        data.OutputToArchiveMap[outputPath].Should().Be(archivePath);
+    }
+
+    [Fact]
+    public void RemoveMapping_Should_RemoveCorrectMapping()
+    {
+        // Arrange
+        var data = new DeploymentData();
+        var archivePath = new RelativePath("archive/file1");
+        var outputPath = new GamePath(GameFolderType.Game, "Data/file1");
+        data.AddMapping(archivePath, outputPath);
+
+        // Act
+        var result = data.RemoveMapping(archivePath);
+
+        // Assert
+        result.Should().BeTrue();
+        data.ArchiveToOutputMap.Should().NotContainKey(archivePath);
+        data.OutputToArchiveMap.Should().NotContainKey(outputPath);
+    }
+
+    [Fact]
+    public void ClearMappings_Should_ClearAllMappings()
+    {
+        // Arrange
+        var data = new DeploymentData();
+        data.AddMapping(new RelativePath("archive/file1"), new GamePath(GameFolderType.Game, "Data/file1"));
+        data.AddMapping(new RelativePath("archive/file2"), new GamePath(GameFolderType.Game, "Data/file2"));
+
+        // Act
+        data.ClearMappings();
+
+        // Assert
+        data.ArchiveToOutputMap.Should().BeEmpty();
+        data.OutputToArchiveMap.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AddMapping_WithDuplicateOutputPath_Should_ThrowMappingAlreadyExists()
+    {
+        // Arrange
+        var data = new DeploymentData();
+        var archivePath1 = new RelativePath("archive/file1");
+        var archivePath2 = new RelativePath("archive/file2");
+        var outputPath = new GamePath(GameFolderType.Game, "Data/file1");
+
+        // Act
+        data.AddMapping(archivePath1, outputPath);
+
+        // Assert
+        var act = () => data.AddMapping(archivePath2, outputPath);
+        act.Should().Throw<MappingAlreadyExistsException>();
+    }
+}

--- a/tests/Games/NexusMods.Games.AdvancedInstaller.Tests/DeploymentDataTests.cs
+++ b/tests/Games/NexusMods.Games.AdvancedInstaller.Tests/DeploymentDataTests.cs
@@ -4,7 +4,7 @@ using NexusMods.Paths;
 
 namespace NexusMods.Games.AdvancedInstaller.Tests;
 
-public class DeploymentDataTests
+public partial class DeploymentDataTests
 {
     // Note: Paths use / as separator on all platforms to ensure conformance with our backend decisions.
     [Fact]

--- a/tests/Games/NexusMods.Games.AdvancedInstaller.Tests/NexusMods.Games.AdvancedInstaller.Tests.csproj
+++ b/tests/Games/NexusMods.Games.AdvancedInstaller.Tests/NexusMods.Games.AdvancedInstaller.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2"/>
+        <PackageReference Include="xunit" Version="2.4.2"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\src\Games\NexusMods.Games.AdvancedInstaller\NexusMods.Games.AdvancedInstaller.csproj"/>
+        <ProjectReference Include="..\..\..\src\Games\NexusMods.Games.Generic\NexusMods.Games.Generic.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/Games/NexusMods.Games.AdvancedInstaller.Tests/Startup.cs
+++ b/tests/Games/NexusMods.Games.AdvancedInstaller.Tests/Startup.cs
@@ -1,0 +1,19 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NexusMods.Common;
+using NexusMods.Games.Generic;
+using NexusMods.Games.TestFramework;
+
+namespace NexusMods.Games.AdvancedInstaller.Tests;
+
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services
+            .AddDefaultServicesForTesting()
+            .AddGenericGameSupport()
+            .AddLogging(builder => builder.AddXUnit())
+            .Validate();
+    }
+}

--- a/tests/Games/NexusMods.Games.AdvancedInstaller.Tests/Usings.cs
+++ b/tests/Games/NexusMods.Games.AdvancedInstaller.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;


### PR DESCRIPTION
This PR implements the core/base of AdvancedInstaller; checklist and more details available here:

- https://github.com/Nexus-Mods/NexusMods.App/issues/635

The only thing not done is the mechanism that causes `AdvancedInstaller` to be invoked. 

The `AdvancedInstaller` IModInstaller is currently a stub. We decided that we still need to discuss with design how the Advanced Installer is to be invoked (e.g. should it be invoked if all other installers don't perform an operation? Should we prompt the user? etc.). 

Thus the activation logic is not included in this PR.