### PR TITLE
Initial support for Workspaces and Panels (split and join)

### DIFF
--- a/src/NexusMods.App.UI/Initializers.cs
+++ b/src/NexusMods.App.UI/Initializers.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Windows.Input;
@@ -25,6 +26,16 @@ public static class Initializers
 
     public static readonly ReactiveCommand<Unit, Unit> EnabledReactiveCommand = ReactiveCommand.Create(() => { }, Observable.Return(true));
     public static readonly ReactiveCommand<Unit, Unit> DisabledReactiveCommand = ReactiveCommand.Create(() => { }, Observable.Return(false));
+
+    public static ReactiveCommand<TInput, Unit> CreateReactiveCommand<TInput>(bool disabled = true)
+    {
+        return ReactiveCommand.Create<TInput, Unit>(_ => Unit.Default, Observable.Return(disabled));
+    }
+
+    public static ReactiveCommand<TInput, TOutput> CreateReactiveCommand<TInput, TOutput>()
+    {
+        return ReactiveCommand.Create<TInput, TOutput>(_ => throw new UnreachableException(), Observable.Return(false));
+    }
 
     public static readonly ModCursor ModCursor = new(LoadoutId,
         ModId.From(new Guid("00000000-0000-0000-0000-000000000002")));

--- a/src/NexusMods.App.UI/NexusMods.App.UI.csproj
+++ b/src/NexusMods.App.UI/NexusMods.App.UI.csproj
@@ -319,6 +319,9 @@
         <Compile Update="WorkspaceSystem\Panel\PanelViewModel.cs">
           <DependentUpon>IPanelViewModel.cs</DependentUpon>
         </Compile>
+        <Compile Update="WorkspaceSystem\Workspace\WorkspacePlaygroundViewModel.cs">
+          <DependentUpon>WorkspacePlaygroundView.axaml</DependentUpon>
+        </Compile>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NexusMods.App.UI/NexusMods.App.UI.csproj
+++ b/src/NexusMods.App.UI/NexusMods.App.UI.csproj
@@ -325,6 +325,9 @@
         <Compile Update="WorkspaceSystem\Workspace\AddPanelInput.cs">
           <DependentUpon>IWorkspaceViewModel.cs</DependentUpon>
         </Compile>
+        <Compile Update="WorkspaceSystem\Workspace\RemovePanelInput.cs">
+          <DependentUpon>IWorkspaceViewModel.cs</DependentUpon>
+        </Compile>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NexusMods.App.UI/NexusMods.App.UI.csproj
+++ b/src/NexusMods.App.UI/NexusMods.App.UI.csproj
@@ -309,6 +309,22 @@
         <Compile Update="Controls\TopBar\TopBarViewModel.cs">
           <DependentUpon>ITopBarViewModel.cs</DependentUpon>
         </Compile>
+        <Compile Update="WorkspaceSystem\Workspace\WorkspaceView.axaml.cs">
+          <DependentUpon>WorkspaceView.axaml</DependentUpon>
+          <SubType>Code</SubType>
+        </Compile>
+        <Compile Update="WorkspaceSystem\Workspace\WorkspaceDesignViewModel.cs">
+          <DependentUpon>IWorkspaceViewModel.cs</DependentUpon>
+        </Compile>
+        <Compile Update="WorkspaceSystem\Workspace\WorkspaceViewModel.cs">
+          <DependentUpon>IWorkspaceViewModel.cs</DependentUpon>
+        </Compile>
+        <Compile Update="WorkspaceSystem\Panel\PanelDesignViewModel.cs">
+          <DependentUpon>IPanelViewModel.cs</DependentUpon>
+        </Compile>
+        <Compile Update="WorkspaceSystem\Panel\PanelViewModel.cs">
+          <DependentUpon>IPanelViewModel.cs</DependentUpon>
+        </Compile>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NexusMods.App.UI/NexusMods.App.UI.csproj
+++ b/src/NexusMods.App.UI/NexusMods.App.UI.csproj
@@ -322,6 +322,9 @@
         <Compile Update="WorkspaceSystem\Workspace\WorkspacePlaygroundViewModel.cs">
           <DependentUpon>WorkspacePlaygroundView.axaml</DependentUpon>
         </Compile>
+        <Compile Update="WorkspaceSystem\Workspace\AddPanelInput.cs">
+          <DependentUpon>IWorkspaceViewModel.cs</DependentUpon>
+        </Compile>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NexusMods.App.UI/NexusMods.App.UI.csproj
+++ b/src/NexusMods.App.UI/NexusMods.App.UI.csproj
@@ -313,9 +313,6 @@
           <DependentUpon>WorkspaceView.axaml</DependentUpon>
           <SubType>Code</SubType>
         </Compile>
-        <Compile Update="WorkspaceSystem\Workspace\WorkspaceDesignViewModel.cs">
-          <DependentUpon>IWorkspaceViewModel.cs</DependentUpon>
-        </Compile>
         <Compile Update="WorkspaceSystem\Workspace\WorkspaceViewModel.cs">
           <DependentUpon>IWorkspaceViewModel.cs</DependentUpon>
         </Compile>

--- a/src/NexusMods.App.UI/NexusMods.App.UI.csproj
+++ b/src/NexusMods.App.UI/NexusMods.App.UI.csproj
@@ -319,9 +319,6 @@
         <Compile Update="WorkspaceSystem\Workspace\WorkspaceViewModel.cs">
           <DependentUpon>IWorkspaceViewModel.cs</DependentUpon>
         </Compile>
-        <Compile Update="WorkspaceSystem\Panel\PanelDesignViewModel.cs">
-          <DependentUpon>IPanelViewModel.cs</DependentUpon>
-        </Compile>
         <Compile Update="WorkspaceSystem\Panel\PanelViewModel.cs">
           <DependentUpon>IPanelViewModel.cs</DependentUpon>
         </Compile>

--- a/src/NexusMods.App.UI/NexusMods.App.UI.csproj.DotSettings
+++ b/src/NexusMods.App.UI/NexusMods.App.UI.csproj.DotSettings
@@ -1,0 +1,3 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=workspacesystem_005Cpanel/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=workspacesystem_005Cworkspace/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/NexusMods.App.UI/Services.cs
+++ b/src/NexusMods.App.UI/Services.cs
@@ -36,6 +36,7 @@ using NexusMods.App.UI.RightContent.LoadoutGrid.Columns.ModVersion;
 using NexusMods.App.UI.RightContent.MyGames;
 using NexusMods.App.UI.Routing;
 using NexusMods.App.UI.Windows;
+using NexusMods.App.UI.WorkspaceSystem;
 using NexusMods.Common;
 using ReactiveUI;
 using DownloadGameNameView = NexusMods.App.UI.RightContent.DownloadGrid.Columns.DownloadGameName.DownloadGameNameView;
@@ -147,6 +148,11 @@ public static class Services
             .AddView<CancelDownloadOverlayView, ICancelDownloadOverlayViewModel>()
             .AddView<MessageBoxOkCancelView, IMessageBoxOkCancelViewModel>()
             .AddView<UpdaterView, IUpdaterViewModel>()
+
+            .AddViewModel<WorkspaceViewModel, IWorkspaceViewModel>()
+            .AddView<WorkspaceView, IWorkspaceViewModel>()
+            .AddViewModel<PanelViewModel, IPanelViewModel>()
+            .AddView<PanelView, IPanelViewModel>()
 
             // Other
             .AddSingleton<InjectedViewLocator>()

