### PR TITLE
More diagnostic improvements

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Games.Diagnostics/Diagnostic.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Games.Diagnostics/Diagnostic.cs
@@ -23,9 +23,16 @@ public record Diagnostic
     public required DiagnosticSeverity Severity { get; init; }
 
     /// <summary>
-    /// Gets the message of the diagnostic.
+    /// Gets the summary of the diagnostic.
     /// </summary>
-    public required DiagnosticMessage Message { get; init; }
+    /// <seealso cref="Details"/>
+    public required DiagnosticMessage Summary { get; init; }
+
+    /// <summary>
+    /// Gets the details of the diagnostic.
+    /// </summary>
+    /// <seealso cref="Summary"/>
+    public required DiagnosticMessage Details { get; init; }
 
     /// <summary>
     /// Gets all data references.
@@ -44,7 +51,7 @@ public record Diagnostic
 public record Diagnostic<TMessageData> : Diagnostic where TMessageData : struct
 {
     /// <summary>
-    /// Gets the message data.
+    /// Gets the message data used for <see cref="Diagnostic.Summary"/> and <see cref="Diagnostic.Details"/>.
     /// </summary>
     public required TMessageData MessageData { get; init; }
 }

--- a/src/Abstractions/NexusMods.Abstractions.Games.Diagnostics/DiagnosticMessage.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Games.Diagnostics/DiagnosticMessage.cs
@@ -3,12 +3,15 @@ using TransparentValueObjects;
 
 namespace NexusMods.Abstractions.Diagnostics;
 
-// TODO: figure out the formatting of this message, so that certain elements can be made clickable
-// example: "Mod '{{modName}}' is broken, please fix!" where {{modName}} should be clickable
-
 /// <summary>
 /// Represents a message of a diagnostic.
 /// </summary>
 [PublicAPI]
 [ValueObject<string>]
-public readonly partial struct DiagnosticMessage { }
+public readonly partial struct DiagnosticMessage : IAugmentWith<DefaultValueAugment>
+{
+    /// <summary>
+    /// Gets the default value.
+    /// </summary>
+    public static DiagnosticMessage DefaultValue { get; } = From("");
+}

--- a/src/Abstractions/NexusMods.Abstractions.Games.Diagnostics/DiagnosticTemplateBuilder.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Games.Diagnostics/DiagnosticTemplateBuilder.cs
@@ -48,18 +48,45 @@ public static class DiagnosticTemplateBuilder
         /// <summary>
         /// Sets the <see cref="DiagnosticSeverity"/>.
         /// </summary>
-        IWithMessageStep WithSeverity(DiagnosticSeverity severity);
+        IWithSummaryStep WithSeverity(DiagnosticSeverity severity);
     }
 
     /// <summary>
-    /// Message Step.
+    /// Summary step.
     /// </summary>
-    public interface IWithMessageStep
+    public interface IWithSummaryStep
     {
         /// <summary>
-        /// Sets the message template.
+        /// Sets the message template for the <see cref="Diagnostic.Summary"/> property.
         /// </summary>
-        IFinishStep WithMessage(string message, Func<IMessageBuilder, IMessageBuilder> messageBuilder);
+        IWithDetailsStep WithSummary(string message);
+    }
+
+    /// <summary>
+    /// Details step.
+    /// </summary>
+    public interface IWithDetailsStep
+    {
+        /// <summary>
+        /// Sets the message template for the <see cref="Diagnostic.Details"/> property.
+        /// </summary>
+        IWithMessageData WithDetails(string message);
+
+        /// <summary>
+        /// Sets nothing for the <see cref="Diagnostic.Details"/> property.
+        /// </summary>
+        IWithMessageData WithoutDetails();
+    }
+
+    /// <summary>
+    /// Message data step.
+    /// </summary>
+    public interface IWithMessageData
+    {
+        /// <summary>
+        /// Configures the message builder.
+        /// </summary>
+        IFinishStep WithMessageData(Func<IMessageBuilder, IMessageBuilder> messageBuilder);
     }
 
     /// <summary>
