### PR TITLE
Convert diagnostic messages into plain text

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Games.Diagnostics/Diagnostic.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Games.Diagnostics/Diagnostic.cs
@@ -52,15 +52,43 @@ public record Diagnostic
     /// Gets the creation time of this diagnostics.
     /// </summary>
     public DateTimeOffset CreatedAt { get; init; } = DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// Formats <see cref="Summary"/> using <paramref name="writer"/>.
+    /// </summary>
+    public virtual void FormatSummary(IDiagnosticWriter writer)
+    {
+        writer.Write(Summary.Value);
+    }
+
+    /// <summary>
+    /// Formats <see cref="Details"/> using <paramref name="writer"/>.
+    /// </summary>
+    public virtual void FormatDetails(IDiagnosticWriter writer)
+    {
+        writer.Write(Details.Value);
+    }
 }
 
 /// <summary>
 /// Diagnostic with message data.
 /// </summary>
-public record Diagnostic<TMessageData> : Diagnostic where TMessageData : struct
+public record Diagnostic<TMessageData> : Diagnostic where TMessageData : struct, IDiagnosticMessageData
 {
     /// <summary>
     /// Gets the message data used for <see cref="Diagnostic.Summary"/> and <see cref="Diagnostic.Details"/>.
     /// </summary>
     public required TMessageData MessageData { get; init; }
+
+    /// <inheritdoc/>
+    public override void FormatSummary(IDiagnosticWriter writer)
+    {
+        MessageData.Format(Summary, writer);
+    }
+
+    /// <inheritdoc/>
+    public override void FormatDetails(IDiagnosticWriter writer)
+    {
+        MessageData.Format(Details, writer);
+    }
 }

--- a/src/Abstractions/NexusMods.Abstractions.Games.Diagnostics/IDiagnosticMessageData.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Games.Diagnostics/IDiagnosticMessageData.cs
@@ -1,0 +1,15 @@
+using JetBrains.Annotations;
+
+namespace NexusMods.Abstractions.Diagnostics;
+
+/// <summary>
+/// Represents message data of a <see cref="Diagnostic{TMessageData}"/>.
+/// </summary>
+[PublicAPI]
+public interface IDiagnosticMessageData
+{
+    /// <summary>
+    /// Formats the given message using the current message data.
+    /// </summary>
+    void Format(DiagnosticMessage message, IDiagnosticWriter writer);
+}

--- a/src/Abstractions/NexusMods.Abstractions.Games.Diagnostics/IDiagnosticWriter.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Games.Diagnostics/IDiagnosticWriter.cs
@@ -38,13 +38,13 @@ public interface IDiagnosticWriter : IDisposable
     /// <summary>
     /// Returns he output of the writer and calls <see cref="Reset"/>.
     /// </summary>
-    string GetOutput();
+    string ToOutput();
 
     /// <summary>
     /// Resets the writer to it's initial state.
     /// </summary>
     /// <remarks>
-    /// This gets called automatically by <see cref="GetOutput"/>.
+    /// This gets called automatically by <see cref="ToOutput"/>.
     /// </remarks>
     void Reset();
 }

--- a/src/Abstractions/NexusMods.Abstractions.Games.Diagnostics/IDiagnosticWriter.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Games.Diagnostics/IDiagnosticWriter.cs
@@ -32,6 +32,9 @@ public interface IDiagnosticWriter : IDisposable
     /// </remarks>
     void Write(ReadOnlySpan<char> value);
 
+    /// <inheritdoc cref="Write(ReadOnlySpan{char})"/>
+    void Write(string value) => Write(value.AsSpan());
+
     /// <summary>
     /// Returns he output of the writer and calls <see cref="Reset"/>.
     /// </summary>

--- a/src/Abstractions/NexusMods.Abstractions.Games.Diagnostics/IDiagnosticWriter.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Games.Diagnostics/IDiagnosticWriter.cs
@@ -1,0 +1,40 @@
+using JetBrains.Annotations;
+
+namespace NexusMods.Abstractions.Diagnostics;
+
+/// <summary>
+/// Represents a writer of diagnostic messages.
+/// </summary>
+/// <remarks>
+/// Implementations of this interface are not thread-safe.
+/// </remarks>
+[PublicAPI]
+public interface IDiagnosticWriter : IDisposable
+{
+    /// <summary>
+    /// Writes <paramref name="value"/> to the output.
+    /// </summary>
+    /// <remarks>
+    /// This is used to write field values to the output.
+    /// </remarks>
+    void Write<T>(T value) where T : notnull;
+
+    /// <inheritdoc cref="Write{T}"/>
+    /// <remarks>
+    /// This is used to write everything between field values to the output.
+    /// </remarks>
+    void Write(ReadOnlySpan<char> value);
+
+    /// <summary>
+    /// Returns he output of the writer and calls <see cref="Reset"/>.
+    /// </summary>
+    string GetOutput();
+
+    /// <summary>
+    /// Resets the writer to it's initial state.
+    /// </summary>
+    /// <remarks>
+    /// This gets called automatically by <see cref="GetOutput"/>.
+    /// </remarks>
+    void Reset();
+}