--- a/src/NexusMods.App.UI/WorkspaceSystem/MathUtils.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/MathUtils.cs
@@ -1,0 +1,34 @@
+using Avalonia;
+
+namespace NexusMods.App.UI.WorkspaceSystem;
+
+internal static class MathUtils
+{
+    /// <summary>
+    /// <see cref="Size"/> with a width and height of zero.
+    /// </summary>
+    internal static readonly Size Zero = new(width: 0.0, height: 0.0);
+
+    /// <summary>
+    /// <see cref="Rect"/> with a width and height of <c>1.0</c> and x
+    /// and y of zero.
+    /// </summary>
+    internal static readonly Rect One = new(
+        x: 0.0,
+        y: 0.0,
+        width: 1.0,
+        height: 1.0
+    );
+
+    /// <summary>
+    /// Calculates the actual bounds of a panel inside a workspace using it's logical bounds.
+    /// </summary>
+    /// <seealso cref="IPanelViewModel.LogicalBounds"/>
+    /// <seealso cref="IPanelViewModel.ActualBounds"/>
+    internal static Rect CalculateActualBounds(Size workspaceSize, Rect logicalBounds)
+    {
+        return logicalBounds * workspaceSize.AsVector();
+    }
+
+    private static Vector AsVector(this Size size) => new(x: size.Width, y: size.Height);
+}

--- a/src/NexusMods.App.UI/WorkspaceSystem/MathUtils.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/MathUtils.cs
@@ -30,5 +30,8 @@ internal static class MathUtils
         return logicalBounds * workspaceSize.AsVector();
     }
 
-    private static Vector AsVector(this Size size) => new(x: size.Width, y: size.Height);
+    /// <summary>
+    /// Converts a <see cref="Size"/> into a <see cref="Vector"/>.
+    /// </summary>
+    internal static Vector AsVector(this Size size) => new(x: size.Width, y: size.Height);
 }

--- a/src/NexusMods.App.UI/WorkspaceSystem/MathUtils.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/MathUtils.cs
@@ -57,9 +57,12 @@ internal static class MathUtils
         return (updatedLogicalBounds, newPanelLogicalBounds);
     }
 
-    internal static Rect Join(Rect a, Rect b)
+    /// <summary>
+    /// Calculates the new combined logical bounds of two panels.
+    /// </summary>
+    internal static Rect Join(Rect logicalBoundsToExpand, Rect logicalBoundsToConsume)
     {
-        throw new NotImplementedException();
+        return logicalBoundsToExpand.Union(logicalBoundsToConsume);
     }
 
     /// <summary>

--- a/src/NexusMods.App.UI/WorkspaceSystem/MathUtils.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/MathUtils.cs
@@ -30,6 +30,10 @@ internal static class MathUtils
         return logicalBounds * workspaceSize.AsVector();
     }
 
+    /// <summary>
+    /// Calculates the logical bounds for the existing panel and the new panel that is going
+    /// to take up half of the existing panels' space.
+    /// </summary>
     internal static (Rect UpdatedLogicalBounds, Rect NewPanelLogicalBounds) Split(Rect currentLogicalBounds, bool vertical)
     {
         Rect newPanelLogicalBounds;

--- a/src/NexusMods.App.UI/WorkspaceSystem/MathUtils.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/MathUtils.cs
@@ -30,6 +30,34 @@ internal static class MathUtils
         return logicalBounds * workspaceSize.AsVector();
     }
 
+    internal static (Rect UpdatedLogicalBounds, Rect NewPanelLogicalBounds) Split(Rect currentLogicalBounds, bool vertical)
+    {
+        Rect newPanelLogicalBounds;
+        Rect updatedLogicalBounds;
+
+        if (vertical)
+        {
+            var newWidth = currentLogicalBounds.Width / 2;
+
+            updatedLogicalBounds = currentLogicalBounds.WithWidth(newWidth);
+            newPanelLogicalBounds = updatedLogicalBounds.WithX(currentLogicalBounds.X + newWidth);
+        }
+        else
+        {
+            var newHeight = currentLogicalBounds.Height / 2;
+
+            updatedLogicalBounds = currentLogicalBounds.WithHeight(newHeight);
+            newPanelLogicalBounds = updatedLogicalBounds.WithY(currentLogicalBounds.Y + newHeight);
+        }
+
+        return (updatedLogicalBounds, newPanelLogicalBounds);
+    }
+
+    internal static Rect Join(Rect a, Rect b)
+    {
+        throw new NotImplementedException();
+    }
+
     /// <summary>
     /// Converts a <see cref="Size"/> into a <see cref="Vector"/>.
     /// </summary>

--- a/src/NexusMods.App.UI/WorkspaceSystem/Panel/IPanelViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Panel/IPanelViewModel.cs
@@ -8,9 +8,28 @@ public interface IPanelViewModel : IViewModelInterface
 
     public IViewModel? Content { get; set; }
 
+    /// <summary>
+    /// Gets or sets the logical bounds the panel.
+    /// </summary>
+    /// <remarks>
+    /// The logical bounds describe the ratio of space the panel takes up inside the workspace.
+    /// The values range from 0.0 up to and including 1.0, where 0.0 means 0% of the space and 1.0
+    /// means 100% of the space.
+    /// </remarks>
+    /// <seealso cref="ActualBounds"/>
     public Rect LogicalBounds { get; set; }
 
-    public Rect ActualBounds { get; set; }
+    /// <summary>
+    /// Gets the actual bounds of the panel.
+    /// </summary>
+    /// <remarks>
+    /// This is the actual size and position of the panel element inside the workspace canvas.
+    /// </remarks>
+    /// <seealso cref="LogicalBounds"/>
+    public Rect ActualBounds { get; }
 
-    public void Arrange(Size workspaceControlSize);
+    /// <summary>
+    /// Updates the <see cref="ActualBounds"/> using the new workspace size.
+    /// </summary>
+    public void Arrange(Size workspaceSize);
 }

--- a/src/NexusMods.App.UI/WorkspaceSystem/Panel/IPanelViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Panel/IPanelViewModel.cs
@@ -1,3 +1,5 @@
+using Avalonia;
+
 namespace NexusMods.App.UI.WorkspaceSystem;
 
 public interface IPanelViewModel : IViewModelInterface
@@ -5,4 +7,10 @@ public interface IPanelViewModel : IViewModelInterface
     public PanelId Id { get; }
 
     public IViewModel? Content { get; set; }
+
+    public Rect LogicalBounds { get; set; }
+
+    public Rect ActualBounds { get; set; }
+
+    public void Arrange(Size workspaceControlSize);
 }

--- a/src/NexusMods.App.UI/WorkspaceSystem/Panel/IPanelViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Panel/IPanelViewModel.cs
@@ -1,0 +1,8 @@
+namespace NexusMods.App.UI.WorkspaceSystem;
+
+public interface IPanelViewModel : IViewModelInterface
+{
+    public PanelId Id { get; }
+
+    public IViewModel? Content { get; set; }
+}

--- a/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelComparer.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelComparer.cs
@@ -1,0 +1,13 @@
+namespace NexusMods.App.UI.WorkspaceSystem;
+
+public class PanelComparer : IComparer<IPanelViewModel>
+{
+    public static readonly PanelComparer Instance = new();
+
+    public int Compare(IPanelViewModel? x, IPanelViewModel? y)
+    {
+        if (ReferenceEquals(x, y)) return 0;
+        // TODO:
+        return 1;
+    }
+}

--- a/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelComparer.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelComparer.cs
@@ -4,10 +4,14 @@ public class PanelComparer : IComparer<IPanelViewModel>
 {
     public static readonly PanelComparer Instance = new();
 
-    public int Compare(IPanelViewModel? x, IPanelViewModel? y)
+    public int Compare(IPanelViewModel? a, IPanelViewModel? b)
     {
-        if (ReferenceEquals(x, y)) return 0;
-        // TODO:
-        return 1;
+        if (a is null) return -1;
+        if (b is null) return 1;
+        if (ReferenceEquals(a, b)) return 0;
+
+        var xComparison = a.LogicalBounds.X.CompareTo(b.LogicalBounds.X);
+        if (xComparison != 0) return xComparison;
+        return a.LogicalBounds.Y.CompareTo(b.LogicalBounds.Y);
     }
 }

--- a/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelDesignViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelDesignViewModel.cs
@@ -1,6 +1,0 @@
-namespace NexusMods.App.UI.WorkspaceSystem;
-
-public class PanelDesignViewModel : PanelViewModel
-{
-
-}

