### PR TITLE
Diagnostics for incompatible SMAPI mods

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Installers/Extensions.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Installers/Extensions.cs
@@ -1,7 +1,9 @@
+using System.Collections.Immutable;
 using NexusMods.Abstractions.FileStore.Trees;
 using NexusMods.Abstractions.GameLocators;
 using NexusMods.Abstractions.Loadouts.Files;
 using NexusMods.Abstractions.Loadouts.Mods;
+using NexusMods.Abstractions.Serialization;
 using NexusMods.Paths;
 using NexusMods.Paths.Trees;
 
@@ -15,9 +17,6 @@ public static class Extensions
     /// <summary>
     /// Creates a StoredFile from a ModFileTreeSource.
     /// </summary>
-    /// <param name="input"></param>
-    /// <param name="to"></param>
-    /// <returns></returns>
     public static StoredFile ToStoredFile(this KeyedBox<RelativePath, ModFileTree> input, GamePath to)
     {
         return new StoredFile
@@ -25,8 +24,25 @@ public static class Extensions
             Id = ModFileId.NewId(),
             To = to,
             Hash = input.Item.Hash,
-            Size = input.Item.Size
+            Size = input.Item.Size,
         };
     }
 
+    /// <summary>
+    /// Creates a StoredFile from a ModFileTreeSource.
+    /// </summary>
+    public static StoredFile ToStoredFile(
+        this KeyedBox<RelativePath, ModFileTree> input,
+        GamePath to,
+        ImmutableList<IMetadata> metadata)
+    {
+        return new StoredFile
+        {
+            Id = ModFileId.NewId(),
+            To = to,
+            Hash = input.Item.Hash,
+            Size = input.Item.Size,
+            Metadata = metadata,
+        };
+    }
 }

--- a/src/Games/NexusMods.Games.StardewValley.SMAPI/NexusMods.Games.StardewValley.SMAPI.csproj
+++ b/src/Games/NexusMods.Games.StardewValley.SMAPI/NexusMods.Games.StardewValley.SMAPI.csproj
@@ -13,6 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <!-- keep in sync with https://github.com/Pathoschild/SMAPI/blob/develop/src/SMAPI.Toolkit/SMAPI.Toolkit.csproj -->
         <PackageReference Include="HtmlAgilityPack" VersionOverride="1.11.52" />
         <PackageReference Include="Newtonsoft.Json" VersionOverride="13.0.3" />
         <PackageReference Include="Pathoschild.Http.FluentClient" VersionOverride="4.3.0" />

--- a/src/Games/NexusMods.Games.StardewValley.SMAPI/NexusMods.Games.StardewValley.SMAPI.csproj
+++ b/src/Games/NexusMods.Games.StardewValley.SMAPI/NexusMods.Games.StardewValley.SMAPI.csproj
@@ -18,6 +18,10 @@
         <PackageReference Include="Pathoschild.Http.FluentClient" VersionOverride="4.3.0" />
     </ItemGroup>
 
+    <ItemGroup>
+        <InternalsVisibleTo Include="NexusMods.Games.StardewValley"/>
+    </ItemGroup>
+
     <Target Name="ValidateSubmodule" AfterTargets="BeforeBuild">
         <Error Condition="!Exists('..\..\..\extern\SMAPI\src')" Text="Missing SMAPI submodule! Make sure to run 'git submodule update --init --recursive'" />
     </Target>

--- a/src/Games/NexusMods.Games.StardewValley/Diagnostics.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Diagnostics.cs
@@ -101,12 +101,37 @@ Mod {Mod} has been made obsolete:
 
 > {ModName} is obsolete because {ReasonPhrase}
 
