### PR TITLE
Use single `UnifiedIcon` in Advanced Installer Views

### DIFF
--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Left/ModContent/TreeEntry/ModContentTreeEntryView.axaml
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Left/ModContent/TreeEntry/ModContentTreeEntryView.axaml
@@ -36,9 +36,7 @@
         <!-- Left Elements -->
         <StackPanel Grid.Column="0" Orientation="Horizontal" Name="FileElementPanel">
             <!-- File / Directory Icon -->
-            <unifiedIcon:UnifiedIcon Classes="File FileTypeIcon" IsVisible="False" x:Name="FileEntryIcon" />
-            <unifiedIcon:UnifiedIcon Classes="FolderOutline FileTypeIcon" IsVisible="False"
-                                     x:Name="FolderEntryIcon" />
+            <unifiedIcon:UnifiedIcon Classes="FileTypeIcon" x:Name="EntryIcon" />
 
             <!-- File Name -->
             <TextBlock Classes="BodyMDNormal" VerticalAlignment="Center"

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Left/ModContent/TreeEntry/ModContentTreeEntryView.axaml.cs
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Left/ModContent/TreeEntry/ModContentTreeEntryView.axaml.cs
@@ -56,6 +56,7 @@ public partial class
     {
         if (vm.IsRoot)
         {
+            EntryIcon.IsVisible = false;
             MakeTextBlockBold();
             FileNameTextBlock.Text = Language.TreeEntryView_FileNameTextBlock_All_mod_files;
             InstallRoundedButtonTextBlock.Text = Language.TreeEntryView_InstallRoundedButtonTextBlock_Install_all;
@@ -66,14 +67,14 @@ public partial class
 
             if (vm.IsDirectory)
             {
-                FolderEntryIcon.IsVisible = true;
+                EntryIcon.Classes.Add("FolderOutline");
                 MakeTextBlockBold();
                 InstallRoundedButtonTextBlock.Text =
                     Language.TreeEntryView_InstallRoundedButtonTextBlock_Install_folder;
             }
             else
             {
-                FileEntryIcon.IsVisible = true;
+                EntryIcon.Classes.Add("File");
                 InstallRoundedButtonTextBlock.Text = Language.TreeEntryView_InstallRoundedButtonTextBlock_Install;
             }
         }

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/Preview/TreeEntry/PreviewTreeEntryView.axaml
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/Preview/TreeEntry/PreviewTreeEntryView.axaml
@@ -41,8 +41,7 @@
         <StackPanel Grid.Column="0" Orientation="Horizontal" x:Name="FileElementGrid">
 
             <!-- File / Directory Icon -->
-            <unifiedIcon:UnifiedIcon Classes="File FileTypeIcon" IsVisible="False" x:Name="FileEntryIcon" />
-            <unifiedIcon:UnifiedIcon Classes="FolderOutline FileTypeIcon" IsVisible="False" x:Name="FolderEntryIcon" />
+            <unifiedIcon:UnifiedIcon Classes="FileTypeIcon" x:Name="EntryIcon" />
 
             <!-- File Name -->
             <TextBlock Classes="BodyMDNormal" VerticalAlignment="Center"

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/Preview/TreeEntry/PreviewTreeEntryView.axaml.cs
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/Preview/TreeEntry/PreviewTreeEntryView.axaml.cs
@@ -44,7 +44,7 @@ public partial class PreviewTreeEntryView : ReactiveUserControl<IPreviewTreeEntr
         // Always show unlink button, it means unlink child nodes if it is a folder.
         if (ViewModel.IsDirectory)
         {
-            FolderEntryIcon.IsVisible = true;
+            EntryIcon.Classes.Add("FolderOutline");
 
             // Make directory name bold.
             FileNameTextBlock.Classes.Remove("BodyMDNormal");
@@ -52,7 +52,7 @@ public partial class PreviewTreeEntryView : ReactiveUserControl<IPreviewTreeEntr
         }
         else
         {
-            FileEntryIcon.IsVisible = true;
+            EntryIcon.Classes.Add("File");
         }
     }
 }

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/SelectLocation/TreeEntry/SelectableTreeEntryView.axaml
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/SelectLocation/TreeEntry/SelectableTreeEntryView.axaml
@@ -49,7 +49,6 @@
             <StackPanel IsVisible="False" Orientation="Horizontal" x:Name="FileElementGrid">
 
                 <!-- File / Directory Icon -->
-                <unifiedIcon:UnifiedIcon Classes="File FileTypeIcon" IsVisible="False" x:Name="FileEntryIcon" />
                 <unifiedIcon:UnifiedIcon Classes="FolderOutline FileTypeIcon" IsVisible="False" x:Name="FolderEntryIcon" />
 
                 <!-- File Name -->


### PR DESCRIPTION
This tiny PR brings makes the AdvancedInstaller's icon presentation strategy to match the strategy used in the new `View Mod Files` functionality.

i.e. Applying ViewModFiles PR Feedback to Advanced Installer

I.e. We now no longer hide icons, but swap them out. 