@@ -90,56 +117,3 @@ public static class DiagnosticTemplateBuilder
 /// </summary>
 /// <seealso cref="DiagnosticTemplateBuilder"/>
 public interface IDiagnosticTemplate;
-
-#if DiagnosticTemplateBuilderExperimentTestOutput
-#if RELEASE
-#else
-
-[SuppressMessage("ReSharper", "UnusedType.Global")]
-[SuppressMessage("ReSharper", "UnusedMember.Local")]
-internal partial class Test
-{
-    private static readonly IDiagnosticTemplate Diagnostic1Template = DiagnosticTemplateBuilder
-        .Start()
-        .WithId(new DiagnosticId(source: "MyCoolSource", number: 13))
-        .WithSeverity(DiagnosticSeverity.Warning)
-        .WithMessage("Mod '{Mod}' is not working!", messageBuilder => messageBuilder
-            .AddDataReference<ModReference>("Mod")
-        )
-        .Finish();
-}
-
-[SuppressMessage("ReSharper", "UnusedType.Global")]
-[SuppressMessage("ReSharper", "UnusedMember.Global")]
-[SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
-internal partial class Test
-{
-    public static Diagnostic<Diagnostic1MessageData> CreateDiagnostic1(ModReference mod)
-    {
-        var messageData = new Diagnostic1MessageData(mod);
-
-        return new Diagnostic<Diagnostic1MessageData>
-        {
-            Id = new DiagnosticId(source: "MyCoolSource", number: 13),
-            Severity = DiagnosticSeverity.Warning,
-            Message = DiagnosticMessage.From("Mod '{Mod}' is not working!"),
-            MessageData = messageData,
-            DataReferences = new Dictionary<DataReferenceDescription, IDataReference>
-            {
-                { DataReferenceDescription.From("Mod"), messageData.Mod },
-            },
-        };
-    }
-
-    public readonly struct Diagnostic1MessageData
-    {
-        public readonly ModReference Mod;
-
-        public Diagnostic1MessageData(ModReference mod)
-        {
-            Mod = mod;
-        }
-    }
-}
-#endif
-#endif

--- a/src/Abstractions/NexusMods.Abstractions.Games.Diagnostics/DiagnosticTemplateBuilder.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Games.Diagnostics/DiagnosticTemplateBuilder.cs
@@ -1,5 +1,3 @@
-#define DiagnosticTemplateBuilderExperimentTestOutput
-
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using JetBrains.Annotations;

--- a/src/Abstractions/NexusMods.Abstractions.Games.Diagnostics/DiagnosticTemplateBuilder.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Games.Diagnostics/DiagnosticTemplateBuilder.cs
@@ -98,6 +98,11 @@ public static class DiagnosticTemplateBuilder
         /// Adds data references to the message.
         /// </summary>
         IMessageBuilder AddDataReference<T>(string name) where T : IDataReference;
+
+        /// <summary>
+        /// Adds a simple value to the message.
+        /// </summary>
+        IMessageBuilder AddValue<T>(string name) where T : notnull;
     }
 
     /// <summary>