-The compatability status was extracted from the internal SMAPI metadata file.
+The compatibility status was extracted from the internal SMAPI metadata file.
 """)
         .WithMessageData(messageBuilder => messageBuilder
             .AddDataReference<ModReference>("Mod")
             .AddValue<string>("ModName")
             .AddValue<string>("ReasonPhrase")
+        )
+        .Finish();
+
+    [DiagnosticTemplate]
+    [UsedImplicitly]
+    internal static IDiagnosticTemplate ModCompatabilityAssumeBrokenTemplate = DiagnosticTemplateBuilder
+        .Start()
+        .WithId(new DiagnosticId(Source, number: 7))
+        .WithTitle("Mod is assumed broken")
+        .WithSeverity(DiagnosticSeverity.Warning)
+        .WithSummary("Mod {Mod} is assumed broken")
+        .WithDetails("""
+Mod {Mod} is marked as broken by SMAPI:
+
+> {ReasonPhrase}
+
+Please check for a version newer than {ModVersion} at {ModLink}.
+
+The compatibility status was extracted from the internal SMAPI metadata file.
+""")
+        .WithMessageData(messageBuilder => messageBuilder
+            .AddDataReference<ModReference>("Mod")
+            .AddValue<string>("ReasonPhrase")
+            .AddValue<NamedLink>("ModLink")
+            .AddValue<string>("ModVersion")
         )
         .Finish();
 }

--- a/src/Games/NexusMods.Games.StardewValley/Diagnostics.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Diagnostics.cs
@@ -105,6 +105,7 @@ The compatability status was extracted from the internal SMAPI metadata file.
 """)
         .WithMessageData(messageBuilder => messageBuilder
             .AddDataReference<ModReference>("Mod")
+            .AddValue<string>("ModName")
             .AddValue<string>("ReasonPhrase")
         )
         .Finish();

--- a/src/Games/NexusMods.Games.StardewValley/Diagnostics.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Diagnostics.cs
@@ -87,4 +87,25 @@ internal static partial class Diagnostics
             .AddDataReference<ModReference>("Dependency")
         )
         .Finish();
+
+    [DiagnosticTemplate]
+    [UsedImplicitly]
+    internal static IDiagnosticTemplate ModCompatabilityObsoleteTemplate = DiagnosticTemplateBuilder
+        .Start()
+        .WithId(new DiagnosticId(Source, number: 6))
+        .WithTitle("Mod is obsolete")
+        .WithSeverity(DiagnosticSeverity.Warning)
+        .WithSummary("Mod {Mod} is obsolete")
+        .WithDetails("""
+Mod {Mod} has been made obsolete:
+
+> {ModName} is obsolete because {ReasonPhrase}
+
+The compatability status was extracted from the internal SMAPI metadata file.
+""")
+        .WithMessageData(messageBuilder => messageBuilder
+            .AddDataReference<ModReference>("Mod")
+            .AddValue<string>("ReasonPhrase")
+        )
+        .Finish();
 }

--- a/src/Games/NexusMods.Games.StardewValley/Emitters/DependencyDiagnosticEmitter.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/DependencyDiagnosticEmitter.cs
@@ -18,7 +18,7 @@ namespace NexusMods.Games.StardewValley.Emitters;
 
 public class DependencyDiagnosticEmitter : ILoadoutDiagnosticEmitter
 {
-    private static readonly Uri NexusModsPage = new("https://nexusmods.com/stardewvalley");
+    private static readonly NamedLink NexusModsLink = new("Nexus Mods", new Uri("https://nexusmods.com/stardewvalley"));
 
     private readonly ILogger<DependencyDiagnosticEmitter> _logger;
     private readonly IFileStore _fileStore;
@@ -158,7 +158,7 @@ public class DependencyDiagnosticEmitter : ILoadoutDiagnosticEmitter
                 return Diagnostics.CreateMissingRequiredDependency(
                     Mod: mod.ToReference(loadout),
                     MissingDependency: missingDependency,
-                    NexusModsDependencyUri: missingDependencyUris.GetValueOrDefault(missingDependency, NexusModsPage).WithName("Nexus Mods")
+                    NexusModsDependencyUri: missingDependencyUris.GetValueOrDefault(missingDependency, NexusModsLink)
                 );
             });
         });
@@ -228,7 +228,7 @@ public class DependencyDiagnosticEmitter : ILoadoutDiagnosticEmitter
             Dependency: loadout.Mods[tuple.DependencyModId].ToReference(loadout),
             MinimumVersion: tuple.MinimumVersion.ToString(),
             CurrentVersion: tuple.CurrentVersion.ToString(),
-            NexusModsDependencyUri: missingDependencyUris.GetValueOrDefault(tuple.DependencyId, NexusModsPage).WithName("Nexus Mods")
+            NexusModsDependencyUri: missingDependencyUris.GetValueOrDefault(tuple.DependencyId, NexusModsLink)
         ));
     }
 