--- a/src/Abstractions/NexusMods.Abstractions.Games.Diagnostics/IDiagnosticWriter.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Games.Diagnostics/IDiagnosticWriter.cs
@@ -21,6 +21,13 @@ public interface IDiagnosticWriter : IDisposable
 
     /// <inheritdoc cref="Write{T}"/>
     /// <remarks>
+    /// This is used to write fields that are value types to the output to prevent
+    /// boxing.
+    /// </remarks>
+    void WriteValueType<T>(T value) where T : struct;
+
+    /// <inheritdoc cref="Write{T}"/>
+    /// <remarks>
     /// This is used to write everything between field values to the output.
     /// </remarks>
     void Write(ReadOnlySpan<char> value);

--- a/src/Abstractions/NexusMods.Abstractions.Games.Diagnostics/Values/NamedLink.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Games.Diagnostics/Values/NamedLink.cs
@@ -1,0 +1,21 @@
+using JetBrains.Annotations;
+
+namespace NexusMods.Abstractions.Diagnostics.Values;
+
+/// <summary>
+/// Represents a named link.
+/// </summary>
+[PublicAPI]
+public readonly record struct NamedLink(string Name, Uri Uri);
+
+/// <summary>
+/// Extension methods for <see cref="Uri"/>.
+/// </summary>
+[PublicAPI]
+public static class UriExtensions
+{
+    /// <summary>
+    /// Converts a <see cref="Uri"/> into a <see cref="NamedLink"/>.
+    /// </summary>
+    public static NamedLink WithName(this Uri uri, string name) => new(name, uri);
+}

--- a/src/Games/NexusMods.Games.StardewValley/Diagnostics.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Diagnostics.cs
@@ -1,6 +1,7 @@
 using JetBrains.Annotations;
 using NexusMods.Abstractions.Diagnostics;
 using NexusMods.Abstractions.Diagnostics.References;
+using NexusMods.Abstractions.Diagnostics.Values;
 using NexusMods.Generators.Diagnostics;
 
 namespace NexusMods.Games.StardewValley;
@@ -21,7 +22,7 @@ internal static partial class Diagnostics
         .WithMessageData(messageBuilder => messageBuilder
             .AddDataReference<ModReference>("Mod")
             .AddValue<string>("MissingDependency")
-            .AddValue<Uri>("NexusModsDependencyUri")
+            .AddValue<NamedLink>("NexusModsDependencyUri")
         )
         .Finish();
 
@@ -39,7 +40,7 @@ internal static partial class Diagnostics
             .AddDataReference<ModReference>("Dependency")
             .AddValue<string>("MinimumVersion")
             .AddValue<string>("CurrentVersion")
-            .AddValue<Uri>("NexusModsDependencyUri")
+            .AddValue<NamedLink>("NexusModsDependencyUri")
         )
         .Finish();
 
@@ -54,7 +55,7 @@ internal static partial class Diagnostics
         .WithDetails("You can install the latest SMAPI version at {NexusModsSMAPIUri}.")
         .WithMessageData(messageBuilder => messageBuilder
             .AddValue<int>("ModCount")
-            .AddValue<Uri>("NexusModsSMAPIUri")
+            .AddValue<NamedLink>("NexusModsSMAPIUri")
         )
         .Finish();
 

--- a/src/Games/NexusMods.Games.StardewValley/Emitters/DependencyDiagnosticEmitter.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/DependencyDiagnosticEmitter.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.Diagnostics;
 using NexusMods.Abstractions.Diagnostics.Emitters;
 using NexusMods.Abstractions.Diagnostics.References;
+using NexusMods.Abstractions.Diagnostics.Values;
 using NexusMods.Abstractions.IO;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Loadouts.Mods;
@@ -110,7 +111,7 @@ public class DependencyDiagnosticEmitter : ILoadoutDiagnosticEmitter
                 return Diagnostics.CreateMissingRequiredDependency(
                     Mod: mod.ToReference(loadout),
                     MissingDependency: missingDependency,
-                    NexusModsDependencyUri: missingDependencyUris.GetValueOrDefault(missingDependency, NexusModsPage)
+                    NexusModsDependencyUri: missingDependencyUris.GetValueOrDefault(missingDependency, NexusModsPage).WithName("Nexus Mods")
                 );
             });
         });
@@ -177,7 +178,7 @@ public class DependencyDiagnosticEmitter : ILoadoutDiagnosticEmitter
             Dependency: loadout.Mods[tuple.DependencyModId].ToReference(loadout),
             MinimumVersion: tuple.MinimumVersion.ToString(),
             CurrentVersion: tuple.CurrentVersion.ToString(),
-            NexusModsDependencyUri: missingDependencyUris.GetValueOrDefault(tuple.DependencyId, NexusModsPage)
+            NexusModsDependencyUri: missingDependencyUris.GetValueOrDefault(tuple.DependencyId, NexusModsPage).WithName("Nexus Mods")
         ));
     }
 

