### PR TITLE
FOMOD installer fixes

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.GuidedInstallers/GuidedInstallationStep.cs
+++ b/src/Abstractions/NexusMods.Abstractions.GuidedInstallers/GuidedInstallationStep.cs
@@ -33,9 +33,4 @@ public record GuidedInstallationStep
     /// Gets whether or not there is a next step.
     /// </summary>
     public bool HasNextStep { get; init; }
-
-    /// <summary>
-    /// Gets whether or not the step is visible.
-    /// </summary>
-    public bool IsVisible { get; init; }
 }

--- a/src/Abstractions/NexusMods.Abstractions.GuidedInstallers/GuidedInstallationStep.cs
+++ b/src/Abstractions/NexusMods.Abstractions.GuidedInstallers/GuidedInstallationStep.cs
@@ -33,4 +33,9 @@ public record GuidedInstallationStep
     /// Gets whether or not there is a next step.
     /// </summary>
     public bool HasNextStep { get; init; }
+
+    /// <summary>
+    /// Gets whether or not the step is visible.
+    /// </summary>
+    public bool IsVisible { get; init; }
 }

--- a/src/ArchiveManagement/NexusMods.FileExtractor/Extractors/SevenZipExtractor.cs
+++ b/src/ArchiveManagement/NexusMods.FileExtractor/Extractors/SevenZipExtractor.cs
@@ -140,7 +140,7 @@ public class SevenZipExtractor : IExtractor
 
             var result = await process.WithArguments(new[]
                     {
-                        "x", "-bsp1", "-y", $"-o{fixedDestination}", source.ToString(), "-mmt=off"
+                        "x", "-bsp1", "-y", $"-o{fixedDestination}", source.ToString()
                     }, true)
                 .WithStandardOutputPipe(PipeTarget.ToDelegate(line =>
                 {

--- a/src/Games/NexusMods.Games.FOMOD.UI/Group/GuidedInstallerGroupViewModel.cs
+++ b/src/Games/NexusMods.Games.FOMOD.UI/Group/GuidedInstallerGroupViewModel.cs
@@ -114,7 +114,7 @@ public class GuidedInstallerGroupViewModel : AViewModel<IGuidedInstallerGroupVie
             // Highlight option when it is checked
             _optionsCache
                 .Connect()
-                .WhenPropertyChanged(optionVM => optionVM.IsChecked)
+                .WhenPropertyChanged(optionVM => optionVM.IsChecked, false)
                 .SubscribeWithErrorLogging(option =>
                 {
                     HighlightedOption = option.Sender;

--- a/src/Games/NexusMods.Games.FOMOD.UI/Group/GuidedInstallerGroupViewModel.cs
+++ b/src/Games/NexusMods.Games.FOMOD.UI/Group/GuidedInstallerGroupViewModel.cs
@@ -43,7 +43,8 @@ public class GuidedInstallerGroupViewModel : AViewModel<IGuidedInstallerGroupVie
                     Name = Language.GuidedInstallerGroupViewModel_GuidedInstallerGroupViewModel_None,
                     Type = OptionType.Available,
                     Description = Language.GuidedInstallerGroupViewModel_GuidedInstallerGroupViewModel_Select_nothing,
-                    HoverText = Language.GuidedInstallerGroupViewModel_GuidedInstallerGroupViewModel_Use_this_option_to_select_nothing
+                    HoverText = Language
+                        .GuidedInstallerGroupViewModel_GuidedInstallerGroupViewModel_Use_this_option_to_select_nothing
                 }, group));
             }
 
@@ -107,6 +108,16 @@ public class GuidedInstallerGroupViewModel : AViewModel<IGuidedInstallerGroupVie
                     {
                         optionVM.IsValid = isValid;
                     }
+                })
+                .DisposeWith(disposable);
+
+            // Highlight option when it is checked
+            _optionsCache
+                .Connect()
+                .WhenPropertyChanged(optionVM => optionVM.IsChecked)
+                .SubscribeWithErrorLogging(option =>
+                {
+                    HighlightedOption = option.Sender;
                 })
                 .DisposeWith(disposable);
         });

