### PR TITLE
Downgrade the `Microsoft.CodeAnalaysis.CSharp*` packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,9 @@ updates:
       - dependency-name: "Microsoft.*"
       - dependency-name: "NexusMods.*"
       - dependency-name: "Avalonia*"
+    ignore:
+      # NOTE(erri120): "special" dependencies that are tied to the roslyn compiler version
+      - dependency-name: "Microsoft.CodeAnalysis.CSharp*"
     groups:
       System:
         patterns:

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -59,8 +59,8 @@
     <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="8.0.3" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Fixes the build issues related to the source generator.