--- a/src/Games/NexusMods.Games.StardewValley/Emitters/SMAPIModDatabaseCompatibilityDiagnosticEmitter.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/SMAPIModDatabaseCompatibilityDiagnosticEmitter.cs
@@ -1,6 +1,17 @@
+using System.Runtime.CompilerServices;
+using DynamicData.Kernel;
+using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.Diagnostics;
 using NexusMods.Abstractions.Diagnostics.Emitters;
+using NexusMods.Abstractions.Diagnostics.References;
+using NexusMods.Abstractions.IO;
 using NexusMods.Abstractions.Loadouts;
+using NexusMods.Abstractions.Loadouts.Mods;
+using NexusMods.Extensions.BCL;
+using NexusMods.Games.StardewValley.Models;
+using ModStatus = StardewModdingAPI.Toolkit.Framework.ModData.ModStatus;
+using SMAPIManifest = StardewModdingAPI.Toolkit.Serialization.Models.Manifest;
+using SMAPIModDatabase = StardewModdingAPI.Toolkit.Framework.ModData.ModDatabase;
 
 namespace NexusMods.Games.StardewValley.Emitters;
 
@@ -19,13 +30,98 @@ namespace NexusMods.Games.StardewValley.Emitters;
 /// </summary>
 public class SMAPIModDatabaseCompatibilityDiagnosticEmitter : ILoadoutDiagnosticEmitter
 {
-    public SMAPIModDatabaseCompatibilityDiagnosticEmitter()
+    private readonly ILogger<SMAPIModDatabaseCompatibilityDiagnosticEmitter> _logger;
+    private readonly IFileStore _fileStore;
+
+    public SMAPIModDatabaseCompatibilityDiagnosticEmitter(
+        ILogger<SMAPIModDatabaseCompatibilityDiagnosticEmitter> logger,
+        IFileStore fileStore)
     {
-        
+        _logger = logger;
+        _fileStore = fileStore;
     }
 
-    public IAsyncEnumerable<Diagnostic> Diagnose(Loadout loadout, CancellationToken cancellationToken)
+    public async IAsyncEnumerable<Diagnostic> Diagnose(Loadout loadout, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        throw new NotImplementedException();
+        var optionalSMAPIMod = loadout.Mods
+            .Where(kv => kv.Value.Enabled)
+            .FirstOrOptional(kv => kv.Value.Metadata
+                .OfType<SMAPIMarker>()
+                .Any()
+            );
+
+        if (!optionalSMAPIMod.HasValue) yield break;
+        var smapiMod = optionalSMAPIMod.Value.Value;
+
+        var modDatabase = await GetModDatabase(smapiMod, cancellationToken);
+        if (modDatabase is null) yield break;
+
+        var smapiMods = loadout.Mods
+            .Where(kv => kv.Value.Enabled)
+            .Select(kv => kv.Value)
+            .SelectAsync(async mod => (Mod: mod, Manifest: await GetManifest(mod, cancellationToken)))
+            .Where(tuple => tuple.Manifest is not null);
+
+        var asyncEnumerable = smapiMods.WithCancellation(cancellationToken).ConfigureAwait(false);
+        await foreach (var tuple in asyncEnumerable)
+        {
+            var (mod, manifest) = tuple;
+            var uniqueId = manifest!.UniqueID;
+
+            var dataRecord = modDatabase.Get(uniqueId);
+            if (dataRecord is null) continue;
+
+            var versionedFields = dataRecord.GetVersionedFields(manifest);
+            if (versionedFields.Status != ModStatus.Obsolete) continue;
+
+            var upperVersion = versionedFields.StatusUpperVersion;
+            var matches = upperVersion is null ||
+                          manifest.Version.IsOlderThan(upperVersion) ||
+                          manifest.Version.Equals(upperVersion);
+
+            if (!matches) continue;
+
+            yield return Diagnostics.CreateModCompatabilityObsolete(
+                Mod: mod.ToReference(loadout),
+                ModName: mod.Name,
+                ReasonPhrase: versionedFields.StatusReasonPhrase ?? "the feature/fix has been integrated into SMAPI or Stardew Valley or has otherwise been made obsolete."
+            );
+        }
+    }
+
+    private async ValueTask<SMAPIModDatabase?> GetModDatabase(Mod smapi, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await Interop.GetModDatabase(_fileStore, smapi, cancellationToken);
+        }
+        catch (TaskCanceledException)
+        {
+            // ignored
+            return null;
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Exception trying to get mod database of SMAPI");
+            return null;
+        }
+    }
+
+    private async ValueTask<SMAPIManifest?> GetManifest(Mod mod, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await Interop.GetManifest(_fileStore, mod, cancellationToken);
+        }
+        catch (TaskCanceledException)
+        {
+            // ignored
+            return null;
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Exception trying to get manifest for mod {Mod}", mod.Name);
+            return null;
+        }
     }
 }

