### PR TITLE
Fix crash on close

### DIFF
--- a/src/NexusMods.App.UI/Windows/MainWindow.axaml
+++ b/src/NexusMods.App.UI/Windows/MainWindow.axaml
@@ -81,18 +81,18 @@
                 Margin="0,0,12,12"
                 x:Name="WorkspacesBorder">
 
-            <ItemsControl x:Name="Workspaces">
+            <ItemsControl x:Name="WorkspacesItemsControl">
 
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>
-                        <Grid RowDefinitions="*" ColumnDefinitions="*" />
+                        <Grid RowDefinitions="*" ColumnDefinitions="*" x:Name="WorkspaceContainerGrid"/>
                     </ItemsPanelTemplate>
                 </ItemsControl.ItemsPanel>
 
                 <ItemsControl.ItemTemplate>
                     <DataTemplate DataType="{x:Type workspace:IWorkspaceViewModel}">
                         <reactiveUi:ViewModelViewHost
-                            x:Name="ViewModelViewHost"
+                            x:Name="WorkspaceViewHost"
                             IsVisible="{CompiledBinding IsActive, Mode=OneWay}"
                             ViewModel="{CompiledBinding Mode=OneWay}" />
                     </DataTemplate>

--- a/src/NexusMods.App.UI/Windows/MainWindow.axaml.cs
+++ b/src/NexusMods.App.UI/Windows/MainWindow.axaml.cs
@@ -28,7 +28,7 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
             this.OneWayBind(ViewModel, vm => vm.DevelopmentBuildBanner, v => v.DevelopmentBuildBanner.ViewModel)
                 .DisposeWith(disposables);
 
-            this.OneWayBind(ViewModel, vm => vm.WorkspaceController.AllWorkspaces, view => view.Workspaces.ItemsSource)
+            this.OneWayBind(ViewModel, vm => vm.WorkspaceController.AllWorkspaces, view => view.WorkspacesItemsControl.ItemsSource)
                 .DisposeWith(disposables);
 
             this.WhenAnyValue(view => view.ViewModel!.TopBar.CloseCommand.IsExecuting)

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
@@ -50,8 +50,7 @@ public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceVie
 
     public WorkspaceViewModel(
         IWorkspaceController workspaceController,
-        PageFactoryController factoryController,
-        Action<WorkspaceViewModel> unregisterFunc)
+        PageFactoryController factoryController)
     {
         _workspaceController = workspaceController;
         _factoryController = factoryController;
@@ -213,10 +212,6 @@ public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceVie
                     }
                 })
                 .SubscribeWithErrorLogging()
-                .DisposeWith(disposables);
-
-            Disposable
-                .Create(this, unregisterFunc.Invoke)
                 .DisposeWith(disposables);
         });
     }

--- a/src/NexusMods.App.UI/WorkspaceSystem/WorkspaceController/WorkspaceController.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/WorkspaceController/WorkspaceController.cs
@@ -88,8 +88,7 @@ internal sealed class WorkspaceController : ReactiveObject, IWorkspaceController
 
         var vm = new WorkspaceViewModel(
             workspaceController: this,
-            factoryController: _pageFactoryController,
-            unregisterFunc: UnregisterWorkspace
+            factoryController: _pageFactoryController
         )
         {
             Context = context.HasValue ? context.Value : EmptyContext.Instance,
@@ -116,6 +115,8 @@ internal sealed class WorkspaceController : ReactiveObject, IWorkspaceController
 
     private void UnregisterWorkspace(WorkspaceViewModel workspaceViewModel)
     {
+        //TODO: currently unused, we have no cases where we unregister a workspace
+        // will need this when we support removing loadouts
         Dispatcher.UIThread.VerifyAccess();
 
         _workspaces.Remove(workspaceViewModel.Id);


### PR DESCRIPTION
This was due to `WorkspaceViewModel` unregistering itself from `WorkspaceController.AllWorkspaces` when it is deactivated (`WhenActivated` `DisposeWith`).

This changed the number of children during the `OnDetachedFromVisualTree` calls.
Removing the call to `UnregisterWorkspace` in the disposable here fixes the crash on close.


Currently we don't actually have any way to remove workspaces, as there is no way to delete a loadout. So for now the removal code is inactive. We will figure out how that works when we support deleting loadouts.

Part of #906.