### PR TITLE
Panel resizing

### DIFF
--- a/NexusMods.App.sln.DotSettings
+++ b/NexusMods.App.sln.DotSettings
@@ -17,6 +17,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Loadouts/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=NONINFRINGEMENT/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Projektanker/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Resizers/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=skyrim/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Stardew/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unpersisted/@EntryIndexedValue">True</s:Boolean>

--- a/src/NexusMods.App.UI/NexusMods.App.UI.csproj
+++ b/src/NexusMods.App.UI/NexusMods.App.UI.csproj
@@ -363,6 +363,9 @@
         <Compile Update="Controls\GameWidget\GameWidgetDesignViewModel.cs">
           <DependentUpon>IGameWidgetViewModel.cs</DependentUpon>
         </Compile>
+        <Compile Update="WorkspaceSystem\PanelResizer\PanelResizerViewModel.cs">
+          <DependentUpon>IPanelResizerViewModel.cs</DependentUpon>
+        </Compile>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NexusMods.App.UI/NexusMods.App.UI.csproj.DotSettings
+++ b/src/NexusMods.App.UI/NexusMods.App.UI.csproj.DotSettings
@@ -8,6 +8,7 @@
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=workspacesystem_005Cnewtabpagesectionitem/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=workspacesystem_005Cpage/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=workspacesystem_005Cpanel/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=workspacesystem_005Cpanelresizer/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=workspacesystem_005Cpaneltab/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=workspacesystem_005Cpaneltabheader/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=workspacesystem_005Cworkspace/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/NexusMods.App.UI/Theme/IconStyles.xaml
+++ b/src/NexusMods.App.UI/Theme/IconStyles.xaml
@@ -47,6 +47,8 @@
             <icons:Icon Classes="File"></icons:Icon>
             <icons:Icon Classes="Check"></icons:Icon>
             <icons:Icon Classes="DeleteOutline"></icons:Icon>
+            <icons:Icon Classes="DragHorizontal"></icons:Icon>
+            <icons:Icon Classes="DragVertical"></icons:Icon>
             <Svg Classes="AddCircle" />
         </WrapPanel>
     </Design.PreviewWith>
@@ -209,5 +211,13 @@
 
     <Style Selector="icons|Icon.ChevronRight">
         <Setter Property="Value" Value="mdi-chevron-right"/>
+    </Style>
+
+    <Style Selector="icons|Icon.DragVertical">
+        <Setter Property="Value" Value="mdi-drag-vertical-variant" />
+    </Style>
+
+    <Style Selector="icons|Icon.DragHorizontal">
+        <Setter Property="Value" Value="mdi-drag-horizontal-variant" />
     </Style>
 </Styles>

--- a/src/NexusMods.App.UI/WorkspaceSystem/GridUtils.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/GridUtils.cs
@@ -267,7 +267,9 @@ internal static class GridUtils
         return res.SetItems(updates);
     }
 
-    internal static IReadOnlyList<ResizerInfo> GetResizers(ImmutableDictionary<PanelId, Rect> currentState)
+    internal static IReadOnlyList<ResizerInfo> GetResizers(
+        ImmutableDictionary<PanelId, Rect> currentState,
+        bool isWorkspaceHorizontal = true)
     {
         // TODO: make this less messy
 

--- a/src/NexusMods.App.UI/WorkspaceSystem/GridUtils.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/GridUtils.cs
@@ -9,7 +9,10 @@ internal static class GridUtils
     /// <summary>
     /// Returns all possible new states.
     /// </summary>
-    internal static IEnumerable<ImmutableDictionary<PanelId, Rect>> GetPossibleStates(IReadOnlyList<IPanelViewModel> panels, int columns, int rows)
+    internal static IEnumerable<ImmutableDictionary<PanelId, Rect>> GetPossibleStates(
+        IReadOnlyList<IPanelViewModel> panels,
+        int columns,
+        int rows)
     {
         if (panels.Count == columns * rows) yield break;
         var currentPanels = panels.ToImmutableDictionary(panel => panel.Id, panel => panel.LogicalBounds);
@@ -36,7 +39,11 @@ internal static class GridUtils
         }
     }
 
-    private static ImmutableDictionary<PanelId, Rect> CreateResult(ImmutableDictionary<PanelId, Rect> currentPanels, IPanelViewModel panel, bool vertical, bool inverse)
+    private static ImmutableDictionary<PanelId, Rect> CreateResult(
+        ImmutableDictionary<PanelId, Rect> currentPanels,
+        IPanelViewModel panel,
+        bool vertical,
+        bool inverse)
     {
         var (updatedLogicalBounds, newPanelLogicalBounds) = MathUtils.Split(panel.LogicalBounds, vertical);
 
@@ -67,7 +74,6 @@ internal static class GridUtils
         var currentColumns = 0;
 
         // ReSharper disable once ForCanBeConvertedToForeach
-        // ReSharper disable once LoopCanBeConvertedToQuery
         for (var i = 0; i < panels.Count; i++)
         {
             var other = panels[i];
@@ -92,8 +98,8 @@ internal static class GridUtils
                 !other.LogicalBounds.Right.IsCloseTo(panel.LogicalBounds.Left)) continue;
 
             // 2) check if the panel is in the current row
-            if (other.LogicalBounds.Bottom >= panel.LogicalBounds.Y ||
-                other.LogicalBounds.Top <= panel.LogicalBounds.Y)
+            if (other.LogicalBounds.Bottom.IsGreaterThanOrCloseTo(panel.LogicalBounds.Y) ||
+                other.LogicalBounds.Top.IsLessThanOrCloseTo(panel.LogicalBounds.Y))
                 currentColumns++;
         }
 
@@ -105,7 +111,6 @@ internal static class GridUtils
         var currentRows = 0;
 
         // ReSharper disable once ForCanBeConvertedToForeach
-        // ReSharper disable once LoopCanBeConvertedToQuery
         for (var i = 0; i < panels.Count; i++)
         {
             var other = panels[i];
@@ -130,8 +135,8 @@ internal static class GridUtils
                 !other.LogicalBounds.Bottom.IsCloseTo(panel.LogicalBounds.Top)) continue;
 
             // 2) check if the panel is in the current column
-            if (other.LogicalBounds.Right >= panel.LogicalBounds.X ||
-                other.LogicalBounds.Left <= panel.LogicalBounds.X)
+            if (other.LogicalBounds.Right.IsGreaterThanOrCloseTo(panel.LogicalBounds.X) ||
+                other.LogicalBounds.Left.IsLessThanOrCloseTo(panel.LogicalBounds.X))
                 currentRows++;
         }
 
@@ -169,7 +174,7 @@ internal static class GridUtils
             // same column
             // | a | x |  | b | x |
             // | b | x |  | a | x |
-            if (rect.Left >= currentRect.Left && rect.Right <= currentRect.Right)
+            if (rect.Left.IsGreaterThanOrCloseTo(currentRect.Left) && rect.Right.IsLessThanOrCloseTo(currentRect.Right))
             {
                 if (rect.Top.IsCloseTo(currentRect.Bottom) || rect.Bottom.IsCloseTo(currentRect.Top))
                 {
@@ -180,7 +185,7 @@ internal static class GridUtils
             // same row
             // | a | b |  | b | a |  | a | b |
             // | x | x |  | x | x |  | a | c |
-            if (rect.Top >= currentRect.Top && rect.Bottom <= currentRect.Bottom)
+            if (rect.Top.IsGreaterThanOrCloseTo(currentRect.Top) && rect.Bottom.IsLessThanOrCloseTo(currentRect.Bottom))
             {
                 if (rect.Left.IsCloseTo(currentRect.Right) || rect.Right.IsCloseTo(currentRect.Left))
                 {

--- a/src/NexusMods.App.UI/WorkspaceSystem/GridUtils.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/GridUtils.cs
@@ -339,10 +339,10 @@ internal static class GridUtils
             var (currentId, currentRect) = current;
             var (otherId, rect) = other;
 
-            var pos = MathUtils.GetMidVector(currentRect, rect, isHorizontal);
+            var pos = MathUtils.GetMidPoint(currentRect, rect, isHorizontal);
             tmp.Add(new ResizerInfo(IsHorizontal: isHorizontal, pos, new[] { currentId, otherId }));
         }
     }
 
-    internal record struct ResizerInfo(bool IsHorizontal, Vector LogicalPosition, PanelId[] ConnectedPanels);
+    internal record struct ResizerInfo(bool IsHorizontal, Point LogicalPosition, PanelId[] ConnectedPanels);
 }

--- a/src/NexusMods.App.UI/WorkspaceSystem/MathUtils.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/MathUtils.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Avalonia;
 using Avalonia.Utilities;
 
@@ -82,11 +83,30 @@ internal static class MathUtils
     /// </summary>
     internal static Vector AsVector(this Size size) => new(x: size.Width, y: size.Height);
 
+    private const double DefaultTolerance = 0.001;
+
     /// <summary>
     /// Tolerant equality check.
     /// </summary>
-    internal static bool IsCloseTo(this double left, double right, double tolerance = 0.001)
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool IsCloseTo(this double left, double right, double tolerance = DefaultTolerance)
     {
-        return MathUtilities.AreClose(left, right, eps: tolerance);
+        if (double.IsInfinity(left) || double.IsInfinity(right))
+            return double.IsInfinity(left) && double.IsInfinity(right);
+
+        var delta = left - right;
+        return -tolerance < delta && tolerance > delta;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool IsGreaterThanOrCloseTo(this double left, double right, double tolerance = DefaultTolerance)
+    {
+        return left > right || IsCloseTo(left, right, tolerance);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool IsLessThanOrCloseTo(this double left, double right, double tolerance = DefaultTolerance)
+    {
+        return left < right || IsCloseTo(left, right, tolerance);
     }
 }

--- a/src/NexusMods.App.UI/WorkspaceSystem/MathUtils.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/MathUtils.cs
@@ -58,7 +58,7 @@ internal static class MathUtils
         return (updatedLogicalBounds, newPanelLogicalBounds);
     }
 
-    internal static Vector GetMidVector(Rect a, Rect b, bool isHorizontal)
+    internal static Point GetMidPoint(Rect a, Rect b, bool isHorizontal)
     {
         var smallerRect = a.Width * a.Height < b.Width * b.Height ? a : b;
 
@@ -74,7 +74,7 @@ internal static class MathUtils
             midY = smallerRect.Y + smallerRect.Height / 2;
         }
 
-        return new Vector(midX, midY);
+        return new Point(midX, midY);
     }
 
     /// <summary>

