### PR TITLE
Reorder grid states

### DIFF
--- a/src/NexusMods.App.UI/WorkspaceSystem/GridUtils.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/GridUtils.cs
@@ -66,8 +66,8 @@ public static class GridUtils
         int maxColumns,
         int maxRows)
     {
-        var res1 = new List<WorkspaceGridState>();
-        var res2 = new List<WorkspaceGridState>();
+        var step1Res = new List<WorkspaceGridState>();
+        var step2Res = new List<WorkspaceGridState>();
 
         var (columnCount, maxRowCount) = currentState.CountColumns();
 
@@ -87,8 +87,8 @@ public static class GridUtils
             {
                 foreach (var panelToSplit in rows)
                 {
-                    res1.Add(SplitPanelInHalf(currentState, panelToSplit, splitVertically: false, inverse: false));
-                    res1.Add(SplitPanelInHalf(currentState, panelToSplit, splitVertically: false, inverse: true));
+                    step1Res.Add(SplitPanelInHalf(currentState, panelToSplit, splitVertically: false, inverse: false));
+                    step1Res.Add(SplitPanelInHalf(currentState, panelToSplit, splitVertically: false, inverse: true));
                 }
             }
 
@@ -97,10 +97,14 @@ public static class GridUtils
             // iterations are required (that's what CountColumns does).
             if (rows.Length > 1 && columnCount != maxColumns)
             {
-                res1.Add(AddColumn(currentState, column.Info, rows, inverse: false));
-                res1.Add(AddColumn(currentState, column.Info, rows, inverse: true));
+                step1Res.Add(AddColumn(currentState, column.Info, rows, inverse: false));
+                step1Res.Add(AddColumn(currentState, column.Info, rows, inverse: true));
             }
         }
+
+        // NOTE(erri120): Reverses the order of edits. This is a design decision
+        // so that the first edits are for the last columns.
+        step1Res = step1Res.Chunk(size: 2).Reverse().SelectMany(x => x).ToList();
 
         var seenColumnSlice = seenColumns[..columnCount];
 
@@ -122,8 +126,8 @@ public static class GridUtils
 
                 if (columnCount == 1)
                 {
-                    res2.Add(SplitPanelInHalf(currentState, panelToSplit, splitVertically: true, inverse: false));
-                    res2.Add(SplitPanelInHalf(currentState, panelToSplit, splitVertically: true, inverse: true));
+                    step2Res.Add(SplitPanelInHalf(currentState, panelToSplit, splitVertically: true, inverse: false));
+                    step2Res.Add(SplitPanelInHalf(currentState, panelToSplit, splitVertically: true, inverse: true));
                     continue;
                 }
 
@@ -136,15 +140,15 @@ public static class GridUtils
                         var updatedLogicalBounds = new Rect(rect.X, rect.Y, seenColumn.X, rect.Height);
                         var newPanelLogicalBounds = new Rect(seenColumn.X, rect.Y, seenColumn.Width, rect.Height);
 
-                        res2.Add(SplitPanelWithBounds(currentState, panelToSplit,updatedLogicalBounds,newPanelLogicalBounds, inverse: false));
-                        res2.Add(SplitPanelWithBounds(currentState, panelToSplit, updatedLogicalBounds, newPanelLogicalBounds, inverse: true));
+                        step2Res.Add(SplitPanelWithBounds(currentState, panelToSplit,updatedLogicalBounds,newPanelLogicalBounds, inverse: false));
+                        step2Res.Add(SplitPanelWithBounds(currentState, panelToSplit, updatedLogicalBounds, newPanelLogicalBounds, inverse: true));
                     }
                 }
             }
         }
 