--- a/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelDesignViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelDesignViewModel.cs
@@ -1,0 +1,6 @@
+namespace NexusMods.App.UI.WorkspaceSystem;
+
+public class PanelDesignViewModel : PanelViewModel
+{
+
+}

--- a/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelId.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelId.cs
@@ -1,0 +1,6 @@
+using Vogen;
+
+namespace NexusMods.App.UI.WorkspaceSystem;
+
+[ValueObject<Guid>]
+public readonly partial struct PanelId { }

--- a/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelView.axaml
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelView.axaml
@@ -11,7 +11,7 @@
     <!-- <reactive:ViewModelViewHost x:Name="ViewModelViewHost"/> -->
 
     <Design.DataContext>
-        <workspace:PanelDesignViewModel/>
+        <workspace:PanelViewModel/>
     </Design.DataContext>
 
     <TextBlock Classes="Body2RobotoRegularBold">Hello World!</TextBlock>

--- a/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelView.axaml
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelView.axaml
@@ -1,0 +1,19 @@
+<reactive:ReactiveUserControl
+    x:TypeArguments="workspace:IPanelViewModel" xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:reactive="http://reactiveui.net"
+    xmlns:workspace="clr-namespace:NexusMods.App.UI.WorkspaceSystem"
+    mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+    x:Class="NexusMods.App.UI.WorkspaceSystem.PanelView">
+
+    <!-- <reactive:ViewModelViewHost x:Name="ViewModelViewHost"/> -->
+
+    <Design.DataContext>
+        <workspace:PanelDesignViewModel/>
+    </Design.DataContext>
+
+    <TextBlock Classes="Body2RobotoRegularBold">Hello World!</TextBlock>
+
+</reactive:ReactiveUserControl>

--- a/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelView.axaml
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelView.axaml
@@ -6,7 +6,8 @@
     xmlns:reactive="http://reactiveui.net"
     xmlns:workspace="clr-namespace:NexusMods.App.UI.WorkspaceSystem"
     mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
-    x:Class="NexusMods.App.UI.WorkspaceSystem.PanelView">
+    x:Class="NexusMods.App.UI.WorkspaceSystem.PanelView"
+    Width="0" Height="0">
 
     <!-- <reactive:ViewModelViewHost x:Name="ViewModelViewHost"/> -->
 
@@ -14,6 +15,6 @@
         <workspace:PanelViewModel/>
     </Design.DataContext>
 
-    <TextBlock Classes="Body2RobotoRegularBold">Hello World!</TextBlock>
+    <TextBlock>Hello World!</TextBlock>
 
 </reactive:ReactiveUserControl>

--- a/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelView.axaml.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelView.axaml.cs
@@ -1,0 +1,20 @@
+using System.Reactive.Disposables;
+using Avalonia.ReactiveUI;
+using ReactiveUI;
+
+namespace NexusMods.App.UI.WorkspaceSystem;
+
+public partial class PanelView : ReactiveUserControl<IPanelViewModel>
+{
+    public PanelView()
+    {
+        InitializeComponent();
+
+        // this.WhenActivated(disposables =>
+        // {
+        //     this.OneWayBind(ViewModel, vm => vm.Content, view => view.ViewModelViewHost.ViewModel)
+        //         .DisposeWith(disposables);
+        // });
+    }
+}
+

--- a/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelView.axaml.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelView.axaml.cs
@@ -1,6 +1,4 @@
-using System.Reactive.Disposables;
 using Avalonia.ReactiveUI;
-using ReactiveUI;
 
 namespace NexusMods.App.UI.WorkspaceSystem;
 

--- a/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelView.axaml.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelView.axaml.cs
@@ -1,18 +1,39 @@
+using System.Reactive.Disposables;
+using Avalonia.Controls;
+using Avalonia.Media;
+using Avalonia.Media.Immutable;
 using Avalonia.ReactiveUI;
+using ReactiveUI;
 
 namespace NexusMods.App.UI.WorkspaceSystem;
 
 public partial class PanelView : ReactiveUserControl<IPanelViewModel>
 {
+    private static byte GetRandomByte()
+    {
+        var i = Random.Shared.Next(byte.MinValue, byte.MaxValue);
+        return (byte)i;
+    }
+
     public PanelView()
     {
         InitializeComponent();
 
-        // this.WhenActivated(disposables =>
-        // {
-        //     this.OneWayBind(ViewModel, vm => vm.Content, view => view.ViewModelViewHost.ViewModel)
-        //         .DisposeWith(disposables);
-        // });
+        var color = Color.FromRgb(GetRandomByte(), GetRandomByte(), GetRandomByte());
+        Background = new ImmutableSolidColorBrush(color);
+
+        this.WhenActivated(disposables =>
+        {
+            this.WhenAnyValue(view => view.ViewModel!.ActualBounds)
+                .Subscribe(bounds =>
+                {
+                    Width = bounds.Width;
+                    Height = bounds.Height;
+                    Canvas.SetLeft(this, bounds.X);
+                    Canvas.SetTop(this, bounds.Y);
+                })
+                .DisposeWith(disposables);
+        });
     }
 }
 

--- a/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelViewModel.cs
@@ -31,6 +31,7 @@ public class PanelViewModel : AViewModel<IPanelViewModel>, IPanelViewModel
     private void UpdateActualBounds()
     {
         ActualBounds = MathUtils.CalculateActualBounds(_workspaceSize, LogicalBounds);
+        Console.WriteLine(ActualBounds.ToString());
     }
 
     /// <inheritdoc/>

--- a/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelViewModel.cs
@@ -1,3 +1,6 @@
+using System.Reactive.Disposables;
+using Avalonia;
+using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
 
 namespace NexusMods.App.UI.WorkspaceSystem;
@@ -8,4 +11,40 @@ public class PanelViewModel : AViewModel<IPanelViewModel>, IPanelViewModel
 
     [Reactive]
     public IViewModel? Content { get; set; }
+
+    [Reactive]
+    public Rect LogicalBounds { get; set; }
+
+    [Reactive]
+    public Rect ActualBounds { get; set; }
+
+    private Size _workspaceControlSize = new(0, 0);
+
+    public PanelViewModel()
+    {
+        this.WhenActivated(disposables =>
+        {
+            this.WhenAnyValue(vm => vm.LogicalBounds)
+                .SubscribeWithErrorLogging(_ => UpdateActualBounds())
+                .DisposeWith(disposables);
+        });
+    }
+
+    public void Arrange(Size workspaceControlSize)
+    {
+        Console.WriteLine(nameof(Arrange));
+        _workspaceControlSize = workspaceControlSize;
+        UpdateActualBounds();
+    }
+
+    private void UpdateActualBounds()
+    {
+        Console.WriteLine(nameof(UpdateActualBounds));
+        ActualBounds = new Rect(
+            x: LogicalBounds.X * _workspaceControlSize.Width,
+            y: LogicalBounds.Y * _workspaceControlSize.Height,
+            width: LogicalBounds.Width * _workspaceControlSize.Width,
+            height: LogicalBounds.Height * _workspaceControlSize.Height
+        );
+    }
 }

--- a/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelViewModel.cs
@@ -1,0 +1,11 @@
+using ReactiveUI.Fody.Helpers;
+
+namespace NexusMods.App.UI.WorkspaceSystem;
+
+public class PanelViewModel : AViewModel<IPanelViewModel>, IPanelViewModel
+{
+    public PanelId Id { get; } = PanelId.From(Guid.NewGuid());
+
+    [Reactive]
+    public IViewModel? Content { get; set; }
+}