--- a/src/NexusMods.App.UI/WorkspaceSystem/MathUtils.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/MathUtils.cs
@@ -61,17 +61,17 @@ internal static class MathUtils
 
     internal static Point GetMidPoint(Rect a, Rect b, bool isHorizontal)
     {
-        var smallerRect = a.Width * a.Height < b.Width * b.Height ? a : b;
+        var (smallerRect, biggerRect) = a.Width * a.Height < b.Width * b.Height ? (a, b) : (b, a);
 
         double midX, midY;
         if (isHorizontal)
         {
-            midX = smallerRect.X + smallerRect.Width / 2;;
-            midY = (a.Y + a.Height + b.Y) / 2;
+            midX = smallerRect.X + smallerRect.Width / 2;
+            midY = (smallerRect.Y + smallerRect.Height + biggerRect.Y) / 2;
         }
         else
         {
-            midX = (a.X + a.Width + b.X) / 2;
+            midX = (smallerRect.X + smallerRect.Width + biggerRect.X) / 2;
             midY = smallerRect.Y + smallerRect.Height / 2;
         }
 

--- a/src/NexusMods.App.UI/WorkspaceSystem/MathUtils.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/MathUtils.cs
@@ -58,6 +58,25 @@ internal static class MathUtils
         return (updatedLogicalBounds, newPanelLogicalBounds);
     }
 
+    internal static Vector GetMidVector(Rect a, Rect b, bool isHorizontal)
+    {
+        var smallerRect = a.Width * a.Height < b.Width * b.Height ? a : b;
+
+        double midX, midY;
+        if (isHorizontal)
+        {
+            midX = smallerRect.X + smallerRect.Width / 2;;
+            midY = (a.Y + a.Height + b.Y) / 2;
+        }
+        else
+        {
+            midX = (a.X + a.Width + b.X) / 2;
+            midY = smallerRect.Y + smallerRect.Height / 2;
+        }
+
+        return new Vector(midX, midY);
+    }
+
     /// <summary>
     /// Converts a <see cref="Size"/> into a <see cref="Vector"/>.
     /// </summary>

--- a/src/NexusMods.App.UI/WorkspaceSystem/MathUtils.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/MathUtils.cs
@@ -1,6 +1,5 @@
 using System.Runtime.CompilerServices;
 using Avalonia;
-using Avalonia.Utilities;
 
 namespace NexusMods.App.UI.WorkspaceSystem;
 
@@ -61,18 +60,20 @@ internal static class MathUtils
 
     internal static Point GetMidPoint(Rect a, Rect b, bool isHorizontal)
     {
-        var (smallerRect, biggerRect) = a.Width * a.Height < b.Width * b.Height ? (a, b) : (b, a);
-
         double midX, midY;
         if (isHorizontal)
         {
-            midX = smallerRect.X + smallerRect.Width / 2;
-            midY = (smallerRect.Y + smallerRect.Height + biggerRect.Y) / 2;
+            midX = a.Left.IsLessThanOrCloseTo(b.Left) && a.Right.IsGreaterThanOrCloseTo(b.Right)
+                ? b.Left + b.Width / 2
+                : a.Left + b.Width / 2;
+            midY = Math.Max(a.Top, b.Top);
         }
         else
         {
-            midX = (smallerRect.X + smallerRect.Width + biggerRect.X) / 2;
-            midY = smallerRect.Y + smallerRect.Height / 2;
+            midX = Math.Max(a.Left, b.Left);
+            midY = a.Top.IsLessThanOrCloseTo(b.Top) && a.Bottom.IsGreaterThanOrCloseTo(b.Bottom)
+                ? b.Top + b.Height / 2
+                : a.Top + a.Height / 2;
         }
 
         return new Point(midX, midY);

--- a/src/NexusMods.App.UI/WorkspaceSystem/Page/PageFactoryId.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Page/PageFactoryId.cs
@@ -3,4 +3,4 @@ using TransparentValueObjects;
 namespace NexusMods.App.UI.WorkspaceSystem;
 
 [ValueObject<Guid>]
-public readonly partial struct PageFactoryId { }
+public readonly partial struct PageFactoryId : IAugmentWith<JsonAugment> { }

--- a/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelView.axaml.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelView.axaml.cs
@@ -1,5 +1,6 @@
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.ReactiveUI;
@@ -10,6 +11,7 @@ namespace NexusMods.App.UI.WorkspaceSystem;
 public partial class PanelView : ReactiveUserControl<IPanelViewModel>
 {
     private const double ScrollOffset = 250;
+    private const double DefaultPadding = 6.0;
 
     public PanelView()
     {
@@ -17,6 +19,19 @@ public partial class PanelView : ReactiveUserControl<IPanelViewModel>
 
         this.WhenActivated(disposables =>
         {
+            this.WhenAnyValue(view => view.ViewModel!.LogicalBounds)
+                .Do(logicalBounds =>
+                {
+                    var left = logicalBounds.Left.IsCloseTo(0.0) ? 0.0 : DefaultPadding;
+                    var top = logicalBounds.Top.IsCloseTo(0.0) ? 0.0 : DefaultPadding;
+                    var right = logicalBounds.Right.IsCloseTo(1.0) ? 0.0 : DefaultPadding;
+                    var bottom = logicalBounds.Bottom.IsCloseTo(1.0) ? 0.0 : DefaultPadding;
+
+                    Padding = new Thickness(left, top, right, bottom);
+                })
+                .Subscribe()
+                .DisposeWith(disposables);
+
             // toggle visibility of the scrollbar related elements
             this.WhenAnyValue(
                     view => view.TabHeaderScrollViewer.Extent,

--- a/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/IPanelResizerViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/IPanelResizerViewModel.cs
@@ -1,4 +1,5 @@
 using Avalonia;
+using ReactiveUI;
 
 namespace NexusMods.App.UI.WorkspaceSystem;
 
@@ -13,4 +14,6 @@ public interface IPanelResizerViewModel : IViewModelInterface
     public PanelId[] ConnectedPanels { get; }
 
     public void Arrange(Size workspaceSize);
+
+    public ReactiveCommand<Point, Point> DragCommand { get; }
 }

--- a/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/IPanelResizerViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/IPanelResizerViewModel.cs
@@ -1,3 +1,4 @@
+using System.Reactive;
 using Avalonia;
 using ReactiveUI;
 
@@ -16,4 +17,6 @@ public interface IPanelResizerViewModel : IViewModelInterface
     public void Arrange(Size workspaceSize);
 
     public ReactiveCommand<Point, Point> DragCommand { get; }
+
+    public ReactiveCommand<Unit, Unit> FinishDragCommand { get; }
 }

--- a/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/IPanelResizerViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/IPanelResizerViewModel.cs
@@ -6,17 +6,50 @@ namespace NexusMods.App.UI.WorkspaceSystem;
 
 public interface IPanelResizerViewModel : IViewModelInterface
 {
+    /// <summary>
+    /// Gets or sets the logical position of the resizer in the workspace.
+    /// </summary>
+    /// <remarks>
+    /// Logical positions range from 0.0 to 1.0. A logical position of
+    /// X=0.5 and Y=0.5 will be in the center of the workspace.
+    /// </remarks>
     public Point LogicalPosition { get; set; }
 
+    /// <summary>
+    /// Gets or sets the actual position of the resizer in the workspace.
+    /// </summary>
+    /// <remarks>
+    /// This gets calculated from the <see cref="LogicalPosition"/> using
+    /// <see cref="Arrange"/>.
+    /// </remarks>
     public Point ActualPosition { get; set; }
 
+    /// <summary>
+    /// Gets whether the resizer is horizontally aligned.
+    /// </summary>
     public bool IsHorizontal { get; }
 
+    /// <summary>
+    /// Gets all connected panels that have to move with the resizer.
+    /// </summary>
     public PanelId[] ConnectedPanels { get; }
 
+    /// <summary>
+    /// Arranges the resizer with the size of the workspace by
+    /// updating the <see cref="ActualPosition"/>.
+    /// </summary>
     public void Arrange(Size workspaceSize);
 
-    public ReactiveCommand<Point, Point> DragCommand { get; }
+    /// <summary>
+    /// Gets the command invoked by the resizer when the user drags the control around.
+    /// </summary>
+    /// <remarks>
+    /// This will return the current position of the control.
+    /// </remarks>
+    public ReactiveCommand<Point, Point> DragStartCommand { get; }
 
-    public ReactiveCommand<Unit, Unit> FinishDragCommand { get; }
+    /// <summary>
+    /// Gets the command invoked by the resizer when the user stopped dragging the control.
+    /// </summary>
+    public ReactiveCommand<Unit, Unit> DragEndCommand { get; }
 }

--- a/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/IPanelResizerViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/IPanelResizerViewModel.cs
@@ -1,0 +1,16 @@
+using Avalonia;
+
+namespace NexusMods.App.UI.WorkspaceSystem;
+
+public interface IPanelResizerViewModel : IViewModelInterface
+{
+    public Point LogicalPosition { get; set; }
+
+    public Point ActualPosition { get; set; }
+
+    public bool IsHorizontal { get; }
+
+    public PanelId[] ConnectedPanels { get; }
+
+    public void Arrange(Size workspaceSize);
+}

--- a/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerView.axaml
+++ b/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerView.axaml
@@ -1,0 +1,15 @@
+<reactive:ReactiveUserControl
+    x:TypeArguments="workspace:IPanelResizerViewModel"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:reactive="http://reactiveui.net"
+    xmlns:workspace="clr-namespace:NexusMods.App.UI.WorkspaceSystem"
+    xmlns:icons="clr-namespace:Projektanker.Icons.Avalonia;assembly=Projektanker.Icons.Avalonia"
+    mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+    x:Class="NexusMods.App.UI.WorkspaceSystem.PanelResizerView">
+
+    <icons:Icon x:Name="Icon" Width="24" Height="24" Foreground="White"/>
+
+</reactive:ReactiveUserControl>

--- a/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerView.axaml
+++ b/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerView.axaml
@@ -10,6 +10,6 @@
     mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
     x:Class="NexusMods.App.UI.WorkspaceSystem.PanelResizerView">
 
-    <icons:Icon x:Name="Icon" Width="24" Height="24" Foreground="White"/>
+    <icons:Icon x:Name="Icon" FontSize="50" Foreground="White"/>
 
 </reactive:ReactiveUserControl>

--- a/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerView.axaml
+++ b/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerView.axaml
@@ -10,6 +10,6 @@
     mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
     x:Class="NexusMods.App.UI.WorkspaceSystem.PanelResizerView">
 
-    <icons:Icon x:Name="Icon" FontSize="50" Foreground="White"/>
+    <icons:Icon x:Name="Icon" FontSize="30" Foreground="{StaticResource FontDarkPrimary}"/>
 
 </reactive:ReactiveUserControl>

--- a/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerView.axaml.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerView.axaml.cs
@@ -36,6 +36,22 @@ public partial class PanelResizerView : ReactiveUserControl<IPanelResizerViewMod
                 })
                 .DisposeWith(disposables);
 
+            // hover
+            Observable.FromEventPattern<PointerEventArgs>(
+                addHandler: handler => PointerEntered += handler,
+                removeHandler: handler => PointerEntered -= handler)
+                .Do(_ =>
+                {
+                    if (ViewModel is null) return;
+
+                    SetCursor(ViewModel.IsHorizontal
+                        ? StandardCursorType.SizeNorthSouth
+                        : StandardCursorType.SizeWestEast
+                    );
+                })
+                .Subscribe()
+                .DisposeWith(disposables);
+
             // pressed
             Observable.FromEventPattern<PointerPressedEventArgs>(
                     addHandler: handler => PointerPressed += handler,
@@ -57,6 +73,8 @@ public partial class PanelResizerView : ReactiveUserControl<IPanelResizerViewMod
                 {
                     _isPressed = false;
                     _startPoint = new Point(0, 0);
+
+                    SetCursor(StandardCursorType.Arrow);
                 })
                 .Subscribe()
                 .DisposeWith(disposables);
@@ -69,6 +87,11 @@ public partial class PanelResizerView : ReactiveUserControl<IPanelResizerViewMod
                 .Select(eventPattern =>
                 {
                     if (ViewModel is null) return new Point(0, 0);
+
+                    SetCursor(ViewModel.IsHorizontal
+                        ? StandardCursorType.SizeNorthSouth
+                        : StandardCursorType.SizeWestEast
+                    );
 
                     var parent = (Parent as Control)!;
                     var currentPos = eventPattern.EventArgs.GetPosition(parent);
@@ -88,6 +111,20 @@ public partial class PanelResizerView : ReactiveUserControl<IPanelResizerViewMod
     private void PopulateFromViewModel(IPanelResizerViewModel viewModel)
     {
         Icon.Classes.Add(viewModel.IsHorizontal ? "DragHorizontal" : "DragVertical");
+    }
+
+    private void SetCursor(StandardCursorType standardCursorType)
+    {
+        // TODO: doesn't work?
+        Cursor = new Cursor(standardCursorType);
+
+        // var topLevel = TopLevel.GetTopLevel(this);
+        // Console.WriteLine(topLevel);
+        //
+        // if (topLevel is not null)
+        // {
+        //     topLevel.Cursor = new Cursor(standardCursorType);
+        // }
     }
 }
 

--- a/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerView.axaml.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerView.axaml.cs
@@ -1,3 +1,4 @@
+using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using Avalonia;
@@ -58,7 +59,8 @@ public partial class PanelResizerView : ReactiveUserControl<IPanelResizerViewMod
                     _isPressed = false;
                     _startPoint = new Point(0, 0);
                 })
-                .Subscribe()
+                .Select(_ => Unit.Default)
+                .InvokeCommand(this, view => view.ViewModel!.FinishDragCommand)
                 .DisposeWith(disposables);
 
             // moved

--- a/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerView.axaml.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerView.axaml.cs
@@ -23,8 +23,11 @@ public partial class PanelResizerView : ReactiveUserControl<IPanelResizerViewMod
             this.WhenAnyValue(view => view.ViewModel!.ActualPosition)
                 .SubscribeWithErrorLogging(point =>
                 {
-                    Canvas.SetLeft(this, point.X);
-                    Canvas.SetTop(this, point.Y);
+                    var x = point.X - Bounds.Width / 2;
+                    var y = point.Y - Bounds.Height / 2;
+
+                    Canvas.SetLeft(this, x);
+                    Canvas.SetTop(this, y);
                 })
                 .DisposeWith(disposables);
         });

