### PR TITLE
Try to fix Join-Path failures in Signing script

### DIFF
--- a/scripts/sign.ps1
+++ b/scripts/sign.ps1
@@ -43,17 +43,17 @@ TestFile($executableToSign)
 $codeSignToolDir = $env:CodeSignToolDir
 TestDirectory($codeSignToolDir)
 
-$javaPath = Join-Path $codeSignToolDir "jdk-11.0.2" "bin" "java.exe"
+$javaPath = Join-Path -Path $codeSignToolDir -ChildPath "jdk-11.0.2" | Join-Path -ChildPath "bin" | Join-Path -ChildPath "java.exe"
 TestFile($javaPath)
 
-$jarPath = Join-Path $codeSignToolDir "jar" "code_sign_tool-1.3.0.jar"
+$jarPath = Join-Path -Path $codeSignToolDir -ChildPath "jar" | Join-Path -ChildPath "code_sign_tool-1.3.0.jar"
 TestFile($jarPath)
 
 # CodeSignTool requires user interaction to confirm an overwrite of the original file.
 # We circumvent this by setting the output directory to some temp directory and replacing
 # the original file with the newly signed file.
 
-$tmpDir = Join-Path $(Resolve-Path .) "tmp"
+$tmpDir = Join-Path -Path $(Resolve-Path .) -ChildPath "tmp"
 if (Test-Path $tmpDir -PathType Container) {
     Remove-Item -Path $tmpDir -Recurse -Force
 }


### PR DESCRIPTION
Apparently multiple parameters fails even if it is marked as supported in the docs. This should work instead. 
(powershell is still crap)