--- a/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelViewModel.cs
@@ -9,16 +9,13 @@ public class PanelViewModel : AViewModel<IPanelViewModel>, IPanelViewModel
 {
     public PanelId Id { get; } = PanelId.From(Guid.NewGuid());
 
-    [Reactive]
-    public IViewModel? Content { get; set; }
+    [Reactive] public IViewModel? Content { get; set; }
 
-    [Reactive]
-    public Rect LogicalBounds { get; set; }
+    /// <inheritdoc/>
+    [Reactive] public Rect LogicalBounds { get; set; }
 
-    [Reactive]
-    public Rect ActualBounds { get; set; }
-
-    private Size _workspaceControlSize = new(0, 0);
+    /// <inheritdoc/>
+    [Reactive] public Rect ActualBounds { get; set; }
 
     public PanelViewModel()
     {
@@ -30,21 +27,16 @@ public class PanelViewModel : AViewModel<IPanelViewModel>, IPanelViewModel
         });
     }
 
-    public void Arrange(Size workspaceControlSize)
-    {
-        Console.WriteLine(nameof(Arrange));
-        _workspaceControlSize = workspaceControlSize;
-        UpdateActualBounds();
-    }
-
+    private Size _workspaceSize = MathUtils.Zero;
     private void UpdateActualBounds()
     {
-        Console.WriteLine(nameof(UpdateActualBounds));
-        ActualBounds = new Rect(
-            x: LogicalBounds.X * _workspaceControlSize.Width,
-            y: LogicalBounds.Y * _workspaceControlSize.Height,
-            width: LogicalBounds.Width * _workspaceControlSize.Width,
-            height: LogicalBounds.Height * _workspaceControlSize.Height
-        );
+        ActualBounds = MathUtils.CalculateActualBounds(_workspaceSize, LogicalBounds);
+    }
+
+    /// <inheritdoc/>
+    public void Arrange(Size workspaceSize)
+    {
+        _workspaceSize = workspaceSize;
+        UpdateActualBounds();
     }
 }

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/AddPanelInput.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/AddPanelInput.cs
@@ -1,3 +1,8 @@
 namespace NexusMods.App.UI.WorkspaceSystem;
 
+/// <summary>
+/// Input for <see cref="IWorkspaceViewModel.AddPanelCommand"/>.
+/// </summary>
+/// <param name="PanelToSplit">The panel to split. Null is only allowed if the workspace contains no panels.</param>
+/// <param name="SplitVertically">Whether to split the panel vertically or horizontally.</param>
 public record struct AddPanelInput(IPanelViewModel? PanelToSplit, bool SplitVertically);

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/AddPanelInput.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/AddPanelInput.cs
@@ -1,0 +1,3 @@
+namespace NexusMods.App.UI.WorkspaceSystem;
+
+public record struct AddPanelInput(IPanelViewModel? PanelToSplit, bool SplitVertically);

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/IWorkspaceViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/IWorkspaceViewModel.cs
@@ -9,7 +9,7 @@ public interface IWorkspaceViewModel : IViewModelInterface
 {
     public ReadOnlyObservableCollection<IPanelViewModel> Panels { get; }
 
-    public ReactiveCommand<Unit, Unit> AddPanelCommand { get; }
+    public ReactiveCommand<AddPanelInput, IPanelViewModel> AddPanelCommand { get; }
 
     public ReactiveCommand<Unit, Unit> RemovePanelCommand { get; }
 

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/IWorkspaceViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/IWorkspaceViewModel.cs
@@ -1,0 +1,14 @@
+using System.Collections.ObjectModel;
+using System.Reactive;
+using ReactiveUI;
+
+namespace NexusMods.App.UI.WorkspaceSystem;
+
+public interface IWorkspaceViewModel : IViewModelInterface
+{
+    public ReadOnlyObservableCollection<IPanelViewModel> Panels { get; }
+
+    public ReactiveCommand<Unit, Unit> AddPanelCommand { get; }
+
+    public ReactiveCommand<Unit, Unit> RemovePanelCommand { get; }
+}

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/IWorkspaceViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/IWorkspaceViewModel.cs
@@ -9,8 +9,17 @@ public interface IWorkspaceViewModel : IViewModelInterface
 {
     public ReadOnlyObservableCollection<IPanelViewModel> Panels { get; }
 
+    /// <summary>
+    /// Command for adding a new panel to the workspace.
+    /// </summary>
+    /// <remarks>
+    /// This command returns the new panel.
+    /// </remarks>
     public ReactiveCommand<AddPanelInput, IPanelViewModel> AddPanelCommand { get; }
 
+    /// <summary>
+    /// Command for remove an existing panel from the workspace.
+    /// </summary>
     public ReactiveCommand<RemovePanelInput, Unit> RemovePanelCommand { get; }
 
     public void ArrangePanels(Size workspaceControlSize);

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/IWorkspaceViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/IWorkspaceViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using System.Reactive;
+using Avalonia;
 using ReactiveUI;
 
 namespace NexusMods.App.UI.WorkspaceSystem;
@@ -11,4 +12,6 @@ public interface IWorkspaceViewModel : IViewModelInterface
     public ReactiveCommand<Unit, Unit> AddPanelCommand { get; }
 
     public ReactiveCommand<Unit, Unit> RemovePanelCommand { get; }
+
+    public void ArrangePanels(Size workspaceControlSize);
 }

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/IWorkspaceViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/IWorkspaceViewModel.cs
@@ -11,7 +11,7 @@ public interface IWorkspaceViewModel : IViewModelInterface
 
     public ReactiveCommand<AddPanelInput, IPanelViewModel> AddPanelCommand { get; }
 
-    public ReactiveCommand<Unit, Unit> RemovePanelCommand { get; }
+    public ReactiveCommand<RemovePanelInput, Unit> RemovePanelCommand { get; }
 
     public void ArrangePanels(Size workspaceControlSize);
 }

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/RemovePanelInput.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/RemovePanelInput.cs
@@ -1,0 +1,3 @@
+namespace NexusMods.App.UI.WorkspaceSystem;
+
+public record struct RemovePanelInput(IPanelViewModel PanelToConsume, IPanelViewModel PanelToExpand);

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/RemovePanelInput.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/RemovePanelInput.cs
@@ -1,3 +1,8 @@
 namespace NexusMods.App.UI.WorkspaceSystem;
 
+/// <summary>
+/// Input for <see cref="IWorkspaceViewModel.RemovePanelCommand"/>.
+/// </summary>
+/// <param name="PanelToConsume">The panel that is going to be removed from the workspace.</param>
+/// <param name="PanelToExpand">The panel that is going to take up the new space.</param>
 public record struct RemovePanelInput(IPanelViewModel PanelToConsume, IPanelViewModel PanelToExpand);

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceDesignViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceDesignViewModel.cs
@@ -1,5 +1,0 @@
-namespace NexusMods.App.UI.WorkspaceSystem;
-
-public class WorkspaceDesignViewModel : WorkspaceViewModel
-{
-}

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceDesignViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceDesignViewModel.cs
@@ -1,0 +1,5 @@
+namespace NexusMods.App.UI.WorkspaceSystem;
+
+public class WorkspaceDesignViewModel : WorkspaceViewModel
+{
+}

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspacePlaygroundView.axaml
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspacePlaygroundView.axaml
@@ -13,19 +13,23 @@
     </Design.DataContext>
 
     <Grid RowDefinitions="Auto, *">
-        <StackPanel Orientation="Horizontal" Grid.Row="0">
-            <Button x:Name="AddPanelButton" Classes="Standard PrimaryOutlined">
-                <TextBlock>Add Panel</TextBlock>
+        <Grid Grid.Row="0" ColumnDefinitions="Auto, Auto" RowDefinitions="Auto, Auto">
+            <Button Grid.Row="0" Grid.Column="0" Classes="Standard PrimaryOutlined" x:Name="TopLeftButton">
+                <TextBlock x:Name="TopLeftTextBlock"/>
             </Button>
 
-            <Button x:Name="RemovePanelButton" Classes="Standard PrimaryOutlined">
-                <TextBlock>Remove Panel</TextBlock>
+            <Button Grid.Row="0" Grid.Column="1" Classes="Standard PrimaryOutlined" x:Name="TopRightButton">
+                <TextBlock x:Name="TopRightTextBlock"/>
             </Button>
 