-        res2.Add(res1);
-        return res2;
+        step2Res.Add(step1Res);
+        return step2Res;
     }
 
     private static List<WorkspaceGridState> GetPossibleStatesForVertical(
@@ -152,8 +156,8 @@ public static class GridUtils
         int maxColumns,
         int maxRows)
     {
-        var res1 = new List<WorkspaceGridState>();
-        var res2 = new List<WorkspaceGridState>();
+        var step1Res = new List<WorkspaceGridState>();
+        var step2Res = new List<WorkspaceGridState>();
 
         var (rowCount, maxColumnCount) = currentState.CountRows();
 
@@ -172,8 +176,8 @@ public static class GridUtils
             {
                 foreach (var panelToSplit in columns)
                 {
-                    res1.Add(SplitPanelInHalf(currentState, panelToSplit, splitVertically: true, inverse: false));
-                    res1.Add(SplitPanelInHalf(currentState, panelToSplit, splitVertically: true, inverse: true));
+                    step1Res.Add(SplitPanelInHalf(currentState, panelToSplit, splitVertically: true, inverse: false));
+                    step1Res.Add(SplitPanelInHalf(currentState, panelToSplit, splitVertically: true, inverse: true));
                 }
             }
 
@@ -182,10 +186,14 @@ public static class GridUtils
             // iterations are required (that's what CountRows does).
             if (columns.Length > 1 && rowCount != maxRows)
             {
-                res1.Add(AddRow(currentState, row.Info, columns, inverse: false));
-                res1.Add(AddRow(currentState, row.Info, columns, inverse: true));
+                step1Res.Add(AddRow(currentState, row.Info, columns, inverse: false));
+                step1Res.Add(AddRow(currentState, row.Info, columns, inverse: true));
             }
         }
+
+        // NOTE(erri120): Reverses the order of edits. This is a design decision
+        // so that the first edits are for the last rows.
+        step1Res = step1Res.Chunk(size: 2).Reverse().SelectMany(x => x).ToList();
 
         var seenRowSlice = seenRows[..rowCount];
 
@@ -207,8 +215,8 @@ public static class GridUtils
 
                 if (rowCount == 1)
                 {
-                    res2.Add(SplitPanelInHalf(currentState, panelToSplit, splitVertically: false, inverse: false));
-                    res2.Add(SplitPanelInHalf(currentState, panelToSplit, splitVertically: false, inverse: true));
+                    step2Res.Add(SplitPanelInHalf(currentState, panelToSplit, splitVertically: false, inverse: false));
+                    step2Res.Add(SplitPanelInHalf(currentState, panelToSplit, splitVertically: false, inverse: true));
                 }
 
                 foreach (var seenRow in seenRowSlice)
@@ -220,15 +228,15 @@ public static class GridUtils
                         var updatedLogicalBounds = new Rect(rect.X, rect.Y, rect.Width, seenRow.Y);
                         var newPanelLogicalBounds = new Rect(rect.X, seenRow.Y, rect.Width, seenRow.Height);
 
-                        res2.Add(SplitPanelWithBounds(currentState, panelToSplit,updatedLogicalBounds,newPanelLogicalBounds, inverse: false));
-                        res2.Add(SplitPanelWithBounds(currentState, panelToSplit, updatedLogicalBounds, newPanelLogicalBounds, inverse: true));
+                        step2Res.Add(SplitPanelWithBounds(currentState, panelToSplit,updatedLogicalBounds,newPanelLogicalBounds, inverse: false));
+                        step2Res.Add(SplitPanelWithBounds(currentState, panelToSplit, updatedLogicalBounds, newPanelLogicalBounds, inverse: true));
                     }
                 }
             }
         }
 
