### PR TITLE
Tell codecov to ignore axaml and .g.cs

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -11,6 +11,6 @@ coverage:
       default:
         threshold: 0.05 # 5%
 ignore:
- - "*.axaml.cs"
- - "*.axaml"
- - "*.g.cs:
+ - "**/*.axaml.cs"
+ - "**/*.axaml"
+ - "**/*.g.cs:

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -13,4 +13,4 @@ coverage:
 ignore:
   - "**/*.axaml.cs"
   - "**/*.axaml"
-  - "**/*.g.cs:
+  - "**/*.g.cs"

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -11,6 +11,6 @@ coverage:
       default:
         threshold: 0.05 # 5%
 ignore:
- - "**/*.axaml.cs"
- - "**/*.axaml"
- - "**/*.g.cs:
+  - "**/*.axaml.cs"
+  - "**/*.axaml"
+  - "**/*.g.cs:

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -10,3 +10,7 @@ coverage:
     project:
       default:
         threshold: 0.05 # 5%
+ignore:
+ - *.axaml.cs
+ - *.axaml
+ - *.g.cs

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -11,6 +11,6 @@ coverage:
       default:
         threshold: 0.05 # 5%
 ignore:
- - *.axaml.cs
- - *.axaml
- - *.g.cs
+ - "*.axaml.cs"
+ - "*.axaml"
+ - "*.g.cs:


### PR DESCRIPTION
To make codecov better reflect our testing methodologies; update the codecov.yaml file to ignore .axaml and .g.cs files. 