-            <CheckBox x:Name="VerticalSplitCheckbox">
-                <TextBlock Classes="ButtonMontserratSemi">Split Vertically</TextBlock>
-            </CheckBox>
-        </StackPanel>
+            <Button Grid.Row="1" Grid.Column="0" Classes="Standard PrimaryOutlined" x:Name="BottomLeftButton">
+                <TextBlock x:Name="BottomLeftTextBlock"/>
+            </Button>
+
+            <Button Grid.Row="1" Grid.Column="1" Classes="Standard PrimaryOutlined" x:Name="BottomRightButton">
+                <TextBlock x:Name="BottomRightTextBlock"/>
+            </Button>
+        </Grid>
 
         <reactive:ViewModelViewHost Grid.Row="1" x:Name="ViewModelViewHost" />
     </Grid>

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspacePlaygroundView.axaml
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspacePlaygroundView.axaml
@@ -1,0 +1,28 @@
+<reactive:ReactiveUserControl
+    x:TypeArguments="workspace:WorkspacePlaygroundViewModel" xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:reactive="http://reactiveui.net"
+    xmlns:workspace="clr-namespace:NexusMods.App.UI.WorkspaceSystem"
+    mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+    x:Class="NexusMods.App.UI.WorkspaceSystem.WorkspacePlaygroundView">
+
+    <Design.DataContext>
+        <workspace:WorkspacePlaygroundViewModel />
+    </Design.DataContext>
+
+    <Grid RowDefinitions="Auto, *">
+        <StackPanel Orientation="Horizontal" Grid.Row="0">
+            <Button x:Name="AddPanelButton" Classes="Standard PrimaryOutlined">
+                <TextBlock>Add Panel</TextBlock>
+            </Button>
+            <Button x:Name="RemovePanelButton" Classes="Standard PrimaryOutlined">
+                <TextBlock>Remove Panel</TextBlock>
+            </Button>
+        </StackPanel>
+
+        <reactive:ViewModelViewHost Grid.Row="1" x:Name="ViewModelViewHost" />
+    </Grid>
+
+</reactive:ReactiveUserControl>

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspacePlaygroundView.axaml
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspacePlaygroundView.axaml
@@ -17,9 +17,14 @@
             <Button x:Name="AddPanelButton" Classes="Standard PrimaryOutlined">
                 <TextBlock>Add Panel</TextBlock>
             </Button>
+
             <Button x:Name="RemovePanelButton" Classes="Standard PrimaryOutlined">
                 <TextBlock>Remove Panel</TextBlock>
             </Button>
+
+            <CheckBox x:Name="VerticalSplitCheckbox">
+                <TextBlock Classes="ButtonMontserratSemi">Split Vertically</TextBlock>
+            </CheckBox>
         </StackPanel>
 
         <reactive:ViewModelViewHost Grid.Row="1" x:Name="ViewModelViewHost" />

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspacePlaygroundView.axaml.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspacePlaygroundView.axaml.cs
@@ -19,6 +19,9 @@ public partial class WorkspacePlaygroundView : ReactiveUserControl<WorkspacePlay
 
             this.BindCommand(ViewModel, vm => vm.WorkspaceViewModel.RemovePanelCommand, view => view.RemovePanelButton)
                 .DisposeWith(disposables);
+
+            this.Bind(ViewModel, vm => vm.SplitVertically, view => view.VerticalSplitCheckbox.IsChecked)
+                .DisposeWith(disposables);
         });
     }
 }

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspacePlaygroundView.axaml.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspacePlaygroundView.axaml.cs
@@ -1,9 +1,14 @@
+using System.Linq.Expressions;
+using System.Reactive;
 using System.Reactive.Disposables;
+using Avalonia.Controls;
 using Avalonia.ReactiveUI;
+using JetBrains.Annotations;
 using ReactiveUI;
 
 namespace NexusMods.App.UI.WorkspaceSystem;
 
+[UsedImplicitly]
 public partial class WorkspacePlaygroundView : ReactiveUserControl<WorkspacePlaygroundViewModel>
 {
     public WorkspacePlaygroundView()
@@ -14,15 +19,28 @@ public partial class WorkspacePlaygroundView : ReactiveUserControl<WorkspacePlay
         {
             ViewModelViewHost.ViewModel = ViewModel?.WorkspaceViewModel;
 
-            this.BindCommand(ViewModel, vm => vm.WorkspaceViewModel.AddPanelCommand, view => view.AddPanelButton)
-                .DisposeWith(disposables);
-
-            this.BindCommand(ViewModel, vm => vm.WorkspaceViewModel.RemovePanelCommand, view => view.RemovePanelButton)
-                .DisposeWith(disposables);
-
-            this.Bind(ViewModel, vm => vm.SplitVertically, view => view.VerticalSplitCheckbox.IsChecked)
-                .DisposeWith(disposables);
+            Setup(disposables, TopLeftTextBlock, view => view.ViewModel!.HasTopLeftPanel, view => view.TopLeftButton, vm => vm.ToggleTopLeftPanel);
+            Setup(disposables, TopRightTextBlock, view => view.ViewModel!.HasTopRightPanel, view => view.TopRightButton, vm => vm.ToggleTopRightPanel);
+            Setup(disposables, BottomLeftTextBlock, view => view.ViewModel!.HasBottomLeftPanel, view => view.BottomLeftButton, vm => vm.ToggleBottomLeftPanel);
+            Setup(disposables, BottomRightTextBlock, view => view.ViewModel!.HasBottomRightPanel, view => view.BottomRightButton, vm => vm.ToggleBottomRightPanel);
         });
     }
+
+    private void Setup(
+        CompositeDisposable disposables,
+        TextBlock textBlock,
+        Expression<Func<WorkspacePlaygroundView, bool>> hasPanelExpression,
+        Expression<Func<WorkspacePlaygroundView, Button>> toggleButtonExpression,
+        Expression<Func<WorkspacePlaygroundViewModel, ReactiveCommand<Unit, Unit>?>> toggleButtonCommandExpression)
+    {
+        this.WhenAnyValue(hasPanelExpression)
+            .SubscribeWithErrorLogging(value => textBlock.Text = GetText(value))
+            .DisposeWith(disposables);
+
+        this.BindCommand(ViewModel, toggleButtonCommandExpression, toggleButtonExpression)
+            .DisposeWith(disposables);
+    }
+
+    private static string GetText(bool value) => value ? "Remove Panel" : "Add Panel";
 }
 

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspacePlaygroundView.axaml.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspacePlaygroundView.axaml.cs
@@ -1,0 +1,25 @@
+using System.Reactive.Disposables;
+using Avalonia.ReactiveUI;
+using ReactiveUI;
+
+namespace NexusMods.App.UI.WorkspaceSystem;
+
+public partial class WorkspacePlaygroundView : ReactiveUserControl<WorkspacePlaygroundViewModel>
+{
+    public WorkspacePlaygroundView()
+    {
+        InitializeComponent();
+
+        this.WhenActivated(disposables =>
+        {
+            ViewModelViewHost.ViewModel = ViewModel?.WorkspaceViewModel;
+
+            this.BindCommand(ViewModel, vm => vm.WorkspaceViewModel.AddPanelCommand, view => view.AddPanelButton)
+                .DisposeWith(disposables);
+
+            this.BindCommand(ViewModel, vm => vm.WorkspaceViewModel.RemovePanelCommand, view => view.RemovePanelButton)
+                .DisposeWith(disposables);
+        });
+    }
+}
+

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspacePlaygroundViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspacePlaygroundViewModel.cs
@@ -1,3 +1,7 @@
+using System.Reactive.Disposables;
+using ReactiveUI;
+using ReactiveUI.Fody.Helpers;
+
 namespace NexusMods.App.UI.WorkspaceSystem;
 
 public interface IWorkspacePlaygroundViewModel{}