--- a/src/Games/NexusMods.Games.StardewValley/Emitters/MissingSMAPIEmitter.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/MissingSMAPIEmitter.cs
@@ -1,5 +1,6 @@
 using NexusMods.Abstractions.Diagnostics;
 using NexusMods.Abstractions.Diagnostics.Emitters;
+using NexusMods.Abstractions.Diagnostics.Values;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Games.StardewValley.Models;
 
@@ -7,7 +8,7 @@ namespace NexusMods.Games.StardewValley.Emitters;
 
 public class MissingSMAPIEmitter : ILoadoutDiagnosticEmitter
 {
-    private static readonly Uri NexusModsSMAPIUri = new("https://nexusmods.com/stardewvalley/mods/2400");
+    private static readonly NamedLink NexusModsSMAPILink = new("Nexus Mods", new Uri("https://nexusmods.com/stardewvalley/mods/2400"));
 
     public async IAsyncEnumerable<Diagnostic> Diagnose(Loadout loadout)
     {
@@ -25,7 +26,7 @@ public class MissingSMAPIEmitter : ILoadoutDiagnosticEmitter
         {
             yield return Diagnostics.CreateSMAPIRequiredButNotInstalled(
                 ModCount: smapiModCount,
-                NexusModsSMAPIUri: NexusModsSMAPIUri
+                NexusModsSMAPIUri: NexusModsSMAPILink
             );
         }
 

--- a/src/NexusMods.App.Generators.Diagnostics/NexusMods.App.Generators.Diagnostics/DiagnosticTemplateIncrementalSourceGenerator.cs
+++ b/src/NexusMods.App.Generators.Diagnostics/NexusMods.App.Generators.Diagnostics/DiagnosticTemplateIncrementalSourceGenerator.cs
@@ -236,7 +236,14 @@ public class DiagnosticTemplateIncrementalSourceGenerator : IIncrementalGenerato
                         cw.AppendLine($"if (fieldName.Equals(nameof({field.Name}), global::System.StringComparison.Ordinal))");
                         using (cw.AddBlock())
                         {
-                            cw.AppendLine($"writer.Write({field.Name});");
+                            if (field.TypeSymbol.IsValueType)
+                            {
+                                cw.AppendLine($"writer.WriteValueType({field.Name});");
+                            }
+                            else
+                            {
+                                cw.AppendLine($"writer.Write({field.Name});");
+                            }
                         }
                     }
 

--- a/src/NexusMods.App.Generators.Diagnostics/NexusMods.App.Generators.Diagnostics/DiagnosticTemplateIncrementalSourceGenerator.cs
+++ b/src/NexusMods.App.Generators.Diagnostics/NexusMods.App.Generators.Diagnostics/DiagnosticTemplateIncrementalSourceGenerator.cs
@@ -172,9 +172,10 @@ public class DiagnosticTemplateIncrementalSourceGenerator : IIncrementalGenerato
             cw.AppendLine(";");
         }
 
-        cw.AppendLine($"internal readonly struct {diagnosticName}MessageData");
+        cw.AppendLine($"internal readonly struct {diagnosticName}MessageData : {Constants.DiagnosticsNamespace}.IDiagnosticMessageData");
         using (cw.AddBlock())
         {
+            // fields
             foreach (var field in parsedData.ParsedMessageBuilderFields)
             {
                 cw.AppendLine($"public readonly {field.TypeSymbol.ToDisplayString(CustomSymbolDisplayFormats.GlobalFormat)} {field.Name};");
@@ -182,6 +183,7 @@ public class DiagnosticTemplateIncrementalSourceGenerator : IIncrementalGenerato
 
             cw.AppendLine();
 
+            // constructor
             cw.Append($"public {diagnosticName}MessageData(");
             for (var i = 0; i < parsedData.ParsedMessageBuilderFields.Count; i++)
             {
@@ -196,6 +198,61 @@ public class DiagnosticTemplateIncrementalSourceGenerator : IIncrementalGenerato
                 {
                     cw.AppendLine($"this.{field.Name} = {field.Name};");
                 }
+            }
+
+            // Format method
+            cw.AppendLine($"public void Format({Constants.DiagnosticsNamespace}.DiagnosticMessage message, {Constants.DiagnosticsNamespace}.IDiagnosticWriter writer)");
+            using (cw.AddBlock())
+            {
+                cw.AppendLine("var value = message.Value;");
+                cw.AppendLine("var span = value.AsSpan();");
+
+                cw.AppendLine("int i;");
+                cw.AppendLine("var bracesStartIndex = -1;");
+                cw.AppendLine("var bracesEndIndex = -1;");
+                cw.AppendLine("for (i = 0; i < value.Length; i++)");
+                using (cw.AddBlock())
+                {
+                    cw.AppendLine("var c = value[i];");
+
+                    cw.AppendLine("if (bracesStartIndex == -1)");
+                    using (cw.AddBlock())
+                    {
+                        cw.AppendLine("if (c != '{') continue;");
+                        cw.AppendLine("bracesStartIndex = i;");
+
+                        cw.AppendLine("var slice = span.Slice(bracesEndIndex + 1, i - bracesEndIndex - 1);");
+                        cw.AppendLine("writer.Write(slice);");
+                        cw.AppendLine("continue;");
+                    }
+
+                    cw.AppendLine("if (c != '}') continue;");
+
+                    cw.AppendLine("var fieldName = span.Slice(bracesStartIndex + 1, i - bracesStartIndex - 1);");
+                    for (var i = 0; i < parsedData.ParsedMessageBuilderFields.Count; i++)
+                    {
+                        if (i != 0) cw.Append(" else ");
+                        var field = parsedData.ParsedMessageBuilderFields[i];
+                        cw.AppendLine($"if (fieldName.Equals(nameof({field.Name}), global::System.StringComparison.Ordinal))");
+                        using (cw.AddBlock())
+                        {
+                            cw.AppendLine($"writer.Write({field.Name});");
+                        }
+                    }
+
+                    cw.AppendLine("else");
+                    using (cw.AddBlock())
+                    {
+                        cw.AppendLine("throw new global::System.NotImplementedException();");
+                    }
+
+                    cw.AppendLine("bracesStartIndex = -1;");
+                    cw.AppendLine("bracesEndIndex = -1;");
+                }
+
+                cw.AppendLine("if (bracesEndIndex == i) return;");
+                cw.AppendLine("var endSlice = span.Slice(bracesEndIndex + 1, i - bracesEndIndex - 1);");
+                cw.AppendLine("writer.Write(endSlice);");
             }
         }
 
@@ -258,7 +315,7 @@ public class DiagnosticTemplateIncrementalSourceGenerator : IIncrementalGenerato
         }
 
         // WithSummary