--- a/src/Games/NexusMods.Games.MountAndBlade2Bannerlord/Emitters/BuiltInEmitter.cs
+++ b/src/Games/NexusMods.Games.MountAndBlade2Bannerlord/Emitters/BuiltInEmitter.cs
@@ -91,7 +91,8 @@ public class BuiltInEmitter : ILoadoutDiagnosticEmitter
         return new Diagnostic
         {
             Id = new DiagnosticId(Source, (ushort) issue.Type),
-            Message = DiagnosticMessage.From(message.ToString()),
+            Summary = DiagnosticMessage.From(message.ToString()),
+            Details = DiagnosticMessage.DefaultValue,
             Severity = level,
             DataReferences = new Dictionary<DataReferenceDescription, IDataReference>
             {

--- a/src/Games/NexusMods.Games.StardewValley/Diagnostics.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Diagnostics.cs
@@ -15,7 +15,8 @@ internal static class Diagnostics
         {
             Id = new DiagnosticId(Source, 1),
             Severity = DiagnosticSeverity.Warning,
-            Message = DiagnosticMessage.From($"Mod '{mod.Name}' is missing required dependency '{missingDependency}'"),
+            Summary = DiagnosticMessage.From($"Mod '{mod.Name}' is missing required dependency '{missingDependency}'"),
+            Details = DiagnosticMessage.DefaultValue,
             DataReferences = new Dictionary<DataReferenceDescription, IDataReference>
             {
                 { DataReferenceDescription.Loadout, loadout.ToReference() },

--- a/src/NexusMods.App.Generators.Diagnostics/NexusMods.App.Generators.Diagnostics.Sample/ExampleDiagnostics.cs
+++ b/src/NexusMods.App.Generators.Diagnostics/NexusMods.App.Generators.Diagnostics.Sample/ExampleDiagnostics.cs
@@ -11,11 +11,12 @@ public partial class ExampleDiagnostics
         .Start()
         .WithId(new DiagnosticId(source: "Example", number: 1))
         .WithSeverity(DiagnosticSeverity.Warning)
-        .WithSummary("Mod '{ModA}' conflicts with '{ModB}'!")
+        .WithSummary("Mod '{ModA}' conflicts with '{ModB}' because it's missing '{Something}'!")
         .WithoutDetails()
         .WithMessageData(messageBuilder => messageBuilder
             .AddDataReference<ModReference>("ModA")
             .AddDataReference<ModReference>("ModB")
+            .AddValue<string>("Something")
         )
         .Finish();
 }

--- a/src/NexusMods.App.Generators.Diagnostics/NexusMods.App.Generators.Diagnostics.Sample/ExampleDiagnostics.cs
+++ b/src/NexusMods.App.Generators.Diagnostics/NexusMods.App.Generators.Diagnostics.Sample/ExampleDiagnostics.cs
@@ -11,7 +11,9 @@ public partial class ExampleDiagnostics
         .Start()
         .WithId(new DiagnosticId(source: "Example", number: 1))
         .WithSeverity(DiagnosticSeverity.Warning)
-        .WithMessage("Mod '{ModA}' conflicts with '{ModB}'!", messageBuilder => messageBuilder
+        .WithSummary("Mod '{ModA}' conflicts with '{ModB}'!")
+        .WithoutDetails()
+        .WithMessageData(messageBuilder => messageBuilder
             .AddDataReference<ModReference>("ModA")
             .AddDataReference<ModReference>("ModB")
         )

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/Emitters/001_MissingDependencyTests.cs
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/Emitters/001_MissingDependencyTests.cs
@@ -42,7 +42,7 @@ public class MissingDependenciesEmitterTests : ALoadoutDiagnosticEmitterTest<Sta
         var diagnostic = await GetSingleDiagnostic(loadoutMarker.Value);
         diagnostic.Id.Should().Be(new DiagnosticId(Diagnostics.Source, 1));
         diagnostic.Severity.Should().Be(DiagnosticSeverity.Warning);
-        diagnostic.Message.Should().Be(DiagnosticMessage.From($"Mod 'ModA' is missing required dependency 'ModB'"));
+        diagnostic.Summary.Should().Be(DiagnosticMessage.From("Mod 'ModA' is missing required dependency 'ModB'"));
         diagnostic.DataReferences.Values.Should().Equal(
             loadoutMarker.Value.ToReference(),
             modA.ToReference(loadoutMarker.Value)

--- a/tests/NexusMods.App.Generators.Diagnostics.Tests/DiagnosticTemplateIncrementalSourceGeneratorTests.TestGenerator#TestNamespace.MyClass.Diagnostic1Template.g.verified.cs
+++ b/tests/NexusMods.App.Generators.Diagnostics.Tests/DiagnosticTemplateIncrementalSourceGeneratorTests.TestGenerator#TestNamespace.MyClass.Diagnostic1Template.g.verified.cs
@@ -6,15 +6,15 @@ namespace TestNamespace;
 
 partial class MyClass
 {
-	internal static global::NexusMods.Abstractions.Diagnostics.Diagnostic<Diagnostic1MessageData> CreateDiagnostic1(global::NexusMods.Abstractions.Diagnostics.References.ModReference ModA, global::NexusMods.Abstractions.Diagnostics.References.ModReference ModB)
+	internal static global::NexusMods.Abstractions.Diagnostics.Diagnostic<Diagnostic1MessageData> CreateDiagnostic1(global::NexusMods.Abstractions.Diagnostics.References.ModReference ModA, global::NexusMods.Abstractions.Diagnostics.References.ModReference ModB, global::System.String Something)
 	{
-		var messageData = new Diagnostic1MessageData(ModA, ModB);
+		var messageData = new Diagnostic1MessageData(ModA, ModB, Something);
 
 		return new global::NexusMods.Abstractions.Diagnostics.Diagnostic<Diagnostic1MessageData>
 		{
 			Id = new global::NexusMods.Abstractions.Diagnostics.DiagnosticId(source: "Example",number: 1),
 			Severity = global::NexusMods.Abstractions.Diagnostics.DiagnosticSeverity.Warning,
-			Summary = global::NexusMods.Abstractions.Diagnostics.DiagnosticMessage.From("Mod '{ModA}' conflicts with '{ModB}'!"),
+			Summary = global::NexusMods.Abstractions.Diagnostics.DiagnosticMessage.From("Mod '{ModA}' conflicts with '{ModB}' because it's missing '{Something}'!"),
 			Details = global::NexusMods.Abstractions.Diagnostics.DiagnosticMessage.DefaultValue,
 			MessageData = messageData,
 			DataReferences = new global::System.Collections.Generic.Dictionary<global::NexusMods.Abstractions.Diagnostics.References.DataReferenceDescription, global::NexusMods.Abstractions.Diagnostics.References.IDataReference>
@@ -33,11 +33,13 @@ partial class MyClass
 	{
 		public readonly global::NexusMods.Abstractions.Diagnostics.References.ModReference ModA;
 		public readonly global::NexusMods.Abstractions.Diagnostics.References.ModReference ModB;
+		public readonly global::System.String Something;
 
-		public Diagnostic1MessageData(global::NexusMods.Abstractions.Diagnostics.References.ModReference ModA, global::NexusMods.Abstractions.Diagnostics.References.ModReference ModB)
+		public Diagnostic1MessageData(global::NexusMods.Abstractions.Diagnostics.References.ModReference ModA, global::NexusMods.Abstractions.Diagnostics.References.ModReference ModB, global::System.String Something)
 		{
 			this.ModA = ModA;
 			this.ModB = ModB;
+			this.Something = Something;
 		}
 
 	}

--- a/tests/NexusMods.App.Generators.Diagnostics.Tests/DiagnosticTemplateIncrementalSourceGeneratorTests.TestGenerator#TestNamespace.MyClass.Diagnostic1Template.g.verified.cs
+++ b/tests/NexusMods.App.Generators.Diagnostics.Tests/DiagnosticTemplateIncrementalSourceGeneratorTests.TestGenerator#TestNamespace.MyClass.Diagnostic1Template.g.verified.cs
@@ -12,9 +12,10 @@ partial class MyClass
 
 		return new global::NexusMods.Abstractions.Diagnostics.Diagnostic<Diagnostic1MessageData>
 		{
-			Id = new global::NexusMods.Abstractions.Diagnostics.DiagnosticId(source: "MyCoolSource",number: 13),
+			Id = new global::NexusMods.Abstractions.Diagnostics.DiagnosticId(source: "Example",number: 1),
 			Severity = global::NexusMods.Abstractions.Diagnostics.DiagnosticSeverity.Warning,
-			Message = global::NexusMods.Abstractions.Diagnostics.DiagnosticMessage.From("Mod '{ModA}' is not working because of '{ModB}'!"),
+			Summary = global::NexusMods.Abstractions.Diagnostics.DiagnosticMessage.From("Mod '{ModA}' conflicts with '{ModB}'!"),
+			Details = global::NexusMods.Abstractions.Diagnostics.DiagnosticMessage.DefaultValue,
 			MessageData = messageData,
 			DataReferences = new global::System.Collections.Generic.Dictionary<global::NexusMods.Abstractions.Diagnostics.References.DataReferenceDescription, global::NexusMods.Abstractions.Diagnostics.References.IDataReference>
 			{

--- a/tests/NexusMods.App.Generators.Diagnostics.Tests/DiagnosticTemplateIncrementalSourceGeneratorTests.cs
+++ b/tests/NexusMods.App.Generators.Diagnostics.Tests/DiagnosticTemplateIncrementalSourceGeneratorTests.cs
@@ -18,9 +18,11 @@ internal partial class MyClass
     [DiagnosticTemplate]
     private static readonly IDiagnosticTemplate Diagnostic1Template = DiagnosticTemplateBuilder
         .Start()
-        .WithId(new DiagnosticId(source: ""MyCoolSource"", number: 13))
+        .WithId(new DiagnosticId(source: ""Example"", number: 1))
         .WithSeverity(DiagnosticSeverity.Warning)
-        .WithMessage(""Mod '{ModA}' is not working because of '{ModB}'!"", messageBuilder => messageBuilder
+        .WithSummary(""Mod '{ModA}' conflicts with '{ModB}'!"")
+        .WithoutDetails()
+        .WithMessageData(messageBuilder => messageBuilder
             .AddDataReference<ModReference>(""ModA"")
             .AddDataReference<ModReference>(""ModB"")
         )

--- a/tests/NexusMods.App.Generators.Diagnostics.Tests/DiagnosticTemplateIncrementalSourceGeneratorTests.cs
+++ b/tests/NexusMods.App.Generators.Diagnostics.Tests/DiagnosticTemplateIncrementalSourceGeneratorTests.cs
@@ -20,11 +20,12 @@ internal partial class MyClass
         .Start()
         .WithId(new DiagnosticId(source: ""Example"", number: 1))
         .WithSeverity(DiagnosticSeverity.Warning)
-        .WithSummary(""Mod '{ModA}' conflicts with '{ModB}'!"")
+        .WithSummary(""Mod '{ModA}' conflicts with '{ModB}' because it's missing '{Something}'!"")
         .WithoutDetails()
         .WithMessageData(messageBuilder => messageBuilder
             .AddDataReference<ModReference>(""ModA"")
             .AddDataReference<ModReference>(""ModB"")
+            .AddValue<string>(""Something"")
         )
         .Finish();
 }";

--- a/tests/NexusMods.DataModel.Tests/Diagnostics/DiagnosticManagerTests.cs
+++ b/tests/NexusMods.DataModel.Tests/Diagnostics/DiagnosticManagerTests.cs
@@ -37,7 +37,7 @@ public class DiagnosticManagerTests : ADataModelTest<DiagnosticManagerTests>
 
         var diagnostic = _diagnosticManager.ActiveDiagnostics.Should().ContainSingle().Which;
         diagnostic.Id.Number.Should().Be(1);
-        diagnostic.Message.Should().Be(DummyLoadoutDiagnosticEmitter.CreateMessage(BaseList.Value));
+        diagnostic.Summary.Should().Be(DummyLoadoutDiagnosticEmitter.CreateMessage(BaseList.Value));
     }
 
     [Fact]
@@ -53,7 +53,7 @@ public class DiagnosticManagerTests : ADataModelTest<DiagnosticManagerTests>
 
         var diagnostic = _diagnosticManager.ActiveDiagnostics.Should().ContainSingle().Which;
         diagnostic.Id.Number.Should().Be(1);
-        diagnostic.Message.Should().Be(DummyModDiagnosticEmitter.CreateMessage(BaseList.Value, mod));
+        diagnostic.Summary.Should().Be(DummyModDiagnosticEmitter.CreateMessage(BaseList.Value, mod));
 
         BaseList.Remove(mod);
         BaseList.Value.Mods.Count.Should().Be(1);
@@ -82,8 +82,9 @@ public class DiagnosticManagerTests : ADataModelTest<DiagnosticManagerTests>
             new()
             {
                 Id = new DiagnosticId(),
-                Message = DiagnosticMessage.From(""),
                 Severity = DiagnosticSeverity.Warning,
+                Summary = DiagnosticMessage.DefaultValue,
+                Details = DiagnosticMessage.DefaultValue,
                 DataReferences = new Dictionary<DataReferenceDescription, IDataReference>()
             }
         };
@@ -108,8 +109,9 @@ public class DiagnosticManagerTests : ADataModelTest<DiagnosticManagerTests>
             new()
             {
                 Id = new DiagnosticId("foo", 1),
-                Message = DiagnosticMessage.From(""),
                 Severity = DiagnosticSeverity.Warning,
+                Summary = DiagnosticMessage.DefaultValue,
+                Details = DiagnosticMessage.DefaultValue,
                 DataReferences = new Dictionary<DataReferenceDescription, IDataReference>()
             }
         };

--- a/tests/NexusMods.DataModel.Tests/Diagnostics/DummyLoadoutDiagnosticEmitter.cs
+++ b/tests/NexusMods.DataModel.Tests/Diagnostics/DummyLoadoutDiagnosticEmitter.cs
@@ -17,8 +17,9 @@ public class DummyLoadoutDiagnosticEmitter : ILoadoutDiagnosticEmitter
         yield return new Diagnostic
         {
             Id = new DiagnosticId("NexusMods.DataModel.Tests.Diagnostics.DummyLoadoutDiagnosticEmitter", 1),
-            Message = CreateMessage(loadout),
             Severity = DiagnosticSeverity.Critical,
+            Summary = CreateMessage(loadout),
+            Details = DiagnosticMessage.DefaultValue,
             DataReferences = new Dictionary<DataReferenceDescription, IDataReference>()
             {
                 { DataReferenceDescription.Loadout, loadout.ToReference() }

--- a/tests/NexusMods.DataModel.Tests/Diagnostics/DummyModDiagnosticEmitter.cs
+++ b/tests/NexusMods.DataModel.Tests/Diagnostics/DummyModDiagnosticEmitter.cs
@@ -19,7 +19,8 @@ public class DummyModDiagnosticEmitter : IModDiagnosticEmitter
         {
             Id = new DiagnosticId("NexusMods.DataModels.Tests.Diagnostics.DummyModDiagnosticEmitter", 1),
             Severity = DiagnosticSeverity.Critical,
-            Message = CreateMessage(loadout, mod),
+            Summary = CreateMessage(loadout, mod),
+            Details = DiagnosticMessage.DefaultValue,
             DataReferences = new Dictionary<DataReferenceDescription, IDataReference>
             {
                 { DataReferenceDescription.Loadout, loadout.ToReference() },


### PR DESCRIPTION
Part of #977 and required for #915.

Changes:

- Replaced `Diagnostic.Message` with `Diagnostic.Summary` and `Diagnostic.Details`.
- Added `AddValue<T>` to the message builder. This allows you to include any kind of data in the diagnostic message data struct.