### PR TITLE
Use separate activity to report Chunk dl reading progress.

### DIFF
--- a/src/Networking/NexusMods.Networking.Downloaders/Tasks/NxmDownloadTask.cs
+++ b/src/Networking/NexusMods.Networking.Downloaders/Tasks/NxmDownloadTask.cs
@@ -1,3 +1,4 @@
+using DynamicData.Kernel;
 using NexusMods.Abstractions.DateTime;
 using NexusMods.DataModel.Activities;
 using NexusMods.Networking.Downloaders.Interfaces;
@@ -31,7 +32,7 @@ public class NxmDownloadTask : IDownloadTask, IHaveDownloadVersion, IHaveFileSiz
     private long _defaultDownloadedSize;
 
     /// <inheritdoc />
-    public long DownloadedSizeBytes => (long)(_state.ActivityStatus?.MakeTypedReport().Current.Value.Value ?? (ulong)_defaultDownloadedSize);
+    public long DownloadedSizeBytes => (long)(_state.ActivityStatus?.MakeTypedReport().Current.ValueOrDefault().Value ?? (ulong)_defaultDownloadedSize);
 
     /// <inheritdoc />
     public long CalculateThroughput()


### PR DESCRIPTION
Fixes download getting double the progress value
Fixes #834