-        if (!IsInvocationWithName(next, withSummary, out var withSummaryArguments, out next));
+        if (!IsInvocationWithName(next, withSummary, out var withSummaryArguments, out next)) return false;
         if (withSummaryArguments.Count != 1) return false;
         var summaryTemplateExpression = withSummaryArguments[0].Expression;
 
@@ -269,7 +326,7 @@ public class DiagnosticTemplateIncrementalSourceGenerator : IIncrementalGenerato
         var severityName = severityMemberAccess.Name.Identifier.ToString();
 
         // WithTitle
-        if (!IsInvocationWithName(next, withTitle, out var withTitleArguments, out next));
+        if (!IsInvocationWithName(next, withTitle, out var withTitleArguments, out next)) return false;
         if (withTitleArguments.Count != 1) return false;
         var titleExpression = withTitleArguments[0].Expression;
 

--- a/src/NexusMods.App.UI/DiagnosticSystem/DiagnosticWriter.cs
+++ b/src/NexusMods.App.UI/DiagnosticSystem/DiagnosticWriter.cs
@@ -39,7 +39,7 @@ internal sealed class DiagnosticWriter : IDiagnosticWriter
 
     public void Write(ReadOnlySpan<char> value) => _sb.Append(value);
 
-    public string GetOutput()
+    public string ToOutput()
     {
         var res = _sb.ToString();
         Reset();

--- a/src/NexusMods.App.UI/DiagnosticSystem/DiagnosticWriter.cs
+++ b/src/NexusMods.App.UI/DiagnosticSystem/DiagnosticWriter.cs
@@ -1,0 +1,40 @@
+using System.Text;
+using NexusMods.Abstractions.Diagnostics;
+
+namespace NexusMods.App.UI.DiagnosticSystem;
+
+internal sealed class DiagnosticWriter : IDiagnosticWriter
+{
+    private readonly ValueFormatterCache _formatterCache;
+    private readonly StringBuilder _sb = new();
+
+    public DiagnosticWriter(ValueFormatterCache formatterCache)
+    {
+        _formatterCache = formatterCache;
+    }
+
+    public void Write<T>(T value) where T : notnull
+    {
+        if (_formatterCache.TryGetFormatter<T>(out var formatter))
+        {
+            formatter.Format(value, this);
+        }
+        else
+        {
+            Write(value.ToString().AsSpan());
+        }
+    }
+
+    public void Write(ReadOnlySpan<char> value) => _sb.Append(value);
+
+    public string GetOutput()
+    {
+        var res = _sb.ToString();
+        Reset();
+        return res;
+    }
+
+    public void Reset() => _sb.Clear();
+
+    public void Dispose() { }
+}

--- a/src/NexusMods.App.UI/DiagnosticSystem/DiagnosticWriter.cs
+++ b/src/NexusMods.App.UI/DiagnosticSystem/DiagnosticWriter.cs
@@ -25,6 +25,18 @@ internal sealed class DiagnosticWriter : IDiagnosticWriter
         }
     }
 