--- a/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerView.axaml.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerView.axaml.cs
@@ -41,12 +41,16 @@ public partial class PanelResizerView : ReactiveUserControl<IPanelResizerViewMod
             Observable.FromEventPattern<PointerPressedEventArgs>(
                     addHandler: handler => PointerPressed += handler,
                     removeHandler: handler => PointerPressed -= handler)
-                .Do(eventPattern =>
+                .Do(_ =>
                 {
                     _isPressed = true;
-                    _startPoint = eventPattern.EventArgs.GetPosition(Parent! as Control);
+                    _startPoint = ViewModel!.ActualPosition;
                 })
-                .Finally(() => _isPressed = false)
+                .Finally(() =>
+                {
+                    _isPressed = false;
+                    _startPoint = new Point(0, 0);
+                })
                 .Subscribe()
                 .DisposeWith(disposables);
 

--- a/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerView.axaml.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerView.axaml.cs
@@ -1,0 +1,38 @@
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using Avalonia.Controls;
+using Avalonia.ReactiveUI;
+using ReactiveUI;
+
+namespace NexusMods.App.UI.WorkspaceSystem;
+
+public partial class PanelResizerView : ReactiveUserControl<IPanelResizerViewModel>
+{
+    public PanelResizerView()
+    {
+        InitializeComponent();
+
+        this.WhenActivated(disposables =>
+        {
+            this.WhenAnyValue(view => view.ViewModel)
+                .WhereNotNull()
+                .Do(PopulateFromViewModel)
+                .Subscribe()
+                .DisposeWith(disposables);
+
+            this.WhenAnyValue(view => view.ViewModel!.ActualPosition)
+                .SubscribeWithErrorLogging(point =>
+                {
+                    Canvas.SetLeft(this, point.X);
+                    Canvas.SetTop(this, point.Y);
+                })
+                .DisposeWith(disposables);
+        });
+    }
+
+    private void PopulateFromViewModel(IPanelResizerViewModel viewModel)
+    {
+        Icon.Classes.Add(viewModel.IsHorizontal ? "DragHorizontal" : "DragVertical");
+    }
+}
+

--- a/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerView.axaml.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerView.axaml.cs
@@ -36,22 +36,6 @@ public partial class PanelResizerView : ReactiveUserControl<IPanelResizerViewMod
                 })
                 .DisposeWith(disposables);
 
-            // hover
-            Observable.FromEventPattern<PointerEventArgs>(
-                addHandler: handler => PointerEntered += handler,
-                removeHandler: handler => PointerEntered -= handler)
-                .Do(_ =>
-                {
-                    if (ViewModel is null) return;
-
-                    SetCursor(ViewModel.IsHorizontal
-                        ? StandardCursorType.SizeNorthSouth
-                        : StandardCursorType.SizeWestEast
-                    );
-                })
-                .Subscribe()
-                .DisposeWith(disposables);
-
             // pressed
             Observable.FromEventPattern<PointerPressedEventArgs>(
                     addHandler: handler => PointerPressed += handler,
@@ -73,8 +57,6 @@ public partial class PanelResizerView : ReactiveUserControl<IPanelResizerViewMod
                 {
                     _isPressed = false;
                     _startPoint = new Point(0, 0);
-
-                    SetCursor(StandardCursorType.Arrow);
                 })
                 .Subscribe()
                 .DisposeWith(disposables);
@@ -87,11 +69,6 @@ public partial class PanelResizerView : ReactiveUserControl<IPanelResizerViewMod
                 .Select(eventPattern =>
                 {
                     if (ViewModel is null) return new Point(0, 0);
-
-                    SetCursor(ViewModel.IsHorizontal
-                        ? StandardCursorType.SizeNorthSouth
-                        : StandardCursorType.SizeWestEast
-                    );
 
                     var parent = (Parent as Control)!;
                     var currentPos = eventPattern.EventArgs.GetPosition(parent);
@@ -110,21 +87,8 @@ public partial class PanelResizerView : ReactiveUserControl<IPanelResizerViewMod
 
     private void PopulateFromViewModel(IPanelResizerViewModel viewModel)
     {
+        Cursor = new Cursor(viewModel.IsHorizontal ? StandardCursorType.SizeNorthSouth : StandardCursorType.SizeWestEast);
         Icon.Classes.Add(viewModel.IsHorizontal ? "DragHorizontal" : "DragVertical");
-    }
-
-    private void SetCursor(StandardCursorType standardCursorType)
-    {
-        // TODO: doesn't work?
-        Cursor = new Cursor(standardCursorType);
-
-        // var topLevel = TopLevel.GetTopLevel(this);
-        // Console.WriteLine(topLevel);
-        //
-        // if (topLevel is not null)
-        // {
-        //     topLevel.Cursor = new Cursor(standardCursorType);
-        // }
     }
 }
 

--- a/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerView.axaml.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerView.axaml.cs
@@ -60,7 +60,7 @@ public partial class PanelResizerView : ReactiveUserControl<IPanelResizerViewMod
                     _startPoint = new Point(0, 0);
                 })
                 .Select(_ => Unit.Default)
-                .InvokeCommand(this, view => view.ViewModel!.FinishDragCommand)
+                .InvokeCommand(this, view => view.ViewModel!.DragEndCommand)
                 .DisposeWith(disposables);
 
             // moved
@@ -82,7 +82,7 @@ public partial class PanelResizerView : ReactiveUserControl<IPanelResizerViewMod
 
                     return newPosition;
                 })
-                .InvokeCommand(this, view => view.ViewModel!.DragCommand)
+                .InvokeCommand(this, view => view.ViewModel!.DragStartCommand)
                 .DisposeWith(disposables);
         });
     }

--- a/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerViewModel.cs
@@ -1,3 +1,4 @@
+using System.Reactive;
 using System.Reactive.Disposables;
 using Avalonia;
 using ReactiveUI;
@@ -15,6 +16,8 @@ public class PanelResizerViewModel : AViewModel<IPanelResizerViewModel>, IPanelR
 
     public ReactiveCommand<Point, Point> DragCommand { get; }
 