-        res2.Add(res1);
-        return res2;
+        step2Res.Add(step1Res);
+        return step2Res;
     }
 
     private static WorkspaceGridState AddRow(

--- a/src/NexusMods.App.UI/WorkspaceSystem/GridUtils.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/GridUtils.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Avalonia;
+using DynamicData;
 
 namespace NexusMods.App.UI.WorkspaceSystem;
 
@@ -65,7 +66,8 @@ public static class GridUtils
         int maxColumns,
         int maxRows)
     {
-        var res = new List<WorkspaceGridState>();
+        var res1 = new List<WorkspaceGridState>();
+        var res2 = new List<WorkspaceGridState>();
 
         var (columnCount, maxRowCount) = currentState.CountColumns();
 
@@ -85,8 +87,8 @@ public static class GridUtils
             {
                 foreach (var panelToSplit in rows)
                 {
-                    res.Add(SplitPanelInHalf(currentState, panelToSplit, splitVertically: false, inverse: false));
-                    res.Add(SplitPanelInHalf(currentState, panelToSplit, splitVertically: false, inverse: true));
+                    res1.Add(SplitPanelInHalf(currentState, panelToSplit, splitVertically: false, inverse: false));
+                    res1.Add(SplitPanelInHalf(currentState, panelToSplit, splitVertically: false, inverse: true));
                 }
             }
 
@@ -95,8 +97,8 @@ public static class GridUtils
             // iterations are required (that's what CountColumns does).
             if (rows.Length > 1 && columnCount != maxColumns)
             {
-                res.Add(AddColumn(currentState, column.Info, rows, inverse: false));
-                res.Add(AddColumn(currentState, column.Info, rows, inverse: true));
+                res1.Add(AddColumn(currentState, column.Info, rows, inverse: false));
+                res1.Add(AddColumn(currentState, column.Info, rows, inverse: true));
             }
         }
 
@@ -120,8 +122,8 @@ public static class GridUtils
 
                 if (columnCount == 1)
                 {
-                    res.Add(SplitPanelInHalf(currentState, panelToSplit, splitVertically: true, inverse: false));
-                    res.Add(SplitPanelInHalf(currentState, panelToSplit, splitVertically: true, inverse: true));
+                    res2.Add(SplitPanelInHalf(currentState, panelToSplit, splitVertically: true, inverse: false));
+                    res2.Add(SplitPanelInHalf(currentState, panelToSplit, splitVertically: true, inverse: true));
                     continue;
                 }
 
@@ -134,14 +136,15 @@ public static class GridUtils
                         var updatedLogicalBounds = new Rect(rect.X, rect.Y, seenColumn.X, rect.Height);
                         var newPanelLogicalBounds = new Rect(seenColumn.X, rect.Y, seenColumn.Width, rect.Height);
 
-                        res.Add(SplitPanelWithBounds(currentState, panelToSplit,updatedLogicalBounds,newPanelLogicalBounds, inverse: false));
-                        res.Add(SplitPanelWithBounds(currentState, panelToSplit, updatedLogicalBounds, newPanelLogicalBounds, inverse: true));
+                        res2.Add(SplitPanelWithBounds(currentState, panelToSplit,updatedLogicalBounds,newPanelLogicalBounds, inverse: false));
+                        res2.Add(SplitPanelWithBounds(currentState, panelToSplit, updatedLogicalBounds, newPanelLogicalBounds, inverse: true));
                     }
                 }
             }
         }
 
-        return res;
+        res2.Add(res1);
+        return res2;
     }
 
     private static List<WorkspaceGridState> GetPossibleStatesForVertical(
@@ -149,7 +152,8 @@ public static class GridUtils
         int maxColumns,
         int maxRows)
     {
-        var res = new List<WorkspaceGridState>();
+        var res1 = new List<WorkspaceGridState>();
+        var res2 = new List<WorkspaceGridState>();
 
         var (rowCount, maxColumnCount) = currentState.CountRows();
 
@@ -168,8 +172,8 @@ public static class GridUtils
             {
                 foreach (var panelToSplit in columns)
                 {
-                    res.Add(SplitPanelInHalf(currentState, panelToSplit, splitVertically: true, inverse: false));
-                    res.Add(SplitPanelInHalf(currentState, panelToSplit, splitVertically: true, inverse: true));
+                    res1.Add(SplitPanelInHalf(currentState, panelToSplit, splitVertically: true, inverse: false));
+                    res1.Add(SplitPanelInHalf(currentState, panelToSplit, splitVertically: true, inverse: true));
                 }
             }
 
@@ -178,8 +182,8 @@ public static class GridUtils
             // iterations are required (that's what CountRows does).
             if (columns.Length > 1 && rowCount != maxRows)
             {
-                res.Add(AddRow(currentState, row.Info, columns, inverse: false));
-                res.Add(AddRow(currentState, row.Info, columns, inverse: true));
+                res1.Add(AddRow(currentState, row.Info, columns, inverse: false));
+                res1.Add(AddRow(currentState, row.Info, columns, inverse: true));
             }
         }
 
