### PR TITLE
Prototype: Eliminate TreeNodeVM

### DIFF
--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Left/ModContent/ModContentViewModel.cs
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Left/ModContent/ModContentViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using DynamicData;
 using NexusMods.Abstractions.FileStore.Trees;
 using NexusMods.App.UI.Helpers;
+using NexusMods.App.UI.Helpers.TreeDataGrid;
 using NexusMods.Paths;
 using NexusMods.Paths.Trees;
 using NexusMods.Paths.Trees.Traits;

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Left/ModContent/TreeEntry/IModContentTreeEntryViewModel.cs
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Left/ModContent/TreeEntry/IModContentTreeEntryViewModel.cs
@@ -2,6 +2,7 @@
 using DynamicData.Kernel;
 using NexusMods.Abstractions.GameLocators;
 using NexusMods.App.UI.Helpers;
+using NexusMods.App.UI.Helpers.TreeDataGrid;
 using NexusMods.Games.AdvancedInstaller.UI.Preview;
 using NexusMods.Paths;
 using ReactiveUI;

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/Preview/PreviewViewModel.cs
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/Preview/PreviewViewModel.cs
@@ -2,6 +2,7 @@
 using DynamicData;
 using NexusMods.Abstractions.GameLocators;
 using NexusMods.App.UI.Helpers;
+using NexusMods.App.UI.Helpers.TreeDataGrid;
 
 namespace NexusMods.Games.AdvancedInstaller.UI.Preview;
 

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/Preview/TreeEntry/IPreviewTreeEntryViewModel.cs
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/Preview/TreeEntry/IPreviewTreeEntryViewModel.cs
@@ -3,6 +3,7 @@ using System.Reactive;
 using DynamicData.Kernel;
 using NexusMods.Abstractions.GameLocators;
 using NexusMods.App.UI.Helpers;
+using NexusMods.App.UI.Helpers.TreeDataGrid;
 using NexusMods.Games.AdvancedInstaller.UI.ModContent;
 using ReactiveUI;
 

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/SelectLocation/SelectLocationViewModel.cs
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/SelectLocation/SelectLocationViewModel.cs
@@ -4,6 +4,7 @@ using NexusMods.Abstractions.GameLocators;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.App.UI.Extensions;
 using NexusMods.App.UI.Helpers;
+using NexusMods.App.UI.Helpers.TreeDataGrid;
 using NexusMods.Games.AdvancedInstaller.UI.Resources;
 using NexusMods.Paths;
 

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/SelectLocation/TreeEntry/ISelectableTreeEntryViewModel.cs
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/SelectLocation/TreeEntry/ISelectableTreeEntryViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reactive;
 using NexusMods.Abstractions.GameLocators;
 using NexusMods.App.UI.Helpers;
+using NexusMods.App.UI.Helpers.TreeDataGrid;
 using NexusMods.Paths;
 using ReactiveUI;
 

--- a/src/NexusMods.App.UI/Controls/ModInfo/ModFiles/IModFilesViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/ModInfo/ModFiles/IModFilesViewModel.cs
@@ -5,7 +5,6 @@ using NexusMods.Abstractions.Loadouts.Mods;
 using NexusMods.App.UI.Controls.Trees.Files;
 
 namespace NexusMods.App.UI.Controls.ModInfo.ModFiles;
-using ModFileNode = TreeNodeVM<IFileTreeNodeViewModel, GamePath>;
 
 public interface IModFilesViewModel : IViewModelInterface
 {
@@ -22,7 +21,7 @@ public interface IModFilesViewModel : IViewModelInterface
     /// <summary>
     ///     All items to be displayed.
     /// </summary>
-    ReadOnlyObservableCollection<ModFileNode> Items { get; }
+    ReadOnlyObservableCollection<IFileTreeNodeViewModel> Items { get; }
 
     void Initialize(LoadoutId loadoutId, ModId modId) { }
 }

--- a/src/NexusMods.App.UI/Controls/ModInfo/ModFiles/ModFilesDesignViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/ModInfo/ModFiles/ModFilesDesignViewModel.cs
@@ -6,17 +6,16 @@ using NexusMods.App.UI.Controls.Trees.Files;
 using NexusMods.Paths;
 
 namespace NexusMods.App.UI.Controls.ModInfo.ModFiles;