--- a/src/Games/NexusMods.Games.StardewValley/Emitters/SMAPIModDatabaseCompatibilityDiagnosticEmitter.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/SMAPIModDatabaseCompatibilityDiagnosticEmitter.cs
@@ -1,0 +1,31 @@
+using NexusMods.Abstractions.Diagnostics;
+using NexusMods.Abstractions.Diagnostics.Emitters;
+using NexusMods.Abstractions.Loadouts;
+
+namespace NexusMods.Games.StardewValley.Emitters;
+
+/// <summary>
+/// This diagnostic emitter uses the internal SMAPI "mod database" to create
+/// compatibility diagnostics. The internal "mod database" from SMAPI can
+/// be found in the "smapi-internal/metadata.json" file or on GitHub:
+///
+/// https://github.com/Pathoschild/SMAPI/blob/develop/src/SMAPI.Web/wwwroot/SMAPI.metadata.json
+///
+/// NOTE(erri120): Technically, we can always get the latest version using the
+/// link above, or through the SMAPI server: https://smapi.io/SMAPI.metadata.json.
+///
+/// However, these compatibility details only make sense for the currently installed
+/// SMAPI version, so we'll use the local metadata file instead of the remote one.
+/// </summary>
+public class SMAPIModDatabaseCompatibilityDiagnosticEmitter : ILoadoutDiagnosticEmitter
+{
+    public SMAPIModDatabaseCompatibilityDiagnosticEmitter()
+    {
+        
+    }
+
+    public IAsyncEnumerable<Diagnostic> Diagnose(Loadout loadout, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Games/NexusMods.Games.StardewValley/Installers/SMAPIModInstaller.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Installers/SMAPIModInstaller.cs
@@ -26,17 +26,10 @@ public class SMAPIModInstaller : AModInstaller
     /// DI Constructor
     /// </summary>
     /// <param name="serviceProvider"></param>
-    private SMAPIModInstaller(IServiceProvider serviceProvider) : base(serviceProvider)
+    public SMAPIModInstaller(IServiceProvider serviceProvider) : base(serviceProvider)
     {
         _logger = serviceProvider.GetRequiredService<ILogger<SMAPIModInstaller>>();
     }
-
-    /// <summary>
-    /// Creates a new instance of <see cref="SMAPIModInstaller"/>.
-    /// </summary>
-    /// <param name="serviceProvider"></param>
-    /// <returns></returns>
-    public static SMAPIModInstaller Create(IServiceProvider serviceProvider) => new(serviceProvider);
 
     private async ValueTask<List<(KeyedBox<RelativePath, ModFileTree>, SMAPIManifest)>> GetManifestFiles(
         KeyedBox<RelativePath, ModFileTree> files)

--- a/src/Games/NexusMods.Games.StardewValley/Interop.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Interop.cs
@@ -22,8 +22,17 @@ internal static class Interop
         using var sr = new StreamReader(stream, Encoding.UTF8);
         var json = await sr.ReadToEndAsync();
 
-        var manifest = SMAPIJsonHelper.Deserialize<T>(json);
-        return manifest;
+        var res = SMAPIJsonHelper.Deserialize<T>(json);
+        return res;
+    }
+
+    private static async ValueTask<T?> DeserializeWithDefaults<T>(Stream stream) where T : notnull
+    {
+        using var sr = new StreamReader(stream, Encoding.UTF8);
+        var json = await sr.ReadToEndAsync();
+
+        var res = Newtonsoft.Json.JsonConvert.DeserializeObject<T>(json);
+        return res;
     }
 
     public static ValueTask<Manifest?> DeserializeManifest(Stream stream) => Deserialize<Manifest>(stream);
@@ -47,7 +56,7 @@ internal static class Interop
 
         // https://github.com/Pathoschild/SMAPI/blob/e8a86a0b98061d322c2af89af845ed9f5fd15468/src/SMAPI.Toolkit/ModToolkit.cs#L66-L71
         await using var stream = await fileStore.GetFileStream(storedFile.Hash, cancellationToken);
-        var metadata = await Deserialize<MetadataModel>(stream);
+        var metadata = await DeserializeWithDefaults<MetadataModel>(stream);
         if (metadata is null) return null;
 
         var records = metadata.ModData.Select(kv => new ModDataRecord(kv.Key, kv.Value)).ToArray();

--- a/src/Games/NexusMods.Games.StardewValley/Interop.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Interop.cs
@@ -4,6 +4,7 @@ using NexusMods.Abstractions.Loadouts.Extensions;
 using NexusMods.Abstractions.Loadouts.Files;
 using NexusMods.Abstractions.Loadouts.Mods;
 using NexusMods.Games.StardewValley.Models;
+using StardewModdingAPI.Toolkit.Framework.ModData;
 using StardewModdingAPI.Toolkit.Serialization;
 using StardewModdingAPI.Toolkit.Serialization.Models;
 
@@ -16,14 +17,16 @@ internal static class Interop
 {
     internal static readonly JsonHelper SMAPIJsonHelper = new();
 
-    public static async ValueTask<Manifest?> DeserializeManifest(Stream stream)
+    private static async ValueTask<T?> Deserialize<T>(Stream stream) where T : notnull
     {
         using var sr = new StreamReader(stream, Encoding.UTF8);
         var json = await sr.ReadToEndAsync();
 
-        var manifest = SMAPIJsonHelper.Deserialize<Manifest>(json);
+        var manifest = SMAPIJsonHelper.Deserialize<T>(json);
         return manifest;
     }
+
+    public static ValueTask<Manifest?> DeserializeManifest(Stream stream) => Deserialize<Manifest>(stream);
 
     public static async ValueTask<Manifest?> GetManifest(IFileStore fileStore, Mod mod, CancellationToken cancellationToken = default)
     {
@@ -32,5 +35,22 @@ internal static class Interop
 
         await using var stream = await fileStore.GetFileStream(storedFile.Hash, cancellationToken);
         return await DeserializeManifest(stream);
+    }
+
+    public static async ValueTask<ModDatabase?> GetModDatabase(
+        IFileStore fileStore,
+        Mod smapi,
+        CancellationToken cancellationToken = default)
+    {
+        var manifestFile = smapi.Files.Values.FirstOrDefault(f => f.HasMetadata<SMAPIModDatabaseMarker>());
+        if (manifestFile is not StoredFile storedFile) return null;
+
+        // https://github.com/Pathoschild/SMAPI/blob/e8a86a0b98061d322c2af89af845ed9f5fd15468/src/SMAPI.Toolkit/ModToolkit.cs#L66-L71
+        await using var stream = await fileStore.GetFileStream(storedFile.Hash, cancellationToken);
+        var metadata = await Deserialize<MetadataModel>(stream);
+        if (metadata is null) return null;
+
+        var records = metadata.ModData.Select(kv => new ModDataRecord(kv.Key, kv.Value)).ToArray();
+        return new ModDatabase(records, static _ => null);
     }
 }

--- a/src/Games/NexusMods.Games.StardewValley/Models/SMAPIModDatabaseMarker.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Models/SMAPIModDatabaseMarker.cs
@@ -1,0 +1,7 @@
+using NexusMods.Abstractions.Serialization;
+using NexusMods.Abstractions.Serialization.Attributes;
+
+namespace NexusMods.Games.StardewValley.Models;
+
+[JsonName("NexusMods.Games.StardewValley.Models.SMAPIModDatabaseMarker")]
+public record SMAPIModDatabaseMarker : IMetadata;

--- a/src/Games/NexusMods.Games.StardewValley/Services.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Services.cs
@@ -17,11 +17,19 @@ public static class Services
         services
             .AddGame<StardewValley>()
             .AddSingleton<ITool, RunGameTool<StardewValley>>()
+
+            // Installers
+            .AddSingleton<SMAPIInstaller>()
+            .AddSingleton<SMAPIModInstaller>()
+
+            // Diagnostics
             .AddSingleton<DependencyDiagnosticEmitter>()
             .AddSingleton<MissingSMAPIEmitter>()
+            .AddSingleton<SMAPIModDatabaseCompatibilityDiagnosticEmitter>()
+
+            // Misc
             .AddSingleton<ISMAPIWebApi, SMAPIWebApi>()
-            .AddSingleton<ITypeFinder, TypeFinder>()
-            .AddSingleton<SMAPIInstaller>();
+            .AddSingleton<ITypeFinder, TypeFinder>();
 
         return services;
     }

