### PR TITLE
Ability to set your own game version in AGame

### DIFF
--- a/src/NexusMods.DataModel/Games/AGame.cs
+++ b/src/NexusMods.DataModel/Games/AGame.cs
@@ -55,7 +55,10 @@ public abstract class AGame : IGame
     /// <inheritdoc />
     public virtual IEnumerable<IModInstaller> Installers { get; } = Array.Empty<IModInstaller>();
 
-    private Version GetVersion(GameLocatorResult installation)
+    /// <summary>
+    /// Returns the game version if GameLocatorResult failed to get the game version.
+    /// </summary>
+    protected virtual Version GetVersion(GameLocatorResult installation)
     {
         try
         {


### PR DESCRIPTION
To have the same functionality, you have to override `AGame.Installations` with copying the `AGame.GetInstallations()` method