@@ -203,8 +207,8 @@ public static class GridUtils
 
                 if (rowCount == 1)
                 {
-                    res.Add(SplitPanelInHalf(currentState, panelToSplit, splitVertically: false, inverse: false));
-                    res.Add(SplitPanelInHalf(currentState, panelToSplit, splitVertically: false, inverse: true));
+                    res2.Add(SplitPanelInHalf(currentState, panelToSplit, splitVertically: false, inverse: false));
+                    res2.Add(SplitPanelInHalf(currentState, panelToSplit, splitVertically: false, inverse: true));
                 }
 
                 foreach (var seenRow in seenRowSlice)
@@ -216,14 +220,15 @@ public static class GridUtils
                         var updatedLogicalBounds = new Rect(rect.X, rect.Y, rect.Width, seenRow.Y);
                         var newPanelLogicalBounds = new Rect(rect.X, seenRow.Y, rect.Width, seenRow.Height);
 
-                        res.Add(SplitPanelWithBounds(currentState, panelToSplit,updatedLogicalBounds,newPanelLogicalBounds, inverse: false));
-                        res.Add(SplitPanelWithBounds(currentState, panelToSplit, updatedLogicalBounds, newPanelLogicalBounds, inverse: true));
+                        res2.Add(SplitPanelWithBounds(currentState, panelToSplit,updatedLogicalBounds,newPanelLogicalBounds, inverse: false));
+                        res2.Add(SplitPanelWithBounds(currentState, panelToSplit, updatedLogicalBounds, newPanelLogicalBounds, inverse: true));
                     }
                 }
             }
         }
 
-        return res;
+        res2.Add(res1);
+        return res2;
     }
 
     private static WorkspaceGridState AddRow(

--- a/tests/NexusMods.UI.Tests/WorkspaceSystem/GridUtilsTests/GetPossibleStatesTests.cs
+++ b/tests/NexusMods.UI.Tests/WorkspaceSystem/GridUtilsTests/GetPossibleStatesTests.cs
@@ -181,18 +181,6 @@ public partial class GridUtilsTests
                 {
                     CreateState(
                         isHorizontal: false,
-                        new PanelGridState(firstPanelId, new Rect(0, 0, 0.5, height)),
-                        new PanelGridState(secondPanelId, new Rect(0, height, 1, 1 - height)),
-                        new PanelGridState(newPanelId, new Rect(0.5, 0, 0.5, height))
-                    ),
-                    CreateState(
-                        isHorizontal: false,
-                        new PanelGridState(newPanelId, new Rect(0, 0, 0.5, height)),
-                        new PanelGridState(secondPanelId, new Rect(0, height, 1, 1 - height)),
-                        new PanelGridState(firstPanelId, new Rect(0.5, 0, 0.5, height))
-                    ),
-                    CreateState(
-                        isHorizontal: false,
                         new PanelGridState(firstPanelId, new Rect(0, 0, 1, height)),
                         new PanelGridState(secondPanelId, new Rect(0,height, 0.5, 1 - height)),
                         new PanelGridState(newPanelId, new Rect(0.5,height, 0.5, 1 - height))
@@ -202,6 +190,18 @@ public partial class GridUtilsTests
                         new PanelGridState(firstPanelId, new Rect(0, 0, 1, height)),
                         new PanelGridState(newPanelId, new Rect(0,height, 0.5, 1 - height)),
                         new PanelGridState(secondPanelId, new Rect(0.5,height, 0.5, 1 - height))
+                    ),
+                    CreateState(
+                        isHorizontal: false,
+                        new PanelGridState(firstPanelId, new Rect(0, 0, 0.5, height)),
+                        new PanelGridState(secondPanelId, new Rect(0, height, 1, 1 - height)),
+                        new PanelGridState(newPanelId, new Rect(0.5, 0, 0.5, height))
+                    ),
+                    CreateState(
+                        isHorizontal: false,
+                        new PanelGridState(newPanelId, new Rect(0, 0, 0.5, height)),
+                        new PanelGridState(secondPanelId, new Rect(0, height, 1, 1 - height)),
+                        new PanelGridState(firstPanelId, new Rect(0.5, 0, 0.5, height))
                     ),
                 }
             };
