### PR TITLE
Fix imprecisions in the workspace system

### DIFF
--- a/src/NexusMods.App.UI/WorkspaceSystem/GridUtils.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/GridUtils.cs
@@ -20,7 +20,10 @@ public static class GridUtils
         foreach (var panelState in gridState)
         {
             var (id, rect) = panelState;
-            if (rect.Left < 0.0 || rect.Right > 1.0 || rect.Top < 0.0 || rect.Bottom > 1.0)
+            if (!rect.Left.IsGreaterThanOrCloseTo(0.0) ||
+                !rect.Right.IsLessThanOrCloseTo(1.0)   ||
+                !rect.Top.IsGreaterThanOrCloseTo(0.0)  ||
+                !rect.Bottom.IsLessThanOrCloseTo(1.0))
             {
                 throw new Exception($"Panel {panelState} is out of bounds");
             }

--- a/src/NexusMods.App.UI/WorkspaceSystem/MathUtils.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/MathUtils.cs
@@ -68,12 +68,20 @@ internal static class MathUtils
             var yStart = a.Top.IsLessThanOrCloseTo(b.Top) ? a.Top : b.Top;
             var yEnd = a.Bottom.IsGreaterThanOrCloseTo(b.Bottom) ? a.Bottom : b.Bottom;
 
+            x = Math.Min(x, 1.0);
+            yStart = Math.Max(yStart, 0.0);
+            yEnd = Math.Min(yEnd, 1.0);
+
             return (new Point(x, yStart), new Point(x, yEnd));
         }
 
         var y = a.Bottom.IsCloseTo(b.Top) ? a.Bottom : b.Bottom;
         var xStart = a.Left.IsLessThanOrCloseTo(b.Left) ? a.Left : b.Left;
         var xEnd = a.Right.IsGreaterThanOrCloseTo(b.Right) ? a.Right : b.Right;
+
+        y = Math.Min(y, 1.0);
+        xStart = Math.Max(xStart, 0.0);
+        xEnd = Math.Min(xEnd, 1.0);
 
         return (new Point(xStart, y), new Point(xEnd, y));
     }

--- a/src/NexusMods.App.UI/WorkspaceSystem/WorkspaceGridState.ColumnEnumerator.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/WorkspaceGridState.ColumnEnumerator.cs
@@ -8,6 +8,8 @@ public readonly partial struct WorkspaceGridState
     public readonly record struct ColumnInfo(double X, double Width)
     {
         public double Right() => X + Width;
+
+        public bool IsInfinity() => double.IsInfinity(X) || double.IsInfinity(Width);
     }
 
     public readonly ref struct Column(ColumnInfo info, ReadOnlySpan<PanelGridState> rows)