--- a/src/Games/NexusMods.Games.StardewValley/StardewValley.cs
+++ b/src/Games/NexusMods.Games.StardewValley/StardewValley.cs
@@ -96,13 +96,14 @@ public class StardewValley : AGame, ISteamGame, IGogGame, IXboxGame
     public override IEnumerable<IModInstaller> Installers => new IModInstaller[]
     {
         _serviceProvider.GetRequiredService<SMAPIInstaller>(),
-        SMAPIModInstaller.Create(_serviceProvider),
+        _serviceProvider.GetRequiredService<SMAPIModInstaller>(),
     };
 
     public override IDiagnosticEmitter[] DiagnosticEmitters =>
     [
         _serviceProvider.GetRequiredService<DependencyDiagnosticEmitter>(),
         _serviceProvider.GetRequiredService<MissingSMAPIEmitter>(),
+        _serviceProvider.GetRequiredService<SMAPIModDatabaseCompatibilityDiagnosticEmitter>(),
     ];
 
     public override List<IModInstallDestination> GetInstallDestinations(IReadOnlyDictionary<LocationId, AbsolutePath> locations) => ModInstallDestinationHelpers.GetCommonLocations(locations);

--- a/src/Games/NexusMods.Games.StardewValley/TypeFinder.cs
+++ b/src/Games/NexusMods.Games.StardewValley/TypeFinder.cs
@@ -16,6 +16,7 @@ public class TypeFinder : ITypeFinder
         typeof(SMAPIMarker),
         typeof(SMAPIModMarker),
         typeof(SMAPIManifestMetadata),