--- a/src/Games/NexusMods.Games.FOMOD.UI/Resources/Language.Designer.cs
+++ b/src/Games/NexusMods.Games.FOMOD.UI/Resources/Language.Designer.cs
@@ -60,7 +60,7 @@ namespace NexusMods.Games.FOMOD.UI.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Finish.
+        ///   Looks up a localized string similar to FINISH.
         /// </summary>
         public static string FooterStepperView_FooterStepperView_Finish {
             get {

--- a/src/Games/NexusMods.Games.FOMOD.UI/Resources/Language.resx
+++ b/src/Games/NexusMods.Games.FOMOD.UI/Resources/Language.resx
@@ -22,7 +22,7 @@
         <value>Installation complete</value>
     </data>
     <data name="FooterStepperView_FooterStepperView_Finish" xml:space="preserve">
-        <value>Finish</value>
+        <value>FINISH</value>
     </data>
     <data name="FooterStepperView_FooterStepperView_Next" xml:space="preserve">
         <value>NEXT</value>

--- a/src/Games/NexusMods.Games.FOMOD.UI/Step/GuidedInstallerStepView.axaml
+++ b/src/Games/NexusMods.Games.FOMOD.UI/Step/GuidedInstallerStepView.axaml
@@ -30,7 +30,7 @@
                 <Border Grid.Row="1" x:Name="BodyBorder">
                     <Grid x:Name="BodyStackPanel" RowDefinitions="Auto, *">
                         <Border Grid.Row="0" x:Name="HeadingAndSubHeadingBorder">
-                            <StackPanel x:Name="HeadingAndSubHeadingStackPanel">
+                            <StackPanel x:Name="HeadingAndSubHeadingStackPanel" Spacing="4">
 
                                 <TextBlock Classes="HeadingXSSemi" x:Name="ModName" />
                                 <TextBlock Classes="HeadingMDSemi" x:Name="StepName" />
@@ -61,7 +61,8 @@
                                         Classes="RoundedTop OutlineStrong">
                                     <Grid ColumnDefinitions="*, Auto, Auto">
 
-                                        <TextBlock Grid.Column="0" x:Name="PreviewTitleTextBox" Classes="BodyXLBold" />
+                                        <TextBlock Grid.Column="0" x:Name="PreviewTitleTextBox" Classes="BodyXLBold"
+                                                   VerticalAlignment="Center"/>
                                         <icons:Icon Grid.Column="2" x:Name="PreviewHeaderDescriptionIcon"
                                                     Classes="Description PreviewIcon" VerticalAlignment="Center" />
                                         <icons:Icon Grid.Column="1" x:Name="PreviewHeaderImageIcon"
@@ -74,13 +75,13 @@
                                         Classes="RoundedBottom OutlineStrong"
                                         BorderThickness="1,0,1,1">
                                     <ScrollViewer x:Name="PreviewScrollViewer">
-                                        <StackPanel x:Name="PreviewContentsStackPanel" Orientation="Vertical"
+                                        <StackPanel x:Name="PreviewContentsStackPanel" Orientation="Vertical" Spacing="8"
                                                     VerticalAlignment="Stretch">
-
-                                            <Image Stretch="Uniform" IsVisible="False" x:Name="HighlightedOptionImage" />
                                             <TextBlock Classes="BodyMDNormal" x:Name="HighlightedOptionDescription"
                                                        TextWrapping="Wrap"
                                                        Text="{x:Static resources:Language.HighlightedOptionDescription_No_Extra_Details}" />
+                                            <Image Stretch="Uniform" IsVisible="False" x:Name="HighlightedOptionImage" />
+
 
                                         </StackPanel>
                                     </ScrollViewer>

--- a/src/Games/NexusMods.Games.FOMOD.UI/Step/GuidedInstallerStepView.axaml
+++ b/src/Games/NexusMods.Games.FOMOD.UI/Step/GuidedInstallerStepView.axaml
@@ -57,7 +57,8 @@
                             </Border>
 
                             <Grid Grid.Column="1" x:Name="PreviewStackPanel" RowDefinitions="Auto,*">
-                                <Border Grid.Row="0" x:Name="PreviewTitleBorder" Classes="Rounded OutlineStrong">
+                                <Border Grid.Row="0" x:Name="PreviewTitleBorder"
+                                        Classes="RoundedTop OutlineStrong">
                                     <Grid ColumnDefinitions="*, Auto, Auto">
 
                                         <TextBlock Grid.Column="0" x:Name="PreviewTitleTextBox" Classes="BodyXLBold" />
@@ -69,7 +70,9 @@
                                     </Grid>
                                 </Border>
 
-                                <Border Grid.Row="1" x:Name="PreviewContentBorder" Classes="Rounded OutlineStrong">
+                                <Border Grid.Row="1" x:Name="PreviewContentBorder"
+                                        Classes="RoundedBottom OutlineStrong"
+                                        BorderThickness="1,0,1,1">
                                     <ScrollViewer x:Name="PreviewScrollViewer">
                                         <StackPanel x:Name="PreviewContentsStackPanel" Orientation="Vertical"
                                                     VerticalAlignment="Stretch">

--- a/src/Games/NexusMods.Games.FOMOD.UI/Step/GuidedInstallerStepView.axaml.cs
+++ b/src/Games/NexusMods.Games.FOMOD.UI/Step/GuidedInstallerStepView.axaml.cs
@@ -35,12 +35,12 @@ public partial class GuidedInstallerStepView : ReactiveUserControl<IGuidedInstal
             this.WhenAnyValue(view => view.ViewModel!.HighlightedOptionViewModel)
                 .SubscribeWithErrorLogging(optionVM =>
                 {
-                    HighlightedOptionImage.IsVisible = false;
                     HighlightedOptionDescription.Text = optionVM?.Option.Description ?? Language.GuidedInstallerStepView_GuidedInstallerStepView_No_additional_details_available;
 
                     PreviewTitleTextBox.Text = optionVM?.Option.Name;
                     PreviewHeaderDescriptionIcon.IsVisible = optionVM?.Option.Description is not null;
                     PreviewHeaderImageIcon.IsVisible = optionVM?.Option.Image is not null;
+                    HighlightedOptionImage.IsVisible = optionVM?.Option.Image is not null;
                 })
                 .DisposeWith(disposables);
 

--- a/src/Games/NexusMods.Games.FOMOD.UI/Step/GuidedInstallerStepViewModel.cs
+++ b/src/Games/NexusMods.Games.FOMOD.UI/Step/GuidedInstallerStepViewModel.cs
@@ -114,7 +114,7 @@ public class GuidedInstallerStepViewModel : AViewModel<IGuidedInstallerStepViewM
             // group highlighting
             _groupsSource
                 .Connect()
-                .WhenPropertyChanged(groupVM => groupVM.HighlightedOption)
+                .WhenPropertyChanged(groupVM => groupVM.HighlightedOption, false)
                 .Where(propertyValue => propertyValue.Value is not null)
                 .Do(propertyValue =>
                 {
@@ -151,7 +151,9 @@ public class GuidedInstallerStepViewModel : AViewModel<IGuidedInstallerStepViewM
                     vm => vm.TaskCompletionSource,
                     vm => vm.InstallationStep,
                     vm => vm.ShowInstallationCompleteScreen,
-                    (tcs, step, showInstallationCompleteScreen) => showInstallationCompleteScreen || (tcs is not null && step is not null && step.HasPreviousStep))
+                    (tcs, step, showInstallationCompleteScreen) => showInstallationCompleteScreen ||
+                                                                   (tcs is not null && step is not null &&
+                                                                    step.HasPreviousStep))
                 .BindToVM(this, vm => vm.FooterStepperViewModel.CanGoPrev)
                 .DisposeWith(disposables);
 

--- a/src/Games/NexusMods.Games.FOMOD.UI/Window/GuidedInstallerWindow.axaml
+++ b/src/Games/NexusMods.Games.FOMOD.UI/Window/GuidedInstallerWindow.axaml
@@ -9,7 +9,7 @@
     x:Class="NexusMods.Games.FOMOD.UI.GuidedInstallerWindow"
     x:TypeArguments="ui:IGuidedInstallerWindowViewModel"
     Title="GuidedInstallerWindow"
-    MinHeight="672" MinWidth="1232" MaxHeight="818" MaxWidth="1500">
+    MinHeight="672" MinWidth="1232">
 
     <Design.DataContext>
         <ui:GuidedInstallerWindowDesignViewModel />

--- a/src/Games/NexusMods.Games.FOMOD/CoreDelegates/UiDelegate.cs
+++ b/src/Games/NexusMods.Games.FOMOD/CoreDelegates/UiDelegate.cs
@@ -139,7 +139,11 @@ public sealed class UiDelegates : FomodInstaller.Interface.ui.IUIDelegates, IDis
             optionIdMappings
         );
 
-        var progress = Percent.CreateClamped(currentStepId, installSteps.Length);
+
+        // Progress is computed as currentIndex + 1 /(all steps before the current step + future visible steps + 1).
+        // The +1 are to avoid having the bar at 0% when we're at the first step, and to account for the extra finish screen.
+        var progress = Percent.CreateClamped(currentStepId + 1,
+            currentStepId + 1 + installSteps.Skip(currentStepId + 1).Count(step => step.visible) + 1);
 
         _guidedInstaller
             .RequestUserChoice(guidedInstallationStep, progress, CancellationToken.None)
@@ -243,6 +247,7 @@ public sealed class UiDelegates : FomodInstaller.Interface.ui.IUIDelegates, IDis
             Id = StepId.From(Guid.NewGuid()),
             Name = installSteps[currentStepId].name ?? string.Empty,
             Groups = stepGroups.ToArray(),
+            IsVisible = installSteps[currentStepId].visible,
             HasPreviousStep = currentStepId != 0,
             HasNextStep = currentStepId != installSteps.Count - 1,
         };