@@ -101,8 +103,10 @@ public readonly partial struct WorkspaceGridState
                     var index = _seenColumns.BinarySearch(info, XComparer.Instance);
                     if (index < 0)
                     {
+                        var other = _seenColumns[~index];
+                        if (other.IsInfinity()) _numColumns += 1;
+
                         _seenColumns[~index] = info;
-                        _numColumns += 1;
                     }
                     else
                     {

--- a/src/NexusMods.App.UI/WorkspaceSystem/WorkspaceGridState.RowEnumerator.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/WorkspaceGridState.RowEnumerator.cs
@@ -8,6 +8,8 @@ public readonly partial struct WorkspaceGridState
     public readonly record struct RowInfo(double Y, double Height)
     {
         public double Bottom() => Y + Height;
+
+        public bool IsInfinity() => double.IsInfinity(Y) || double.IsInfinity(Height);
     }
 
     public readonly ref struct Row(RowInfo info, ReadOnlySpan<PanelGridState> columns)
@@ -101,8 +103,10 @@ public readonly partial struct WorkspaceGridState
                     var index = _seenRows.BinarySearch(info, YComparer.Instance);
                     if (index < 0)
                     {
+                        var other = _seenRows[~index];
+                        if (other.IsInfinity()) _numRows += 1;
+
                         _seenRows[~index] = info;
-                        _numRows += 1;
                     }
                     else
                     {

--- a/src/NexusMods.App.UI/WorkspaceSystem/WorkspaceGridState.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/WorkspaceGridState.cs
@@ -22,12 +22,6 @@ public readonly partial struct WorkspaceGridState :
         IsHorizontal = isHorizontal;
     }
 
-    [Obsolete("Usages of the Workspace State as an ImmutableDictionary<> will be phased out.")]
-    public ImmutableDictionary<PanelId, Rect> ToDictionary()
-    {
-        return Inner.ToImmutableDictionary(x => x.Id, x => x.Rect);
-    }
-
     public static WorkspaceGridState From(IEnumerable<IPanelViewModel> panels, bool isHorizontal)
     {
         return new WorkspaceGridState(
@@ -85,7 +79,7 @@ public readonly partial struct WorkspaceGridState :
             return true;
         }
 
-        panel = default;
+        panel = default(PanelGridState);
         return false;
     }
 

--- a/src/NexusMods.App.UI/WorkspaceSystem/WorkspaceGridState.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/WorkspaceGridState.cs
@@ -114,6 +114,9 @@ public readonly partial struct WorkspaceGridState :
         Span<PanelGridState> rowBuffer = stackalloc PanelGridState[MaxRows];
         while (enumerator.MoveNext(rowBuffer))
         {
+            var current = enumerator.Current;
+            if (current.Info.IsInfinity()) continue;
+
             columnCount += 1;
             maxRowCount = Math.Max(maxRowCount, enumerator.Current.Rows.Length);
         }
@@ -132,6 +135,9 @@ public readonly partial struct WorkspaceGridState :
         Span<PanelGridState> columnBuffer = stackalloc PanelGridState[MaxColumns];
         while (enumerator.MoveNext(columnBuffer))
         {
+            var current = enumerator.Current;
+            if (current.Info.IsInfinity()) continue;
+
             rowCount += 1;
             maxColumnCount = Math.Max(maxColumnCount, enumerator.Current.Columns.Length);
         }

--- a/tests/NexusMods.UI.Tests/WorkspaceSystem/GridUtilsTests/GetResizersTests.cs
+++ b/tests/NexusMods.UI.Tests/WorkspaceSystem/GridUtilsTests/GetResizersTests.cs
@@ -12,6 +12,7 @@ public partial class GridUtilsTests
 {
     [Theory]
     [MemberData(nameof(TestData_GetResizers_Generated))]
+    [MemberData(nameof(TestData_GetResizers_Issue1065))]
     [SuppressMessage("Usage", "xUnit1026:Theory methods should use all of their parameters")]
     public void Test_GetResizers(
         string name,
@@ -33,6 +34,32 @@ public partial class GridUtilsTests
             actual.End.Should().Be(expected.End);
             actual.ConnectedPanels.Order().Should().Equal(expected.ConnectedPanels.Order());
         }
+    }
+
+    public static TheoryData<string, WorkspaceGridState, List<GridUtils.ResizerInfo>> TestData_GetResizers_Issue1065()
+    {
+        var firstPanelId = PanelId.From(Guid.Parse("11111111-1111-1111-1111-111111111111"));
+        var secondPanelId = PanelId.From(Guid.Parse("22222222-2222-2222-2222-222222222222"));
+        var thirdPanelId = PanelId.From(Guid.Parse("33333333-3333-3333-3333-333333333333"));
+        var fourthPanelId = PanelId.From(Guid.Parse("44444444-4444-4444-4444-444444444444"));
+
+        var res = new TheoryData<string, WorkspaceGridState, List<GridUtils.ResizerInfo>>();
+
+        res.Add("Issue #1065", CreateState(
+            isHorizontal: true,
+            panels: [
+                new PanelGridState(firstPanelId, new Rect(0, 0, 0.40358467243510504, 0.64897074756229689)),
+                new PanelGridState(secondPanelId, new Rect(0, 0.64897074756229689, 0.40358467243510504, 0.35102925243770305)),
+                new PanelGridState(thirdPanelId, new Rect(0.40358467243510504, 0, 0.59641532756489557, 0.38678223185265437)),
+                new PanelGridState(fourthPanelId, new Rect(0.40358467243510504, 0.38678223185265437, 0.59641532756489557, 0.6132177681473453)),
+            ]
+        ), [
+            new GridUtils.ResizerInfo(new Point(0, 0.6489707475622969), new Point(0.40358467243510504, 0.6489707475622969), true, [firstPanelId, secondPanelId]),
+            new GridUtils.ResizerInfo(new Point(0.40358467243510504, 0), new Point(0.40358467243510504, 1), false, [firstPanelId, secondPanelId, thirdPanelId, fourthPanelId]),
+            new GridUtils.ResizerInfo(new Point(0.40358467243510504, 0.38678223185265437), new Point(1.0000000000000007, 0.38678223185265437), true, [thirdPanelId, fourthPanelId]),
+        ]);
+
+        return res;
     }
 
     public static TheoryData<string, WorkspaceGridState, List<GridUtils.ResizerInfo>> TestData_GetResizers_Generated()

--- a/tests/NexusMods.UI.Tests/WorkspaceSystem/GridUtilsTests/GetResizersTests.cs
+++ b/tests/NexusMods.UI.Tests/WorkspaceSystem/GridUtilsTests/GetResizersTests.cs
@@ -56,7 +56,7 @@ public partial class GridUtilsTests
         ), [
             new GridUtils.ResizerInfo(new Point(0, 0.6489707475622969), new Point(0.40358467243510504, 0.6489707475622969), true, [firstPanelId, secondPanelId]),
             new GridUtils.ResizerInfo(new Point(0.40358467243510504, 0), new Point(0.40358467243510504, 1), false, [firstPanelId, secondPanelId, thirdPanelId, fourthPanelId]),
-            new GridUtils.ResizerInfo(new Point(0.40358467243510504, 0.38678223185265437), new Point(1.0000000000000007, 0.38678223185265437), true, [thirdPanelId, fourthPanelId]),
+            new GridUtils.ResizerInfo(new Point(0.40358467243510504, 0.38678223185265437), new Point(1, 0.38678223185265437), true, [thirdPanelId, fourthPanelId]),
         ]);
 
         return res;

