### PR TITLE
Apply fixes and refinements

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.DiskState/DiskStateTree.cs
+++ b/src/Abstractions/NexusMods.Abstractions.DiskState/DiskStateTree.cs
@@ -45,6 +45,7 @@ class DiskStateConverter : JsonConverter<DiskStateTree>
         reader.Read();
         
         var revId = options.Converters.OfType<IdJsonConverter>().First().Read(ref reader, typeof(IId), options);
+        reader.Read();
         
         if (reader.TokenType != JsonTokenType.PropertyName)
             throw new JsonException();

--- a/src/Abstractions/NexusMods.Abstractions.DiskState/DiskStateTree.cs
+++ b/src/Abstractions/NexusMods.Abstractions.DiskState/DiskStateTree.cs
@@ -3,6 +3,7 @@ using System.Text.Json.Serialization;
 using NexusMods.Abstractions.GameLocators;
 using NexusMods.Abstractions.GameLocators.Trees;
 using NexusMods.Abstractions.Loadouts;
+using NexusMods.Abstractions.Serialization.DataModel.Converters;
 using NexusMods.Abstractions.Serialization.DataModel.Ids;
 using NexusMods.Hashing.xxHash64;
 using NexusMods.Paths;
@@ -33,6 +34,24 @@ class DiskStateConverter : JsonConverter<DiskStateTree>
 {
     public override DiskStateTree Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
+        if (reader.TokenType != JsonTokenType.StartObject)
+            throw new JsonException();
+        reader.Read();
+        
+        if (reader.TokenType != JsonTokenType.PropertyName)
+            throw new JsonException();
+        if (reader.GetString() != "loadoutRevision")
+            throw new JsonException();
+        reader.Read();
+        
+        var revId = options.Converters.OfType<IdJsonConverter>().First().Read(ref reader, typeof(IId), options);
+        
+        if (reader.TokenType != JsonTokenType.PropertyName)
+            throw new JsonException();
+        if (reader.GetString() != "files")
+            throw new JsonException();
+        reader.Read();
+        
         if (reader.TokenType != JsonTokenType.StartArray)
             throw new JsonException();
 
@@ -40,7 +59,7 @@ class DiskStateConverter : JsonConverter<DiskStateTree>
         while (reader.Read())
         {
             if (reader.TokenType == JsonTokenType.EndArray)
-                return DiskStateTree.Create(itms);
+               break;
 
             if (reader.TokenType != JsonTokenType.StartArray)
                 throw new JsonException();
@@ -67,12 +86,23 @@ class DiskStateConverter : JsonConverter<DiskStateTree>
                 LastModified = lastModified
             }));
         }
-
-        return DiskStateTree.Create(itms);
+        reader.Read();
+        
+        if(reader.TokenType != JsonTokenType.EndObject)
+            throw new JsonException();
+        
+        var tree = DiskStateTree.Create(itms);
+        tree.LoadoutRevision = revId;
+        return tree;
     }
 
     public override void Write(Utf8JsonWriter writer, DiskStateTree value, JsonSerializerOptions options)
     {
+        writer.WriteStartObject();
+        writer.WritePropertyName("loadoutRevision");
+        options.Converters.OfType<IdJsonConverter>().First().Write(writer, value.LoadoutRevision, options);
+        
+        writer.WritePropertyName("files");
         writer.WriteStartArray();
         foreach (var boxed in value.GetAllDescendentFiles())
         {
@@ -88,5 +118,6 @@ class DiskStateConverter : JsonConverter<DiskStateTree>
             writer.WriteEndArray();
         }
         writer.WriteEndArray();
+        writer.WriteEndObject();
     }
 }

--- a/src/Abstractions/NexusMods.Abstractions.DiskState/IDiskStateRegistry.cs
+++ b/src/Abstractions/NexusMods.Abstractions.DiskState/IDiskStateRegistry.cs
@@ -27,4 +27,8 @@ public interface IDiskStateRegistry
     /// <returns></returns>
     IId? GetLastAppliedLoadout(GameInstallation gameInstallation);
     
+    /// <summary>
+    /// Observable of all the last applied revisions for all game installations
+    /// </summary>
+    IObservable<(GameInstallation gameInstallation, IId loadoutRevision)> LastAppliedRevisionObservable { get; }
 }

--- a/src/Abstractions/NexusMods.Abstractions.DiskState/IDiskStateRegistry.cs
+++ b/src/Abstractions/NexusMods.Abstractions.DiskState/IDiskStateRegistry.cs
@@ -1,5 +1,5 @@
 using NexusMods.Abstractions.GameLocators;
-using NexusMods.Abstractions.Loadouts;
+using NexusMods.Abstractions.Serialization.DataModel.Ids;
 
 namespace NexusMods.Abstractions.DiskState;
 
@@ -19,4 +19,12 @@ public interface IDiskStateRegistry
     /// </summary>
     /// <returns></returns>
     DiskStateTree? GetState(GameInstallation gameInstallation);
+    
+    /// <summary>
+    /// Gets the Loadout Revision Id of the last applied state for a given game installation
+    /// </summary>
+    /// <param name="gameInstallation"></param>
+    /// <returns></returns>
+    IId? GetLastAppliedLoadout(GameInstallation gameInstallation);
+    
 }

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts/IApplyService.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts/IApplyService.cs
@@ -21,6 +21,12 @@ public interface IApplyService
     /// </summary>
     /// <param name="gameInstallation"></param>
     /// <returns>A tuple of the LoadoutId and loadout revision Id of the last applied state</returns>
-    public (LoadoutId, IId)? GetLastAppliedLoadout(GameInstallation gameInstallation);
+    public IId? GetLastAppliedLoadout(GameInstallation gameInstallation);
     
+    /// <summary>
+    /// Returns an observable of the last applied revisions for a specific game installation
+    /// </summary>
+    /// <param name="gameInstallation"></param>
+    /// <returns></returns>
+    public IObservable<IId> LastAppliedRevisionFor(GameInstallation gameInstallation);    
 }

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts/IApplyService.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts/IApplyService.cs
@@ -21,5 +21,6 @@ public interface IApplyService
     /// </summary>
     /// <param name="gameInstallation"></param>
     /// <returns>A tuple of the LoadoutId and loadout revision Id of the last applied state</returns>