+    public void WriteValueType<T>(T value) where T : struct
+    {
+        if (_formatterCache.TryGetFormatter<T>(out var formatter))
+        {
+            formatter.Format(value, this);
+        }
+        else
+        {
+            Write(value.ToString().AsSpan());
+        }
+    }
+
     public void Write(ReadOnlySpan<char> value) => _sb.Append(value);
 
     public string GetOutput()

--- a/src/NexusMods.App.UI/DiagnosticSystem/IValueFormatter.cs
+++ b/src/NexusMods.App.UI/DiagnosticSystem/IValueFormatter.cs
@@ -3,20 +3,22 @@ using NexusMods.Abstractions.Diagnostics;
 
 namespace NexusMods.App.UI.DiagnosticSystem;
 
+/// <summary>
+/// Marker interface for value formatters. This should never be implemented
+/// directly, use <see cref="IValueFormatter{T}"/> instead.
+/// </summary>
 [PublicAPI]
-public interface IValueFormatter
-{
-    void Format(object value, IDiagnosticWriter writer);
-}
+public interface IValueFormatter;
 
+/// <summary>
+/// Generic value formatter for values of type <typeparamref name="T"/>.
+/// </summary>
 [PublicAPI]
 public interface IValueFormatter<in T> : IValueFormatter where T : notnull
 {
-    void IValueFormatter.Format(object value, IDiagnosticWriter writer)
-    {
-        if (value is not T actualValue) throw new NotImplementedException();
-        Format(actualValue, writer);
-    }
-
+    /// <summary>
+    /// Formats the given value of type <typeparamref name="T"/> and writes it
+    /// to the given <see cref="IDiagnosticWriter"/>.
+    /// </summary>
     void Format(T value, IDiagnosticWriter writer);
 }

--- a/src/NexusMods.App.UI/DiagnosticSystem/IValueFormatter.cs
+++ b/src/NexusMods.App.UI/DiagnosticSystem/IValueFormatter.cs
@@ -1,0 +1,22 @@
+using JetBrains.Annotations;
+using NexusMods.Abstractions.Diagnostics;
+
+namespace NexusMods.App.UI.DiagnosticSystem;
+
+[PublicAPI]
+public interface IValueFormatter
+{
+    void Format(object value, IDiagnosticWriter writer);
+}
+
+[PublicAPI]
+public interface IValueFormatter<in T> : IValueFormatter where T : notnull
+{
+    void IValueFormatter.Format(object value, IDiagnosticWriter writer)
+    {
+        if (value is not T actualValue) throw new NotImplementedException();
+        Format(actualValue, writer);
+    }
+
+    void Format(T value, IDiagnosticWriter writer);
+}

--- a/src/NexusMods.App.UI/DiagnosticSystem/LoadoutReferenceFormatter.cs
+++ b/src/NexusMods.App.UI/DiagnosticSystem/LoadoutReferenceFormatter.cs
@@ -1,0 +1,22 @@
+using NexusMods.Abstractions.Diagnostics;
+using NexusMods.Abstractions.Diagnostics.References;
+using NexusMods.Abstractions.Loadouts;
+
+namespace NexusMods.App.UI.DiagnosticSystem;
+
+internal sealed class LoadoutReferenceFormatter : IValueFormatter<LoadoutReference>
+{
+    private readonly ILoadoutRegistry _loadoutRegistry;
+
+    public LoadoutReferenceFormatter(ILoadoutRegistry loadoutRegistry)
+    {
+        _loadoutRegistry = loadoutRegistry;
+    }
+
+    public void Format(LoadoutReference value, IDiagnosticWriter writer)
+    {
+        // TODO: custom markdown control
+        var loadout = _loadoutRegistry.Get(value.DataId);
+        writer.Write(loadout?.Name ?? "MISSING LOADOUT");
+    }
+}

--- a/src/NexusMods.App.UI/DiagnosticSystem/ModReferenceFormatter.cs
+++ b/src/NexusMods.App.UI/DiagnosticSystem/ModReferenceFormatter.cs
@@ -1,0 +1,22 @@
+using NexusMods.Abstractions.Diagnostics;
+using NexusMods.Abstractions.Diagnostics.References;
+using NexusMods.Abstractions.Loadouts;
+
+namespace NexusMods.App.UI.DiagnosticSystem;
+
+internal sealed class ModReferenceFormatter : IValueFormatter<ModReference>
+{
+    private readonly ILoadoutRegistry _loadoutRegistry;
+
+    public ModReferenceFormatter(ILoadoutRegistry loadoutRegistry)
+    {
+        _loadoutRegistry = loadoutRegistry;
+    }
+
+    public void Format(ModReference value, IDiagnosticWriter writer)
+    {
+        // TODO: custom markdown control
+        var mod = _loadoutRegistry.Get(value.DataId);
+        writer.Write(mod?.Name ?? "MISSING MOD");
+    }
+}