--- a/src/Games/NexusMods.Games.FOMOD/CoreDelegates/UiDelegate.cs
+++ b/src/Games/NexusMods.Games.FOMOD/CoreDelegates/UiDelegate.cs
@@ -247,7 +247,6 @@ public sealed class UiDelegates : FomodInstaller.Interface.ui.IUIDelegates, IDis
             Id = StepId.From(Guid.NewGuid()),
             Name = installSteps[currentStepId].name ?? string.Empty,
             Groups = stepGroups.ToArray(),
-            IsVisible = installSteps[currentStepId].visible,
             HasPreviousStep = currentStepId != 0,
             HasNextStep = currentStepId != installSteps.Count - 1,
         };

--- a/src/Games/NexusMods.Games.FOMOD/CoreDelegates/UiDelegate.cs
+++ b/src/Games/NexusMods.Games.FOMOD/CoreDelegates/UiDelegate.cs
@@ -29,6 +29,7 @@ public sealed class UiDelegates : FomodInstaller.Interface.ui.IUIDelegates, IDis
     /// <param name="selectedGroupId">The ID of the selected group.</param>
     /// <param name="selectedOptionIds">The IDs of the selected options.</param>
     private delegate void SelectOptions(int stepId, int selectedGroupId, int[] selectedOptionIds);