@@ -366,18 +366,6 @@ public partial class GridUtilsTests
                 {
                     CreateState(
                         isHorizontal: true,
-                        new PanelGridState(firstPanelId, new Rect(0, 0, width, 0.5)),
-                        new PanelGridState(newPanelId, new Rect(0, 0.5, width, 0.5)),
-                        new PanelGridState(secondPanelId, new Rect(width, 0, 1 - width, 1))
-                    ),
-                    CreateState(
-                        isHorizontal: true,
-                        new PanelGridState(newPanelId, new Rect(0, 0, width, 0.5)),
-                        new PanelGridState(firstPanelId, new Rect(0, 0.5, width, 0.5)),
-                        new PanelGridState(secondPanelId, new Rect(width, 0, 1 - width, 1))
-                    ),
-                    CreateState(
-                        isHorizontal: true,
                         new PanelGridState(firstPanelId, new Rect(0, 0, width, 1)),
                         new PanelGridState(secondPanelId, new Rect(width, 0, 1 - width, 0.5)),
                         new PanelGridState(newPanelId, new Rect(width, 0.5, 1 - width, 0.5))
@@ -387,6 +375,18 @@ public partial class GridUtilsTests
                         new PanelGridState(firstPanelId, new Rect(0, 0, width, 1)),
                         new PanelGridState(newPanelId, new Rect(width, 0, 1 - width, 0.5)),
                         new PanelGridState(secondPanelId, new Rect(width, 0.5, 1 - width, 0.5))
+                    ),
+                    CreateState(
+                        isHorizontal: true,
+                        new PanelGridState(firstPanelId, new Rect(0, 0, width, 0.5)),
+                        new PanelGridState(newPanelId, new Rect(0, 0.5, width, 0.5)),
+                        new PanelGridState(secondPanelId, new Rect(width, 0, 1 - width, 1))
+                    ),
+                    CreateState(
+                        isHorizontal: true,
+                        new PanelGridState(newPanelId, new Rect(0, 0, width, 0.5)),
+                        new PanelGridState(firstPanelId, new Rect(0, 0.5, width, 0.5)),
+                        new PanelGridState(secondPanelId, new Rect(width, 0, 1 - width, 1))
                     ),
                 }
             };