-using ModFileNode = TreeNodeVM<IFileTreeNodeViewModel, GamePath>;
 
 public class ModFilesDesignViewModel : AViewModel<IModFilesViewModel>,
     IModFilesViewModel
 {
-    private ReadOnlyObservableCollection<ModFileNode> _items;
+    private ReadOnlyObservableCollection<IFileTreeNodeViewModel> _items;
     private int _rootCount;
 
     public int RootCount => _rootCount;
     
-    public ReadOnlyObservableCollection<ModFileNode> Items => _items;
+    public ReadOnlyObservableCollection<IFileTreeNodeViewModel> Items => _items;
 
     private string? _primaryRootLocation;
     public string? PrimaryRootLocation => _primaryRootLocation;

--- a/src/NexusMods.App.UI/Controls/ModInfo/ModFiles/ModFilesView.axaml
+++ b/src/NexusMods.App.UI/Controls/ModInfo/ModFiles/ModFilesView.axaml
@@ -10,7 +10,8 @@
     xmlns:reactiveUi="http://reactiveui.net"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:resources="clr-namespace:NexusMods.App.UI.Resources"
-    xmlns:viewModFiles="clr-namespace:NexusMods.App.UI.Controls.ModInfo.ModFiles">
+    xmlns:viewModFiles="clr-namespace:NexusMods.App.UI.Controls.ModInfo.ModFiles"
+    xmlns:files="clr-namespace:NexusMods.App.UI.Controls.Trees.Files">
     <Design.DataContext>
         <!-- This ViewModel has a bool switch 'showMultipleRoots' to toggle a view which also has Saves -->
         <viewModFiles:ModFilesDesignViewModel AlwaysRootFolders="False" ShowMultipleRoots="False" />
@@ -64,7 +65,13 @@
         
         <TreeDataGrid Grid.Row="2" Classes="TreeWhiteCaret"
                       ShowColumnHeaders="True"
-                      x:Name="ModFilesTreeDataGrid" />
+                      x:Name="ModFilesTreeDataGrid" >
+            <TreeDataGrid.Resources>
+                <DataTemplate x:Key="CustomRow" DataType="{x:Type files:IFileTreeNodeViewModel}">
+                    <files:FileTreeNodeView DataContext="{CompiledBinding}" />
+                </DataTemplate>
+            </TreeDataGrid.Resources>
+        </TreeDataGrid>
     </Grid>
 </reactiveUi:ReactiveUserControl>
 

--- a/src/NexusMods.App.UI/Controls/ModInfo/ModFiles/ModFilesView.axaml.cs
+++ b/src/NexusMods.App.UI/Controls/ModInfo/ModFiles/ModFilesView.axaml.cs
@@ -13,7 +13,6 @@ using NexusMods.App.UI.Resources;
 using ReactiveUI;
 
 namespace NexusMods.App.UI.Controls.ModInfo.ModFiles;
-using ModFileNode = TreeNodeVM<IFileTreeNodeViewModel, GamePath>;
 
 public partial class ModFilesView : ReactiveUserControl<IModFilesViewModel>
 {
@@ -44,17 +43,17 @@ public partial class ModFilesView : ReactiveUserControl<IModFilesViewModel>
         MultiLocationCountText.Text = $"{ViewModel.RootCount}";
     }
 
-    private static HierarchicalTreeDataGridSource<ModFileNode> CreateTreeSource(
-        ReadOnlyObservableCollection<ModFileNode> treeRoots)
+    private static HierarchicalTreeDataGridSource<IFileTreeNodeViewModel> CreateTreeSource(
+        ReadOnlyObservableCollection<IFileTreeNodeViewModel> treeRoots)
     {
-        return new HierarchicalTreeDataGridSource<ModFileNode>(treeRoots)
+        return new HierarchicalTreeDataGridSource<IFileTreeNodeViewModel>(treeRoots)
         {
             Columns =
             {
-                new HierarchicalExpanderColumn<ModFileNode>(
-                    new TemplateColumn<ModFileNode>(
+                new HierarchicalExpanderColumn<IFileTreeNodeViewModel>(
+                    new TemplateColumn<IFileTreeNodeViewModel>(
                         Language.Helpers_GenerateHeader_NAME,
-                        new FuncDataTemplate<ModFileNode>((node, _) =>
+                        new FuncDataTemplate<IFileTreeNodeViewModel>((node, _) =>
                             {
                                 // This should never be null but can be during rapid resize, due to
                                 // virtualization shenanigans. Think this is a control bug, but well, gotta work with what we have.
@@ -63,7 +62,7 @@ public partial class ModFilesView : ReactiveUserControl<IModFilesViewModel>
                                     return new Control();
 
                                 var view = new FileTreeNodeView();
-                                view.DataContext = node.Item;
+                                view.DataContext = node;
                                 return view;
                             }
                         ),
@@ -74,15 +73,15 @@ public partial class ModFilesView : ReactiveUserControl<IModFilesViewModel>
                             CompareAscending = (x, y) =>
                             {
                                 if (x == null || y == null) return 0;
-                                var folderComparison = x.Item.IsFile.CompareTo(y!.Item.IsFile); 
-                                return folderComparison != 0 ? folderComparison : string.Compare(x.Item.Name, y!.Item.Name, StringComparison.OrdinalIgnoreCase);
+                                var folderComparison = x.IsFile.CompareTo(y.IsFile); 
+                                return folderComparison != 0 ? folderComparison : string.Compare(x.Name, y.Name, StringComparison.OrdinalIgnoreCase);
                             },
 
                             CompareDescending = (x, y) => 
                             {
                                 if (x == null || y == null) return 0;
-                                var folderComparison = x.Item.IsFile.CompareTo(y!.Item.IsFile); 
-                                return folderComparison != 0 ? folderComparison : string.Compare(y.Item.Name, x!.Item.Name, StringComparison.OrdinalIgnoreCase);
+                                var folderComparison = x.IsFile.CompareTo(y.IsFile); 
+                                return folderComparison != 0 ? folderComparison : string.Compare(y.Name, x.Name, StringComparison.OrdinalIgnoreCase);
                             },
                         }
                     ),
@@ -90,24 +89,24 @@ public partial class ModFilesView : ReactiveUserControl<IModFilesViewModel>
                     null,
                     node => node.IsExpanded),
                 
-                new TextColumn<ModFileNode,string?>(
+                new TextColumn<IFileTreeNodeViewModel,string?>(
                     Language.Helpers_GenerateHeader_SIZE,
-                    x => ByteSize.FromBytes(x.Item.FileSize).ToString(),
+                    x => ByteSize.FromBytes(x.FileSize).ToString(),
                     options: new()
                     {
                         // Compares if folder first, such that folders show first, then by file name.
                         CompareAscending = (x, y) => 
                         {
                             if (x == null || y == null) return 0;
-                            var folderComparison = x.Item.IsFile.CompareTo(y.Item.IsFile);
-                            return folderComparison != 0 ? folderComparison : x.Item.FileSize.CompareTo(y!.Item.FileSize);
+                            var folderComparison = x.IsFile.CompareTo(y.IsFile);
+                            return folderComparison != 0 ? folderComparison : x.FileSize.CompareTo(y.FileSize);
                         },
 
                         CompareDescending = (x, y) => 
                         {
                             if (x == null || y == null) return 0;
-                            var folderComparison = x.Item.IsFile.CompareTo(y.Item.IsFile);  
-                            return folderComparison != 0 ? folderComparison : y.Item.FileSize.CompareTo(x!.Item.FileSize);
+                            var folderComparison = x.IsFile.CompareTo(y.IsFile);  
+                            return folderComparison != 0 ? folderComparison : y.FileSize.CompareTo(x.FileSize);
                         },
                     },
                     // HACK(sewer): If I don't overwrite this, the column may be zero sized if put into certain containers, e.g. StackPanel

--- a/src/NexusMods.App.UI/Controls/ModInfo/ModFiles/ModFilesView.axaml.cs
+++ b/src/NexusMods.App.UI/Controls/ModInfo/ModFiles/ModFilesView.axaml.cs
@@ -53,19 +53,7 @@ public partial class ModFilesView : ReactiveUserControl<IModFilesViewModel>
                 new HierarchicalExpanderColumn<IFileTreeNodeViewModel>(
                     new TemplateColumn<IFileTreeNodeViewModel>(
                         Language.Helpers_GenerateHeader_NAME,
-                        new FuncDataTemplate<IFileTreeNodeViewModel>((node, _) =>
-                            {
-                                // This should never be null but can be during rapid resize, due to
-                                // virtualization shenanigans. Think this is a control bug, but well, gotta work with what we have.
-                                // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
-                                if (node == null)
-                                    return new Control();
-
-                                var view = new FileTreeNodeView();
-                                view.DataContext = node;
-                                return view;
-                            }
-                        ),
+                        "CustomRow",
                         width: new GridLength(1, GridUnitType.Star),
                         options: new()
                         {

--- a/src/NexusMods.App.UI/Controls/ModInfo/ModFiles/ModFilesView.axaml.cs
+++ b/src/NexusMods.App.UI/Controls/ModInfo/ModFiles/ModFilesView.axaml.cs
@@ -55,7 +55,7 @@ public partial class ModFilesView : ReactiveUserControl<IModFilesViewModel>
                         Language.Helpers_GenerateHeader_NAME,
                         "CustomRow",
                         width: new GridLength(1, GridUnitType.Star),
-                        options: new()
+                        options: new TemplateColumnOptions<IFileTreeNodeViewModel>
                         {
                             // Compares if folder first, such that folders show first, then by file name.
                             CompareAscending = (x, y) =>
@@ -80,7 +80,7 @@ public partial class ModFilesView : ReactiveUserControl<IModFilesViewModel>
                 new TextColumn<IFileTreeNodeViewModel,string?>(
                     Language.Helpers_GenerateHeader_SIZE,
                     x => ByteSize.FromBytes(x.FileSize).ToString(),
-                    options: new()
+                    options: new TextColumnOptions<IFileTreeNodeViewModel>
                     {
                         // Compares if folder first, such that folders show first, then by file name.
                         CompareAscending = (x, y) => 

--- a/src/NexusMods.App.UI/Controls/ModInfo/ModFiles/ModFilesViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/ModInfo/ModFiles/ModFilesViewModel.cs
@@ -10,7 +10,8 @@ using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Loadouts.Files;
 using NexusMods.Abstractions.Loadouts.Mods;
 using NexusMods.App.UI.Controls.Trees.Files;
-using ModFileNode = NexusMods.App.UI.TreeNodeVM<NexusMods.App.UI.Controls.Trees.Files.IFileTreeNodeViewModel, NexusMods.Abstractions.GameLocators.GamePath>;
+using NexusMods.App.UI.Helpers.TreeDataGrid;
+
 namespace NexusMods.App.UI.Controls.ModInfo.ModFiles;
 
 [UsedImplicitly]
@@ -18,18 +19,18 @@ public class ModFilesViewModel : AViewModel<IModFilesViewModel>, IModFilesViewMo
 {
     private readonly ILoadoutRegistry _registry;
     private readonly SourceCache<IFileTreeNodeViewModel, GamePath> _sourceCache;
-    private ReadOnlyObservableCollection<ModFileNode> _items;
+    private ReadOnlyObservableCollection<IFileTreeNodeViewModel> _items;
     private int _rootCount;
     private string? _primaryRootLocation;
 
-    public ReadOnlyObservableCollection<ModFileNode> Items => _items;
+    public ReadOnlyObservableCollection<IFileTreeNodeViewModel> Items => _items;
     public int RootCount => _rootCount;
     public string? PrimaryRootLocation => _primaryRootLocation;
 
     public ModFilesViewModel(ILoadoutRegistry registry, IFileStore fileStore)
     {
         _registry = registry;
-        _items = new ReadOnlyObservableCollection<ModFileNode>([]);
+        _items = new ReadOnlyObservableCollection<IFileTreeNodeViewModel>([]);
         _sourceCache = new SourceCache<IFileTreeNodeViewModel, GamePath>(x => x.Key);
     }
 
@@ -137,7 +138,7 @@ public class ModFilesViewModel : AViewModel<IModFilesViewModel>, IModFilesViewMo
         SourceCache<IFileTreeNodeViewModel, GamePath> cache, 
         Dictionary<LocationId, string> locations, 
         bool alwaysRoot, 
-        out ReadOnlyObservableCollection<ModFileNode> result,
+        out ReadOnlyObservableCollection<IFileTreeNodeViewModel> result,
         out int rootCount,
         out string? primaryRootLocation)
     {
@@ -168,7 +169,7 @@ public class ModFilesViewModel : AViewModel<IModFilesViewModel>, IModFilesViewMo
         
         cache.Connect()
             .TransformToTree(model => model.ParentKey)
-            .Transform(node => new ModFileNode(node))
+            .Transform(node => node.Item.Initialize(node))
             .Bind(out result)
             .Subscribe(); // force evaluation
     }

--- a/src/NexusMods.App.UI/Controls/Trees/Files/FileTreeNodeDesignViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/Trees/Files/FileTreeNodeDesignViewModel.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using JetBrains.Annotations;
 using NexusMods.Abstractions.GameLocators;
 using ReactiveUI.Fody.Helpers;
@@ -17,9 +18,11 @@ public class FileTreeNodeDesignViewModel : AViewModel<IFileTreeNodeViewModel>, I
     public bool IsFile { get; }
     public string Name { get; }
     public ulong FileSize { get; }
-    public GamePath Key { get; }
+    public GamePath Key { get; set; }
     public GamePath ParentKey { get; }
     public bool IsExpanded { get; set; }
+    public ReadOnlyObservableCollection<IFileTreeNodeViewModel>? Children { get; set; }
+    public IFileTreeNodeViewModel? Parent { get; set; }
     
     public FileTreeNodeDesignViewModel() : this(true, new GamePath(LocationId.Game, ""), "Design Folder Name")
     {

--- a/src/NexusMods.App.UI/Controls/Trees/Files/FileTreeNodeViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/Trees/Files/FileTreeNodeViewModel.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using NexusMods.Abstractions.GameLocators;
 using ReactiveUI.Fody.Helpers;
@@ -13,9 +14,11 @@ public class FileTreeNodeViewModel : AViewModel<IFileTreeNodeViewModel>, IFileTr
     public bool IsFile { get; }
     public string Name => Key.FileName;
     public ulong FileSize { get; }
-    public GamePath Key { get; }
+    public GamePath Key { get; set; }
     public GamePath ParentKey { get; }
     [Reactive] public bool IsExpanded { get; set; }
+    public ReadOnlyObservableCollection<IFileTreeNodeViewModel>? Children { get; set; }
+    public IFileTreeNodeViewModel? Parent { get; set; }
 
     public FileTreeNodeViewModel(GamePath fullPath, GamePath parentPath, bool isFile, ulong fileSize)
     {

--- a/src/NexusMods.App.UI/Controls/Trees/Files/IFileTreeNodeViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/Trees/Files/IFileTreeNodeViewModel.cs
@@ -5,7 +5,7 @@ using NexusMods.App.UI.Helpers.TreeDataGrid;
 
 namespace NexusMods.App.UI.Controls.Trees.Files;
 
-public interface IFileTreeNodeViewModel : IViewModelInterface, IExpandableItem
+public interface IFileTreeNodeViewModel : IViewModelInterface, IExpandableItem, IDynamicDataTreeItem<IFileTreeNodeViewModel, GamePath>
 {
     /// <summary>
     ///     The icon that's used to display this specific node.
@@ -26,11 +26,6 @@ public interface IFileTreeNodeViewModel : IViewModelInterface, IExpandableItem
     ///     The size of the file, in bytes.
     /// </summary>
     ulong FileSize { get; }
-    
-    /// <summary>
-    ///     The key to this node.
-    /// </summary>
-    GamePath Key { get; }
 
     /// <summary>
     ///     The key to the parent of this node.

--- a/src/NexusMods.App.UI/Controls/Trees/Files/IFileTreeNodeViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/Trees/Files/IFileTreeNodeViewModel.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 using NexusMods.Abstractions.GameLocators;
 using NexusMods.App.UI.Helpers;
+using NexusMods.App.UI.Helpers.TreeDataGrid;
 
 namespace NexusMods.App.UI.Controls.Trees.Files;
 

--- a/src/NexusMods.App.UI/Helpers/TreeDataGrid/IDynamicDataTreeItem.cs
+++ b/src/NexusMods.App.UI/Helpers/TreeDataGrid/IDynamicDataTreeItem.cs
@@ -1,0 +1,125 @@
+using System.Collections.ObjectModel;
+using DynamicData;
+
+namespace NexusMods.App.UI.Helpers.TreeDataGrid;
+
+/// <summary>
+///     This interface provides the implementation for ViewModels which are based on
+///     <see cref="DynamicData" />'s <see cref="ObservableCacheEx.TransformToTree{TObject,TKey}" /> method.
+///     <br />
+///     This interface provides the implementation for ViewModels to accept a
+///     <see cref="Node{TItem,TKey}" /> and assign it to the current ViewModel.
+/// </summary>
+public interface IDynamicDataTreeItem<TItem, TKey>
+    where TItem : class, IDynamicDataTreeItem<TItem, TKey>
+    where TKey : notnull
+{
+    /// <summary>
+    ///     Collection of child nodes.
+    ///     This is an observable collection so that the UI can be
+    ///     notified of changes to the tree structure.
+    /// </summary>
+    public ReadOnlyObservableCollection<TItem> Children { get; internal set; }
+
+    /// <summary>
+    ///     The parent of the current node.
+    /// </summary>
+    TItem? Parent { get; internal set; }
+
+    /// <summary>
+    ///     The Id used in the <see cref="SourceCache{TObject,TKey}" /> for the original item.
+    /// </summary>
+    TKey Key { get; internal set; }
+}
+
+public static class DynamicDataTreeItemExtensions
+{
+    /// <summary>
+    ///     Initializes this <see cref="IDynamicDataTreeItem{TItem,TKey}" />.
+    ///     <br />
+    ///     Call this after DynamicData's <see cref="ObservableCacheEx.TransformToTree{TObject,TKey}" /> method.
+    ///     Creates a new <see cref="TreeNodeVM{TItem,TKey}" /> from a <see cref="Node{TItem,TKey}" />.
+    ///     <see cref="Node{TItem,TKey}" /> is the output of DynamicData TransformToTree().
+    /// </summary>
+    /// <param name="self">The ViewModel itself.</param>
+    /// <param name="node">The DynamicData node type that wraps this element.</param>
+    /// <param name="parent">The parent of the current node.</param>
+    public static TItem Initialize<TSelf, TItem, TKey>(this TSelf self, Node<TItem, TKey> node, IDynamicDataTreeItem<TItem, TKey>? parent = null)
+        where TSelf : IDynamicDataTreeItem<TItem, TKey> // <= hint for potential JIT devirtualization
+        where TItem : class, IDynamicDataTreeItem<TItem, TKey>
+        where TKey : notnull
+    {
+        self.Key = node.Key;
+        self.Parent = parent as TItem;
+        node.Children
+            .Connect()
+            .Transform(child => child.Item.Initialize(child, self))
+            .Bind(out var children)
+            .Subscribe();
+
+        self.Children = children;
+        // guaranteed not null due to generic constraint:
+        // where TItem : class, IDynamicDataTreeItem<TItem, TKey>
+        return (self as TItem)!;
+    }
+
+    /// <summary>
+    ///     Returns a collection of all the descendent <typeparamref name="TKey" />
+    ///     of this node (excluding this node).
+    /// </summary>
+    public static List<TKey> GetAllDescendentKeys<TSelf, TItem, TKey>(this TSelf self)
+        where TSelf : IDynamicDataTreeItem<TItem, TKey> // <= hint for potential JIT devirtualization
+        where TItem : class, IDynamicDataTreeItem<TItem, TKey>
+        where TKey : notnull
+    {
+        var results = new List<TKey>();
+        if (self.Children.Count == 0)
+            return results;
+
+        // guaranteed not null due to generic constraint:
+        // where TItem : class, IDynamicDataTreeItem<TItem, TKey>
+        GetAllDescendentKeysRecursive((self as TItem)!, results);
+        return results;
+    }
+
+    private static void GetAllDescendentKeysRecursive<TItem, TKey>(TItem node, List<TKey> results)
+        where TItem : class, IDynamicDataTreeItem<TItem, TKey>
+        where TKey : notnull
+    {
+        foreach (var child in node.Children)
+        {
+            results.Add(child.Key);
+            GetAllDescendentKeysRecursive(child, results);
+        }
+    }
+
+    /// <summary>
+    ///     Returns a collection of all the descendent nodes of this node (excluding this node).
+    /// </summary>
+    /// <returns></returns>
+    public static List<TItem> GetAllDescendentNodes<TSelf, TItem, TKey>(this TSelf self)
+        where TSelf : IDynamicDataTreeItem<TItem, TKey> // <= hint for potential JIT devirtualization
+        where TItem : class, IDynamicDataTreeItem<TItem, TKey>
+        where TKey : notnull
+    {
+        var results = new List<TItem>();
+        if (self.Children.Count == 0)
+            return results;
+
+        // guaranteed not null due to generic constraint:
+        // where TItem : class, IDynamicDataTreeItem<TItem, TKey>
+        GetAllDescendentNodesRecursive<TItem, TKey>((self as TItem)!, results);
+        return results;
+    }
+
+    private static void GetAllDescendentNodesRecursive<TItem, TKey>(TItem node, List<TItem> results)
+        where TItem : class, IDynamicDataTreeItem<TItem, TKey>
+        where TKey : notnull
+    {
+        foreach (var child in node.Children)
+        {
+            results.Add(child);
+            GetAllDescendentNodesRecursive<TItem, TKey>(child, results);
+        }
+    }
+}

--- a/src/NexusMods.App.UI/Helpers/TreeDataGrid/IDynamicDataTreeItem.cs
+++ b/src/NexusMods.App.UI/Helpers/TreeDataGrid/IDynamicDataTreeItem.cs
@@ -19,7 +19,7 @@ public interface IDynamicDataTreeItem<TItem, TKey>
     ///     This is an observable collection so that the UI can be
     ///     notified of changes to the tree structure.
     /// </summary>
-    public ReadOnlyObservableCollection<TItem> Children { get; internal set; }
+    public ReadOnlyObservableCollection<TItem>? Children { get; internal set; }
 
     /// <summary>
     ///     The parent of the current node.
@@ -73,7 +73,7 @@ public static class DynamicDataTreeItemExtensions
         where TKey : notnull
     {
         var results = new List<TKey>();
-        if (self.Children.Count == 0)
+        if (self.Children?.Count == 0)
             return results;
 
         // guaranteed not null due to generic constraint:
@@ -86,7 +86,7 @@ public static class DynamicDataTreeItemExtensions
         where TItem : class, IDynamicDataTreeItem<TItem, TKey>
         where TKey : notnull
     {
-        foreach (var child in node.Children)
+        foreach (var child in node.Children!)
         {
             results.Add(child.Key);
             GetAllDescendentKeysRecursive(child, results);
@@ -103,7 +103,7 @@ public static class DynamicDataTreeItemExtensions
         where TKey : notnull
     {
         var results = new List<TItem>();
-        if (self.Children.Count == 0)
+        if (self.Children?.Count == 0)
             return results;
 
         // guaranteed not null due to generic constraint:
@@ -116,7 +116,7 @@ public static class DynamicDataTreeItemExtensions
         where TItem : class, IDynamicDataTreeItem<TItem, TKey>
         where TKey : notnull
     {
-        foreach (var child in node.Children)
+        foreach (var child in node.Children!)
         {
             results.Add(child);
             GetAllDescendentNodesRecursive<TItem, TKey>(child, results);

--- a/src/NexusMods.App.UI/Helpers/TreeDataGrid/IExpandableItem.cs
+++ b/src/NexusMods.App.UI/Helpers/TreeDataGrid/IExpandableItem.cs
@@ -1,0 +1,12 @@
+namespace NexusMods.App.UI.Helpers.TreeDataGrid;
+
+/// <summary>
+///     Represents a ViewModel that can be expanded.
+/// </summary>
+public interface IExpandableItem
+{
+    /// <summary>
+    ///     Whether the node is expanded in the UI.
+    /// </summary>
+    public bool IsExpanded { get; set; }
+}

--- a/src/NexusMods.App.UI/Helpers/TreeDataGrid/TreeDataGridHelpers.cs
+++ b/src/NexusMods.App.UI/Helpers/TreeDataGrid/TreeDataGridHelpers.cs
@@ -5,7 +5,7 @@ using Avalonia.Controls.Templates;
 using ReactiveUI;
 using Splat;
 
-namespace NexusMods.App.UI.Helpers;
+namespace NexusMods.App.UI.Helpers.TreeDataGrid;
 
 /// <summary>
 /// Helper functions for constructing <see cref="TreeDataGrid"/>(s)
@@ -76,13 +76,3 @@ public static class TreeDataGridHelpers
     }
 }
 
-/// <summary>
-///     Represents a ViewModel that can be expanded.
-/// </summary>
-public interface IExpandableItem
-{
-    /// <summary>
-    /// Whether the node is expanded in the UI.
-    /// </summary>
-    public bool IsExpanded { get; set; }
-}

--- a/src/NexusMods.App.UI/TreeNodeVM.cs
+++ b/src/NexusMods.App.UI/TreeNodeVM.cs
@@ -4,6 +4,7 @@ using System.Reactive.Linq;
 using DynamicData;
 using DynamicData.Kernel;
 using NexusMods.App.UI.Helpers;
+using NexusMods.App.UI.Helpers.TreeDataGrid;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
 
@@ -85,34 +86,6 @@ public class TreeNodeVM<TItem, TKey> : ReactiveObject, IActivatableViewModel
                 .Subscribe();
             return children;
         });
-    }
-
-    /// <summary>
-    /// Convenience constructor for creating Design time fake <see cref="TreeNodeVM{TItem,TKey}"/>
-    /// </summary>
-    /// <param name="item">Contained Item</param>
-    /// <param name="id">Contained Id</param>
-    public TreeNodeVM(TItem item, TKey id)
-    {
-        Item = item;
-        Id = id;
-        _children = new Lazy<ReadOnlyObservableCollection<TreeNodeVM<TItem, TKey>>>(new ReadOnlyObservableCollection<TreeNodeVM<TItem, TKey>>([]));
-    }
-
-    /// <summary>
-    /// Recursively search the tree for a node with the given Id.
-    /// </summary>
-    /// <param name="id">The Id of the node to find</param>
-    /// <returns>Null if not found</returns>
-    public  TreeNodeVM<TItem, TKey>? FindNode(TKey id)
-    {
-        if (Id.Equals(id))
-        {
-            return this;
-        }
-
-        return Children.Select(child => child.FindNode(id))
-            .FirstOrDefault(found => found != null);
     }
 
     /// <summary>

--- a/src/NexusMods.App.UI/TreeNodeVM.cs
+++ b/src/NexusMods.App.UI/TreeNodeVM.cs
@@ -1,12 +1,9 @@
 using System.Collections.ObjectModel;
 using System.Reactive.Disposables;
-using System.Reactive.Linq;
 using DynamicData;
 using DynamicData.Kernel;
-using NexusMods.App.UI.Helpers;
 using NexusMods.App.UI.Helpers.TreeDataGrid;
 using ReactiveUI;
-using ReactiveUI.Fody.Helpers;
 
 namespace NexusMods.App.UI;
 


### PR DESCRIPTION
-----------

Checks off `Consider unifying TreeNodeVM with the underlying flat item view model.` in
https://github.com/Nexus-Mods/NexusMods.App/issues/1048

Successor to:
- #1053 

Need to merge previous PR if you want a slightly cleaner diff against main, as this PR builds upon it.
(Or just look at the new commits since that PR in isolation)

------------

This is a prototype which shows an implementation of inlining what was formerly `TreeNodeVM` directly into the ViewModels, for cleanliness. This PR adds the new system for doing so via `IDynamicDataTreeItem<TItem, TKey>`, and implements it for the `View Mod Files` view. 

This PR is purely for feedback/iteration on the idea we had. i.e. a working prototype.
For @Al12rs and anyone else interested.

## Notable Differences:

DynamicData tree creation changes from:

```csharp
cache.Connect()
    .TransformToTree(model => model.ParentKey)
    .Transform(node => new ModFileNode(node))
    .Bind(out result)
    .Subscribe(); // force evaluation
```

To

```csharp
cache.Connect()
    .TransformToTree(model => model.ParentKey)
    .Transform(node => node.Item.Initialize(node))
    .Bind(out result)
    .Subscribe(); // force evaluation
```

ViewModels that inherit from `IDynamicDataTreeItem` must expose 2 more properties.

```csharp
// Example: IFileTreeNodeViewModel
public ReadOnlyObservableCollection<IFileTreeNodeViewModel>? Children { get; set; }
public IFileTreeNodeViewModel? Parent { get; set; }
```

Aside from that, no difference in usability from consumer end. The reactiveness works just a-ok, we can access children, access parents. etc. 

The `TreeNodeVM` wrapper is no longer needed, the hack of re-broadcasting `PropertyChanged` from inner `Item` is no longer needed, and code that interacts with the ViewModel no longer needs to have `.Item` all over the place. This saves on the amount of code we have to write.

Logically speaking, there's no difference in how things operate behind the scenes. The difference is, `Node<TObject,TKey>` now holds a transitive reference to `TItem` instead of `TreeNodeVM<TItem, TKey>` via the `.Children.Connect()` subscription.