### PR TITLE
Added: A Writer Lock for SqliteDataStore

### DIFF
--- a/src/NexusMods.DataModel/FileHashCache.cs
+++ b/src/NexusMods.DataModel/FileHashCache.cs
@@ -131,6 +131,7 @@ public class FileHashCache : IFileHashCache
             DiskStateEntry.From(h))));
     }
 
+    [SkipLocalsInit] // We don't need to zero the memory here
     private void PutCachedAsync(AbsolutePath path, FileHashCacheEntry entry)
     {
         var normalized = path.ToString();


### PR DESCRIPTION
This PR adds a simple writer lock into `SqliteDataStore`, such that concurrent access to the database doesn't result in failure. 

Although we will deprecate the data store I also (just in case) timed the performance of real workloads against this PR. Difference is negligible.

For more details, see #1089 

----
fixes #1089