--- a/tests/NexusMods.UI.Tests/WorkspaceSystem/GridUtilsTests/GetPossibleStatesTests.cs
+++ b/tests/NexusMods.UI.Tests/WorkspaceSystem/GridUtilsTests/GetPossibleStatesTests.cs
@@ -79,16 +79,6 @@ public partial class GridUtilsTests
             {
                 CreateState(
                     isHorizontal: false,
-                    new PanelGridState(firstPanelId, new Rect(0, 0, 0.5, 1)),
-                    new PanelGridState(newPanelId, new Rect(0.5, 0, 0.5, 1))
-                ),
-                CreateState(
-                    isHorizontal: false,
-                    new PanelGridState(newPanelId, new Rect(0, 0, 0.5, 1)),
-                    new PanelGridState(firstPanelId, new Rect(0.5, 0, 0.5, 1))
-                ),
-                CreateState(
-                    isHorizontal: false,
                     new PanelGridState(firstPanelId, new Rect(0, 0, 1, 0.5)),
                     new PanelGridState(newPanelId, new Rect(0, 0.5, 1, 0.5))
                 ),
@@ -96,6 +86,16 @@ public partial class GridUtilsTests
                     isHorizontal: false,
                     new PanelGridState(newPanelId, new Rect(0, 0, 1, 0.5)),
                     new PanelGridState(firstPanelId, new Rect(0, 0.5, 1, 0.5))
+                ),
+                CreateState(
+                    isHorizontal: false,
+                    new PanelGridState(firstPanelId, new Rect(0, 0, 0.5, 1)),
+                    new PanelGridState(newPanelId, new Rect(0.5, 0, 0.5, 1))
+                ),
+                CreateState(
+                    isHorizontal: false,
+                    new PanelGridState(newPanelId, new Rect(0, 0, 0.5, 1)),
+                    new PanelGridState(firstPanelId, new Rect(0.5, 0, 0.5, 1))
                 ),
             }
         };
@@ -123,18 +123,6 @@ public partial class GridUtilsTests
                 CreateState(
                     isHorizontal: false,
                     new PanelGridState(firstPanelId, new Rect(0, 0, 0.5, 0.5)),
-                    new PanelGridState(secondPanelId, new Rect(0.5, 0, 0.5, 0.5)),
-                    new PanelGridState(newPanelId, new Rect(0, 0.5, 1.0, 0.5))
-                ),
-                CreateState(
-                    isHorizontal: false,
-                    new PanelGridState(newPanelId, new Rect(0, 0, 1.0, 0.5)),
-                    new PanelGridState(firstPanelId, new Rect(0, 0.5, 0.5, 0.5)),
-                    new PanelGridState(secondPanelId, new Rect(0.5, 0.5, 0.5, 0.5))
-                ),
-                CreateState(
-                    isHorizontal: false,
-                    new PanelGridState(firstPanelId, new Rect(0, 0, 0.5, 0.5)),
                     new PanelGridState(newPanelId, new Rect(0, 0.5, 0.5, 0.5)),
                     new PanelGridState(secondPanelId, new Rect(0.5, 0, 1 - 0.5, 1))
                 ),
@@ -155,6 +143,18 @@ public partial class GridUtilsTests
                     new PanelGridState(firstPanelId, new Rect(0, 0, 0.5, 1)),
                     new PanelGridState(newPanelId, new Rect(0.5, 0, 1 - 0.5, 0.5)),
                     new PanelGridState(secondPanelId, new Rect(0.5, 0.5, 1 - 0.5, 0.5))
+                ),
+                CreateState(
+                    isHorizontal: false,
+                    new PanelGridState(firstPanelId, new Rect(0, 0, 0.5, 0.5)),
+                    new PanelGridState(secondPanelId, new Rect(0.5, 0, 0.5, 0.5)),
+                    new PanelGridState(newPanelId, new Rect(0, 0.5, 1.0, 0.5))
+                ),
+                CreateState(
+                    isHorizontal: false,
+                    new PanelGridState(newPanelId, new Rect(0, 0, 1.0, 0.5)),
+                    new PanelGridState(firstPanelId, new Rect(0, 0.5, 0.5, 0.5)),
+                    new PanelGridState(secondPanelId, new Rect(0.5, 0.5, 0.5, 0.5))
                 ),
             }
         };