-    public (LoadoutId, IId) GetLastAppliedLoadout(GameInstallation gameInstallation);
+    public (LoadoutId, IId)? GetLastAppliedLoadout(GameInstallation gameInstallation);
+    
 }

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts/IApplyService.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts/IApplyService.cs
@@ -10,11 +10,21 @@ public interface IApplyService
 {
     /// <summary>
     /// Apply a loadout to its game installation.
+    /// This will also ingest outside changes and merge unapplied changes on top and apply them.
     /// </summary>
     /// <param name="loadoutId"></param>
     /// <returns></returns>
     public Task<Loadout> Apply(LoadoutId loadoutId);
 
+    
+    /// <summary>
+    /// Ingest any detected outside changes into the last applied loadout.
+    /// This will also rebase any unapplied changes on top of the last applied state, but will not apply them to disk.
+    /// The loadoutId will point to the new merged loadout
+    /// </summary>
+    /// <param name="gameInstallation"></param>
+    /// <returns>The merged loadout</returns>
+    public Task<Loadout> Ingest(GameInstallation gameInstallation);
 
     /// <summary>
     /// Returns the last applied loadout for a given game installation.

--- a/src/Abstractions/NexusMods.Abstractions.Serialization/Services.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Serialization/Services.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.Serialization.DataModel;
+using NexusMods.Abstractions.Serialization.DataModel.Converters;
 using NexusMods.Abstractions.Serialization.Json;
 
 namespace NexusMods.Abstractions.Serialization;
@@ -25,6 +26,7 @@ public static class Services
         services.AddSingleton(typeof(EntityDictionaryConverter<,>));
         services.AddSingleton<JsonConverter, EntityLinkConverterFactory>();
         services.AddSingleton(typeof(EntityLinkConverter<>));
+        services.AddSingleton<JsonConverter, IdJsonConverter>();
 
         services.AddSingleton(s =>
         {

--- a/src/NexusMods.App.UI/LeftMenu/Items/ApplyControlDesignViewModel.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Items/ApplyControlDesignViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows.Input;
+using NexusMods.App.UI.Resources;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
 
@@ -11,6 +12,7 @@ public class ApplyControlDesignViewModel : AViewModel<IApplyControlViewModel>, I
     [Reactive] public bool IsApplying { get; private set; } = false;
 
     public ILaunchButtonViewModel LaunchButtonViewModel { get; } = new LaunchButtonDesignViewModel();
+    public string ApplyButtonText { get; } = Language.ApplyControlViewModel__APPLY;
 
     public ApplyControlDesignViewModel()
     {

--- a/src/NexusMods.App.UI/LeftMenu/Items/ApplyControlDesignViewModel.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Items/ApplyControlDesignViewModel.cs
@@ -12,7 +12,7 @@ public class ApplyControlDesignViewModel : AViewModel<IApplyControlViewModel>, I
     [Reactive] public bool IsApplying { get; private set; } = false;
 
     public ILaunchButtonViewModel LaunchButtonViewModel { get; } = new LaunchButtonDesignViewModel();
-    public string ApplyButtonText { get; } = Language.ApplyControlViewModel__APPLY;
+    public string ApplyButtonText { get; } = Language.ApplyControlViewModel__ACTIVATE_AND_APPLY;
 
     public ApplyControlDesignViewModel()
     {

--- a/src/NexusMods.App.UI/LeftMenu/Items/ApplyControlView.axaml
+++ b/src/NexusMods.App.UI/LeftMenu/Items/ApplyControlView.axaml
@@ -7,7 +7,7 @@
                                 xmlns:unifiedIcon="clr-namespace:NexusMods.App.UI.Controls.UnifiedIcon;assembly=NexusMods.App.UI"
                                 xmlns:progressRing="clr-namespace:NexusMods.App.UI.Controls.ProgressRing"
                                 xmlns:resources="clr-namespace:NexusMods.App.UI.Resources"
-                                mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="100"
+                                mc:Ignorable="d" d:DesignWidth="200" d:DesignHeight="100"
                                 x:Class="NexusMods.App.UI.LeftMenu.Items.ApplyControlView">
     <Design.DataContext>
         <items:ApplyControlDesignViewModel />
@@ -24,12 +24,14 @@
             <Button Classes="Standard SecondaryOutlined"
                     HorizontalAlignment="Stretch"
                     x:Name="ApplyButton">
-                <StackPanel Orientation="Horizontal"
-                            HorizontalAlignment="Center">
-                    <unifiedIcon:UnifiedIcon Size="24" Classes="Check" />
-                    <TextBlock Classes="TitleSMSemi"
-                               x:Name="ApplyButtonTextBlock"/>
-                </StackPanel>
+                <Viewbox StretchDirection="DownOnly">
+                    <StackPanel Orientation="Horizontal"
+                                HorizontalAlignment="Center">
+                        <unifiedIcon:UnifiedIcon Size="24" Classes="Check" />
+                        <TextBlock Classes="TitleSMSemi"
+                                   x:Name="ApplyButtonTextBlock" />
+                    </StackPanel>
+                </Viewbox>
             </Button>
 
             <Border Padding="12"
@@ -37,16 +39,16 @@
                     x:Name="InProgressBorder">
                 <StackPanel Orientation="Horizontal"
                             Classes="Spacing-1_5">
-                    <progressRing:ProgressRing/>
+                    <progressRing:ProgressRing />
                     <TextBlock Classes="BodySMNormal ForegroundModerate"
                                Text="{x:Static resources:Language.ApplyingControlView__ApplyingText}"
                                VerticalAlignment="Center"
-                               x:Name="ApplyingTextBlock"/>
+                               x:Name="ApplyingTextBlock" />
                 </StackPanel>
             </Border>
 
-            <items:LaunchButtonView x:Name="LaunchButtonView" 
-                                    HorizontalAlignment="Stretch"/>
+            <items:LaunchButtonView x:Name="LaunchButtonView"
+                                    HorizontalAlignment="Stretch" />
         </StackPanel>
     </Border>
 </reactiveUi:ReactiveUserControl>

--- a/src/NexusMods.App.UI/LeftMenu/Items/ApplyControlView.axaml
+++ b/src/NexusMods.App.UI/LeftMenu/Items/ApplyControlView.axaml
@@ -6,6 +6,7 @@
                                 xmlns:items="clr-namespace:NexusMods.App.UI.LeftMenu.Items"
                                 xmlns:unifiedIcon="clr-namespace:NexusMods.App.UI.Controls.UnifiedIcon;assembly=NexusMods.App.UI"
                                 xmlns:progressRing="clr-namespace:NexusMods.App.UI.Controls.ProgressRing"
+                                xmlns:resources="clr-namespace:NexusMods.App.UI.Resources"
                                 mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="100"
                                 x:Class="NexusMods.App.UI.LeftMenu.Items.ApplyControlView">
     <Design.DataContext>
@@ -17,7 +18,8 @@
             HorizontalAlignment="Stretch">
 
         <StackPanel Orientation="Vertical"
-                    Classes="Spacing-2">
+                    Classes="Spacing-2"
+                    HorizontalAlignment="Stretch">
 
             <Button Classes="Standard SecondaryOutlined"
                     HorizontalAlignment="Stretch"
@@ -26,7 +28,7 @@
                             HorizontalAlignment="Center">
                     <unifiedIcon:UnifiedIcon Size="24" Classes="Check" />
                     <TextBlock Classes="TitleSMSemi"
-                               Text="APPLY" />
+                               x:Name="ApplyButtonTextBlock"/>
                 </StackPanel>
             </Button>
 
@@ -37,12 +39,14 @@
                             Classes="Spacing-1_5">
                     <progressRing:ProgressRing/>
                     <TextBlock Classes="BodySMNormal ForegroundModerate"
-                               Text="Applying..."
-                               VerticalAlignment="Center"/>
+                               Text="{x:Static resources:Language.ApplyingControlView__ApplyingText}"
+                               VerticalAlignment="Center"
+                               x:Name="ApplyingTextBlock"/>
                 </StackPanel>
             </Border>
 
-            <items:LaunchButtonView x:Name="LaunchButtonView" />
+            <items:LaunchButtonView x:Name="LaunchButtonView" 
+                                    HorizontalAlignment="Stretch"/>
         </StackPanel>
     </Border>
 </reactiveUi:ReactiveUserControl>

--- a/src/NexusMods.App.UI/LeftMenu/Items/ApplyControlView.axaml
+++ b/src/NexusMods.App.UI/LeftMenu/Items/ApplyControlView.axaml
@@ -29,7 +29,8 @@
                                 HorizontalAlignment="Center">
                         <unifiedIcon:UnifiedIcon Size="24" Classes="Check" />
                         <TextBlock Classes="TitleSMSemi"
-                                   x:Name="ApplyButtonTextBlock" />
+                                   x:Name="ApplyButtonTextBlock" 
+                                   VerticalAlignment="Center"/>
                     </StackPanel>
                 </Viewbox>
             </Button>

--- a/src/NexusMods.App.UI/LeftMenu/Items/ApplyControlView.axaml.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Items/ApplyControlView.axaml.cs
@@ -24,6 +24,9 @@ public partial class ApplyControlView : ReactiveUserControl<IApplyControlViewMod
             
             this.OneWayBind(ViewModel, vm => vm.IsApplying, v => v.InProgressBorder.IsVisible)
                 .DisposeWith(disposables);
+            
+            this.OneWayBind(ViewModel, vm => vm.ApplyButtonText, v => v.ApplyButtonTextBlock.Text)
+                .DisposeWith(disposables);
 
             this.WhenAnyValue(view => view.ViewModel!.IsApplying)
                 .Select(isApplying => !isApplying)

--- a/src/NexusMods.App.UI/LeftMenu/Items/ApplyControlViewModel.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Items/ApplyControlViewModel.cs
@@ -45,7 +45,9 @@ public class ApplyControlViewModel : AViewModel<IApplyControlViewModel>, IApplyC
         _gameInstallation = _loadoutRegistry.Get(_loadoutId)?.Installation ??
                             throw new ArgumentException("Loadout not found: " + _loadoutId);
 
-        (_lastAppliedLoadoutId, _lastAppliedRevisionId) = GetLastAppliedLoadout();
+        _lastAppliedRevisionId = _applyService.GetLastAppliedLoadout(_gameInstallation) ??
+                                                         throw new ArgumentException("No last applied loadout found for: " +
+                                                                                 _gameInstallation);
 
         _newestLoadout = _loadoutRegistry.RevisionsAsLoadouts(loadoutId)
             .ToProperty(this, vm => vm.NewestLoadout, scheduler: RxApp.MainThreadScheduler);
@@ -81,15 +83,5 @@ public class ApplyControlViewModel : AViewModel<IApplyControlViewModel>, IApplyC
                 await _applyService.Apply(_loadoutId);
             }
         );
-    }
-
-    private (LoadoutId, IId) GetLastAppliedLoadout()
-    {
-        // TODO: uncomment this when the method is implemented
-        // return _applyService.GetLastAppliedLoadout(_gameInstallation);
-
-        // Fake implementation returns the current loadout and latest revision
-        var revId = _loadoutRegistry.Get(_loadoutId)!.DataStoreId;
-        return (_loadoutId, revId);
     }
 }

--- a/src/NexusMods.App.UI/LeftMenu/Items/ApplyControlViewModel.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Items/ApplyControlViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reactive.Disposables;
+using System.Reactive.Linq;
 using System.Windows.Input;
 using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.GameLocators;
@@ -16,15 +17,16 @@ public class ApplyControlViewModel : AViewModel<IApplyControlViewModel>, IApplyC
 
     private readonly LoadoutId _loadoutId;
     private readonly GameInstallation _gameInstallation;
-    private LoadoutId _lastAppliedLoadoutId;
-    private IId _lastAppliedRevisionId;
-    private readonly ObservableAsPropertyHelper<Abstractions.Loadouts.Loadout> _newestLoadout;
 
-    private Abstractions.Loadouts.Loadout NewestLoadout => _newestLoadout.Value;
-
-    public ICommand ApplyCommand => _applyReactiveCommand;
 
     private readonly ReactiveCommand<System.Reactive.Unit, System.Reactive.Unit> _applyReactiveCommand;
+    
+    [Reactive] private IId LastAppliedRevisionId { get; set; }
+    [Reactive] private LoadoutId LastAppliedLoadoutId { get; set; }
+    [Reactive] private Abstractions.Loadouts.Loadout NewestLoadout { get; set; }
+    
+    
+    public ICommand ApplyCommand => _applyReactiveCommand;
 
     [Reactive] public bool CanApply { get; private set; }
 
@@ -40,30 +42,50 @@ public class ApplyControlViewModel : AViewModel<IApplyControlViewModel>, IApplyC
         _applyService = serviceProvider.GetRequiredService<IApplyService>();
         LaunchButtonViewModel = serviceProvider.GetRequiredService<ILaunchButtonViewModel>();
         LaunchButtonViewModel.LoadoutId = loadoutId;
+        
+        NewestLoadout = _loadoutRegistry.Get(_loadoutId) ??
+                       throw new ArgumentException("Loadout not found: " + _loadoutId);
+        
+        _gameInstallation = NewestLoadout.Installation;
 
-
-        _gameInstallation = _loadoutRegistry.Get(_loadoutId)?.Installation ??
-                            throw new ArgumentException("Loadout not found: " + _loadoutId);
-
-        _lastAppliedRevisionId = _applyService.GetLastAppliedLoadout(_gameInstallation) ??
-                                                         throw new ArgumentException("No last applied loadout found for: " +
-                                                                                 _gameInstallation);
-
-        _newestLoadout = _loadoutRegistry.RevisionsAsLoadouts(loadoutId)
-            .ToProperty(this, vm => vm.NewestLoadout, scheduler: RxApp.MainThreadScheduler);
+        LastAppliedRevisionId = _applyService.GetLastAppliedLoadout(_gameInstallation) ??
+                                throw new ArgumentException("No last applied loadout found for: " +
+                                                            _gameInstallation);
         
         _applyReactiveCommand = ReactiveCommand.CreateFromTask(async () => await Apply());
 
         this.WhenActivated(disposables =>
         {
+            _loadoutRegistry.RevisionsAsLoadouts(loadoutId)
+                .OnUI()
+                .BindToVM(this, vm => vm.NewestLoadout)
+                .DisposeWith(disposables);
+
+            _applyService.LastAppliedRevisionFor(_gameInstallation)
+                .OnUI()
+                .BindToVM(this, vm => vm.LastAppliedRevisionId)
+                .DisposeWith(disposables);
+            
+            this.WhenAnyValue(vm => vm.LastAppliedRevisionId)
+                .Select(revId =>
+                {
+                    var loadout = _loadoutRegistry.GetLoadout(revId);
+                    if (loadout is null)
+                        throw new ArgumentException("Loadout not found for revision: " + revId);
+                    return loadout.LoadoutId;
+                })
+                .OnUI()
+                .BindToVM(this, vm => vm.LastAppliedLoadoutId)
+                .DisposeWith(disposables);
+            
             this.WhenAnyValue(vm => vm.NewestLoadout,
-                    vm => vm._lastAppliedLoadoutId,
+                    vm => vm.LastAppliedRevisionId,
                     vm => vm.IsApplying)
                 .Subscribe(_ =>
                 {
                     CanApply = !IsApplying && (
-                        !_lastAppliedLoadoutId.Equals(_loadoutId) ||
-                        !NewestLoadout.DataStoreId.Equals(_lastAppliedRevisionId));
+                        !LastAppliedLoadoutId.Equals(_loadoutId) ||
+                        !NewestLoadout.DataStoreId.Equals(LastAppliedRevisionId));
                 })
                 .DisposeWith(disposables);
             
@@ -75,9 +97,6 @@ public class ApplyControlViewModel : AViewModel<IApplyControlViewModel>, IApplyC
 
     private async Task Apply()
     {
-        _lastAppliedLoadoutId = _loadoutId;
-        _lastAppliedRevisionId = _loadoutRegistry.Get(_loadoutId)!.DataStoreId;
-
         await Task.Run(async () =>
             {
                 await _applyService.Apply(_loadoutId);

--- a/src/NexusMods.App.UI/LeftMenu/Items/ApplyControlViewModel.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Items/ApplyControlViewModel.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.GameLocators;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Serialization.DataModel.Ids;
+using NexusMods.App.UI.Resources;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
 
@@ -17,6 +18,10 @@ public class ApplyControlViewModel : AViewModel<IApplyControlViewModel>, IApplyC
 
     private readonly LoadoutId _loadoutId;
     private readonly GameInstallation _gameInstallation;
+    private readonly string _activateLoadoutText = Language.ApplyControlViewModel__ACTIVATE_LOADOUT;
+    private readonly string _activateAndApplyText = Language.ApplyControlViewModel__ACTIVATE_AND_APPLY;
+    private readonly string _applyText = Language.ApplyControlViewModel__APPLY;
+    
 
 
     private readonly ReactiveCommand<System.Reactive.Unit, System.Reactive.Unit> _applyReactiveCommand;
@@ -31,6 +36,8 @@ public class ApplyControlViewModel : AViewModel<IApplyControlViewModel>, IApplyC
     [Reactive] public bool CanApply { get; private set; }
 
     [Reactive] public bool IsApplying { get; private set; }
+    
+    [Reactive] public string ApplyButtonText { get; private set; } = Language.ApplyControlViewModel__APPLY;
 
     public ILaunchButtonViewModel LaunchButtonViewModel { get; }
 
@@ -91,6 +98,13 @@ public class ApplyControlViewModel : AViewModel<IApplyControlViewModel>, IApplyC
             
             _applyReactiveCommand.IsExecuting
                 .Subscribe(isExecuting => IsApplying = isExecuting)
+                .DisposeWith(disposables);
+            
+            this.WhenAnyValue(vm => vm.LastAppliedLoadoutId,
+                    vm => vm.NewestLoadout)
+                .Select(_ => !LastAppliedLoadoutId.Equals(_loadoutId) ? _activateAndApplyText : _applyText)
+                .OnUI()
+                .BindToVM(this, vm => vm.ApplyButtonText)
                 .DisposeWith(disposables);
         });
     }

--- a/src/NexusMods.App.UI/LeftMenu/Items/IApplyControlViewModel.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Items/IApplyControlViewModel.cs
@@ -11,4 +11,6 @@ public interface IApplyControlViewModel : IViewModelInterface
     bool IsApplying { get; }
 
     ILaunchButtonViewModel LaunchButtonViewModel { get; }
+    
+    string ApplyButtonText { get; }
 }

--- a/src/NexusMods.App.UI/LeftMenu/Loadout/LoadoutLeftMenuView.axaml
+++ b/src/NexusMods.App.UI/LeftMenu/Loadout/LoadoutLeftMenuView.axaml
@@ -4,7 +4,7 @@
                                 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                                 xmlns:reactiveUi="http://reactiveui.net"
                                 xmlns:left="clr-namespace:NexusMods.App.UI.LeftMenu.Loadout"
-                                mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+                                mc:Ignorable="d" d:DesignWidth="200" d:DesignHeight="450"
                                 x:Class="NexusMods.App.UI.LeftMenu.Loadout.LoadoutLeftMenuView">
     <Design.DataContext>
         <left:LoadoutLeftMenuDesignViewModel />
@@ -21,11 +21,7 @@
             </ItemsControl.ItemsPanel>
         </ItemsControl>
 
-        <Border Grid.Row="1"
-                Classes="Rounded-lg Low"
-                Padding="12">
-                <reactiveUi:ViewModelViewHost x:Name="ApplyControlViewHost" />
-        </Border>
+        <reactiveUi:ViewModelViewHost Grid.Row="1" x:Name="ApplyControlViewHost" />
     </Grid>
 
 

--- a/src/NexusMods.App.UI/Resources/Language.Designer.cs
+++ b/src/NexusMods.App.UI/Resources/Language.Designer.cs
@@ -60,6 +60,42 @@ namespace NexusMods.App.UI.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to ACTIVATE &amp; APPLY.
+        /// </summary>
+        public static string ApplyControlViewModel__ACTIVATE_AND_APPLY {
+            get {
+                return ResourceManager.GetString("ApplyControlViewModel__ACTIVATE_AND_APPLY", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ACTIVATE LOADOUT.
+        /// </summary>
+        public static string ApplyControlViewModel__ACTIVATE_LOADOUT {
+            get {
+                return ResourceManager.GetString("ApplyControlViewModel__ACTIVATE_LOADOUT", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to APPLY.
+        /// </summary>
+        public static string ApplyControlViewModel__APPLY {
+            get {
+                return ResourceManager.GetString("ApplyControlViewModel__APPLY", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Applying....
+        /// </summary>
+        public static string ApplyingControlView__ApplyingText {
+            get {
+                return ResourceManager.GetString("ApplyingControlView__ApplyingText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to 0 mins.
         /// </summary>
         public static string BoldMinutesRemainingTextBlock {

--- a/src/NexusMods.App.UI/Resources/Language.resx
+++ b/src/NexusMods.App.UI/Resources/Language.resx
@@ -279,4 +279,16 @@
     <data name="InProgressDownloadsPage_Title" xml:space="preserve">
         <value>Downloads</value>
     </data>
+    <data name="ApplyControlViewModel__ACTIVATE_LOADOUT" xml:space="preserve">
+        <value>ACTIVATE LOADOUT</value>
+    </data>
+    <data name="ApplyControlViewModel__ACTIVATE_AND_APPLY" xml:space="preserve">
+        <value>ACTIVATE &amp; APPLY</value>
+    </data>
+    <data name="ApplyControlViewModel__APPLY" xml:space="preserve">
+        <value>APPLY</value>
+    </data>
+    <data name="ApplyingControlView__ApplyingText" xml:space="preserve">
+        <value>Applying...</value>
+    </data>
 </root>

--- a/src/NexusMods.DataModel/ApplyService.cs
+++ b/src/NexusMods.DataModel/ApplyService.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System.Reactive.Linq;
+using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.DiskState;
 using NexusMods.Abstractions.GameLocators;
 using NexusMods.Abstractions.Games.Loadouts;
@@ -14,6 +15,7 @@ public class ApplyService : IApplyService
     private readonly ILoadoutRegistry _loadoutRegistry;
     private readonly ILogger<ApplyService> _logger;
     private readonly IDiskStateRegistry _diskStateRegistry;
+    private readonly IObservable<(GameInstallation gameInstallation, IId loadoutRevision)> _lastAppliedRevisionObservable;
 
     /// <summary>
     /// DI Constructor
@@ -23,6 +25,8 @@ public class ApplyService : IApplyService
         _loadoutRegistry = loadoutRegistry;
         _logger = logger;
         _diskStateRegistry = diskStateRegistry;
+
+        _lastAppliedRevisionObservable = _diskStateRegistry.LastAppliedRevisionObservable;
     }
 
     /// <inheritdoc />
@@ -35,9 +39,13 @@ public class ApplyService : IApplyService
         if (loadout is null)
             throw new ArgumentException("Loadout not found", nameof(loadoutId));
 
-        _logger.LogInformation("Applying loadout {LoadoutId} to {GameName} {GameVersion}", loadout.LoadoutId,
-            loadout.Installation.Game.Name, loadout.Installation.Version
+        _logger.LogInformation(
+            "Applying loadout {LoadoutId} to {GameName} {GameVersion}",
+            loadout.LoadoutId,
+            loadout.Installation.Game.Name,
+            loadout.Installation.Version
         );
+
         try
         {
             await loadout.Apply();
@@ -48,12 +56,27 @@ public class ApplyService : IApplyService
                 loadout.Installation.Game.Name, loadout.Installation.Version
             );
 
-            await loadout.Ingest();
+            Loadout lastAppliedLoadout;
+            var lastAppliedRevision = GetLastAppliedLoadout(loadout.Installation);
+            if (lastAppliedRevision is not null)
+            {
+                var lastLoadout = _loadoutRegistry.GetLoadout(lastAppliedRevision);
+                lastAppliedLoadout = lastLoadout ?? throw new Exception("Loadout not found for last applied revision");
+            }
+            else
+            {
+                // There is apparently no last applied revision, so we'll just use the loadout we're trying to apply
+                lastAppliedLoadout = loadout;
+            }
+
+            // TODO: Actually do something with the loadoutWithIngest, right now we just ignore it
+            var loadoutWithIngest = await lastAppliedLoadout.Ingest();
 
             _logger.LogInformation("Applying loadout {LoadoutId} to {GameName} {GameVersion}", loadout.LoadoutId,
                 loadout.Installation.Game.Name, loadout.Installation.Version
             );
-
+            
+            // TODO: Apply a loadout containing both the ingest and the unapplied changes
             await loadout.Apply();
         }
 
@@ -61,17 +84,20 @@ public class ApplyService : IApplyService
     }
 
     /// <inheritdoc />
-    public (LoadoutId, IId)? GetLastAppliedLoadout(GameInstallation gameInstallation)
+    public IId? GetLastAppliedLoadout(GameInstallation gameInstallation)
     {
         var loadoutRevision = _diskStateRegistry.GetLastAppliedLoadout(gameInstallation);
-        if (loadoutRevision is null)
-            return null;
-        
-        var loadoutId = _loadoutRegistry.GetLoadout(loadoutRevision);
-        if (loadoutId is null)
-            throw new Exception("Loadout not found for last applied revision");
-        
-        return (loadoutId.LoadoutId, loadoutRevision);
+        return loadoutRevision;
     }
-    
+
+    /// <inheritdoc />
+    public IObservable<IId> LastAppliedRevisionFor(GameInstallation gameInstallation)
+    {
+        // Return a deferred observable that computes the starting value only on first subscription
+        return Observable.Defer(() => _lastAppliedRevisionObservable
+            .Where(x => x.gameInstallation.Equals(gameInstallation))
+            .Select(x => x.loadoutRevision)
+            .StartWith(_diskStateRegistry.GetLastAppliedLoadout(gameInstallation) ?? IdEmpty.Empty)
+        );
+    }
 }

--- a/src/NexusMods.DataModel/ApplyService.cs
+++ b/src/NexusMods.DataModel/ApplyService.cs
@@ -16,7 +16,6 @@ public class ApplyService : IApplyService
     private readonly ILoadoutRegistry _loadoutRegistry;
     private readonly ILogger<ApplyService> _logger;
     private readonly IDiskStateRegistry _diskStateRegistry;
-    private readonly IObservable<(GameInstallation gameInstallation, IId loadoutRevision)> _lastAppliedRevisionObservable;
 
     /// <summary>
     /// DI Constructor
@@ -26,8 +25,6 @@ public class ApplyService : IApplyService
         _loadoutRegistry = loadoutRegistry;
         _logger = logger;
         _diskStateRegistry = diskStateRegistry;
-
-        _lastAppliedRevisionObservable = _diskStateRegistry.LastAppliedRevisionObservable;
     }
 
     /// <inheritdoc />
@@ -135,7 +132,7 @@ public class ApplyService : IApplyService
     public IObservable<IId> LastAppliedRevisionFor(GameInstallation gameInstallation)
     {
         // Return a deferred observable that computes the starting value only on first subscription
-        return Observable.Defer(() => _lastAppliedRevisionObservable
+        return Observable.Defer(() => _diskStateRegistry.LastAppliedRevisionObservable
             .Where(x => x.gameInstallation.Equals(gameInstallation))
             .Select(x => x.loadoutRevision)
             .StartWith(_diskStateRegistry.GetLastAppliedLoadout(gameInstallation) ?? IdEmpty.Empty)

--- a/src/NexusMods.DataModel/ApplyService.cs
+++ b/src/NexusMods.DataModel/ApplyService.cs
@@ -59,7 +59,7 @@ public class ApplyService : IApplyService
             if (lastAppliedRevision is not null)
             {
                 var lastLoadout = _loadoutRegistry.GetLoadout(lastAppliedRevision);
-                lastAppliedLoadout = lastLoadout ?? throw new Exception("Loadout not found for last applied revision");
+                lastAppliedLoadout = lastLoadout ?? throw new KeyNotFoundException("Loadout not found for last applied revision");
             }
             else
             {
@@ -95,14 +95,14 @@ public class ApplyService : IApplyService
         }
 
         var lastLoadout = _loadoutRegistry.GetLoadout(lastAppliedRevision);
-        var lastAppliedLoadout = lastLoadout ?? throw new Exception("Loadout not found for last applied revision");
+        var lastAppliedLoadout = lastLoadout ?? throw new KeyNotFoundException("Loadout not found for last applied revision");
         
         var loadoutWithIngest = await lastAppliedLoadout.Ingest();
         
         // Get the latest loadout revision
         var latestRevision = _loadoutRegistry.Get(loadoutWithIngest.LoadoutId);
         if (latestRevision is null)
-            throw new Exception("No latest revision found for last applied loadout");
+            throw new KeyNotFoundException("No latest revision found for last applied loadout");
         
         // if latest revision is the same as the last applied revision, no need to rebase
         if (latestRevision.DataStoreId.Equals(loadoutWithIngest.DataStoreId))

--- a/src/NexusMods.DataModel/ApplyService.cs
+++ b/src/NexusMods.DataModel/ApplyService.cs
@@ -88,6 +88,7 @@ public class ApplyService : IApplyService
         return loadout;
     }
 
+    /// <inheritdoc />
     public async Task<Loadout> Ingest(GameInstallation gameInstallation)
     {
         var lastAppliedRevision = GetLastAppliedLoadout(gameInstallation);

--- a/src/NexusMods.DataModel/Loadouts/DiskStateRegistry.cs
+++ b/src/NexusMods.DataModel/Loadouts/DiskStateRegistry.cs
@@ -79,7 +79,7 @@ public class DiskStateRegistry : IDiskStateRegistry
         return JsonSerializer.Deserialize<DiskStateTree>(compressed, _jsonSerializerOptions);
     }
 
-    /// <Inheritdoc />
+    /// <inheritdoc />
     public IId? GetLastAppliedLoadout(GameInstallation gameInstallation)
     {
         if (_lastAppliedRevisionDictionary.TryGetValue(gameInstallation, out var lastAppliedLoadout))

--- a/src/NexusMods.DataModel/Loadouts/DiskStateRegistry.cs
+++ b/src/NexusMods.DataModel/Loadouts/DiskStateRegistry.cs
@@ -50,7 +50,8 @@ public class DiskStateRegistry : IDiskStateRegistry
 
     private IId MakeId(GameInstallation installation)
     {
-        var str = $"{installation.Game.Name}|{installation.Version}|{installation.Store.Value}";
+        var str = $"{installation.Game.GetType()}|{installation.LocationsRegister[LocationId.Game]}";
+
         var bytes = Encoding.UTF8.GetBytes(str);
         return IId.FromSpan(EntityCategory.DiskState, bytes); 
     }

--- a/src/NexusMods.DataModel/Loadouts/DiskStateRegistry.cs
+++ b/src/NexusMods.DataModel/Loadouts/DiskStateRegistry.cs
@@ -87,6 +87,7 @@ public class DiskStateRegistry : IDiskStateRegistry
 
         var diskStateTree = GetState(gameInstallation);
         if (diskStateTree is null) return null;
+        Debug.Assert(!diskStateTree.LoadoutRevision.Equals(IdEmpty.Empty), "diskState.LoadoutRevision must be set");
 
         _lastAppliedRevisionDictionary[gameInstallation] = diskStateTree.LoadoutRevision;
         return diskStateTree.LoadoutRevision;

--- a/src/NexusMods.DataModel/ToolManager.cs
+++ b/src/NexusMods.DataModel/ToolManager.cs
@@ -44,27 +44,16 @@ public class ToolManager : IToolManager
     /// <inheritdoc />
     public async Task<Loadout> RunTool(ITool tool, Loadout loadout, ModId? generatedFilesMod = null, CancellationToken token = default)
     {
-
         if (!tool.Domains.Contains(loadout.Installation.Game.Domain))
             throw new Exception("Tool does not support this game");
-
-        _logger.LogInformation("Applying loadout {LoadoutId} to {GameName} {GameVersion}", loadout.LoadoutId, loadout.Installation.Game.Name, loadout.Installation.Version);
-        try
-        {
-            await loadout.Apply();
-        }
-        catch (NeedsIngestException)
-        {
-            _logger.LogInformation("Ingesting loadout {LoadoutId} from {GameName} {GameVersion}", loadout.LoadoutId, loadout.Installation.Game.Name, loadout.Installation.Version);
-            await loadout.Ingest();
-            _logger.LogInformation("Applying loadout {LoadoutId} to {GameName} {GameVersion}", loadout.LoadoutId, loadout.Installation.Game.Name, loadout.Installation.Version);
-            await loadout.Apply();
-        }
 
         _logger.LogInformation("Running tool {ToolName} for loadout {LoadoutId} on {GameName} {GameVersion}", tool.Name, loadout.LoadoutId, loadout.Installation.Game.Name, loadout.Installation.Version);
         await tool.Execute(loadout, token);
 
-        _logger.LogInformation("Ingesting loadout {LoadoutId} from {GameName} {GameVersion}", loadout.LoadoutId, loadout.Installation.Game.Name, loadout.Installation.Version);
-        return await loadout.Ingest();
+        // TODO: Auto ingest newly generated files. Need to first resolve how ingested changes will be applied to loadout (rebase, merge, etc)
+        // _logger.LogInformation("Ingesting loadout {LoadoutId} from {GameName} {GameVersion}", loadout.LoadoutId, loadout.Installation.Game.Name, loadout.Installation.Version);
+        // return await _applyService.Ingest(loadout.Installation);
+        
+        return loadout;
     }
 }

--- a/src/NexusMods.DataModel/ToolManager.cs
+++ b/src/NexusMods.DataModel/ToolManager.cs
@@ -18,6 +18,7 @@ public class ToolManager : IToolManager
     private readonly IDataStore _dataStore;
     private readonly LoadoutRegistry _loadoutRegistry;
     private readonly ILogger<ToolManager> _logger;
+    private readonly IApplyService _applyService;
 
     /// <summary>
     /// DI Constructor
@@ -26,13 +27,14 @@ public class ToolManager : IToolManager
     /// <param name="loadoutSynchronizer"></param>
     /// <param name="dataStore"></param>
     /// <param name="loadoutRegistry"></param>
-    public ToolManager(ILogger<ToolManager> logger, IEnumerable<ITool> tools, IDataStore dataStore, LoadoutRegistry loadoutRegistry)
+    public ToolManager(ILogger<ToolManager> logger, IEnumerable<ITool> tools, IDataStore dataStore, LoadoutRegistry loadoutRegistry, IApplyService applyService)
     {
         _logger = logger;
         _dataStore = dataStore;
         _tools = tools.SelectMany(tool => tool.Domains.Select(domain => (domain, tool)))
             .ToLookup(t => t.domain, t => t.tool);
         _loadoutRegistry = loadoutRegistry;
+        _applyService = applyService;
     }
 
     /// <inheritdoc />
@@ -50,10 +52,8 @@ public class ToolManager : IToolManager
         _logger.LogInformation("Running tool {ToolName} for loadout {LoadoutId} on {GameName} {GameVersion}", tool.Name, loadout.LoadoutId, loadout.Installation.Game.Name, loadout.Installation.Version);
         await tool.Execute(loadout, token);
 
-        // TODO: Auto ingest newly generated files. Need to first resolve how ingested changes will be applied to loadout (rebase, merge, etc)
-        // _logger.LogInformation("Ingesting loadout {LoadoutId} from {GameName} {GameVersion}", loadout.LoadoutId, loadout.Installation.Game.Name, loadout.Installation.Version);
-        // return await _applyService.Ingest(loadout.Installation);
-        
-        return loadout;
+        // This will ingest the changes into the last applied loadout without but will not apply any loadout
+        _logger.LogInformation("Ingesting loadout {LoadoutId} from {GameName} {GameVersion}", loadout.LoadoutId, loadout.Installation.Game.Name, loadout.Installation.Version);
+        return await _applyService.Ingest(loadout.Installation);
     }
 }

--- a/tests/NexusMods.DataModel.Tests/ApplyServiceTests.cs
+++ b/tests/NexusMods.DataModel.Tests/ApplyServiceTests.cs
@@ -1,0 +1,102 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using NexusMods.Abstractions.GameLocators;
+using NexusMods.Abstractions.Loadouts;
+using NexusMods.Abstractions.Loadouts.Files;
+using NexusMods.DataModel.Tests.Harness;
+
+namespace NexusMods.DataModel.Tests;
+
+public class ApplyServiceTests : ADataModelTest<ApplyServiceTests>
+{
+    private readonly IApplyService _applyService;
+    private readonly ILoadoutRegistry _loadoutRegistry;
+    
+    public ApplyServiceTests(IServiceProvider provider) : base(provider)
+    {
+        _applyService = provider.GetRequiredService<IApplyService>();
+        _loadoutRegistry = provider.GetRequiredService<ILoadoutRegistry>();
+    }
+    
+    [Fact]
+    public async Task CanApplyLoadout()
+    {
+        // Arrange
+        await AddMods(BaseList, Data7ZLzma2, "Mod1");
+        var loadout = BaseList.Value;
+        var gameFolder = BaseList.Value.Installation.LocationsRegister[LocationId.Game];
+        
+        gameFolder.Combine("rootFile.txt").FileExists.Should().BeFalse("loadout has not yet been applied");
+        
+        // Act
+        var result = await _applyService.Apply(loadout.LoadoutId);
+        
+        // Assert
+        gameFolder.Combine("rootFile.txt").FileExists.Should().BeTrue("loadout has been applied");
+        gameFolder.Combine("folder1/folder1file.txt").FileExists.Should().BeTrue("loadout has been applied");
+    }
+    
+    [Fact]
+    public async Task CanApplyAndIngestLoadout()
+    {
+        // Arrange
+        await AddMods(BaseList, Data7ZLzma2, "Mod1");
+        var loadout = BaseList.Value;
+        var gameFolder = BaseList.Value.Installation.LocationsRegister[LocationId.Game];
+        
+        gameFolder.Combine("rootFile.txt").FileExists.Should().BeFalse("loadout has not yet been applied");
+        
+        // Act
+        FileSystem.CreateFile(gameFolder.Combine("newFile.txt"));
+        var result = await _applyService.Apply(loadout.LoadoutId);
+        
+        // Assert
+        gameFolder.Combine("rootFile.txt").FileExists.Should().BeTrue("loadout has been applied");
+        gameFolder.Combine("folder1/folder1file.txt").FileExists.Should().BeTrue("loadout has been applied");
+        
+        var loadoutResult = _loadoutRegistry.Get(result.LoadoutId);
+        loadoutResult.Should().NotBeNull();
+        loadoutResult!.Mods.Values.SelectMany(mod=> mod.Files.Values).OfType<IToFile>()
+            .Should().Contain(file => file.To.EndsWith( "newFile.txt"));
+    }
+
+    [Fact]
+    public async Task CanIngestNewFiles()
+    {
+        // Arrange
+        BaseList.Value.Mods.Should().HaveCount(1);
+        var gameFolder = BaseList.Value.Installation.LocationsRegister[LocationId.Game];
+        BaseList.Value.Mods.Values.SelectMany(mod=> mod.Files.Values).OfType<IToFile>()
+            .Should().NotContain(file => file.To.EndsWith( "newDiskFile.txt"));
+        
+        // Act
+        FileSystem.CreateFile(gameFolder.Combine("newDiskFile.txt"));
+        var result = await _applyService.Ingest(BaseList.Value.Installation);
+        
+        // Assert
+        var loadout = _loadoutRegistry.Get(result.LoadoutId);
+        loadout.Should().NotBeNull();
+        loadout!.Mods.Values.SelectMany(mod=> mod.Files.Values).OfType<IToFile>()
+            .Should().Contain(file => file.To.EndsWith( "newDiskFile.txt"));
+    }
+    
+    [Fact]
+    public async Task CanIngestDeletedFiles()
+    {
+        // Arrange
+        BaseList.Value.Mods.Should().HaveCount(1);
+        var gameFolder = BaseList.Value.Installation.LocationsRegister[LocationId.Game];
+        gameFolder.Combine("config.ini").FileExists.Should().BeTrue("base game file was not deleted yet");
+
+        // Act
+        FileSystem.DeleteFile(gameFolder.Combine("config.ini"));
+        gameFolder.Combine("config.ini").FileExists.Should().BeFalse("File was deleted");
+        var result = await _applyService.Ingest(BaseList.Value.Installation);
+        
+        // Assert
+        var loadout = _loadoutRegistry.Get(result.LoadoutId);
+        loadout.Should().NotBeNull();
+        loadout!.Mods.Values.SelectMany(mod=> mod.Files.Values).OfType<IToFile>()
+            .Should().NotContain(file => file.To.EndsWith( "config.ini"));
+    }
+}

--- a/tests/NexusMods.StandardGameLocators.TestHelpers/ListFilesTool.cs
+++ b/tests/NexusMods.StandardGameLocators.TestHelpers/ListFilesTool.cs
@@ -22,5 +22,5 @@ public class ListFilesTool : ITool
     }
 
     public string Name => "List Files";
-    public static readonly GamePath GeneratedFilePath = new(LocationId.Game, "files.txt");
+    public static readonly GamePath GeneratedFilePath = new(LocationId.Game, "toolFiles.txt");
 }


### PR DESCRIPTION
- fixes #986
- fixes #987
- fixes #984
- fixes #983
- Handles parts of #995

### Recap:
- Apply button now correctly shows up when current loadout revision != last applied revision
- Apply button now shows Activate text when you need to switch loadouts
- Apply button now ingests outside changes and merges uncommitted changes on top
- Launch button no longer applies, but still merges at the end of the run
- Last applied revision is now correctly saved and restored
- Bunch of Apply button styling fixes and improvements

## Warning!
This requires nuking the Datamodel. App will crash and burn otherwise as its missing lastAppliedRevision