### PR TITLE
Use IGeneratedSortRule rules by default

### DIFF
--- a/src/NexusMods.DataModel/ArchiveInstaller.cs
+++ b/src/NexusMods.DataModel/ArchiveInstaller.cs
@@ -182,6 +182,7 @@ public class ArchiveInstaller : IArchiveInstaller
                             Enabled = true,
                             Name = mod.Name,
                             Version = mod.Version,
+                            SortRules = mod.SortRules,
                             Files = mod.Files,
                             Metadata = mod.Metadata
                         });

--- a/src/NexusMods.DataModel/LoadoutSynchronizer/ALoadoutSynchronizer.cs
+++ b/src/NexusMods.DataModel/LoadoutSynchronizer/ALoadoutSynchronizer.cs
@@ -581,7 +581,7 @@ public class ALoadoutSynchronizer : IStandardizedLoadoutSynchronizer
     /// <exception cref="NotImplementedException"></exception>
     protected virtual async ValueTask<ISortRule<Mod, ModId>[]> ModSortRules(Loadout loadout, Mod mod)
     {
-        var builtInSortRules = mod.SortRules;
+        var builtInSortRules = mod.SortRules.Where(x => x is not IGeneratedSortRule);
         var customSortRules = mod.SortRules.ToAsyncEnumerable()
             .OfType<IGeneratedSortRule>()
             .SelectMany(x => x.GenerateSortRules(mod.Id, loadout));

--- a/src/NexusMods.DataModel/LoadoutSynchronizer/ALoadoutSynchronizer.cs
+++ b/src/NexusMods.DataModel/LoadoutSynchronizer/ALoadoutSynchronizer.cs
@@ -579,9 +579,13 @@ public class ALoadoutSynchronizer : IStandardizedLoadoutSynchronizer
     /// <param name="mod"></param>
     /// <returns></returns>
     /// <exception cref="NotImplementedException"></exception>
-    protected virtual ValueTask<ISortRule<Mod, ModId>[]> ModSortRules(Loadout loadout, Mod mod)
+    protected virtual async ValueTask<ISortRule<Mod, ModId>[]> ModSortRules(Loadout loadout, Mod mod)
     {
-        return ValueTask.FromResult(mod.SortRules.ToArray());
+        var builtInSortRules = mod.SortRules;
+        var customSortRules = mod.SortRules.ToAsyncEnumerable()
+            .OfType<IGeneratedSortRule>()
+            .SelectMany(x => x.GenerateSortRules(mod.Id, loadout));
+        return await builtInSortRules.ToAsyncEnumerable().Concat(customSortRules).ToArrayAsync();
     }
 
 


### PR DESCRIPTION
Currently, only the built-in sort rules will be considered by `ALoadoutSynchronizer`. Since we have a special interface `IGeneratedSortRule`, it should be used by default, I think would be a better default behaviour from an extension developer point of view!  

I've also added SortRules propagation in ArchiveInstaller