--- a/src/NexusMods.App.UI/DiagnosticSystem/NamedLinkFormatter.cs
+++ b/src/NexusMods.App.UI/DiagnosticSystem/NamedLinkFormatter.cs
@@ -1,0 +1,13 @@
+using NexusMods.Abstractions.Diagnostics;
+using NexusMods.Abstractions.Diagnostics.Values;
+
+namespace NexusMods.App.UI.DiagnosticSystem;
+
+internal sealed class NamedLinkFormatter : IValueFormatter<NamedLink>
+{
+    public void Format(NamedLink value, IDiagnosticWriter writer)
+    {
+        // TODO: markdown link
+        writer.Write(value.Uri.ToString());
+    }
+}

--- a/src/NexusMods.App.UI/DiagnosticSystem/ValueFormatterCache.cs
+++ b/src/NexusMods.App.UI/DiagnosticSystem/ValueFormatterCache.cs
@@ -21,7 +21,7 @@ internal sealed class ValueFormatterCache
         formatter = _formatters.OfType<IValueFormatter<T>>().FirstOrDefault();
         if (formatter is not null) return true;
 
-        _logger.LogDebug("Unable to find formatter for type {Type}", typeof(T).ToString());
+        _logger.LogTrace("Unable to find formatter for type {Type}", typeof(T).ToString());
         return false;
     }
 }

--- a/src/NexusMods.App.UI/DiagnosticSystem/ValueFormatterCache.cs
+++ b/src/NexusMods.App.UI/DiagnosticSystem/ValueFormatterCache.cs
@@ -1,0 +1,27 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Logging;
+
+namespace NexusMods.App.UI.DiagnosticSystem;
+
+internal sealed class ValueFormatterCache
+{
+    private readonly ILogger<ValueFormatterCache> _logger;
+    private readonly IValueFormatter[] _formatters;
+
+    public ValueFormatterCache(
+        ILogger<ValueFormatterCache> logger,
+        IEnumerable<IValueFormatter> formatters)
+    {
+        _logger = logger;
+        _formatters = formatters.ToArray();
+    }
+
+    public bool TryGetFormatter<T>([NotNullWhen(true)] out IValueFormatter<T>? formatter) where T : notnull
+    {
+        formatter = _formatters.OfType<IValueFormatter<T>>().FirstOrDefault();
+        if (formatter is not null) return true;
+
+        _logger.LogDebug("Unable to find formatter for type {Type}", typeof(T).ToString());
+        return false;
+    }
+}

--- a/src/NexusMods.App.UI/NexusMods.App.UI.csproj
+++ b/src/NexusMods.App.UI/NexusMods.App.UI.csproj
@@ -444,6 +444,15 @@
         <Compile Update="DiagnosticSystem\ValueFormatterCache.cs">
           <DependentUpon>IValueFormatter.cs</DependentUpon>
         </Compile>
+        <Compile Update="DiagnosticSystem\ModReferenceFormatter.cs">
+          <DependentUpon>IValueFormatter.cs</DependentUpon>
+        </Compile>
+        <Compile Update="DiagnosticSystem\LoadoutReferenceFormatter.cs">
+          <DependentUpon>IValueFormatter.cs</DependentUpon>
+        </Compile>
+        <Compile Update="DiagnosticSystem\NamedLinkFormatter.cs">
+          <DependentUpon>IValueFormatter.cs</DependentUpon>
+        </Compile>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NexusMods.App.UI/NexusMods.App.UI.csproj
+++ b/src/NexusMods.App.UI/NexusMods.App.UI.csproj
@@ -77,6 +77,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\Abstractions\NexusMods.Abstractions.App.Settings\NexusMods.Abstractions.App.Settings.csproj" />
+        <ProjectReference Include="..\Abstractions\NexusMods.Abstractions.Games.Diagnostics\NexusMods.Abstractions.Games.Diagnostics.csproj" />
         <ProjectReference Include="..\Abstractions\NexusMods.Abstractions.GuidedInstallers\NexusMods.Abstractions.GuidedInstallers.csproj" />
         <ProjectReference Include="..\Extensions\NexusMods.Extensions.DynamicData\NexusMods.Extensions.DynamicData.csproj" />
         <ProjectReference Include="..\Networking\NexusMods.Networking.Downloaders\NexusMods.Networking.Downloaders.csproj" />
@@ -439,6 +440,9 @@
         </Compile>
         <Compile Update="Controls\ModInfo\ModFiles\ModFilesViewModel.cs">
           <DependentUpon>IModFilesViewModel.cs</DependentUpon>
+        </Compile>
+        <Compile Update="DiagnosticSystem\ValueFormatterCache.cs">
+          <DependentUpon>IValueFormatter.cs</DependentUpon>
         </Compile>
     </ItemGroup>
 

--- a/src/NexusMods.App.UI/Services.cs
+++ b/src/NexusMods.App.UI/Services.cs
@@ -217,6 +217,9 @@ public static class Services
 
             // Diagnostics
             .AddSingleton<ValueFormatterCache>()