--- a/tests/NexusMods.UI.Tests/WorkspaceSystem/MathUtilsTests.cs
+++ b/tests/NexusMods.UI.Tests/WorkspaceSystem/MathUtilsTests.cs
@@ -90,5 +90,7 @@ public class MathUtilsTests
 
         { new Rect(0, 0, 1, 0.5), new Rect(0, 0.5, 0.5, 0.5), WorkspaceGridState.AdjacencyKind.SameColumn, new Point(0, 0.5), new Point(1, 0.5) },
         { new Rect(0, 0, 1, 0.5), new Rect(0.5, 0.5, 0.5, 0.5), WorkspaceGridState.AdjacencyKind.SameColumn, new Point(0, 0.5), new Point(1, 0.5) },
+
+        { new Rect(0.40358467243510504, 0, 0.59641532756489557, 0.38678223185265437), new Rect(0.40358467243510504, 0.38678223185265437, 0.59641532756489557, 0.6132177681473453), WorkspaceGridState.AdjacencyKind.SameColumn, new Point(0.40358467243510504, 0.38678223185265437), new Point(1, 0.38678223185265437) },
     };
 }


### PR DESCRIPTION
Fixes #1065.

- Allows `IsPerfectGrid` to be more tolerant
- Snaps resizer points to `0.0` and `1.0`
- Column and Row enumerators provide correct counts and indices