### PR TITLE
Fix DownloadSpine button hover showing the blue Arc

### DIFF
--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Button/SpineDownloadButtonStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Button/SpineDownloadButtonStyles.axaml
@@ -179,10 +179,7 @@
                 <Setter Property="Foreground" Value="{DynamicResource ElementForegroundNeutralStrongBrush}" />
             </Style>
 
-            <!-- Arc -->
-            <Style Selector="^ Arc">
-                <Setter Property="Stroke" Value="{StaticResource ElementForegroundInfoSubduedBrush}" />
-            </Style>
+
         </Style>
 
         <!-- Progress variation -->
@@ -207,6 +204,11 @@
 
             <Style Selector="^ > Grid > StackPanel">
                 <Setter Property="IsVisible" Value="True" />
+            </Style>
+
+            <!-- pointerover color -->
+            <Style Selector="^:pointerover Arc">
+                <Setter Property="Stroke" Value="{StaticResource ElementForegroundInfoSubduedBrush}" />
             </Style>
         </Style>
 


### PR DESCRIPTION
fix #887 
Hover arc color style was applied for all cases, not just the `.Progress` class.
This moves the style to `.Progress:pointerover`