### PR TITLE
Avoid download progress poll ticking while there are no active subscriptions

### DIFF
--- a/src/NexusMods.App.UI/Controls/Spine/Buttons/Download/SpineDownloadButtonViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/Spine/Buttons/Download/SpineDownloadButtonViewModel.cs
@@ -15,8 +15,9 @@ public class SpineDownloadButtonViewModel : AViewModel<ISpineDownloadButtonViewM
 {
     private const int PollTimeMilliseconds = 1000;
 
-    private IObservable<Unit> Tick { get; } = Observable.Interval(TimeSpan.FromMilliseconds(PollTimeMilliseconds))
-        .Select(_ => Unit.Default);
+    private IObservable<Unit> Tick { get; } = Observable.Defer(() =>
+        Observable.Interval(TimeSpan.FromMilliseconds(PollTimeMilliseconds))
+            .Select(_ => Unit.Default));
 
     public SpineDownloadButtonViewModel(IDownloadService downloadService)
     {
@@ -27,7 +28,6 @@ public class SpineDownloadButtonViewModel : AViewModel<ISpineDownloadButtonViewM
                 Number = downloadService.GetThroughput() / Size.MB;
                 Units = "MB/s";
                 Progress = downloadService.GetTotalProgress();
-
             }).DisposeWith(disposables);
         });
     }

--- a/src/NexusMods.App.UI/RightContent/Downloads/InProgressViewModel.cs
+++ b/src/NexusMods.App.UI/RightContent/Downloads/InProgressViewModel.cs
@@ -27,8 +27,9 @@ public class InProgressViewModel : AViewModel<IInProgressViewModel>, IInProgress
 {
     internal const int PollTimeMilliseconds = 1000;
 
-    private IObservable<Unit> Tick { get; set; } = Observable.Interval(TimeSpan.FromMilliseconds(PollTimeMilliseconds))
-        .Select(_ => Unit.Default);
+    private IObservable<Unit> Tick { get; set; } = Observable.Defer(() =>
+        Observable.Interval(TimeSpan.FromMilliseconds(PollTimeMilliseconds))
+            .Select(_ => Unit.Default));
 
     /// <summary>
     /// For designTime and Testing, provides an alternative list of tasks to use.


### PR DESCRIPTION
Uses Observable.Defer to only start ticking when there is a subscription.
There should not be more than one subscription at a time, so there should not be multiple ticks generated from this.