+            .AddSingleton<IValueFormatter, ModReferenceFormatter>()
+            .AddSingleton<IValueFormatter, LoadoutReferenceFormatter>()
+            .AddSingleton<IValueFormatter, NamedLinkFormatter>()
             .AddTransient<IDiagnosticWriter, DiagnosticWriter>()
 
             // Other

--- a/src/NexusMods.App.UI/Services.cs
+++ b/src/NexusMods.App.UI/Services.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.DependencyInjection;
+using NexusMods.Abstractions.Diagnostics;
 using NexusMods.Abstractions.Serialization.ExpressionGenerator;
 using NexusMods.Abstractions.Serialization.Json;
 using NexusMods.App.UI.Controls;
@@ -21,6 +22,7 @@ using NexusMods.App.UI.Controls.Spine.Buttons.Icon;
 using NexusMods.App.UI.Controls.Spine.Buttons.Image;
 using NexusMods.App.UI.Controls.TopBar;
 using NexusMods.App.UI.Controls.Trees.Files;
+using NexusMods.App.UI.DiagnosticSystem;
 using NexusMods.App.UI.LeftMenu;
 using NexusMods.App.UI.LeftMenu.Downloads;
 using NexusMods.App.UI.LeftMenu.Home;
@@ -209,9 +211,15 @@ public static class Services
             .AddSingleton<IWorkspaceAttachmentsFactory, HomeAttachmentsFactory>()
             .AddSingleton<IWorkspaceAttachmentsFactory, LoadoutAttachmentsFactory>()
 
-            // Other
+            // Debugging
             .AddViewModel<DummyViewModel, IDummyViewModel>()
             .AddView<DummyView, IDummyViewModel>()
+
+            // Diagnostics
+            .AddSingleton<ValueFormatterCache>()
+            .AddTransient<IDiagnosticWriter, DiagnosticWriter>()
+
+            // Other
             .AddSingleton<InjectedViewLocator>()
             .AddFileSystem();
     }

--- a/tests/NexusMods.App.Generators.Diagnostics.Tests/DiagnosticTemplateIncrementalSourceGeneratorTests.TestGenerator#TestNamespace.MyClass.Diagnostic1Template.g.verified.cs
+++ b/tests/NexusMods.App.Generators.Diagnostics.Tests/DiagnosticTemplateIncrementalSourceGeneratorTests.TestGenerator#TestNamespace.MyClass.Diagnostic1Template.g.verified.cs
@@ -30,7 +30,7 @@ partial class MyClass
 		;
 	}
 
-	internal readonly struct Diagnostic1MessageData
+	internal readonly struct Diagnostic1MessageData : global::NexusMods.Abstractions.Diagnostics.IDiagnosticMessageData
 	{
 		public readonly global::NexusMods.Abstractions.Diagnostics.References.ModReference ModA;
 		public readonly global::NexusMods.Abstractions.Diagnostics.References.ModReference ModB;
@@ -41,6 +41,56 @@ partial class MyClass
 			this.ModA = ModA;
 			this.ModB = ModB;
 			this.Something = Something;
+		}
+
+		public void Format(global::NexusMods.Abstractions.Diagnostics.DiagnosticMessage message, global::NexusMods.Abstractions.Diagnostics.IDiagnosticWriter writer)
+		{
+			var value = message.Value;
+			var span = value.AsSpan();
+			int i;
+			var bracesStartIndex = -1;
+			var bracesEndIndex = -1;
+			for (i = 0; i < value.Length; i++)
+			{
+				var c = value[i];
+				if (bracesStartIndex == -1)
+				{
+					if (c != '{') continue;
+					bracesStartIndex = i;
+					var slice = span.Slice(bracesEndIndex + 1, i - bracesEndIndex - 1);
+					writer.Write(slice);
+					continue;
+				}
+
+				if (c != '}') continue;
+				var fieldName = span.Slice(bracesStartIndex + 1, i - bracesStartIndex - 1);
+				if (fieldName.Equals(nameof(ModA), global::System.StringComparison.Ordinal))
+				{
+					writer.Write(ModA);
+				}
+
+				 else if (fieldName.Equals(nameof(ModB), global::System.StringComparison.Ordinal))
+				{
+					writer.Write(ModB);
+				}
+
+				 else if (fieldName.Equals(nameof(Something), global::System.StringComparison.Ordinal))
+				{
+					writer.Write(Something);
+				}
+
+				else
+				{
+					throw new global::System.NotImplementedException();
+				}
+
+				bracesStartIndex = -1;
+				bracesEndIndex = -1;
+			}
+
+			if (bracesEndIndex == i) return;
+			var endSlice = span.Slice(bracesEndIndex + 1, i - bracesEndIndex - 1);
+			writer.Write(endSlice);
 		}
 
 	}