@@ -5,4 +9,17 @@ public interface IWorkspacePlaygroundViewModel{}
 public class WorkspacePlaygroundViewModel : AViewModel<IWorkspacePlaygroundViewModel>, IWorkspacePlaygroundViewModel
 {
     public readonly WorkspaceViewModel WorkspaceViewModel = new();
+
+    [Reactive]
+    public bool SplitVertically { get; set; }
+
+    public WorkspacePlaygroundViewModel()
+    {
+        this.WhenActivated(disposables =>
+        {
+            this.WhenAnyValue(vm => vm.SplitVertically)
+                .SubscribeWithErrorLogging(value => WorkspaceViewModel.SplitVertically = value)
+                .DisposeWith(disposables);
+        });
+    }
 }

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspacePlaygroundViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspacePlaygroundViewModel.cs
@@ -1,4 +1,6 @@
+using System.Reactive;
 using System.Reactive.Disposables;
+using System.Reactive.Linq;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
 
@@ -10,16 +12,93 @@ public class WorkspacePlaygroundViewModel : AViewModel<IWorkspacePlaygroundViewM
 {
     public readonly WorkspaceViewModel WorkspaceViewModel = new();
 
-    [Reactive]
-    public bool SplitVertically { get; set; }
+    [Reactive] public ReactiveCommand<Unit, Unit> ToggleTopLeftPanel { get; set; } = Initializers.DisabledReactiveCommand;
+    [Reactive] public ReactiveCommand<Unit, Unit> ToggleTopRightPanel { get; set; } = Initializers.DisabledReactiveCommand;
+    [Reactive] public ReactiveCommand<Unit, Unit> ToggleBottomLeftPanel { get; set; } = Initializers.DisabledReactiveCommand;
+    [Reactive] public ReactiveCommand<Unit, Unit> ToggleBottomRightPanel { get; set; } = Initializers.DisabledReactiveCommand;
+
+    [Reactive] public bool HasTopLeftPanel { get; set; }
+    [Reactive] public bool HasTopRightPanel { get; set; }
+    [Reactive] public bool HasBottomLeftPanel { get; set; }
+    [Reactive] public bool HasBottomRightPanel { get; set; }
+
+    private IPanelViewModel? _topLeftPanel;
+    private IPanelViewModel? _topRightPanel;
+    private IPanelViewModel? _bottomLeftPanel;
+    private IPanelViewModel? _bottomRightPanel;
 
     public WorkspacePlaygroundViewModel()
     {
         this.WhenActivated(disposables =>
         {
-            this.WhenAnyValue(vm => vm.SplitVertically)
-                .SubscribeWithErrorLogging(value => WorkspaceViewModel.SplitVertically = value)
+            this.WhenAnyValue(vm => vm.WorkspaceViewModel.AddPanelCommand)
+                .SubscribeWithErrorLogging(cmd =>
+                {
+                    _topLeftPanel = cmd.Execute(new AddPanelInput
+                    {
+                        PanelToSplit = null,
+                        SplitVertically = true
+                    }).Wait();
+                    HasTopLeftPanel = true;
+                })
                 .DisposeWith(disposables);
+
+            var canToggleTopRightPanel = this.WhenAnyValue(vm => vm.HasTopLeftPanel);
+            ToggleTopRightPanel = ReactiveCommand.Create(() =>
+            {
+                if (!HasTopRightPanel)
+                {
+                    _topRightPanel = WorkspaceViewModel.AddPanelCommand.Execute(new AddPanelInput
+                    {
+                        PanelToSplit = _topLeftPanel,
+                        SplitVertically = true
+                    }).Wait();
+                }
+                else
+                {
+                    throw new NotImplementedException();
+                }
+
+                HasTopRightPanel = !HasTopRightPanel;
+            }, canToggleTopRightPanel).DisposeWith(disposables);
+
+            var canToggleBottomLeftPanel = this.WhenAnyValue(vm => vm.HasTopLeftPanel);
+            ToggleBottomLeftPanel = ReactiveCommand.Create(() =>
+            {
+                if (!HasBottomLeftPanel)
+                {
+                    _bottomLeftPanel = WorkspaceViewModel.AddPanelCommand.Execute(new AddPanelInput
+                    {
+                        PanelToSplit = _topLeftPanel,
+                        SplitVertically = false
+                    }).Wait();
+                }
+                else
+                {
+                    throw new NotImplementedException();
+                }
+
+                HasBottomLeftPanel = !HasBottomLeftPanel;
+            }, canToggleBottomLeftPanel).DisposeWith(disposables);
+
+            var canToggleBottomRightPanel = this.WhenAnyValue(vm => vm.HasTopRightPanel, vm => vm.HasBottomLeftPanel, (hasTopRightPanel, hasBottomLeftPanel) => hasTopRightPanel || hasBottomLeftPanel);
+            ToggleBottomRightPanel = ReactiveCommand.Create(() =>
+            {
+                if (!HasBottomRightPanel)
+                {
+                    _bottomRightPanel = WorkspaceViewModel.AddPanelCommand.Execute(new AddPanelInput
+                    {
+                        PanelToSplit = HasBottomLeftPanel ? _bottomLeftPanel : _topRightPanel,
+                        SplitVertically = HasBottomLeftPanel
+                    }).Wait();
+                }
+                else
+                {
+                    throw new NotImplementedException();
+                }
+
+                HasBottomRightPanel = !HasBottomRightPanel;
+            }, canToggleBottomRightPanel).DisposeWith(disposables);
         });
     }
 }

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspacePlaygroundViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspacePlaygroundViewModel.cs
@@ -1,0 +1,8 @@
+namespace NexusMods.App.UI.WorkspaceSystem;
+
+public interface IWorkspacePlaygroundViewModel{}
+
+public class WorkspacePlaygroundViewModel : AViewModel<IWorkspacePlaygroundViewModel>, IWorkspacePlaygroundViewModel
+{
+    public readonly WorkspaceViewModel WorkspaceViewModel = new();
+}

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceView.axaml
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceView.axaml
@@ -8,20 +8,6 @@
     mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
     x:Class="NexusMods.App.UI.WorkspaceSystem.WorkspaceView">
 
-    <Design.DataContext>
-        <workspace:WorkspaceViewModel/>
-    </Design.DataContext>
-
-    <StackPanel>
-        <Button x:Name="AddPanelButton" Classes="Standard PrimaryOutlined">
-            <TextBlock>Add Panel</TextBlock>
-        </Button>
-
-        <Button x:Name="RemovePanelButton" Classes="Standard PrimaryOutlined">
-            <TextBlock>Remove Panel</TextBlock>
-        </Button>
-
-        <Canvas x:Name="WorkspaceCanvas"></Canvas>
-    </StackPanel>
+    <Canvas x:Name="WorkspaceCanvas"></Canvas>
 
 </reactive:ReactiveUserControl>

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceView.axaml
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceView.axaml
@@ -1,0 +1,28 @@
+<reactive:ReactiveUserControl
+    x:TypeArguments="workspace:IWorkspaceViewModel" xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:reactive="http://reactiveui.net"
+    xmlns:workspace="clr-namespace:NexusMods.App.UI.WorkspaceSystem"
+    mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+    x:Class="NexusMods.App.UI.WorkspaceSystem.WorkspaceView">
+
+    <Design.DataContext>
+        <workspace:WorkspaceDesignViewModel/>
+    </Design.DataContext>
+
+    <StackPanel>
+        <Button x:Name="AddPanelButton" Classes="Standard PrimaryOutlined">
+            <TextBlock>Add Panel</TextBlock>
+        </Button>
+
+        <Button x:Name="RemovePanelButton" Classes="Standard PrimaryOutlined">
+            <TextBlock>Remove Panel</TextBlock>
+        </Button>
+
+        <Canvas x:Name="WorkspaceCanvas"></Canvas>
+    </StackPanel>
+
+
+</reactive:ReactiveUserControl>

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceView.axaml
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceView.axaml
@@ -9,7 +9,7 @@
     x:Class="NexusMods.App.UI.WorkspaceSystem.WorkspaceView">
 
     <Design.DataContext>
