### PR TITLE
Add implicit conversion for `OpenPageBehvaior` entries

### DIFF
--- a/src/NexusMods.App.UI/WorkspaceSystem/Controllers/OpenPageBehavior.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Controllers/OpenPageBehavior.cs
@@ -19,18 +19,21 @@ public class OpenPageBehavior : OneOfBase<
     /// <param name="PanelId">Optional ID of the panel, if this is <see cref="Optional{T}.None"/> the first panel will be used.</param>
     /// <param name="TabId">Optional ID of the tab, if this is <see cref="Optional{T}.None"/> the first tab of the panel will be used.</param>
     public record ReplaceTab(Optional<PanelId> PanelId, Optional<PanelTabId> TabId);
+    public static implicit operator OpenPageBehavior(ReplaceTab input) => new(input);
 
     /// <summary>
     /// Open the page in a new tab in the given panel.
     /// </summary>
     /// <param name="PanelId">Optional ID of the panel, if this is <see cref="Optional{T}.None"/> the first panel will be used.</param>
     public record NewTab(Optional<PanelId> PanelId);
+    public static implicit operator OpenPageBehavior(NewTab input) => new(input);
 
     /// <summary>
     /// Opens the page in a new panel.
     /// </summary>
     /// <param name="NewWorkspaceState">Optional new workspace state, if this is <see cref="Optional{T}.None"/> the first possible state will be used.</param>
     public record NewPanel(Optional<WorkspaceGridState> NewWorkspaceState);
+    public static implicit operator OpenPageBehavior(NewPanel input) => new(input);
 
     public OpenPageBehavior(OneOf<ReplaceTab, NewTab, NewPanel> input) : base(input) { }
 }

--- a/src/NexusMods.App.UI/WorkspaceSystem/Controllers/WorkspaceController.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Controllers/WorkspaceController.cs
@@ -284,6 +284,6 @@ internal sealed class WorkspaceController : ReactiveObject, IWorkspaceController
         // specific pages, specific interaction (mouse button modifiers), source workspace (if popped out or not)
 
         // Current default behavior is to replace the first tab in the first panel
-        return new OpenPageBehavior(new OpenPageBehavior.ReplaceTab(Optional<PanelId>.None, Optional<PanelTabId>.None));
+        return new OpenPageBehavior.ReplaceTab(Optional<PanelId>.None, Optional<PanelTabId>.None);
     }
 }

--- a/src/NexusMods.App.UI/WorkspaceSystem/NewTabPage/NewTabPageViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/NewTabPage/NewTabPageViewModel.cs
@@ -37,7 +37,7 @@ public class NewTabPageViewModel : APageViewModel<INewTabPageViewModel>, INewTab
                 .MergeMany(item => item.SelectItemCommand)
                 .SubscribeWithErrorLogging(pageData =>
                 {
-                    GetWorkspaceController().OpenPage(WorkspaceId, pageData, new OpenPageBehavior(new OpenPageBehavior.ReplaceTab(PanelId, TabId)));
+                    GetWorkspaceController().OpenPage(WorkspaceId, pageData, new OpenPageBehavior.ReplaceTab(PanelId, TabId));
                 })
                 .DisposeWith(disposables);
         });

--- a/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelViewModel.cs
@@ -162,7 +162,7 @@ public class PanelViewModel : AViewModel<IPanelViewModel>, IPanelViewModel
 
     public void AddDefaultTab()
     {
-        _workspaceController.OpenPage(WorkspaceId, Optional<PageData>.None, new OpenPageBehavior(new OpenPageBehavior.NewTab(Id)));
+        _workspaceController.OpenPage(WorkspaceId, Optional<PageData>.None, new OpenPageBehavior.NewTab(Id));
     }
 
     public void AddCustomTab(PageData pageData)


### PR DESCRIPTION
- This avoids having to explicitly wrap the actual behavior with the OpenPageBehavior container when passing it, avoiding the awkward double new

Should make lines more concise and clearer to read