@@ -323,16 +323,6 @@ public partial class GridUtilsTests
             {
                 CreateState(
                     isHorizontal: true,
-                    new PanelGridState(firstPanelId, new Rect(0, 0, 1, 0.5)),
-                    new PanelGridState(newPanelId, new Rect(0, 0.5, 1, 0.5))
-                ),
-                CreateState(
-                    isHorizontal: true,
-                    new PanelGridState(newPanelId, new Rect(0, 0, 1, 0.5)),
-                    new PanelGridState(firstPanelId, new Rect(0, 0.5, 1, 0.5))
-                ),
-                CreateState(
-                    isHorizontal: true,
                     new PanelGridState(firstPanelId, new Rect(0, 0, 0.5, 1)),
                     new PanelGridState(newPanelId, new Rect(0.5, 0, 0.5, 1))
                 ),
@@ -340,6 +330,16 @@ public partial class GridUtilsTests
                     isHorizontal: true,
                     new PanelGridState(newPanelId, new Rect(0, 0, 0.5, 1)),
                     new PanelGridState(firstPanelId, new Rect(0.5, 0, 0.5, 1))
+                ),
+                CreateState(
+                    isHorizontal: true,
+                    new PanelGridState(firstPanelId, new Rect(0, 0, 1, 0.5)),
+                    new PanelGridState(newPanelId, new Rect(0, 0.5, 1, 0.5))
+                ),
+                CreateState(
+                    isHorizontal: true,
+                    new PanelGridState(newPanelId, new Rect(0, 0, 1, 0.5)),
+                    new PanelGridState(firstPanelId, new Rect(0, 0.5, 1, 0.5))
                 ),
             }
         };
@@ -415,18 +415,6 @@ public partial class GridUtilsTests
                 CreateState(
                     isHorizontal: true,
                     new PanelGridState(firstPanelId, new Rect(0, 0, 0.5, 0.5)),
-                    new PanelGridState(secondPanelId, new Rect(0, 0.5, 0.5, 0.5)),
-                    new PanelGridState(newPanelId, new Rect(0.5, 0, 0.5, 1))
-                ),
-                CreateState(
-                    isHorizontal: true,
-                    new PanelGridState(newPanelId, new Rect(0, 0, 0.5, 1)),
-                    new PanelGridState(firstPanelId, new Rect(0.5, 0, 0.5, 0.5)),
-                    new PanelGridState(secondPanelId, new Rect(0.5, 0.5, 0.5, 0.5))
-                ),
-                CreateState(
-                    isHorizontal: true,
-                    new PanelGridState(firstPanelId, new Rect(0, 0, 0.5, 0.5)),
                     new PanelGridState(secondPanelId, new Rect(0, 0.5, 1, 0.5)),
                     new PanelGridState(newPanelId, new Rect(0.5, 0, 0.5, 0.5))
                 ),
@@ -446,6 +434,18 @@ public partial class GridUtilsTests
                     isHorizontal: true,
                     new PanelGridState(firstPanelId, new Rect(0, 0, 1, 0.5)),
                     new PanelGridState(newPanelId, new Rect(0, 0.5, 0.5, 0.5)),
+                    new PanelGridState(secondPanelId, new Rect(0.5, 0.5, 0.5, 0.5))
+                ),
+                CreateState(
+                    isHorizontal: true,
+                    new PanelGridState(firstPanelId, new Rect(0, 0, 0.5, 0.5)),
+                    new PanelGridState(secondPanelId, new Rect(0, 0.5, 0.5, 0.5)),
+                    new PanelGridState(newPanelId, new Rect(0.5, 0, 0.5, 1))
+                ),
+                CreateState(
+                    isHorizontal: true,
+                    new PanelGridState(newPanelId, new Rect(0, 0, 0.5, 1)),
+                    new PanelGridState(firstPanelId, new Rect(0.5, 0, 0.5, 0.5)),
                     new PanelGridState(secondPanelId, new Rect(0.5, 0.5, 0.5, 0.5))
                 ),
             }


### PR DESCRIPTION
Part of #906.

Fixes the order in which the possible grid states are generated. Now, we prioritize and put the primary action first, rather than last, depending on the orientation.