-        <workspace:WorkspaceDesignViewModel/>
+        <workspace:WorkspaceViewModel/>
     </Design.DataContext>
 
     <StackPanel>

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceView.axaml
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceView.axaml
@@ -24,5 +24,4 @@
         <Canvas x:Name="WorkspaceCanvas"></Canvas>
     </StackPanel>
 
-
 </reactive:ReactiveUserControl>

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceView.axaml
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceView.axaml
@@ -8,6 +8,10 @@
     mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
     x:Class="NexusMods.App.UI.WorkspaceSystem.WorkspaceView">
 
+    <Design.DataContext>
+        <workspace:WorkspaceViewModel/>
+    </Design.DataContext>
+
     <Canvas x:Name="WorkspaceCanvas"></Canvas>
 
 </reactive:ReactiveUserControl>

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceView.axaml.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceView.axaml.cs
@@ -21,12 +21,6 @@ public partial class WorkspaceView : ReactiveUserControl<IWorkspaceViewModel>
         {
             Debug.Assert(WorkspaceCanvas.Children.Count == 0);
 
-            this.BindCommand(ViewModel, vm => vm.AddPanelCommand, view => view.AddPanelButton)
-                .DisposeWith(disposables);
-
-            this.BindCommand(ViewModel, vm => vm.RemovePanelCommand, view => view.RemovePanelButton)
-                .DisposeWith(disposables);
-
             ViewModel!.Panels
                 .ToObservableChangeSet()
                 .SubscribeWithErrorLogging(changeSet =>

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceView.axaml.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceView.axaml.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Reactive.Disposables;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.ReactiveUI;
 using DynamicData;
@@ -77,5 +78,12 @@ public partial class WorkspaceView : ReactiveUserControl<IWorkspaceViewModel>
         {
             ViewModel = panelViewModel
         };
+    }
+
+    protected override Size ArrangeOverride(Size finalSize)
+    {
+        Console.WriteLine(nameof(ArrangeOverride));
+        ViewModel?.ArrangePanels(finalSize);
+        return base.ArrangeOverride(finalSize);
     }
 }

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceView.axaml.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceView.axaml.cs
@@ -1,0 +1,70 @@
+using System.Reactive.Disposables;
+using Avalonia.Controls;
+using Avalonia.ReactiveUI;
+using DynamicData;
+using DynamicData.Binding;
+using ReactiveUI;
+
+namespace NexusMods.App.UI.WorkspaceSystem;
+
+public partial class WorkspaceView : ReactiveUserControl<IWorkspaceViewModel>
+{
+    public WorkspaceView()
+    {
+        InitializeComponent();
+
+        this.WhenActivated(disposables =>
+        {
+            this.BindCommand(ViewModel, vm => vm.AddPanelCommand, view => view.AddPanelButton)
+                .DisposeWith(disposables);
+
+            this.BindCommand(ViewModel, vm => vm.RemovePanelCommand, view => view.RemovePanelButton)
+                .DisposeWith(disposables);
+
+            ViewModel!.Panels
+                .ToObservableChangeSet()
+                .SubscribeWithErrorLogging(changeSet =>
+                {
+                    // TODO: this is stupid, find a better way
+
+                    foreach (var change in changeSet)
+                    {
+                        Console.WriteLine(change.Reason);
+
+                        if (change.Reason == ListChangeReason.Add)
+                        {
+                            var item = change.Item.Current;
+                            WorkspaceCanvas.Children.Add(CreateViewModelHost(item));
+                        } else if (change.Reason == ListChangeReason.Remove)
+                        {
+                            var item = change.Item.Current;
+                            var existingControl = WorkspaceCanvas.Children.FirstOrDefault(x =>
+                            {
+                                if (x is not ViewModelViewHost viewModelViewHost) return false;
+                                if (viewModelViewHost.ViewModel is not IPanelViewModel panelViewModel) return false;
+                                return panelViewModel.Id == item.Id;
+                            });
+
+                            if (existingControl is null) return;
+                            WorkspaceCanvas.Children.Remove(existingControl);
+                        } else if (change.Reason == ListChangeReason.AddRange)
+                        {
+                            var items = change.Range;
+                            WorkspaceCanvas.Children.AddRange(items.Select(CreateViewModelHost));
+                        }
+                    }
+                })
+                .DisposeWith(disposables);
+        });
+    }
+
+    private static Control CreateViewModelHost(IPanelViewModel panelViewModel)
+    {
+        var host = new ViewModelViewHost
+        {
+            ViewModel = panelViewModel
+        };
+
+        return host;
+    }
+}

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
@@ -1,0 +1,45 @@
+using System.Collections.ObjectModel;
+using System.Reactive;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using DynamicData;
+using ReactiveUI;
+using ReactiveUI.Fody.Helpers;
+
+namespace NexusMods.App.UI.WorkspaceSystem;
+
+public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceViewModel
+{
+    private readonly SourceCache<IPanelViewModel, PanelId> _panelSource = new(x => x.Id);
+
+    private ReadOnlyObservableCollection<IPanelViewModel> _panels = Initializers.ReadOnlyObservableCollection<IPanelViewModel>();
+    public ReadOnlyObservableCollection<IPanelViewModel> Panels => _panels;
+
+    public ReactiveCommand<Unit, Unit> AddPanelCommand { get; private set; } = Initializers.DisabledReactiveCommand;
+    public ReactiveCommand<Unit, Unit> RemovePanelCommand { get; private set; } = Initializers.DisabledReactiveCommand;
+
+    public WorkspaceViewModel()
+    {
+        this.WhenActivated(disposables =>
+        {
+            _panelSource
+                .Connect()
+                .Sort(PanelComparer.Instance)
+                .Bind(out _panels)
+                .SubscribeWithErrorLogging()
+                .DisposeWith(disposables);
+
+            var canAddPanel = _panelSource.CountChanged.Select(count => count < 4);
+            AddPanelCommand = ReactiveCommand.Create(() =>
+            {
+                _panelSource.AddOrUpdate(new PanelViewModel());
+            }, canAddPanel).DisposeWith(disposables);
+
+            var canRemovePanel = _panelSource.CountChanged.Select(count => count > 0);
+            RemovePanelCommand = ReactiveCommand.Create(() =>
+            {
+                _panelSource.RemoveKey(_panelSource.Keys.First());
+            }, canRemovePanel);
+        });
+    }
+}

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
@@ -3,8 +3,10 @@ using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using Avalonia;
+using Avalonia.Controls;
 using DynamicData;
 using ReactiveUI;
+using ReactiveUI.Fody.Helpers;
 
 namespace NexusMods.App.UI.WorkspaceSystem;
 
@@ -15,7 +17,10 @@ public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceVie
     private ReadOnlyObservableCollection<IPanelViewModel> _panels = Initializers.ReadOnlyObservableCollection<IPanelViewModel>();
     public ReadOnlyObservableCollection<IPanelViewModel> Panels => _panels;
 
+    [Reactive]
     public ReactiveCommand<Unit, Unit> AddPanelCommand { get; private set; } = Initializers.DisabledReactiveCommand;
+
+    [Reactive]
     public ReactiveCommand<Unit, Unit> RemovePanelCommand { get; private set; } = Initializers.DisabledReactiveCommand;
 
     public WorkspaceViewModel()
