### PR TITLE
Run Git Builds on Fridays

### DIFF
--- a/.github/workflows/git-builds.yaml
+++ b/.github/workflows/git-builds.yaml
@@ -4,7 +4,7 @@ on:
   schedule:
     # At minute 17 past hour 8 and 14 (UTC) on every day-of-week from Monday through Thursday
     # https://crontab.guru
-    - cron: '17 08,14 * * 1-4'
+    - cron: '17 08,14 * * 1-5'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Realized that we should let it run on Friday morning as well, so that anyone interested can try the latest commits from late Thursday during the weekend.