+
     private static void DummySelectOptions(int stepId, int selectedGroupId, int[] selectedOptionIds) { }
 
     /// <summary>
@@ -38,6 +39,7 @@ public sealed class UiDelegates : FomodInstaller.Interface.ui.IUIDelegates, IDis
     /// <param name="forward">Whether to move forward or backwards in the installer.</param>
     /// <param name="currentStepId">The ID of the current step.</param>
     private delegate void ContinueToNextStep(bool forward, int currentStepId);
+
     private static void DummyContinueToNextStep(bool forward, int currentStepId) { }
 
     /// <summary>
@@ -45,6 +47,7 @@ public sealed class UiDelegates : FomodInstaller.Interface.ui.IUIDelegates, IDis
     /// should exit.
     /// </summary>
     private delegate void CancelInstaller();
+
     private static void DummyCancelInstaller() { }
 
     private readonly ILogger<UiDelegates> _logger;
@@ -54,7 +57,7 @@ public sealed class UiDelegates : FomodInstaller.Interface.ui.IUIDelegates, IDis
     private ContinueToNextStep _continueToNextStep = DummyContinueToNextStep;
     private CancelInstaller _cancelInstaller = DummyCancelInstaller;
 
-    private readonly SemaphoreSlim _semaphoreSlim = new (1, 1);
+    private readonly SemaphoreSlim _semaphoreSlim = new(1, 1);
     private readonly EventWaitHandle _waitHandle = new ManualResetEvent(initialState: false);
     private long _taskWaitingState;
 
