### PR TITLE
Simplify crating `IconValue`s for `UnifiedIcon` from XAML 

### DIFF
--- a/src/NexusMods.App.UI/Controls/UnifiedIcon/IconValue.cs
+++ b/src/NexusMods.App.UI/Controls/UnifiedIcon/IconValue.cs
@@ -23,24 +23,24 @@ public sealed class IconValue
 {
     public Union Value { get; set; }
 
-    public ProjektankerIcon ProjektankerIconValueSetter
+    public string? MdiValueSetter
     {
-        set => Value = value;
+        set => Value = new ProjektankerIcon(value);
     }
 
-    public AvaloniaImage AvaloniaImageSetter
+    public IImage? ImageSetter
     {
-        set => Value = value;
+        set => Value = new AvaloniaImage(value);
     }
 
-    public AvaloniaSvg AvaloniaSvgSetter
+    public string? SvgSetter
     {
-        set => Value = value;
+        set => Value = new AvaloniaSvg(value);
     }
 
-    public AvaloniaPathIcon AvaloniaPathIconSetter
+    public Geometry? GeometrySetter
     {
-        set => Value = value;
+        set => Value = new AvaloniaPathIcon(value);
     }
 
     public IconValue()

--- a/src/NexusMods.App.UI/Controls/UnifiedIcon/IconValue.cs
+++ b/src/NexusMods.App.UI/Controls/UnifiedIcon/IconValue.cs
@@ -63,53 +63,14 @@ public sealed class IconValue
 public record Empty;
 
 [PublicAPI]
-public class ProjektankerIcon
-{
-    public string? Value { get; set; }
-
-    public ProjektankerIcon() { }
-
-    public ProjektankerIcon(string? value)
-    {
-        Value = value;
-    }
-}
+public record ProjektankerIcon(string? Value);
 
 [PublicAPI]
-public class AvaloniaImage
-{
-    public IImage? Image { get; set; }
-
-    public AvaloniaImage() { }
-
-    public AvaloniaImage(IImage? image)
-    {
-        Image = image;
-    }
-}
+public record AvaloniaImage(IImage? Image);
 
 [PublicAPI]
-public class AvaloniaSvg
-{
-    public string? Path { get; set; }
-
-    public AvaloniaSvg() { }
-
-    public AvaloniaSvg(string? path)
-    {
-        Path = path;
-    }
-}
+public record AvaloniaSvg(string? Path);
 
 [PublicAPI]
-public class AvaloniaPathIcon
-{
-    public Geometry? Data { get; set; }
+public record AvaloniaPathIcon(Geometry? Geometry);
 
-    public AvaloniaPathIcon() { }
-
-    public AvaloniaPathIcon(Geometry? data)
-    {
-        Data = data;
-    }
-}

--- a/src/NexusMods.App.UI/Controls/UnifiedIcon/UnifiedIcon.cs
+++ b/src/NexusMods.App.UI/Controls/UnifiedIcon/UnifiedIcon.cs
@@ -110,7 +110,7 @@ public sealed class UnifiedIcon : ContentControl
             },
             f4: avaloniaPathIcon => new Avalonia.Controls.PathIcon
             {
-                Data = avaloniaPathIcon.Data ?? new LineGeometry(),
+                Data = avaloniaPathIcon.Geometry ?? new LineGeometry(),
                 // NOTE(erri120): bind our Height and Width properties to their properties
                 // otherwise the icon won't be affected by our dimensions
                 [HeightProperty] = this[HeightProperty],

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Resources/UnifiedIconControlTheme.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Resources/UnifiedIconControlTheme.axaml
@@ -6,32 +6,22 @@
 
         <StackPanel Orientation="Horizontal">
             <StackPanel.Resources>
-                <unifiedIcon:IconValue x:Key="ProjektankerIconValue">
-                    <unifiedIcon:IconValue.ProjektankerIconValueSetter>
-                        <unifiedIcon:ProjektankerIcon Value="mdi-cog" />
-                    </unifiedIcon:IconValue.ProjektankerIconValueSetter>
-                </unifiedIcon:IconValue>
+                <!-- Projektanker Icon -->
+                <unifiedIcon:IconValue x:Key="ProjektankerIconValue" MdiValueSetter="mdi-cog"/>
 
-                <unifiedIcon:IconValue x:Key="AvaloniaImageValue">
-                    <unifiedIcon:IconValue.AvaloniaImageSetter>
-                        <unifiedIcon:AvaloniaImage Image="avares://NexusMods.App.UI/Assets/DesignTime/cyberpunk_game.png"/>
-                    </unifiedIcon:IconValue.AvaloniaImageSetter>
-                </unifiedIcon:IconValue>
+                <!-- Image -->
+                <unifiedIcon:IconValue x:Key="AvaloniaImageValue"
+                                       ImageSetter="avares://NexusMods.App.UI/Assets/DesignTime/cyberpunk_game.png"/>
 
-                <unifiedIcon:IconValue x:Key="AvaloniaSvgValue">
-                    <unifiedIcon:IconValue.AvaloniaSvgSetter>
-                        <unifiedIcon:AvaloniaSvg Path="avares://NexusMods.App.UI/Assets/Icons/add_circle_24px.svg"/>
-                    </unifiedIcon:IconValue.AvaloniaSvgSetter>
-                </unifiedIcon:IconValue>
+                <!-- Svg -->
+                <unifiedIcon:IconValue x:Key="AvaloniaSvgValue"
+                                       SvgSetter="avares://NexusMods.App.UI/Assets/Icons/add_circle_24px.svg"/>
 
+                <!-- PathIcon -->
                 <unifiedIcon:IconValue x:Key="AvaloniaPathIconValue">
-                    <unifiedIcon:IconValue.AvaloniaPathIconSetter>
-                        <unifiedIcon:AvaloniaPathIcon>
-                            <unifiedIcon:AvaloniaPathIcon.Data>
-                                <StreamGeometry>m4 12 1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z</StreamGeometry>
-                            </unifiedIcon:AvaloniaPathIcon.Data>
-                        </unifiedIcon:AvaloniaPathIcon>
-                    </unifiedIcon:IconValue.AvaloniaPathIconSetter>
+                    <unifiedIcon:IconValue.GeometrySetter>
+                        <StreamGeometry>m4 12 1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z</StreamGeometry>
+                    </unifiedIcon:IconValue.GeometrySetter>
                 </unifiedIcon:IconValue>
             </StackPanel.Resources>
 


### PR DESCRIPTION
Simplified the various existing Setters on `IconValue` to be easier to use from XAML.

They now take the original types of `string`, `IImage`, `Geometry` instead of the custom types used internally by `IconValue`.
This allows them to be set them inline instead of having to wrap them in the custom types.

This maintains the single `UnifiedIcon.Value` Api, but reduces the number of lines needed to define the contents of an icon from XAML.

Before:
```xml
                <unifiedIcon:IconValue x:Key="ProjektankerIconValue">
                    <unifiedIcon:IconValue.ProjektankerIconValueSetter>
                        <unifiedIcon:ProjektankerIcon Value="mdi-cog" />
                    </unifiedIcon:IconValue.ProjektankerIconValueSetter>
                </unifiedIcon:IconValue>
```
After:
```xml
<unifiedIcon:IconValue x:Key="ProjektankerIconValue" MdiValueSetter="mdi-cog"/>
```