+    public ReactiveCommand<Unit, Unit> FinishDragCommand { get; }
+
     public PanelResizerViewModel(Point logicalPosition, bool isHorizontal, PanelId[] connectedPanels)
     {
         LogicalPosition = logicalPosition;
@@ -22,6 +25,7 @@ public class PanelResizerViewModel : AViewModel<IPanelResizerViewModel>, IPanelR
         ConnectedPanels = connectedPanels;
 
         DragCommand = ReactiveCommand.Create<Point, Point>(input => input);
+        FinishDragCommand = ReactiveCommand.Create(() => { });
 
         this.WhenActivated(disposables =>
         {

--- a/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerViewModel.cs
@@ -13,11 +13,15 @@ public class PanelResizerViewModel : AViewModel<IPanelResizerViewModel>, IPanelR
     public bool IsHorizontal { get; }
     public PanelId[] ConnectedPanels { get; }
 
+    public ReactiveCommand<Point, Point> DragCommand { get; }
+
     public PanelResizerViewModel(Point logicalPosition, bool isHorizontal, PanelId[] connectedPanels)
     {
         LogicalPosition = logicalPosition;
         IsHorizontal = isHorizontal;
         ConnectedPanels = connectedPanels;
+
+        DragCommand = ReactiveCommand.Create<Point, Point>(input => input);
 
         this.WhenActivated(disposables =>
         {

--- a/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerViewModel.cs
@@ -1,0 +1,43 @@
+using System.Reactive.Disposables;
+using Avalonia;
+using ReactiveUI;
+using ReactiveUI.Fody.Helpers;
+
+namespace NexusMods.App.UI.WorkspaceSystem;
+
+public class PanelResizerViewModel : AViewModel<IPanelResizerViewModel>, IPanelResizerViewModel
+{
+    [Reactive] public Point LogicalPosition { get; set; }
+    [Reactive] public Point ActualPosition { get; set; }
+
+    public bool IsHorizontal { get; }
+    public PanelId[] ConnectedPanels { get; }
+
+    public PanelResizerViewModel(Point logicalPosition, bool isHorizontal, PanelId[] connectedPanels)
+    {
+        LogicalPosition = logicalPosition;
+        IsHorizontal = isHorizontal;
+        ConnectedPanels = connectedPanels;
+
+        this.WhenActivated(disposables =>
+        {
+            this.WhenAnyValue(vm => vm.LogicalPosition)
+                .SubscribeWithErrorLogging(_ => UpdateActualPosition())
+                .DisposeWith(disposables);
+        });
+    }
+
+    private Size _workspaceSize = MathUtils.Zero;
+    private void UpdateActualPosition()
+    {
+        var x = LogicalPosition.X * _workspaceSize.Width;
+        var y = LogicalPosition.Y * _workspaceSize.Height;
+        ActualPosition = new Point(x, y);
+    }
+
+    public void Arrange(Size workspaceSize)
+    {
+        _workspaceSize = workspaceSize;
+        UpdateActualPosition();
+    }
+}

--- a/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerViewModel.cs
@@ -14,9 +14,9 @@ public class PanelResizerViewModel : AViewModel<IPanelResizerViewModel>, IPanelR
     public bool IsHorizontal { get; }
     public PanelId[] ConnectedPanels { get; }
 
-    public ReactiveCommand<Point, Point> DragCommand { get; }
+    public ReactiveCommand<Point, Point> DragStartCommand { get; }
 
-    public ReactiveCommand<Unit, Unit> FinishDragCommand { get; }
+    public ReactiveCommand<Unit, Unit> DragEndCommand { get; }
 
     public PanelResizerViewModel(Point logicalPosition, bool isHorizontal, PanelId[] connectedPanels)
     {
@@ -24,8 +24,8 @@ public class PanelResizerViewModel : AViewModel<IPanelResizerViewModel>, IPanelR
         IsHorizontal = isHorizontal;
         ConnectedPanels = connectedPanels;
 
-        DragCommand = ReactiveCommand.Create<Point, Point>(input => input);
-        FinishDragCommand = ReactiveCommand.Create(() => { });
+        DragStartCommand = ReactiveCommand.Create<Point, Point>(input => input);
+        DragEndCommand = ReactiveCommand.Create(() => { });
 
         this.WhenActivated(disposables =>
         {

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/IWorkspaceViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/IWorkspaceViewModel.cs
@@ -7,12 +7,14 @@ public interface IWorkspaceViewModel : IViewModelInterface
 {
     public ReadOnlyObservableCollection<IPanelViewModel> Panels { get; }
 
+    public ReadOnlyObservableCollection<IPanelResizerViewModel> Resizers { get; }
+
     public ReadOnlyObservableCollection<IAddPanelButtonViewModel> AddPanelButtonViewModels { get; }
 
     /// <summary>
     /// Called by the View to notify the VM about the new size of the control.
     /// </summary>
-    public void ArrangePanels(Size workspaceSize);
+    public void Arrange(Size workspaceSize);
 
     /// <summary>
     /// Add a new panel to the workspace.

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/IWorkspaceViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/IWorkspaceViewModel.cs
@@ -15,20 +15,10 @@ public interface IWorkspaceViewModel : IViewModelInterface
     public void ArrangePanels(Size workspaceSize);
 
     /// <summary>
-    /// Swaps the position of two panels.
-    /// </summary>
-    public void SwapPanels(IPanelViewModel first, IPanelViewModel second);
-
-    /// <summary>
     /// Add a new panel to the workspace.
     /// </summary>
     /// <returns>The newly created <see cref="IPanelViewModel"/>.</returns>
     public IPanelViewModel AddPanel(IReadOnlyDictionary<PanelId, Rect> state);
-
-    /// <summary>
-    /// Closes a panel from the workspace.
-    /// </summary>
-    public void ClosePanel(PanelId panelId);
 
     /// <summary>
     /// Transforms the current state of the workspace into a serializable data format.

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceView.axaml.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceView.axaml.cs
@@ -52,6 +52,7 @@ public partial class WorkspaceView : ReactiveUserControl<IWorkspaceViewModel>
 
                     serialDisposable.Disposable = panelsObservable
                         .Merge(resizersObservable)
+                        .RemoveIndex()
                         .Adapt(new ListAdapter<Control>(WorkspaceCanvas.Children))
                         .Subscribe();
                 })

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceView.axaml.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceView.axaml.cs
@@ -24,33 +24,45 @@ public partial class WorkspaceView : ReactiveUserControl<IWorkspaceViewModel>
             Debug.Assert(WorkspaceCanvas.Children.Count == 0);
             var serialDisposable = new SerialDisposable();
 
-            this.WhenAnyValue(view => view.ViewModel!.Panels)
-                .Do(panels =>
+            this.WhenAnyValue(property1: view => view.ViewModel!.Panels, property2: view => view.ViewModel!.Resizers)
+                .Do(tuple =>
                 {
-                    serialDisposable.Disposable = panels
+                    var (panels, resizers) = tuple;
+
+                    var panelsObservable = panels
                         .ToObservableChangeSet()
-                        .Transform(CreateView)
+                        .Transform(panelViewModel => (Control)new PanelView
+                        {
+                            ViewModel = panelViewModel
+                        });
+
+                    var resizersObservable = resizers
+                        .ToObservableChangeSet()
+                        .Transform(resizerViewModel =>
+                        {
+                            var control = (Control)new PanelResizerView
+                            {
+                                ViewModel = resizerViewModel
+                            };
+
+                            // NOTE(erri120): highest number is drawn last
+                            control.SetValue(ZIndexProperty, 999);
+                            return control;
+                        });
+
+                    serialDisposable.Disposable = panelsObservable
+                        .Merge(resizersObservable)
                         .Adapt(new ListAdapter<Control>(WorkspaceCanvas.Children))
                         .Subscribe();
                 })
                 .Subscribe()
                 .DisposeWith(disposables);
-
-            serialDisposable.DisposeWith(disposables);
         });
-    }
-
-    private static Control CreateView(IPanelViewModel panelViewModel)
-    {
-        return new PanelView
-        {
-            ViewModel = panelViewModel
-        };
     }
 
     protected override Size ArrangeOverride(Size finalSize)
     {
-        ViewModel?.ArrangePanels(finalSize);
+        ViewModel?.Arrange(finalSize);
         return base.ArrangeOverride(finalSize);
     }
 }

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
@@ -230,7 +230,7 @@ public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceVie
         {
             updater.Clear();
 
-            var currentState = Panels.ToImmutableDictionary(x => x.Id, x => x.LogicalBounds);
+            var currentState = _panels.ToImmutableDictionary(x => x.Id, x => x.LogicalBounds);
             var resizers = GridUtils.GetResizers(currentState);
 
             updater.AddRange(resizers.Select(info =>

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
@@ -97,17 +97,20 @@ public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceVie
                     item.LogicalPosition = newLogicalPosition;
 
                     var isHorizontal = item.IsHorizontal;
-                    var connectedPanels = item.ConnectedPanels;
+                    var connectedPanelIds = item.ConnectedPanels;
 
                     var firstOnAxis = true;
                     var lastAxisValue = 0.0;
 
-                    foreach (var panelId in connectedPanels)
-                    {
-                        var optional = _panelSource.Lookup(panelId);
-                        if (!optional.HasValue) continue;
+                    var connectedPanels = connectedPanelIds
+                        .Select(panelId => _panelSource.Lookup(panelId))
+                        .Where(optional => optional.HasValue)
+                        .Select(optional => optional.Value)
+                        .Order(PanelComparer.Instance)
+                        .ToArray();
 
-                        var panel = optional.Value;
+                    foreach (var panel in connectedPanels)
+                    {
                         var currentSize = panel.LogicalBounds;
 
                         if (isHorizontal)

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
@@ -180,14 +180,11 @@ public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceVie
                     }
 
                     // move other resizers
-
-                    // ReSharper disable once ArrangeThisQualifier
-                    if (isHorizontal == this.IsHorizontal) return;
-
                     foreach (var resizer in Resizers)
                     {
                         if (ReferenceEquals(item, resizer)) continue;
                         if (resizer.IsHorizontal != isHorizontal) continue;
+                        if (!item.ConnectedPanels.Intersect(resizer.ConnectedPanels).Any()) continue;
 
                         resizer.LogicalPosition = isHorizontal
                             ? resizer.LogicalPosition.WithY(newLogicalPosition.Y)

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
@@ -86,7 +86,6 @@ public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceVie
         }
     }
 
-    /// <inheritdoc/>
     public void SwapPanels(IPanelViewModel first, IPanelViewModel second)
     {
         (second.LogicalBounds, first.LogicalBounds) = (first.LogicalBounds, second.LogicalBounds);
@@ -145,7 +144,6 @@ public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceVie
         return panelViewModel;
     }
 
-    /// <inheritdoc/>
     public void ClosePanel(PanelId panelToClose)
     {
         var currentState = _panels.ToImmutableDictionary(panel => panel.Id, panel => panel.LogicalBounds);

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
@@ -53,12 +53,14 @@ public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceVie
 
         this.WhenActivated(disposables =>
         {
+            // Adding a panel
             _addPanelButtonViewModelSource
                 .Connect()
                 .MergeMany(item => item.AddPanelCommand)
                 .SubscribeWithErrorLogging(nextState => AddPanel(nextState))
                 .DisposeWith(disposables);
 
+            // Closing a panel
             _panelSource
                 .Connect()
                 .MergeMany(item => item.CloseCommand)
@@ -67,6 +69,7 @@ public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceVie
 
             // TODO: popout command
 
+            // Disabling certain features when there is only one panel
             _panelSource
                 .Connect()
                 .Count()
@@ -81,6 +84,15 @@ public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceVie
                 .SubscribeWithErrorLogging()
                 .DisposeWith(disposables);
 
+            // Finished Resizing
+            _resizersSource
+                .Connect()
+                .MergeMany(item => item.FinishDragCommand)
+                .Do(_ => UpdateStates())
+                .Subscribe()
+                .DisposeWith(disposables);
+
+            // Resizing
             _resizersSource
                 .Connect()
                 .MergeManyWithSource(item => item.DragCommand)

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
@@ -89,9 +89,14 @@ public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceVie
                 {
                     var (item, newActualPosition) = tuple;
 
+                    const double minX = 0.2;
+                    const double minY = 0.2;
+                    const double maxX = 1 - minX;
+                    const double maxY = 1 - minY;
+
                     var newLogicalPosition = new Point(
-                        newActualPosition.X / _lastWorkspaceSize.Width,
-                        newActualPosition.Y / _lastWorkspaceSize.Height
+                        Math.Max(minX, Math.Min(maxX, newActualPosition.X / _lastWorkspaceSize.Width)),
+                        Math.Max(minY, Math.Min(maxY, newActualPosition.Y / _lastWorkspaceSize.Height))
                     );
 
                     var lastItemPosition = item.LogicalPosition;

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
@@ -87,7 +87,7 @@ public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceVie
             // Finished Resizing
             _resizersSource
                 .Connect()
-                .MergeMany(item => item.FinishDragCommand)
+                .MergeMany(item => item.DragEndCommand)
                 .Do(_ => UpdateStates())
                 .Subscribe()
                 .DisposeWith(disposables);
@@ -95,7 +95,7 @@ public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceVie
             // Resizing
             _resizersSource
                 .Connect()
-                .MergeManyWithSource(item => item.DragCommand)
+                .MergeManyWithSource(item => item.DragStartCommand)
                 .Where(tuple => tuple.Item2 != new Point(0, 0))
                 .Do(tuple =>
                 {

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
@@ -101,8 +101,8 @@ public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceVie
                 {
                     var (item, newActualPosition) = tuple;
 
-                    const double minX = 0.2;
-                    const double minY = 0.2;
+                    const double minX = 0.3;
+                    const double minY = 0.3;
                     const double maxX = 1 - minX;
                     const double maxY = 1 - minY;
 

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
@@ -80,6 +80,24 @@ public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceVie
                 })
                 .SubscribeWithErrorLogging()
                 .DisposeWith(disposables);
+
+            _resizersSource
+                .Connect()
+                .MergeManyWithSource(item => item.DragCommand)
+                .Where(tuple => tuple.Item2 != new Point(0, 0))
+                .Do(tuple =>
+                {
+                    var (item, newActualPosition) = tuple;
+
+                    var newLogicalPosition = new Point(
+                        newActualPosition.X / _lastWorkspaceSize.Width,
+                        newActualPosition.Y / _lastWorkspaceSize.Height
+                    );
+
+                    item.LogicalPosition = newLogicalPosition;
+                })
+                .Subscribe()
+                .DisposeWith(disposables);
         });
     }
 

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
@@ -229,7 +229,8 @@ public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceVie
             updater.Clear();
             if (_panels.Count == MaxPanelCount) return;
 
-            var states = GridUtils.GetPossibleStates(_panels, Columns, Rows);
+            var panels = _panels.ToImmutableDictionary(panel => panel.Id, panel => panel.LogicalBounds);
+            var states = GridUtils.GetPossibleStates(panels, Columns, Rows);
             foreach (var state in states)
             {
                 var image = IconUtils.StateToBitmap(state);

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
@@ -110,6 +110,7 @@ public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceVie
                     // in case we skip an update, the tolerance for edge checking is higher than usual.
                     const double defaultTolerance = 0.05;
 
+                    // move panels
                     foreach (var panel in connectedPanels)
                     {
                         var currentSize = panel.LogicalBounds;
@@ -160,12 +161,28 @@ public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceVie
 
                         panel.LogicalBounds = newPanelBounds;
                     }
+
+                    // move other resizers
+
+                    // ReSharper disable once ArrangeThisQualifier
+                    if (isHorizontal == this.IsHorizontal) return;
+
+                    foreach (var resizer in Resizers)
+                    {
+                        if (ReferenceEquals(item, resizer)) continue;
+                        if (resizer.IsHorizontal != isHorizontal) continue;
+
+                        resizer.LogicalPosition = isHorizontal
+                            ? resizer.LogicalPosition.WithY(newLogicalPosition.Y)
+                            : resizer.LogicalPosition.WithX(newLogicalPosition.X);
+                    }
                 })
                 .SubscribeWithErrorLogging()
                 .DisposeWith(disposables);
         });
     }
 
+    // TODO: make this reactive
     private Size _lastWorkspaceSize;
     private bool IsHorizontal => _lastWorkspaceSize.Width > _lastWorkspaceSize.Height;
 

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
@@ -106,12 +106,12 @@ public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceVie
                     const double maxX = 1 - minX;
                     const double maxY = 1 - minY;
 
+                    var lastItemPosition = item.LogicalPosition;
                     var newLogicalPosition = new Point(
                         Math.Max(minX, Math.Min(maxX, newActualPosition.X / _lastWorkspaceSize.Width)),
                         Math.Max(minY, Math.Min(maxY, newActualPosition.Y / _lastWorkspaceSize.Height))
                     );
 
-                    var lastItemPosition = item.LogicalPosition;
                     item.LogicalPosition = newLogicalPosition;
 
                     var isHorizontal = item.IsHorizontal;

--- a/tests/NexusMods.UI.Tests/WorkspaceSystem/GridUtilsTests.cs
+++ b/tests/NexusMods.UI.Tests/WorkspaceSystem/GridUtilsTests.cs
@@ -435,7 +435,12 @@ public class GridUtilsTests
         {
             info.IsHorizontal.Should().BeFalse();
             info.LogicalPosition.Should().Be(new Point(0.5, 0.25));
-            info.ConnectedPanels.Should().HaveCount(2).And.Contain(new[] { firstPanelId, secondPanelId, thirdPanelId });
+            info.ConnectedPanels.Should().HaveCount(4).And.Contain(new[] { firstPanelId, secondPanelId, thirdPanelId, fourthPanelId });
+        }, info =>
+        {
+            info.IsHorizontal.Should().BeFalse();
+            info.LogicalPosition.Should().Be(new Point(0.5, 0.75));
+            info.ConnectedPanels.Should().HaveCount(4).And.Contain(new[] { firstPanelId, secondPanelId, thirdPanelId, fourthPanelId });
         }, info =>
         {
             info.IsHorizontal.Should().BeTrue();
@@ -446,18 +451,13 @@ public class GridUtilsTests
             info.IsHorizontal.Should().BeTrue();
             info.LogicalPosition.Should().Be(new Point(0.75, 0.5));
             info.ConnectedPanels.Should().HaveCount(2).And.Contain(new[] { secondPanelId, fourthPanelId });
-        }, info =>
-        {
-            info.IsHorizontal.Should().BeFalse();
-            info.LogicalPosition.Should().Be(new Point(0.5, 0.75));
-            info.ConnectedPanels.Should().HaveCount(2).And.Contain(new[] { thirdPanelId, fourthPanelId, firstPanelId });
         });
 
         // NOTE(erri120):
         // workspace layout is vertical (more height than width), rows have priority over columns
         // | a | b |
         // | c | d |
-        res = GridUtils.GetResizers(state, isWorkspaceHorizontal: true);
+        res = GridUtils.GetResizers(state, isWorkspaceHorizontal: false);
         res.Should().HaveCount(4).And.SatisfyRespectively(info =>
         {
             info.IsHorizontal.Should().BeFalse();
@@ -467,12 +467,12 @@ public class GridUtilsTests
         {
             info.IsHorizontal.Should().BeTrue();
             info.LogicalPosition.Should().Be(new Point(0.25, 0.5));
-            info.ConnectedPanels.Should().HaveCount(2).And.Contain(new[] { firstPanelId, thirdPanelId, secondPanelId });
+            info.ConnectedPanels.Should().HaveCount(4).And.Contain(new[] { firstPanelId, secondPanelId, thirdPanelId, fourthPanelId });
         }, info =>
         {
             info.IsHorizontal.Should().BeTrue();
             info.LogicalPosition.Should().Be(new Point(0.75, 0.5));
-            info.ConnectedPanels.Should().HaveCount(2).And.Contain(new[] { secondPanelId, fourthPanelId, firstPanelId });
+            info.ConnectedPanels.Should().HaveCount(4).And.Contain(new[] { firstPanelId, secondPanelId, thirdPanelId, fourthPanelId });
         }, info =>
         {
             info.IsHorizontal.Should().BeFalse();

--- a/tests/NexusMods.UI.Tests/WorkspaceSystem/GridUtilsTests.cs
+++ b/tests/NexusMods.UI.Tests/WorkspaceSystem/GridUtilsTests.cs
@@ -417,6 +417,7 @@ public class GridUtilsTests
 
 
         // NOTE(erri120):
+        // workspace layout is horizontal (more width than height), columns have priority over rows
         // | a | b |
         // | c | d |
         state = new List<IPanelViewModel>(capacity: columns * rows)
@@ -427,12 +428,12 @@ public class GridUtilsTests
             CreatePanel(fourthPanelId, new Rect(0.5, 0.5, 0.5, 0.5))
         }.ToImmutableDictionary(panel => panel.Id, panel => panel.LogicalBounds);
 
-        res = GridUtils.GetResizers(state);
+        res = GridUtils.GetResizers(state, isWorkspaceHorizontal: true);
         res.Should().HaveCount(4).And.SatisfyRespectively(info =>
         {
             info.IsHorizontal.Should().BeFalse();
             info.LogicalPosition.Should().Be(new Vector(0.5, 0.25));
-            info.ConnectedPanels.Should().HaveCount(2).And.Contain(new[] { firstPanelId, secondPanelId });
+            info.ConnectedPanels.Should().HaveCount(2).And.Contain(new[] { firstPanelId, secondPanelId, thirdPanelId });
         }, info =>
         {
             info.IsHorizontal.Should().BeTrue();
@@ -443,6 +444,33 @@ public class GridUtilsTests
             info.IsHorizontal.Should().BeTrue();
             info.LogicalPosition.Should().Be(new Vector(0.75, 0.5));
             info.ConnectedPanels.Should().HaveCount(2).And.Contain(new[] { secondPanelId, fourthPanelId });
+        }, info =>
+        {
+            info.IsHorizontal.Should().BeFalse();
+            info.LogicalPosition.Should().Be(new Vector(0.5, 0.75));
+            info.ConnectedPanels.Should().HaveCount(2).And.Contain(new[] { thirdPanelId, fourthPanelId, firstPanelId });
+        });
+
+        // NOTE(erri120):
+        // workspace layout is vertical (more height than width), rows have priority over columns
+        // | a | b |
+        // | c | d |
+        res = GridUtils.GetResizers(state, isWorkspaceHorizontal: true);
+        res.Should().HaveCount(4).And.SatisfyRespectively(info =>
+        {
+            info.IsHorizontal.Should().BeFalse();
+            info.LogicalPosition.Should().Be(new Vector(0.5, 0.25));
+            info.ConnectedPanels.Should().HaveCount(2).And.Contain(new[] { firstPanelId, secondPanelId });
+        }, info =>
+        {
+            info.IsHorizontal.Should().BeTrue();
+            info.LogicalPosition.Should().Be(new Vector(0.25, 0.5));
+            info.ConnectedPanels.Should().HaveCount(2).And.Contain(new[] { firstPanelId, thirdPanelId, secondPanelId });
+        }, info =>
+        {
+            info.IsHorizontal.Should().BeTrue();
+            info.LogicalPosition.Should().Be(new Vector(0.75, 0.5));
+            info.ConnectedPanels.Should().HaveCount(2).And.Contain(new[] { secondPanelId, fourthPanelId, firstPanelId });
         }, info =>
         {
             info.IsHorizontal.Should().BeFalse();

--- a/tests/NexusMods.UI.Tests/WorkspaceSystem/GridUtilsTests.cs
+++ b/tests/NexusMods.UI.Tests/WorkspaceSystem/GridUtilsTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using Avalonia;
 using FluentAssertions;
 using JetBrains.Annotations;
@@ -8,6 +9,7 @@ using NSubstitute;
 namespace NexusMods.UI.Tests.WorkspaceSystem;
 
 [UsedImplicitly]
+[SuppressMessage("ReSharper", "HeapView.BoxingAllocation")]
 public class GridUtilsTests
 {
     [Fact]
@@ -335,7 +337,7 @@ public class GridUtilsTests
         res.Should().ContainSingle().And.SatisfyRespectively(info =>
         {
             info.IsHorizontal.Should().BeFalse();
-            info.LogicalPosition.Should().Be(new Vector(0.5, 0.5));
+            info.LogicalPosition.Should().Be(new Point(0.5, 0.5));
             info.ConnectedPanels.Should().HaveCount(2).And.Contain(new[] { firstPanelId, secondPanelId });
         });
 
@@ -353,7 +355,7 @@ public class GridUtilsTests
         res.Should().ContainSingle().And.SatisfyRespectively(info =>
         {
             info.IsHorizontal.Should().BeTrue();
-            info.LogicalPosition.Should().Be(new Vector(0.5, 0.5));
+            info.LogicalPosition.Should().Be(new Point(0.5, 0.5));
             info.ConnectedPanels.Should().HaveCount(2).And.Contain(new[] { firstPanelId, secondPanelId });
         });
 
@@ -372,17 +374,17 @@ public class GridUtilsTests
         res.Should().HaveCount(3).And.SatisfyRespectively(info =>
         {
             info.IsHorizontal.Should().BeFalse();
-            info.LogicalPosition.Should().Be(new Vector(0.5, 0.25));
+            info.LogicalPosition.Should().Be(new Point(0.5, 0.25));
             info.ConnectedPanels.Should().HaveCount(3).And.Contain(new[] { firstPanelId, secondPanelId, thirdPanelId });
         }, info =>
         {
             info.IsHorizontal.Should().BeFalse();
-            info.LogicalPosition.Should().Be(new Vector(0.5, 0.75));
+            info.LogicalPosition.Should().Be(new Point(0.5, 0.75));
             info.ConnectedPanels.Should().HaveCount(3).And.Contain(new[] { firstPanelId, secondPanelId, thirdPanelId });
         }, info =>
         {
             info.IsHorizontal.Should().BeTrue();
-            info.LogicalPosition.Should().Be(new Vector(0.75, 0.5));
+            info.LogicalPosition.Should().Be(new Point(0.75, 0.5));
             info.ConnectedPanels.Should().HaveCount(2).And.Contain(new[] { secondPanelId, thirdPanelId });
         });
 
@@ -401,17 +403,17 @@ public class GridUtilsTests
         res.Should().HaveCount(3).And.SatisfyRespectively(info =>
         {
             info.IsHorizontal.Should().BeTrue();
-            info.LogicalPosition.Should().Be(new Vector(0.25, 0.5));
+            info.LogicalPosition.Should().Be(new Point(0.25, 0.5));
             info.ConnectedPanels.Should().HaveCount(3).And.Contain(new[] { firstPanelId, secondPanelId, thirdPanelId });
         }, info =>
         {
             info.IsHorizontal.Should().BeTrue();
-            info.LogicalPosition.Should().Be(new Vector(0.75, 0.5));
+            info.LogicalPosition.Should().Be(new Point(0.75, 0.5));
             info.ConnectedPanels.Should().HaveCount(3).And.Contain(new[] { firstPanelId, secondPanelId, thirdPanelId });
         }, info =>
         {
             info.IsHorizontal.Should().BeFalse();
-            info.LogicalPosition.Should().Be(new Vector(0.5, 0.75));
+            info.LogicalPosition.Should().Be(new Point(0.5, 0.75));
             info.ConnectedPanels.Should().HaveCount(2).And.Contain(new[] { secondPanelId, thirdPanelId });
         });
 
@@ -432,22 +434,22 @@ public class GridUtilsTests
         res.Should().HaveCount(4).And.SatisfyRespectively(info =>
         {
             info.IsHorizontal.Should().BeFalse();
-            info.LogicalPosition.Should().Be(new Vector(0.5, 0.25));
+            info.LogicalPosition.Should().Be(new Point(0.5, 0.25));
             info.ConnectedPanels.Should().HaveCount(2).And.Contain(new[] { firstPanelId, secondPanelId, thirdPanelId });
         }, info =>
         {
             info.IsHorizontal.Should().BeTrue();
-            info.LogicalPosition.Should().Be(new Vector(0.25, 0.5));
+            info.LogicalPosition.Should().Be(new Point(0.25, 0.5));
             info.ConnectedPanels.Should().HaveCount(2).And.Contain(new[] { firstPanelId, thirdPanelId });
         }, info =>
         {
             info.IsHorizontal.Should().BeTrue();
-            info.LogicalPosition.Should().Be(new Vector(0.75, 0.5));
+            info.LogicalPosition.Should().Be(new Point(0.75, 0.5));
             info.ConnectedPanels.Should().HaveCount(2).And.Contain(new[] { secondPanelId, fourthPanelId });
         }, info =>
         {
             info.IsHorizontal.Should().BeFalse();
-            info.LogicalPosition.Should().Be(new Vector(0.5, 0.75));
+            info.LogicalPosition.Should().Be(new Point(0.5, 0.75));
             info.ConnectedPanels.Should().HaveCount(2).And.Contain(new[] { thirdPanelId, fourthPanelId, firstPanelId });
         });
 
@@ -459,22 +461,22 @@ public class GridUtilsTests
         res.Should().HaveCount(4).And.SatisfyRespectively(info =>
         {
             info.IsHorizontal.Should().BeFalse();
-            info.LogicalPosition.Should().Be(new Vector(0.5, 0.25));
+            info.LogicalPosition.Should().Be(new Point(0.5, 0.25));
             info.ConnectedPanels.Should().HaveCount(2).And.Contain(new[] { firstPanelId, secondPanelId });
         }, info =>
         {
             info.IsHorizontal.Should().BeTrue();
-            info.LogicalPosition.Should().Be(new Vector(0.25, 0.5));
+            info.LogicalPosition.Should().Be(new Point(0.25, 0.5));
             info.ConnectedPanels.Should().HaveCount(2).And.Contain(new[] { firstPanelId, thirdPanelId, secondPanelId });
         }, info =>
         {
             info.IsHorizontal.Should().BeTrue();
-            info.LogicalPosition.Should().Be(new Vector(0.75, 0.5));
+            info.LogicalPosition.Should().Be(new Point(0.75, 0.5));
             info.ConnectedPanels.Should().HaveCount(2).And.Contain(new[] { secondPanelId, fourthPanelId, firstPanelId });
         }, info =>
         {
             info.IsHorizontal.Should().BeFalse();
-            info.LogicalPosition.Should().Be(new Vector(0.5, 0.75));
+            info.LogicalPosition.Should().Be(new Point(0.5, 0.75));
             info.ConnectedPanels.Should().HaveCount(2).And.Contain(new[] { thirdPanelId, fourthPanelId });
         });
     }

--- a/tests/NexusMods.UI.Tests/WorkspaceSystem/GridUtilsTests.cs
+++ b/tests/NexusMods.UI.Tests/WorkspaceSystem/GridUtilsTests.cs
@@ -479,6 +479,33 @@ public class GridUtilsTests
             info.LogicalPosition.Should().Be(new Point(0.5, 0.75));
             info.ConnectedPanels.Should().HaveCount(2).And.Contain(new[] { thirdPanelId, fourthPanelId });
         });
+
+
+        // NOTE(erri120): weird sizes
+        state = new List<IPanelViewModel>(capacity: columns * rows)
+        {
+            CreatePanel(firstPanelId, new Rect(0, 0, 0.35, 0.5)),
+            CreatePanel(secondPanelId, new Rect(0, 0.5, 0.35, 0.5)),
+            CreatePanel(thirdPanelId, new Rect(0.35, 0, 0.65, 1)),
+        }.ToImmutableDictionary(panel => panel.Id, panel => panel.LogicalBounds);
+
+        res = GridUtils.GetResizers(state, isWorkspaceHorizontal: true);
+        res.Should().HaveCount(3).And.SatisfyRespectively(info =>
+        {
+            info.IsHorizontal.Should().BeTrue();
+            info.LogicalPosition.Should().Be(new Point(0.175, 0.5));
+            info.ConnectedPanels.Should().HaveCount(2).And.Contain(new[] { firstPanelId, secondPanelId });
+        }, info =>
+        {
+            info.IsHorizontal.Should().BeFalse();
+            info.LogicalPosition.Should().Be(new Point(0.35, 0.25));
+            info.ConnectedPanels.Should().HaveCount(3).And.Contain(new[] { firstPanelId, secondPanelId, thirdPanelId });
+        }, info =>
+        {
+            info.IsHorizontal.Should().BeFalse();
+            info.LogicalPosition.Should().Be(new Point(0.35, 0.75));
+            info.ConnectedPanels.Should().HaveCount(3).And.Contain(new[] { firstPanelId, secondPanelId, thirdPanelId });
+        });
     }
 
     private static IPanelViewModel CreatePanel(PanelId panelId, Rect logicalBounds)

--- a/tests/NexusMods.UI.Tests/WorkspaceSystem/GridUtilsTests.cs
+++ b/tests/NexusMods.UI.Tests/WorkspaceSystem/GridUtilsTests.cs
@@ -161,7 +161,7 @@ public class GridUtilsTests
         var firstPanelId = PanelId.From(Guid.Parse("11111111-1111-1111-1111-111111111111"));
         var secondPanelId = PanelId.From(Guid.Parse("22222222-2222-2222-2222-222222222222"));
         var thirdPanelId = PanelId.From(Guid.Parse("33333333-3333-3333-3333-333333333333"));
-        var fourthPanelId = PanelId.From(Guid.Parse("44444444-4444-4444-4444-444444444444"));
+        // var fourthPanelId = PanelId.From(Guid.Parse("44444444-4444-4444-4444-444444444444"));
 
         const int columns = 2;
         const int rows = 2;
@@ -308,6 +308,146 @@ public class GridUtilsTests
         {
             kv.Key.Should().Be(thirdPanelId);
             kv.Value.Should().Be(new Rect(0.5, 0, 0.5, 1));
+        });
+    }
+
+    [Fact]
+    public void Test_GetResizers()
+    {
+        var firstPanelId = PanelId.From(Guid.Parse("11111111-1111-1111-1111-111111111111"));
+        var secondPanelId = PanelId.From(Guid.Parse("22222222-2222-2222-2222-222222222222"));
+        var thirdPanelId = PanelId.From(Guid.Parse("33333333-3333-3333-3333-333333333333"));
+        var fourthPanelId = PanelId.From(Guid.Parse("44444444-4444-4444-4444-444444444444"));
+
+        const int columns = 2;
+        const int rows = 2;
+
+        // NOTE(erri120): two columns
+        // | a | b |
+        // | a | b |
+        var state = new List<IPanelViewModel>(capacity: columns * rows)
+        {
+            CreatePanel(firstPanelId, new Rect(0, 0, 0.5, 1)),
+            CreatePanel(secondPanelId, new Rect(0.5, 0, 0.5, 1))
+        }.ToImmutableDictionary(panel => panel.Id, panel => panel.LogicalBounds);
+
+        var res = GridUtils.GetResizers(state);
+        res.Should().ContainSingle().And.SatisfyRespectively(info =>
+        {
+            info.IsHorizontal.Should().BeFalse();
+            info.LogicalPosition.Should().Be(new Vector(0.5, 0.5));
+            info.ConnectedPanels.Should().HaveCount(2).And.Contain(new[] { firstPanelId, secondPanelId });
+        });
+
+
+        // NOTE(erri120): two rows
+        // | a | a |
+        // | b | b |
+        state = new List<IPanelViewModel>(capacity: columns * rows)
+        {
+            CreatePanel(firstPanelId, new Rect(0, 0, 1, 0.5)),
+            CreatePanel(secondPanelId, new Rect(0, 0.5, 1, 0.5))
+        }.ToImmutableDictionary(panel => panel.Id, panel => panel.LogicalBounds);
+
+        res = GridUtils.GetResizers(state);
+        res.Should().ContainSingle().And.SatisfyRespectively(info =>
+        {
+            info.IsHorizontal.Should().BeTrue();
+            info.LogicalPosition.Should().Be(new Vector(0.5, 0.5));
+            info.ConnectedPanels.Should().HaveCount(2).And.Contain(new[] { firstPanelId, secondPanelId });
+        });
+
+
+        // NOTE(erri120):
+        // | a | b |
+        // | a | c |
+        state = new List<IPanelViewModel>(capacity: columns * rows)
+        {
+            CreatePanel(firstPanelId, new Rect(0, 0, 0.5, 1)),
+            CreatePanel(secondPanelId, new Rect(0.5, 0, 0.5, 0.5)),
+            CreatePanel(thirdPanelId, new Rect(0.5, 0.5, 0.5, 0.5))
+        }.ToImmutableDictionary(panel => panel.Id, panel => panel.LogicalBounds);
+
+        res = GridUtils.GetResizers(state);
+        res.Should().HaveCount(3).And.SatisfyRespectively(info =>
+        {
+            info.IsHorizontal.Should().BeFalse();
+            info.LogicalPosition.Should().Be(new Vector(0.5, 0.25));
+            info.ConnectedPanels.Should().HaveCount(3).And.Contain(new[] { firstPanelId, secondPanelId, thirdPanelId });
+        }, info =>
+        {
+            info.IsHorizontal.Should().BeFalse();
+            info.LogicalPosition.Should().Be(new Vector(0.5, 0.75));
+            info.ConnectedPanels.Should().HaveCount(3).And.Contain(new[] { firstPanelId, secondPanelId, thirdPanelId });
+        }, info =>
+        {
+            info.IsHorizontal.Should().BeTrue();
+            info.LogicalPosition.Should().Be(new Vector(0.75, 0.5));
+            info.ConnectedPanels.Should().HaveCount(2).And.Contain(new[] { secondPanelId, thirdPanelId });
+        });
+
+
+        // NOTE(erri120):
+        // | a | a |
+        // | b | c |
+        state = new List<IPanelViewModel>(capacity: columns * rows)
+        {
+            CreatePanel(firstPanelId, new Rect(0, 0, 1, 0.5)),
+            CreatePanel(secondPanelId, new Rect(0, 0.5, 0.5, 0.5)),
+            CreatePanel(thirdPanelId, new Rect(0.5, 0.5, 0.5, 0.5))
+        }.ToImmutableDictionary(panel => panel.Id, panel => panel.LogicalBounds);
+
+        res = GridUtils.GetResizers(state);
+        res.Should().HaveCount(3).And.SatisfyRespectively(info =>
+        {
+            info.IsHorizontal.Should().BeTrue();
+            info.LogicalPosition.Should().Be(new Vector(0.25, 0.5));
+            info.ConnectedPanels.Should().HaveCount(3).And.Contain(new[] { firstPanelId, secondPanelId, thirdPanelId });
+        }, info =>
+        {
+            info.IsHorizontal.Should().BeTrue();
+            info.LogicalPosition.Should().Be(new Vector(0.75, 0.5));
+            info.ConnectedPanels.Should().HaveCount(3).And.Contain(new[] { firstPanelId, secondPanelId, thirdPanelId });
+        }, info =>
+        {
+            info.IsHorizontal.Should().BeFalse();
+            info.LogicalPosition.Should().Be(new Vector(0.5, 0.75));
+            info.ConnectedPanels.Should().HaveCount(2).And.Contain(new[] { secondPanelId, thirdPanelId });
+        });
+
+
+        // NOTE(erri120):
+        // | a | b |
+        // | c | d |
+        state = new List<IPanelViewModel>(capacity: columns * rows)
+        {
+            CreatePanel(firstPanelId, new Rect(0, 0, 0.5, 0.5)),
+            CreatePanel(secondPanelId, new Rect(0.5, 0, 0.5, 0.5)),
+            CreatePanel(thirdPanelId, new Rect(0, 0.5, 0.5, 0.5)),
+            CreatePanel(fourthPanelId, new Rect(0.5, 0.5, 0.5, 0.5))
+        }.ToImmutableDictionary(panel => panel.Id, panel => panel.LogicalBounds);
+
+        res = GridUtils.GetResizers(state);
+        res.Should().HaveCount(4).And.SatisfyRespectively(info =>
+        {
+            info.IsHorizontal.Should().BeFalse();
+            info.LogicalPosition.Should().Be(new Vector(0.5, 0.25));
+            info.ConnectedPanels.Should().HaveCount(2).And.Contain(new[] { firstPanelId, secondPanelId });
+        }, info =>
+        {
+            info.IsHorizontal.Should().BeTrue();
+            info.LogicalPosition.Should().Be(new Vector(0.25, 0.5));
+            info.ConnectedPanels.Should().HaveCount(2).And.Contain(new[] { firstPanelId, thirdPanelId });
+        }, info =>
+        {
+            info.IsHorizontal.Should().BeTrue();
+            info.LogicalPosition.Should().Be(new Vector(0.75, 0.5));
+            info.ConnectedPanels.Should().HaveCount(2).And.Contain(new[] { secondPanelId, fourthPanelId });
+        }, info =>
+        {
+            info.IsHorizontal.Should().BeFalse();
+            info.LogicalPosition.Should().Be(new Vector(0.5, 0.75));
+            info.ConnectedPanels.Should().HaveCount(2).And.Contain(new[] { thirdPanelId, fourthPanelId });
         });
     }
 

--- a/tests/NexusMods.UI.Tests/WorkspaceSystem/GridUtilsTests.cs
+++ b/tests/NexusMods.UI.Tests/WorkspaceSystem/GridUtilsTests.cs
@@ -24,7 +24,7 @@ public class GridUtilsTests
         const int rows = 2;
         var panels = new List<IPanelViewModel>(capacity: columns * rows);
 
-        var res = GridUtils.GetPossibleStates(panels, columns, rows).ToArray();
+        var res = GridUtils.GetPossibleStates(ToInput(), columns, rows).ToArray();
         res.Should().BeEmpty();
 
         // NOTE(erri120): Start with a single "main" panel that takes up the entire space.
@@ -38,7 +38,7 @@ public class GridUtilsTests
         // | 1 | 2 |  | 2 | 1 |  | 1 | 1 |  | 2 | 2 |
         // | 1 | 2 |  | 2 | 1 |  | 2 | 2 |  | 1 | 1 |
 
-        res = GridUtils.GetPossibleStates(panels, columns, rows).ToArray();
+        res = GridUtils.GetPossibleStates(ToInput(), columns, rows).ToArray();
         res.Should().HaveCount(4).And.SatisfyRespectively(dict =>
         {
             dict.Should().HaveCount(2).And.Equal(new KeyValuePair<PanelId, Rect>[]
@@ -78,7 +78,7 @@ public class GridUtilsTests
         // we have 4 possible states (1 = first panel, 2 = second panel, 3 = new panel):
         // | 1 | 2 |  | 3 | 2 |  | 1 | 2 |  | 1 | 3 |
         // | 3 | 2 |  | 1 | 2 |  | 1 | 3 |  | 1 | 2 |
-        res = GridUtils.GetPossibleStates(panels, columns, rows).ToArray();
+        res = GridUtils.GetPossibleStates(ToInput(), columns, rows).ToArray();
         res.Should().HaveCount(4).And.SatisfyRespectively(dict =>
         {
             dict.Should().HaveCount(3).And.Equal(new KeyValuePair<PanelId, Rect>[]
@@ -124,7 +124,7 @@ public class GridUtilsTests
         // in the right column (1 = first panel, 2 = second panel, 3 = third panel, 4 = new panel):
         // | 1 | 2 |  | 1 | 4 |
         // | 3 | 4 |  | 3 | 2 |
-        res = GridUtils.GetPossibleStates(panels, columns, rows).ToArray();
+        res = GridUtils.GetPossibleStates(ToInput(), columns, rows).ToArray();
         res.Should().HaveCount(2).And.SatisfyRespectively(dict =>
         {
             dict.Should().HaveCount(4).And.Equal(new KeyValuePair<PanelId, Rect>[]
@@ -153,8 +153,14 @@ public class GridUtilsTests
         panels.Add(fourthPanel);
 
         // NOTE(erri120): final state reached, no more panels possible.
-        res = GridUtils.GetPossibleStates(panels, columns, rows).ToArray();
+        res = GridUtils.GetPossibleStates(ToInput(), columns, rows).ToArray();
         res.Should().BeEmpty();
+        return;
+
+        ImmutableDictionary<PanelId, Rect> ToInput()
+        {
+            return panels.ToImmutableDictionary(x => x.Id, x => x.LogicalBounds);
+        }
     }
 
     [Fact]

--- a/tests/NexusMods.UI.Tests/WorkspaceSystem/MathUtilsTests.cs
+++ b/tests/NexusMods.UI.Tests/WorkspaceSystem/MathUtilsTests.cs
@@ -70,7 +70,7 @@ public class MathUtilsTests
 
     [Theory]
     [MemberData(nameof(TestData_GetMidPoint))]
-    public void Test_GetMidPoint(Rect a, Rect b, bool isHorizontal, Vector expected)
+    public void Test_GetMidPoint(Rect a, Rect b, bool isHorizontal, Point expected)
     {
         var actual = MathUtils.GetMidPoint(a, b, isHorizontal);
         actual.Should().Be(expected);
@@ -78,13 +78,16 @@ public class MathUtilsTests
 
     public static IEnumerable<object[]> TestData_GetMidPoint() => new[]
     {
-        new object[] { new Rect(0, 0, 0.5, 1.0), new Rect(0.5, 0, 0.5, 1.0), false, new Vector(0.5, 0.5) },
-        new object[] { new Rect(0, 0, 1.0, 0.5), new Rect(0, 0.5, 1.0, 0.5), true, new Vector(0.5, 0.5) },
+        new object[] { new Rect(0, 0, 0.5, 1.0), new Rect(0.5, 0, 0.5, 1.0), false, new Point(0.5, 0.5) },
+        new object[] { new Rect(0, 0, 1.0, 0.5), new Rect(0, 0.5, 1.0, 0.5), true, new Point(0.5, 0.5) },
 
-        new object[] { new Rect(0, 0, 0.5, 1.0), new Rect(0.5, 0, 0.5, 0.5), false, new Vector(0.5, 0.25) },
-        new object[] { new Rect(0, 0, 0.5, 1.0), new Rect(0.5, 0.5, 0.5, 0.5), false, new Vector(0.5, 0.75) },
+        new object[] { new Rect(0, 0, 0.5, 1.0), new Rect(0.5, 0, 0.5, 0.5), false, new Point(0.5, 0.25) },
+        new object[] { new Rect(0, 0, 0.5, 1.0), new Rect(0.5, 0.5, 0.5, 0.5), false, new Point(0.5, 0.75) },
 
-        new object[] { new Rect(0, 0, 1.0, 0.5), new Rect(0, 0.5, 0.5, 0.5), true, new Vector(0.25, 0.5) },
-        new object[] { new Rect(0, 0, 1.0, 0.5), new Rect(0.5, 0.5, 0.5, 0.5), true, new Vector(0.75, 0.5) },
+        new object[] { new Rect(0, 0, 1.0, 0.5), new Rect(0, 0.5, 0.5, 0.5), true, new Point(0.25, 0.5) },
+        new object[] { new Rect(0, 0, 1.0, 0.5), new Rect(0.5, 0.5, 0.5, 0.5), true, new Point(0.75, 0.5) },
+
+        new object[] { new Rect(0, 0, 0.35, 0.5), new Rect(0.35, 0, 0.65, 1), false, new Point(0.35, 0.25) },
+        new object[] { new Rect(0.35, 0, 0.65, 1), new Rect(0, 0, 0.35, 0.5) , false, new Point(0.35, 0.25) },
     };
 }

--- a/tests/NexusMods.UI.Tests/WorkspaceSystem/MathUtilsTests.cs
+++ b/tests/NexusMods.UI.Tests/WorkspaceSystem/MathUtilsTests.cs
@@ -69,14 +69,14 @@ public class MathUtilsTests
     };
 
     [Theory]
-    [MemberData(nameof(TestData_GetMidVector))]
-    public void Test_GetMidVector(Rect a, Rect b, bool isHorizontal, Vector expected)
+    [MemberData(nameof(TestData_GetMidPoint))]
+    public void Test_GetMidPoint(Rect a, Rect b, bool isHorizontal, Vector expected)
     {
-        var actual = MathUtils.GetMidVector(a, b, isHorizontal);
+        var actual = MathUtils.GetMidPoint(a, b, isHorizontal);
         actual.Should().Be(expected);
     }
 
-    public static IEnumerable<object[]> TestData_GetMidVector() => new[]
+    public static IEnumerable<object[]> TestData_GetMidPoint() => new[]
     {
         new object[] { new Rect(0, 0, 0.5, 1.0), new Rect(0.5, 0, 0.5, 1.0), false, new Vector(0.5, 0.5) },
         new object[] { new Rect(0, 0, 1.0, 0.5), new Rect(0, 0.5, 1.0, 0.5), true, new Vector(0.5, 0.5) },

--- a/tests/NexusMods.UI.Tests/WorkspaceSystem/MathUtilsTests.cs
+++ b/tests/NexusMods.UI.Tests/WorkspaceSystem/MathUtilsTests.cs
@@ -1,10 +1,12 @@
+using System.Diagnostics.CodeAnalysis;
 using Avalonia;
 using FluentAssertions;
 using NexusMods.App.UI.WorkspaceSystem;
-using Xunit.Sdk;
 
 namespace NexusMods.UI.Tests.WorkspaceSystem;
 
+[SuppressMessage("ReSharper", "HeapView.ObjectAllocation.Evident")]
+[SuppressMessage("ReSharper", "HeapView.BoxingAllocation")]
 public class MathUtilsTests
 {
     [Theory]
@@ -64,5 +66,25 @@ public class MathUtilsTests
     {
         new object[] { new Rect(0.0, 0.0, 100, 100), true, new Rect(0.0, 0.0, 50, 100), new Rect(50, 0.0, 50, 100) },
         new object[] { new Rect(0.0, 0.0, 100, 100), false, new Rect(0.0, 0.0, 100, 50), new Rect(0.0, 50, 100, 50) },
+    };
+
+    [Theory]
+    [MemberData(nameof(TestData_GetMidVector))]
+    public void Test_GetMidVector(Rect a, Rect b, bool isHorizontal, Vector expected)
+    {
+        var actual = MathUtils.GetMidVector(a, b, isHorizontal);
+        actual.Should().Be(expected);
+    }
+
+    public static IEnumerable<object[]> TestData_GetMidVector() => new[]
+    {
+        new object[] { new Rect(0, 0, 0.5, 1.0), new Rect(0.5, 0, 0.5, 1.0), false, new Vector(0.5, 0.5) },
+        new object[] { new Rect(0, 0, 1.0, 0.5), new Rect(0, 0.5, 1.0, 0.5), true, new Vector(0.5, 0.5) },
+
+        new object[] { new Rect(0, 0, 0.5, 1.0), new Rect(0.5, 0, 0.5, 0.5), false, new Vector(0.5, 0.25) },
+        new object[] { new Rect(0, 0, 0.5, 1.0), new Rect(0.5, 0.5, 0.5, 0.5), false, new Vector(0.5, 0.75) },
+
+        new object[] { new Rect(0, 0, 1.0, 0.5), new Rect(0, 0.5, 0.5, 0.5), true, new Vector(0.25, 0.5) },
+        new object[] { new Rect(0, 0, 1.0, 0.5), new Rect(0.5, 0.5, 0.5, 0.5), true, new Vector(0.75, 0.5) },
     };
 }

--- a/tests/NexusMods.UI.Tests/WorkspaceSystem/MathUtilsTests.cs
+++ b/tests/NexusMods.UI.Tests/WorkspaceSystem/MathUtilsTests.cs
@@ -89,5 +89,8 @@ public class MathUtilsTests
 
         new object[] { new Rect(0, 0, 0.35, 0.5), new Rect(0.35, 0, 0.65, 1), false, new Point(0.35, 0.25) },
         new object[] { new Rect(0.35, 0, 0.65, 1), new Rect(0, 0, 0.35, 0.5) , false, new Point(0.35, 0.25) },
+
+        new object[] { new Rect(0, 0, 0.8, 1.0), new Rect(0.8, 0, 0.2, 0.5), false, new Point(0.8, 0.25) },
+        new object[] { new Rect(0, 0, 0.8, 1.0), new Rect(0.8, 0.5, 0.2, 0.5), false, new Point(0.8, 0.75) }
     };
 }


### PR DESCRIPTION
Resolves #705. Part of #674.

- [x] Panels can be resized.
- [x] Panels have space in between them.
- [ ] Future TODO: #791
- [x] Hovering and interacting with the resizer should change the mouse icon.
- [ ] Bugs:
  - [ ] Cursor icon doesn't change in previewer? Maybe doesn't change at all, I have no idea.
  - [x] Wrong control is removed from the `Children` list.
  - [x] Space isn't expanded for the other control correctly.
  - [x] Resizers are at the wrong position after a panel has been closed.
  - [x] New panel icons aren't updated when the user stops resizing
  - [x] No minimum size for panels.