@@ -150,10 +153,12 @@ public sealed class UiDelegates : FomodInstaller.Interface.ui.IUIDelegates, IDis
 
                     // NOTE(erri120): We have to manually call this method.
                     EndDialog();
-                } else if (result.IsGoToPreviousStep)
+                }
+                else if (result.IsGoToPreviousStep)
                 {
                     _continueToNextStep(forward: false, currentStepId);
-                } else if (result.IsGoToNextStep)
+                }
+                else if (result.IsGoToNextStep)
                 {
                     var selectedOptions = result.AsT2.SelectedOptions;
 
@@ -196,7 +201,8 @@ public sealed class UiDelegates : FomodInstaller.Interface.ui.IUIDelegates, IDis
                         _waitHandle.WaitOne(TimeSpan.FromMilliseconds(200), exitContext: false);
                         _waitHandle.Reset();
 
-                        if (Interlocked.CompareExchange(ref _taskWaitingState, Ready, WaitingForCallback) != WaitingForCallback)
+                        if (Interlocked.CompareExchange(ref _taskWaitingState, Ready, WaitingForCallback) !=
+                            WaitingForCallback)
                             _logger.LogWarning("Unable to CAS!");
                     }
 
@@ -283,7 +289,9 @@ public sealed class UiDelegates : FomodInstaller.Interface.ui.IUIDelegates, IDis
         if (CurrentArchiveFiles is null) return null;
 
         var asPath = RelativePath.FromUnsanitizedInput(image);
-        var node = CurrentArchiveFiles.FindByPathFromRoot(asPath);
+        var node = CurrentArchiveFiles.Path() != RelativePath.Empty
+            ? CurrentArchiveFiles.FindByPathFromRoot(asPath)
+            : CurrentArchiveFiles.FindByPathFromChild(asPath);
         if (node is not null)
             return new OptionImage(new OptionImage.ImageStoredFile(node.Item.Hash));
 

--- a/src/Games/NexusMods.Games.FOMOD/CoreDelegates/UiDelegate.cs
+++ b/src/Games/NexusMods.Games.FOMOD/CoreDelegates/UiDelegate.cs
@@ -293,9 +293,7 @@ public sealed class UiDelegates : FomodInstaller.Interface.ui.IUIDelegates, IDis
         if (CurrentArchiveFiles is null) return null;
 
         var asPath = RelativePath.FromUnsanitizedInput(image);
-        var node = CurrentArchiveFiles.Path() != RelativePath.Empty
-            ? CurrentArchiveFiles.FindByPathFromRoot(asPath)
-            : CurrentArchiveFiles.FindByPathFromChild(asPath);
+        var node = CurrentArchiveFiles.FindByPathFromChild(asPath);
         if (node is not null)
             return new OptionImage(new OptionImage.ImageStoredFile(node.Item.Hash));
 

--- a/src/Games/NexusMods.Games.FOMOD/FomodAnalyzer.cs
+++ b/src/Games/NexusMods.Games.FOMOD/FomodAnalyzer.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using FomodInstaller.Scripting.XmlScript;
 using JetBrains.Annotations;
 using NexusMods.Abstractions.Installers.Trees;