@@ -37,11 +42,9 @@ public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceVie
                 var lastPanel = Panels.LastOrDefault();
                 if (lastPanel is not null)
                 {
-                    var lastLogicalBounds = lastPanel.LogicalBounds;
-                    var newWidth = lastLogicalBounds.Width / 2;
-
-                    newPanelLogicalBounds = lastLogicalBounds.WithWidth(newWidth).WithX(lastLogicalBounds.Left + newWidth);
-                    lastPanel.LogicalBounds = lastLogicalBounds.WithWidth(newWidth);
+                    var tuple = MathUtils.Split(lastPanel.LogicalBounds, vertical: false);
+                    lastPanel.LogicalBounds = tuple.UpdatedLogicalBounds;
+                    newPanelLogicalBounds = tuple.NewPanelLogicalBounds;
                 }
 
                 Console.WriteLine(newPanelLogicalBounds.ToString());

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
@@ -22,6 +22,8 @@ public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceVie
     [Reactive]
     public ReactiveCommand<Unit, Unit> RemovePanelCommand { get; private set; } = Initializers.DisabledReactiveCommand;
 
+    internal bool SplitVertically = true;
+
     public WorkspaceViewModel()
     {
         // TODO: setting?
@@ -44,7 +46,7 @@ public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceVie
                 var lastPanel = Panels.LastOrDefault();
                 if (lastPanel is not null)
                 {
-                    var tuple = MathUtils.Split(lastPanel.LogicalBounds, vertical: false);
+                    var tuple = MathUtils.Split(lastPanel.LogicalBounds, vertical: SplitVertically);
                     lastPanel.LogicalBounds = tuple.UpdatedLogicalBounds;
                     newPanelLogicalBounds = tuple.NewPanelLogicalBounds;
                 }

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
@@ -32,7 +32,7 @@ public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceVie
             var canAddPanel = _panelSource.CountChanged.Select(count => count < 4);
             AddPanelCommand = ReactiveCommand.Create(() =>
             {
-                var newPanelLogicalBounds = new Rect(0.0, 0.0, 1.0, 1.0);
+                var newPanelLogicalBounds = MathUtils.One;
 
                 var lastPanel = Panels.LastOrDefault();
                 if (lastPanel is not null)

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
@@ -16,9 +16,11 @@ public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceVie
     private ReadOnlyObservableCollection<IPanelViewModel> _panels = Initializers.ReadOnlyObservableCollection<IPanelViewModel>();
     public ReadOnlyObservableCollection<IPanelViewModel> Panels => _panels;
 
+    /// <inheritdoc/>
     [Reactive]
     public ReactiveCommand<AddPanelInput, IPanelViewModel> AddPanelCommand { get; private set; } = Initializers.CreateReactiveCommand<AddPanelInput, IPanelViewModel>();
 
+    /// <inheritdoc/>
     [Reactive]
     public ReactiveCommand<RemovePanelInput, Unit> RemovePanelCommand { get; private set; } = Initializers.CreateReactiveCommand<RemovePanelInput>();
 

--- a/tests/NexusMods.UI.Tests/WorkspaceSystem/MathUtilsTests.cs
+++ b/tests/NexusMods.UI.Tests/WorkspaceSystem/MathUtilsTests.cs
@@ -1,0 +1,37 @@
+using Avalonia;
+using FluentAssertions;
+using NexusMods.App.UI.WorkspaceSystem;
+
+namespace NexusMods.UI.Tests.WorkspaceSystem;
+
+public class MathUtilsTests
+{
+    [Theory]
+    [InlineData(0.0, 0.0)]
+    [InlineData(1.0, 1.0)]
+    public void Test_AsVector(double width, double height)
+    {
+        var size = new Size(width, height);
+        var vec = size.AsVector();
+        vec.X.Should().Be(width);
+        vec.Y.Should().Be(height);
+    }
+
+    [Theory]
+    [MemberData(nameof(TestData_CalculateActualBounds))]
+    public void Test_CalculateActualBounds(Size workspaceSize, Rect logicalBounds, Rect expected)
+    {
+        var actual = MathUtils.CalculateActualBounds(workspaceSize, logicalBounds);
+        actual.Should().Be(expected);
+    }
+
+    public static IEnumerable<object[]> TestData_CalculateActualBounds() => new[]
+    {
+        new object[]{ new Size(100, 100), new Rect(0.0, 0.0, 1.0, 1.0), new Rect(0.0, 0.0, 100, 100) },
+        new object[]{ new Size(100, 100), new Rect(0.0, 0.0, 0.5, 1.0), new Rect(0.0, 0.0, 50, 100) },
+        new object[]{ new Size(100, 100), new Rect(0.0, 0.0, 1.0, 0.5), new Rect(0.0, 0.0, 100, 50) },
+        new object[]{ new Size(100, 100), new Rect(0.0, 0.0, 0.5, 0.5), new Rect(0.0, 0.0, 50, 50) },
+
+        new object[]{ new Size(100, 100), new Rect(0.5, 0.5, 0.5, 0.5), new Rect(50, 50, 50, 50) },
+    };
+}

--- a/tests/NexusMods.UI.Tests/WorkspaceSystem/MathUtilsTests.cs
+++ b/tests/NexusMods.UI.Tests/WorkspaceSystem/MathUtilsTests.cs
@@ -34,4 +34,19 @@ public class MathUtilsTests
 
         new object[]{ new Size(100, 100), new Rect(0.5, 0.5, 0.5, 0.5), new Rect(50, 50, 50, 50) },
     };
+
+    [Theory]
+    [MemberData(nameof(TestData_Split))]
+    public void Test_Split(Rect currentLogicalBounds, bool vertical, Rect updatedLogicalBounds, Rect newPanelLogicalBounds)
+    {
+        var tuple = MathUtils.Split(currentLogicalBounds, vertical);
+        tuple.UpdatedLogicalBounds.Should().Be(updatedLogicalBounds);
+        tuple.NewPanelLogicalBounds.Should().Be(newPanelLogicalBounds);
+    }
+
+    public static IEnumerable<object[]> TestData_Split() => new[]
+    {
+        new object[] { new Rect(0.0, 0.0, 100, 100), true, new Rect(0.0, 0.0, 50, 100), new Rect(50, 0.0, 50, 100) },
+        new object[] { new Rect(0.0, 0.0, 100, 100), false, new Rect(0.0, 0.0, 100, 50), new Rect(0.0, 50, 100, 50) },
+    };
 }

--- a/tests/NexusMods.UI.Tests/WorkspaceSystem/MathUtilsTests.cs
+++ b/tests/NexusMods.UI.Tests/WorkspaceSystem/MathUtilsTests.cs
@@ -49,4 +49,18 @@ public class MathUtilsTests
         new object[] { new Rect(0.0, 0.0, 100, 100), true, new Rect(0.0, 0.0, 50, 100), new Rect(50, 0.0, 50, 100) },
         new object[] { new Rect(0.0, 0.0, 100, 100), false, new Rect(0.0, 0.0, 100, 50), new Rect(0.0, 50, 100, 50) },
     };
+
+    [Theory]
+    [MemberData(nameof(TestData_Join))]
+    public void Test_Join(Rect logicalBoundsToExpand, Rect logicalBoundsToConsume, Rect expected)
+    {
+        var actual = MathUtils.Join(logicalBoundsToExpand, logicalBoundsToConsume);
+        actual.Should().Be(expected);
+    }
+
+    public static IEnumerable<object[]> TestData_Join() => new[]
+    {
+        new object[]{ new Rect(0.0, 0.0, 50, 100), new Rect(50, 0.0, 50, 100), new Rect(0.0, 0.0, 100, 100) },
+        new object[]{ new Rect(0.0, 0.0, 100, 50), new Rect(0.0, 50, 100, 50), new Rect(0.0, 0.0, 100, 100) },
+    };
 }


### PR DESCRIPTION
Part of #674.

- Adds a design-only playground for testing. This is currently the only place where the system is used, so the feature is completely isolated. The code for the playground is in constant change, so don't read into it too much.
- Adds a `Workspace` and `Panel` component:
  - Panels can be added (split) and removed (join).
  - Math is outside the VM and fully tested.


![2023-10-04_15-15-58](https://github.com/Nexus-Mods/NexusMods.App/assets/16577545/f5253bd6-80d8-48d9-9b11-f9be9696180e)