### PR TITLE
Override `GetVersion` for Stardew Valley

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,9 +3,9 @@
     <!-- Custom Packages -->
     <PackageVersion Include="LinqGen" Version="0.3.1" />
     <PackageVersion Include="NexusMods.Hashing.xxHash64" Version="2.0.0" />
-    <PackageVersion Include="NexusMods.Paths" Version="0.7.0" />
+      <PackageVersion Include="NexusMods.Paths" Version="0.8.0" />
+      <PackageVersion Include="NexusMods.Paths.TestingHelpers" Version="0.8.0" />
     <PackageVersion Include="NexusMods.Archives.Nx" Version="0.3.8" />
-    <PackageVersion Include="NexusMods.Paths.TestingHelpers" Version="0.7.0" />
     <PackageVersion Include="NexusMods.ProxyConsole.Abstractions" Version="0.6.0" />
     <PackageVersion Include="NexusMods.SingleProcess" Version="0.6.0" />
     <PackageVersion Include="NexusMods.Telemetry.OpenTelemetry" Version="1.0.0" />

--- a/src/Games/NexusMods.Games.StardewValley/StardewValley.cs
+++ b/src/Games/NexusMods.Games.StardewValley/StardewValley.cs
@@ -52,7 +52,13 @@ public class StardewValley : AGame, ISteamGame, IGogGame, IXboxGame
     {
         try
         {
-            var fileInfo = new GamePath(LocationId.Game, "Stardew Valley.dll").Combine(installation.Path).FileInfo;
+            var path = _osInformation.MatchPlatform(
+                onWindows: () => "Stardew Valley.dll",
+                onLinux: () => "Stardew Valley.dll",
+                onOSX: () => "Contents/MacOS/Stardew Valley.dll"
+            );
+
+            var fileInfo = installation.Path.Combine(path).FileInfo;
             return fileInfo.GetFileVersionInfo().FileVersion;
         }
         catch (Exception)

--- a/src/Games/NexusMods.Games.StardewValley/StardewValley.cs
+++ b/src/Games/NexusMods.Games.StardewValley/StardewValley.cs
@@ -48,6 +48,19 @@ public class StardewValley : AGame, ISteamGame, IGogGame, IXboxGame
         );
     }
 
+    protected override Version GetVersion(GameLocatorResult installation)
+    {
+        try
+        {
+            var fileInfo = new GamePath(LocationId.Game, "Stardew Valley.dll").Combine(installation.Path).FileInfo;
+            return fileInfo.GetFileVersionInfo().FileVersion;
+        }
+        catch (Exception)
+        {
+            return new Version(0, 0, 0, 0);
+        }
+    }
+
     protected override IReadOnlyDictionary<LocationId, AbsolutePath> GetLocations(IFileSystem fileSystem,
         GameLocatorResult installation)
     {


### PR DESCRIPTION
Also updates our path libraries to 0.8.

Fixes #1029.