@@ -42,7 +42,9 @@ public class FomodAnalyzer
                 byte[] bytes;
                 try
                 {
-                    var node = allFiles.FindByPathFromRoot(imagePath);
+                    var node = allFiles.Path() != RelativePath.Empty
+                        ? allFiles.FindByPathFromRoot(imagePath)
+                        : allFiles.FindByPathFromChild(imagePath);
                     await using var imageStream = await node!.Item.OpenAsync();
                     using var ms = new MemoryStream();
                     await imageStream.CopyToAsync(ms, ct);

--- a/src/Games/NexusMods.Games.FOMOD/FomodAnalyzer.cs
+++ b/src/Games/NexusMods.Games.FOMOD/FomodAnalyzer.cs
@@ -42,9 +42,7 @@ public class FomodAnalyzer
                 byte[] bytes;
                 try
                 {
-                    var node = allFiles.Path() != RelativePath.Empty
-                        ? allFiles.FindByPathFromRoot(imagePath)
-                        : allFiles.FindByPathFromChild(imagePath);
+                    var node = allFiles.FindByPathFromChild(imagePath);
                     await using var imageStream = await node!.Item.OpenAsync();
                     using var ms = new MemoryStream();
                     await imageStream.CopyToAsync(ms, ct);

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/UserControls/GuidedInstaller/StepViewStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/UserControls/GuidedInstaller/StepViewStyles.axaml
@@ -30,7 +30,7 @@
             <Style Selector="^ Border#GroupsBorder">
                 <Setter Property="Background" Value="{StaticResource ElementBackgroundNeutralMidBrush}" />
                 <Setter Property="CornerRadius" Value="8,8, 8,8" />
-                <Setter Property="Padding" Value="8,8,8,8" />
+                <Setter Property="Padding" Value="16" />
                 <Setter Property="Margin" Value="0,0,16,0" />
             </Style>
 
@@ -47,7 +47,7 @@
                 <Setter Property="CornerRadius" Value="0,0,8,8" />
             </Style>
             <Style Selector="^ TextBlock#HighlightedOptionDescription">
-                <Setter Property="Margin" Value="0,16,0,0" />
+                <Setter Property="Margin" Value="0,0,0,0" />
             </Style>
             <Style Selector="^ StackPanel#PreviewContentsStackPanel">
                 <Setter Property="Margin" Value="0,0,12,0" />

--- a/tests/Games/NexusMods.Games.FOMOD.Tests/FomodXmlAnalyzerTests.cs
+++ b/tests/Games/NexusMods.Games.FOMOD.Tests/FomodXmlAnalyzerTests.cs
@@ -42,6 +42,13 @@ public class FomodXmlAnalyzerTests
         info!.Images[0].Path.Should().Be("fomod/moduleTitle.png");
         info.Images[1].Path.Should().Be("fomod/g1p1i1.png");
         info.Images[2].Path.Should().Be("fomod/g1p2i1.png");
+
+        // Validate that the images have not been replaced with the placeholder (meaning they were not found).
+        var placeholder = await FomodAnalyzer.GetPlaceholderImage(FileSystem.Shared);
+
+        info.Images[0].Image.Should().NotEqual(placeholder);
+        info.Images[1].Image.Should().NotEqual(placeholder);
+        info.Images[2].Image.Should().NotEqual(placeholder);
     }
 
 
@@ -54,8 +61,14 @@ public class FomodXmlAnalyzerTests
         info.Should().NotBeNull();
         info!.Images.Count.Should().Be(3);
 
-        // Placeholder injected.
-        info.Images.Last().Image.Should().Equal(await FomodAnalyzer.GetPlaceholderImage(FileSystem.Shared));
+        // First two images should be valid, last one should be the placeholder.
+        var placeholder = await FomodAnalyzer.GetPlaceholderImage(FileSystem.Shared);
+
+        info.Images[0].Image.Should().NotEqual(placeholder);
+        info.Images[1].Image.Should().NotEqual(placeholder);
+
+        // Should be missing, so it should be the placeholder.
+        info.Images.Last().Image.Should().Equal(placeholder);
     }
 
 }


### PR DESCRIPTION
### Changes:
- Fix #860 
- Fix #864 
- Fix #865 
- Fix #866 
- Improved Fomod progress bar accuracy when there are few steps or hidden steps.
- Fixed tests to detect failures in loading fomod images.
- Enabled Multithreading when extracting archives with 7zip.

#### EDIT: further changes after reviewing with Design:
- Switched highlighted option description and image, so that description would always be visible.
- Various padding/spacing fixes.
- Fix Caps on Finish button.
- Fix auto scrolling to last option when new step is loaded.
