### PR TITLE
Fix tons of little issues found while running the app through the UI

### DIFF
--- a/src/NexusMods.App.UI/LeftMenu/Items/LaunchButtonViewModel.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Items/LaunchButtonViewModel.cs
@@ -61,7 +61,10 @@ public class LaunchButtonViewModel : AViewModel<ILaunchButtonViewModel>, ILaunch
         Label = Language.LaunchButtonViewModel_LaunchGame_RUNNING;
         var marker = _loadoutRegistry.GetMarker(LoadoutId);
         var tool = _toolManager.GetTools(marker.Value).OfType<IRunGameTool>().First();
-        await _toolManager.RunTool(tool, marker.Value, token: token);
+        await Task.Run(async () =>
+        {
+            await _toolManager.RunTool(tool, marker.Value, token: token);
+        }, token);
         Label = Language.LaunchButtonViewModel_LaunchGame_LAUNCH;
     }
 }

--- a/src/NexusMods.App.UI/RightContent/FoundGamesViewModel.cs
+++ b/src/NexusMods.App.UI/RightContent/FoundGamesViewModel.cs
@@ -50,7 +50,13 @@ public class FoundGamesViewModel : AViewModel<IFoundGamesViewModel>, IFoundGames
             {
                 var vm = _provider.GetRequiredService<IGameWidgetViewModel>();
                 vm.Installation = install;
-                vm.PrimaryButton = ReactiveCommand.CreateFromTask(() => ManageGame(install));
+                vm.PrimaryButton = ReactiveCommand.CreateFromTask(async () =>
+                {
+                    await Task.Run(async () =>
+                    {
+                        await ManageGame(install);
+                    });
+                });
                 return vm;
             });
         Games = new ReadOnlyObservableCollection<IGameWidgetViewModel>(new ObservableCollection<IGameWidgetViewModel>(installed));

--- a/src/NexusMods.CLI/Services.cs
+++ b/src/NexusMods.CLI/Services.cs
@@ -56,6 +56,7 @@ public static class Services
             .AddVerb<AddGame>()
             .AddVerb<AnalyzeArchive>()
             .AddVerb<Apply>()
+            .AddVerb<Ingest>()
             .AddVerb<AssociateNxm>()
             .AddVerb<ChangeTracking>()
             .AddVerb<DownloadAndInstallMod>()

--- a/src/NexusMods.CLI/Verbs/Ingest.cs
+++ b/src/NexusMods.CLI/Verbs/Ingest.cs
@@ -1,0 +1,43 @@
+using NexusMods.Abstractions.CLI;
+using NexusMods.DataModel.Loadouts.Extensions;
+using NexusMods.DataModel.Loadouts.Markers;
+using NexusMods.Paths;
+
+namespace NexusMods.CLI.Verbs;
+
+// ReSharper disable once ClassNeverInstantiated.Global
+/// <summary>
+/// Compute and run the steps needed to apply a Loadout to a game folder
+/// </summary>
+public class Ingest : AVerb<LoadoutMarker>, IRenderingVerb
+{
+    /// <inheritdoc />
+    public IRenderer Renderer { get; set; } = null!;
+
+    /// <summary>
+    /// DI constructor
+    /// </summary>
+    /// <param name="loadoutSynchronizer"></param>
+    public Ingest()
+    {
+    }
+
+    /// <inheritdoc />
+    public static VerbDefinition Definition => new("ingest", "Ingest changes from the game folders into the given loadout", new OptionDefinition[]
+    {
+        new OptionDefinition<LoadoutMarker>("l", "loadout", "Loadout ingest changes into"),
+    });
+
+    /// <inheritdoc />
+    public async Task<int> Run(LoadoutMarker loadout, CancellationToken token)
+    {
+        var state = await Renderer.WithProgress(token,
+            async () => await loadout.Value.Ingest());
+
+        loadout.Alter("Ingest changes from the game folder", _ => state);
+
+        await Renderer.Render($"Ingested game folder changes into {loadout.Value.Name}");
+
+        return 0;
+    }
+}

--- a/src/NexusMods.DataModel/LoadoutSynchronizer/ALoadoutSynchronizer.cs
+++ b/src/NexusMods.DataModel/LoadoutSynchronizer/ALoadoutSynchronizer.cs
@@ -137,6 +137,7 @@ public class ALoadoutSynchronizer : IStandardizedLoadoutSynchronizer
                         continue;
                     }
 
+                    resultingItems.Add(newEntry.Path, prevEntry.Value);
                     switch (newEntry.Value!)
                     {
 
@@ -144,6 +145,11 @@ public class ALoadoutSynchronizer : IStandardizedLoadoutSynchronizer
                             // StoredFile files are special cased so we can batch them up and extract them all at once.
                             // Don't add toExtract to the results yet as we'll need to get the modified file times
                             // after we extract them
+
+                            // If both hashes are the same, we can skip this file
+                            if (fa.Hash == entry.Hash)
+                                continue;
+
                             toExtract.Add(KeyValuePair.Create(entry.Path, fa));
                             continue;
                         case IGeneratedFile gf and IToFile:
@@ -473,6 +479,7 @@ public class ALoadoutSynchronizer : IStandardizedLoadoutSynchronizer
         var newLoadout = await FlattenedLoadoutToLoadout(flattenedLoadout, loadout, prevFlattenedLoadout);
 
         await BackupNewFiles(loadout, fileTree);
+        _diskStateRegistry.SaveState(loadout.LoadoutId, diskState);
 
         return newLoadout;
     }

--- a/src/NexusMods.DataModel/Loadouts/LoadoutRegistry.cs
+++ b/src/NexusMods.DataModel/Loadouts/LoadoutRegistry.cs
@@ -426,7 +426,7 @@ public class LoadoutRegistry : IDisposable
             name = SuggestName(installation);
 
         var result = await installation.Game.Synchronizer.Manage(installation);
-        Alter(result.LoadoutId, $"Manage new instance of {installation.Game.Name} as {name}",
+        result = Alter(result.LoadoutId, $"Manage new instance of {installation.Game.Name} as {name}",
             _ => result with
         {
             Name = name

--- a/src/NexusMods.DataModel/Loadouts/LoadoutRegistry.cs
+++ b/src/NexusMods.DataModel/Loadouts/LoadoutRegistry.cs
@@ -431,6 +431,8 @@ public class LoadoutRegistry : IDisposable
         {
             Name = name
         });
+        var withExtraFiles = await installation.Game.Synchronizer.Ingest(result);
+        Alter(result.LoadoutId, $"Adding extra files found in game folder", _ => withExtraFiles);
         return GetMarker(result.LoadoutId);
     }
 


### PR DESCRIPTION
While prepping for the close of Milestone 2 actually used the app for once and discovered several issues:

* fixes #747 - (game files weren't ingested when managed)
* fixes #603 - manage game was running on the UI thread
* Fixes game freeze when launching app (game launching was on the UI thread)
* Fixed a massive performance regression caused by #626, resulting in the entire loadout being re-extracted on every launch of the game
* Added an Ingest cli command so we can fix loadouts when they break sometimes