+        typeof(SMAPIModDatabaseMarker),
         typeof(SMAPISorter),
     };
 }

--- a/src/Games/NexusMods.Games.StardewValley/WebAPI/ISMAPIWebApi.cs
+++ b/src/Games/NexusMods.Games.StardewValley/WebAPI/ISMAPIWebApi.cs
@@ -1,4 +1,5 @@
 using JetBrains.Annotations;
+using NexusMods.Abstractions.Diagnostics.Values;
 using NexusMods.Paths;
 
 namespace NexusMods.Games.StardewValley.WebAPI;
@@ -12,7 +13,7 @@ public interface ISMAPIWebApi : IDisposable
     /// <summary>
     /// Gets all mod page urls of the given mods.
     /// </summary>
-    public Task<IReadOnlyDictionary<string, Uri>> GetModPageUrls(
+    public Task<IReadOnlyDictionary<string, NamedLink>> GetModPageUrls(
         IOSInformation os,
         Version gameVersion,
         Version smapiVersion,

--- a/src/NexusMods.App.Generators.Diagnostics/NexusMods.App.Generators.Diagnostics/DiagnosticTemplateIncrementalSourceGenerator.cs
+++ b/src/NexusMods.App.Generators.Diagnostics/NexusMods.App.Generators.Diagnostics/DiagnosticTemplateIncrementalSourceGenerator.cs
@@ -129,7 +129,7 @@ public class DiagnosticTemplateIncrementalSourceGenerator : IIncrementalGenerato
                 cw.Append("Title = ");
                 if (parsedData.TitleExpression is LiteralExpressionSyntax literalTitle)
                 {
-                    cw.Append($"\"{literalTitle.Token.ValueText}\"");
+                    cw.Append(literalTitle.Token.Text);
                 }
                 cw.AppendLine(",");
 
@@ -140,7 +140,7 @@ public class DiagnosticTemplateIncrementalSourceGenerator : IIncrementalGenerato
                 cw.Append($"Summary = {Constants.DiagnosticsNamespace}.DiagnosticMessage.From(");
                 if (parsedData.SummaryTemplateExpression is LiteralExpressionSyntax literalSummary)
                 {
-                    cw.Append($"\"{literalSummary.Token.ValueText}\"");
+                    cw.Append(literalSummary.Token.Text);
                 }
                 cw.AppendLine("),");
 
@@ -151,7 +151,7 @@ public class DiagnosticTemplateIncrementalSourceGenerator : IIncrementalGenerato
                     cw.AppendLine("DefaultValue,");
                 } else if (parsedData.DetailsTemplateExpression is LiteralExpressionSyntax literalDetails)
                 {
-                    cw.AppendLine($"From(\"{literalDetails.Token.ValueText}\"),");
+                    cw.AppendLine($"From({literalDetails.Token.Text}),");
                 }
 
                 // MessageData

--- a/tests/NexusMods.App.Generators.Diagnostics.Tests/DiagnosticTemplateIncrementalSourceGeneratorTests.TestGenerator#TestNamespace.MyClass.Diagnostic1Template.g.verified.cs
+++ b/tests/NexusMods.App.Generators.Diagnostics.Tests/DiagnosticTemplateIncrementalSourceGeneratorTests.TestGenerator#TestNamespace.MyClass.Diagnostic1Template.g.verified.cs
@@ -15,7 +15,9 @@ partial class MyClass
 			Id = new global::NexusMods.Abstractions.Diagnostics.DiagnosticId(source: Source, number: 1),
 			Title = "Diagnostic 1",
 			Severity = global::NexusMods.Abstractions.Diagnostics.DiagnosticSeverity.Warning,
-			Summary = global::NexusMods.Abstractions.Diagnostics.DiagnosticMessage.From("Mod '{ModA}' conflicts with '{ModB}' because it's missing '{Something}' and {Count} other stuff!"),
+			Summary = global::NexusMods.Abstractions.Diagnostics.DiagnosticMessage.From("""
+Mod '{ModA}' conflicts with '{ModB}' because it's missing '{Something}' and {Count} other stuff!
+"""),
 			Details = global::NexusMods.Abstractions.Diagnostics.DiagnosticMessage.DefaultValue,
 			MessageData = messageData,
 			DataReferences = new global::System.Collections.Generic.Dictionary<global::NexusMods.Abstractions.Diagnostics.References.DataReferenceDescription, global::NexusMods.Abstractions.Diagnostics.References.IDataReference>

--- a/tests/NexusMods.App.Generators.Diagnostics.Tests/DiagnosticTemplateIncrementalSourceGeneratorTests.cs
+++ b/tests/NexusMods.App.Generators.Diagnostics.Tests/DiagnosticTemplateIncrementalSourceGeneratorTests.cs
@@ -8,7 +8,7 @@ namespace NexusMods.App.Generators.Diagnostics.Tests;
 public class DiagnosticTemplateIncrementalSourceGeneratorTests
 {
     [LanguageInjection("csharp")]
-    private const string SourceText = """
+    private const string SourceText = """"
 using NexusMods.Generators.Diagnostics;
 using NexusMods.Abstractions.Diagnostic;
 using NexusMods.Abstractions.Diagnostics.References;
@@ -25,7 +25,10 @@ internal partial class MyClass
         .WithId(new DiagnosticId(source: Source, number: 1))
         .WithTitle("Diagnostic 1")
         .WithSeverity(DiagnosticSeverity.Warning)
-        .WithSummary("Mod '{ModA}' conflicts with '{ModB}' because it's missing '{Something}' and {Count} other stuff!")
+        .WithSummary(
+"""
+Mod '{ModA}' conflicts with '{ModB}' because it's missing '{Something}' and {Count} other stuff!
+""")
         .WithoutDetails()
         .WithMessageData(messageBuilder => messageBuilder
             .AddDataReference<ModReference>("ModA")
@@ -35,7 +38,7 @@ internal partial class MyClass
         )
         .Finish();
 }
-""";
+"""";
 
     [Fact]
     public Task TestGenerator()


### PR DESCRIPTION
Resolves #1119.

This PR adds two new diagnostics for Stardew Valley:

![2024-03-26_12-06-56](https://github.com/Nexus-Mods/NexusMods.App/assets/16577545/e8a4de44-5301-460c-9d59-8061492674e8)
![2024-03-26_12-07-10](https://github.com/Nexus-Mods/NexusMods.App/assets/16577545/9d2f7dff-dc3e-4f75-bba6-719aa4755486)

The data for these diagnostics are sourced from the internal "mod database" file located at `smapi-internal/metadata.json`. SMAPI itself reads this file at startup to issue warnings and errors, we mirror this behavior in the App with diagnostics.

Other changes:

- Upgrades the SMAPI submodule from 3.18.6` to `4.0.2`.
- Fixes the diagnostic source generator when using raw string literals, multi-line strings, or escaped strings.
- Made the `DiagnosticManager` more robust when one emitter throws an exception.