--- a/tests/NexusMods.App.Generators.Diagnostics.Tests/DiagnosticTemplateIncrementalSourceGeneratorTests.TestGenerator#TestNamespace.MyClass.Diagnostic1Template.g.verified.cs
+++ b/tests/NexusMods.App.Generators.Diagnostics.Tests/DiagnosticTemplateIncrementalSourceGeneratorTests.TestGenerator#TestNamespace.MyClass.Diagnostic1Template.g.verified.cs
@@ -6,16 +6,16 @@ namespace TestNamespace;
 
 partial class MyClass
 {
-	internal static global::NexusMods.Abstractions.Diagnostics.Diagnostic<Diagnostic1MessageData> CreateDiagnostic1(global::NexusMods.Abstractions.Diagnostics.References.ModReference ModA, global::NexusMods.Abstractions.Diagnostics.References.ModReference ModB, global::System.String Something)
+	internal static global::NexusMods.Abstractions.Diagnostics.Diagnostic<Diagnostic1MessageData> CreateDiagnostic1(global::NexusMods.Abstractions.Diagnostics.References.ModReference ModA, global::NexusMods.Abstractions.Diagnostics.References.ModReference ModB, global::System.String Something, global::System.Int32 Count)
 	{
-		var messageData = new Diagnostic1MessageData(ModA, ModB, Something);
+		var messageData = new Diagnostic1MessageData(ModA, ModB, Something, Count);
 
 		return new global::NexusMods.Abstractions.Diagnostics.Diagnostic<Diagnostic1MessageData>
 		{
 			Id = new global::NexusMods.Abstractions.Diagnostics.DiagnosticId(source: Source, number: 1),
 			Title = "Diagnostic 1",
 			Severity = global::NexusMods.Abstractions.Diagnostics.DiagnosticSeverity.Warning,
-			Summary = global::NexusMods.Abstractions.Diagnostics.DiagnosticMessage.From("Mod '{ModA}' conflicts with '{ModB}' because it's missing '{Something}'!"),
+			Summary = global::NexusMods.Abstractions.Diagnostics.DiagnosticMessage.From("Mod '{ModA}' conflicts with '{ModB}' because it's missing '{Something}' and {Count} other stuff!"),
 			Details = global::NexusMods.Abstractions.Diagnostics.DiagnosticMessage.DefaultValue,
 			MessageData = messageData,
 			DataReferences = new global::System.Collections.Generic.Dictionary<global::NexusMods.Abstractions.Diagnostics.References.DataReferenceDescription, global::NexusMods.Abstractions.Diagnostics.References.IDataReference>
@@ -35,12 +35,14 @@ partial class MyClass
 		public readonly global::NexusMods.Abstractions.Diagnostics.References.ModReference ModA;
 		public readonly global::NexusMods.Abstractions.Diagnostics.References.ModReference ModB;
 		public readonly global::System.String Something;
+		public readonly global::System.Int32 Count;
 
-		public Diagnostic1MessageData(global::NexusMods.Abstractions.Diagnostics.References.ModReference ModA, global::NexusMods.Abstractions.Diagnostics.References.ModReference ModB, global::System.String Something)
+		public Diagnostic1MessageData(global::NexusMods.Abstractions.Diagnostics.References.ModReference ModA, global::NexusMods.Abstractions.Diagnostics.References.ModReference ModB, global::System.String Something, global::System.Int32 Count)
 		{
 			this.ModA = ModA;
 			this.ModB = ModB;
 			this.Something = Something;
+			this.Count = Count;
 		}
 
 		public void Format(global::NexusMods.Abstractions.Diagnostics.DiagnosticMessage message, global::NexusMods.Abstractions.Diagnostics.IDiagnosticWriter writer)
@@ -77,6 +79,11 @@ partial class MyClass
 				 else if (fieldName.Equals(nameof(Something), global::System.StringComparison.Ordinal))
 				{
 					writer.Write(Something);
+				}
+
+				 else if (fieldName.Equals(nameof(Count), global::System.StringComparison.Ordinal))
+				{
+					writer.WriteValueType(Count);
 				}
 
 				else

--- a/tests/NexusMods.App.Generators.Diagnostics.Tests/DiagnosticTemplateIncrementalSourceGeneratorTests.cs
+++ b/tests/NexusMods.App.Generators.Diagnostics.Tests/DiagnosticTemplateIncrementalSourceGeneratorTests.cs
@@ -25,12 +25,13 @@ internal partial class MyClass
         .WithId(new DiagnosticId(source: Source, number: 1))
         .WithTitle("Diagnostic 1")
         .WithSeverity(DiagnosticSeverity.Warning)
-        .WithSummary("Mod '{ModA}' conflicts with '{ModB}' because it's missing '{Something}'!")
+        .WithSummary("Mod '{ModA}' conflicts with '{ModB}' because it's missing '{Something}' and {Count} other stuff!")
         .WithoutDetails()
         .WithMessageData(messageBuilder => messageBuilder
             .AddDataReference<ModReference>("ModA")
             .AddDataReference<ModReference>("ModB")
             .AddValue<string>("Something")
+            .AddValue<int>("Count")
         )
         .Finish();
 }


### PR DESCRIPTION
This is the first step towards rendering diagnostics in the UI. Diagnostic messages can now be written as plain text with all their fields populated.