### PR TITLE
Fixes for various crashes while managing and running games

### DIFF
--- a/src/NexusMods.App.UI/Controls/Spine/SpineViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/Spine/SpineViewModel.cs
@@ -75,6 +75,7 @@ public class SpineViewModel : AViewModel<ISpineViewModel>, ISpineViewModel
         this.WhenActivated(disposables =>
         {
             router.Messages
+                .OnUI()
                 .SubscribeWithErrorLogging(logger, HandleMessage)
                 .DisposeWith(disposables);
 

--- a/src/NexusMods.App.UI/RightContent/FoundGamesViewModel.cs
+++ b/src/NexusMods.App.UI/RightContent/FoundGamesViewModel.cs
@@ -52,10 +52,7 @@ public class FoundGamesViewModel : AViewModel<IFoundGamesViewModel>, IFoundGames
                 vm.Installation = install;
                 vm.PrimaryButton = ReactiveCommand.CreateFromTask(async () =>
                 {
-                    await Task.Run(async () =>
-                    {
-                        await ManageGame(install);
-                    });
+                    await Task.Run(async () => await ManageGame(install));
                 });
                 return vm;
             });

--- a/src/NexusMods.DataModel/LoadoutSynchronizer/ALoadoutSynchronizer.cs
+++ b/src/NexusMods.DataModel/LoadoutSynchronizer/ALoadoutSynchronizer.cs
@@ -8,6 +8,7 @@ using NexusMods.DataModel.Loadouts;
 using NexusMods.DataModel.Loadouts.LoadoutSynchronizerDTOs;
 using NexusMods.DataModel.Loadouts.ModFiles;
 using NexusMods.DataModel.Loadouts.Mods;
+using NexusMods.DataModel.LoadoutSynchronizer.Exceptions;
 using NexusMods.DataModel.Sorting;
 using NexusMods.DataModel.Sorting.Rules;
 using NexusMods.FileExtractor.StreamFactories;
@@ -252,7 +253,7 @@ public class ALoadoutSynchronizer : IStandardizedLoadoutSynchronizer
     /// <param name="entry"></param>
     public virtual void HandleNeedIngest(HashedEntry entry)
     {
-        throw new Exception("File changed during apply, need to ingest");
+        throw new NeedsIngestException();
     }
 
     /// <inheritdoc />

--- a/src/NexusMods.DataModel/LoadoutSynchronizer/Exceptions/NeedsIngestException.cs
+++ b/src/NexusMods.DataModel/LoadoutSynchronizer/Exceptions/NeedsIngestException.cs
@@ -1,0 +1,16 @@
+namespace NexusMods.DataModel.LoadoutSynchronizer.Exceptions;
+
+/// <summary>
+/// Thrown when there are changes in the game folder that need to be ingested before a loadout can be applied
+/// </summary>
+public class NeedsIngestException : Exception
+{
+    /// <summary>
+    /// Thrown when a loadout needs to be ingested before it can be applied
+    /// </summary>
+    public NeedsIngestException() : base("Loadout needs to be ingested before it can be applied")
+    {
+
+    }
+
+}


### PR DESCRIPTION
* When running a tool, if a ingest is required, the app now performs that ingest
* No longer tries to navigate to a new page on whatever thread requested the route (the router always uses the UI thread now)
* Loadout Syncronizer's "Needs Ingest" error now throws a specific error for better catching upstream
* Added logging to the ToolManager's Run process