### PR TITLE
Fix build on main

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -72,14 +72,15 @@ public class ALoadoutSynchronizer : IStandardizedLoadoutSynchronizer
     /// Helper constructor that takes only a service provider, and resolves the dependencies from it.
     /// </summary>
     /// <param name="provider"></param>
-    protected ALoadoutSynchronizer(IServiceProvider provider, IOSInformation os) : this(
+    protected ALoadoutSynchronizer(IServiceProvider provider) : this(
         provider.GetRequiredService<ILogger<ALoadoutSynchronizer>>(),
         provider.GetRequiredService<IFileHashCache>(),
         provider.GetRequiredService<IDataStore>(),
         provider.GetRequiredService<ILoadoutRegistry>(),
         provider.GetRequiredService<IDiskStateRegistry>(),
         provider.GetRequiredService<IFileStore>(),
-        provider.GetRequiredService<ISorter>(), os)
+        provider.GetRequiredService<ISorter>(),
+        provider.GetRequiredService<IOSInformation>())
 
     {
 

--- a/tests/Abstractions/NexusMods.Abstractions.DataModel.Entities.Tests/Startup.cs
+++ b/tests/Abstractions/NexusMods.Abstractions.DataModel.Entities.Tests/Startup.cs
@@ -6,6 +6,7 @@ using NexusMods.Abstractions.Installers;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Serialization;
 using NexusMods.Activities;
+using NexusMods.CrossPlatform;
 using NexusMods.DataModel;
 using NexusMods.FileExtractor;
 using NexusMods.Paths;
@@ -30,6 +31,7 @@ public class Startup
             .AddStubbedGameLocators()
             .AddSerializationAbstractions()
             .AddInstallerTypes()
+            .AddCrossPlatform()
             .AddLogging(builder => builder.AddXUnit());
     }
 }

--- a/tests/Games/NexusMods.Games.BethesdaGameStudios.Tests/Startup.cs
+++ b/tests/Games/NexusMods.Games.BethesdaGameStudios.Tests/Startup.cs
@@ -8,6 +8,7 @@ using NexusMods.Abstractions.Serialization;
 using NexusMods.Activities;
 using NexusMods.App.BuildInfo;
 using NexusMods.CLI;
+using NexusMods.CrossPlatform;
 using NexusMods.Games.FOMOD;
 using NexusMods.Games.Generic;
 using NexusMods.Games.TestFramework;
@@ -38,6 +39,7 @@ public class Startup
             .AddCLI()
             .AddSingleton<IGuidedInstaller, NullGuidedInstaller>()
             .AddLogging(builder => builder.AddXunitOutput())
+            .AddCrossPlatform()
             .Validate();
     }
 }

--- a/tests/Games/NexusMods.Games.BladeAndSorcery.Tests/Startup.cs
+++ b/tests/Games/NexusMods.Games.BladeAndSorcery.Tests/Startup.cs
@@ -7,6 +7,7 @@ using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Serialization;
 using NexusMods.Activities;
 using NexusMods.App.BuildInfo;
+using NexusMods.CrossPlatform;
 using NexusMods.Games.TestFramework;
 using NexusMods.StandardGameLocators.TestHelpers;
 
@@ -27,6 +28,7 @@ public class Startup
             .AddActivityMonitor()
             .AddSerializationAbstractions()
             .AddInstallerTypes()
+            .AddCrossPlatform()
             .Validate();
     }
 }

--- a/tests/Games/NexusMods.Games.MountAndBlade2Bannerlord.Tests/Startup.cs
+++ b/tests/Games/NexusMods.Games.MountAndBlade2Bannerlord.Tests/Startup.cs
@@ -6,6 +6,7 @@ using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Serialization;
 using NexusMods.Activities;
 using NexusMods.App.BuildInfo;
+using NexusMods.CrossPlatform;
 using NexusMods.Games.TestFramework;
 using NexusMods.StandardGameLocators.TestHelpers;
 using Xunit.DependencyInjection.Logging;
@@ -27,6 +28,7 @@ public class Startup
             .AddFileStoreAbstractions()
             .AddLoadoutAbstractions()
             .AddInstallerTypes()
+            .AddCrossPlatform()
             .Validate();
     }
 }

--- a/tests/Games/NexusMods.Games.RedEngine.Tests/Startup.cs
+++ b/tests/Games/NexusMods.Games.RedEngine.Tests/Startup.cs
@@ -7,6 +7,7 @@ using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Serialization;
 using NexusMods.Activities;
 using NexusMods.App.BuildInfo;
+using NexusMods.CrossPlatform;
 using NexusMods.Games.TestFramework;
 using NexusMods.StandardGameLocators.TestHelpers;
 
@@ -27,6 +28,7 @@ public class Startup
             .AddLoadoutAbstractions()
             .AddFileStoreAbstractions()
             .AddInstallerTypes()
+            .AddCrossPlatform()
             .Validate();
     }
 }

--- a/tests/NexusMods.CLI.Tests/Startup.cs
+++ b/tests/NexusMods.CLI.Tests/Startup.cs
@@ -7,6 +7,7 @@ using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Serialization;
 using NexusMods.Activities;
 using NexusMods.App.BuildInfo;
+using NexusMods.CrossPlatform;
 using NexusMods.DataModel;
 using NexusMods.FileExtractor;
 using NexusMods.Networking.HttpDownloader;
@@ -42,6 +43,7 @@ public class Startup
                 .AddSerializationAbstractions()
                 .AddGames()
                 .AddInstallerTypes()
+                .AddCrossPlatform()
                 .AddLogging(builder => builder.SetMinimumLevel(LogLevel.Trace))
                 .AddSingleton<LocalHttpServer>()
                 .AddLogging(builder => builder.AddXUnit())

--- a/tests/NexusMods.DataModel.Tests/Startup.cs
+++ b/tests/NexusMods.DataModel.Tests/Startup.cs
@@ -10,6 +10,7 @@ using NexusMods.Abstractions.Serialization;
 using NexusMods.Abstractions.Serialization.ExpressionGenerator;
 using NexusMods.Activities;
 using NexusMods.App.BuildInfo;
+using NexusMods.CrossPlatform;
 using NexusMods.DataModel.Tests.Diagnostics;
 using NexusMods.FileExtractor;
 using NexusMods.Paths;
@@ -42,6 +43,7 @@ public class Startup
             .AddSerializationAbstractions()
             .AddActivityMonitor()
             .AddInstallerTypes()
+            .AddCrossPlatform()
             .AddSingleton<ITypeFinder>(_ => new AssemblyTypeFinder(typeof(Startup).Assembly))
 
             // Diagnostics


### PR DESCRIPTION
Main was broken after #949
`ALoadoutSynchronizer()` was expected to have a single parameter by many subclasses or users, which broke when the Os param was added