### PR TITLE
Removed Database Transaction Bottlenecks

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Serialization/DataModel/EntityDictionary.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Serialization/DataModel/EntityDictionary.cs
@@ -113,8 +113,10 @@ public readonly struct EntityDictionary<TK, TV> :
     public EntityDictionary<TK, TV> With(IEnumerable<TV> val, Func<TV, TK> keyFn)
     {
         var builder = _coll.ToBuilder();
-        foreach (var v in val)
-            builder[keyFn(v)] = v.WithPersist(_store).DataStoreId;
+        var valArr = val.ToArray();
+        var dataStoreIds = _store.PutAll(valArr.AsSpan());
+        for (var x = 0; x < valArr.Length; x++)
+            builder[keyFn(valArr[x])] = dataStoreIds[x];
 
         return new EntityDictionary<TK, TV>(_store, builder.ToImmutable());
     }
@@ -127,8 +129,12 @@ public readonly struct EntityDictionary<TK, TV> :
     public EntityDictionary<TK, TV> With(IEnumerable<KeyValuePair<TK, TV>> items)
     {
         var builder = _coll.ToBuilder();
-        foreach (var (k, v) in items)
-            builder[k] = v.WithPersist(_store).DataStoreId;
+        
+        var kv = items.ToArray();
+        var dataStoreIds = _store.PutAll(kv.AsSpan());
+        for (var x = 0; x < kv.Length; x++)
+            builder[kv[x].Key] = dataStoreIds[x];
+
         return new EntityDictionary<TK, TV>(_store, builder.ToImmutable());
     }
 

--- a/src/Abstractions/NexusMods.Abstractions.Serialization/IDataStore.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Serialization/IDataStore.cs
@@ -70,6 +70,12 @@ public interface IDataStore
     void PutRaw(IId key, ReadOnlySpan<byte> val);
 
     /// <summary>
+    /// Places all entities inside the data store.
+    /// </summary>
+    /// <param name="items">The items to place in the data store.</param>
+    public void PutAllRaw(Span<(IId id, byte[] value)> items);
+
+    /// <summary>
     /// Performs a compare and swap operation on the given key. If the expected
     /// value matches the current value, the new value is set, and the method
     /// returns true. If the expected value does not match the current value,

--- a/src/Abstractions/NexusMods.Abstractions.Serialization/IDataStore.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Serialization/IDataStore.cs
@@ -26,6 +26,13 @@ public interface IDataStore
     public void Put<T>(IId id, T value) where T : Entity;
 
     /// <summary>
+    /// Places all entities inside the data store.
+    /// </summary>
+    /// <param name="items">The items to place in the data store.</param>
+    /// <typeparam name="T"></typeparam>
+    public void PutAll<T>(Span<(IId id, T value)> items) where T : Entity;
+
+    /// <summary>
     /// Retrieves an individual item with a specified ID from the data store.
     /// </summary>
     /// <param name="id">Unique identifier for the item.</param>

--- a/src/Abstractions/NexusMods.Abstractions.Serialization/IDataStore.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Serialization/IDataStore.cs
@@ -33,6 +33,12 @@ public interface IDataStore
     public void PutAll<T>(Span<(IId id, T value)> items) where T : Entity;
 
     /// <summary>
+    /// Places all entities inside the data store (raw).
+    /// </summary>
+    /// <param name="values">The values to place in the data store.</param>
+    public Id64[] PutAll<T>(Span<T> values) where T : Entity;
+    
+    /// <summary>
     /// Retrieves an individual item with a specified ID from the data store.
     /// </summary>
     /// <param name="id">Unique identifier for the item.</param>

--- a/src/Abstractions/NexusMods.Abstractions.Serialization/IDataStore.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Serialization/IDataStore.cs
@@ -36,6 +36,12 @@ public interface IDataStore
     /// Places all entities inside the data store (raw).
     /// </summary>
     /// <param name="values">The values to place in the data store.</param>
+    public Id64[] PutAll<TK, TV>(Span<KeyValuePair<TK, TV>> values) where TV : Entity;
+    
+    /// <summary>
+    /// Places all entities inside the data store (raw).
+    /// </summary>
+    /// <param name="values">The values to place in the data store.</param>
     public Id64[] PutAll<T>(Span<T> values) where T : Entity;
     
     /// <summary>

--- a/src/NexusMods.DataModel/NxFileStore.cs
+++ b/src/NexusMods.DataModel/NxFileStore.cs
@@ -121,6 +121,7 @@ public class NxFileStore : IFileStore
         }
     }
 
+    [SkipLocalsInit]
     private IId IdFor(Hash hash, Guid guid)
     {
         Span<byte> buffer = stackalloc byte[24];

--- a/src/NexusMods.DataModel/SqliteDataStore.cs
+++ b/src/NexusMods.DataModel/SqliteDataStore.cs
@@ -147,12 +147,15 @@ public class SqliteDataStore : IDataStore, IDisposable
     {
         using var conn = _pool.RentDisposable();
         var ids = GC.AllocateUninitializedArray<Id64>(values.Length);
+        using var tx = conn.Value.BeginTransaction();
         for (var x = 0; x < values.Length; x++)
         {
             ids[x] = ContentHashId(values[x].Value, out var data);
             PutRawItem(ids[x], data, conn);
         }
-
+        
+        tx.Commit();
+        
         foreach (var id in ids)
             NotifyOfUpdatedId(id);
 
@@ -164,6 +167,7 @@ public class SqliteDataStore : IDataStore, IDisposable
     {
         using var conn = _pool.RentDisposable();
         var ids = GC.AllocateUninitializedArray<Id64>(values.Length);
+        using var tx = conn.Value.BeginTransaction();
         for (var x = 0; x < values.Length; x++)
         {
             var value = values[x];
@@ -171,6 +175,7 @@ public class SqliteDataStore : IDataStore, IDisposable
             PutRawItem(ids[x], data, conn);
         }
 
+        tx.Commit();
         foreach (var id in ids)
             NotifyOfUpdatedId(id);
 

--- a/src/NexusMods.DataModel/SqliteDataStore.cs
+++ b/src/NexusMods.DataModel/SqliteDataStore.cs
@@ -153,8 +153,11 @@ public class SqliteDataStore : IDataStore, IDisposable
             ids[x] = ContentHashId(values[x].Value, out var data);
             PutRawItem(ids[x], data, conn);
         }
-        
-        tx.Commit();
+
+        lock (_writerLock)
+        {
+            tx.Commit();
+        }
         
         foreach (var id in ids)
             NotifyOfUpdatedId(id);
@@ -175,7 +178,11 @@ public class SqliteDataStore : IDataStore, IDisposable
             PutRawItem(ids[x], data, conn);
         }
 
-        tx.Commit();
+        lock (_writerLock)
+        {
+            tx.Commit();
+        }
+
         foreach (var id in ids)
             NotifyOfUpdatedId(id);
 
@@ -193,7 +200,10 @@ public class SqliteDataStore : IDataStore, IDisposable
         foreach (var item in items)
             PutOneItem(item.id, item.value, conn);
 
-        tx.Commit();
+        lock (_writerLock)
+        {
+            tx.Commit();
+        }
 
         // We notify after DB has the item.
         foreach (var item in items)
@@ -211,7 +221,10 @@ public class SqliteDataStore : IDataStore, IDisposable
         foreach (var item in items)
             PutRawItem(item.id, item.value, conn);
 
-        tx.Commit();
+        lock (_writerLock)
+        {
+            tx.Commit();
+        }
 
         // We notify after DB has the item.
         foreach (var item in items)

--- a/src/NexusMods.DataModel/SqliteDataStore.cs
+++ b/src/NexusMods.DataModel/SqliteDataStore.cs
@@ -107,6 +107,12 @@ public class SqliteDataStore : IDataStore, IDisposable
             pragma.CommandText = "PRAGMA journal_mode = WAL";
             pragma.ExecuteNonQuery();
         }
+        
+        using (var pragma = conn.Value.CreateCommand())
+        {
+            pragma.CommandText = "PRAGMA synchronous = NORMAL";
+            pragma.ExecuteNonQuery();
+        }
 
         foreach (var table in EntityCategoryExtensions.GetValues())
         {

--- a/tests/NexusMods.DataModel.Tests/Harness/ADataModelTest.cs
+++ b/tests/NexusMods.DataModel.Tests/Harness/ADataModelTest.cs
@@ -125,8 +125,11 @@ public abstract class ADataModelTest<T> : IDisposable, IAsyncLifetime
         }
 
         memoryStream.Position = 0;
-        await using var fileStream = tmpFile.Path.Create();
-        await memoryStream.CopyToAsync(fileStream, Token);
+        await using (var fileStream = tmpFile.Path.Create())
+        {
+            await memoryStream.CopyToAsync(fileStream, Token);
+        }
+
         return await FileOriginRegistry.RegisterDownload(tmpFile.Path, new FilePathMetadata {OriginalName = tmpFile.Path.FileName, Quality = Quality.Low}, CancellationToken.None);
     }
 

--- a/tests/NexusMods.DataModel.Tests/Harness/ADataModelTest.cs
+++ b/tests/NexusMods.DataModel.Tests/Harness/ADataModelTest.cs
@@ -113,7 +113,8 @@ public abstract class ADataModelTest<T> : IDisposable, IAsyncLifetime
     protected async Task<DownloadId> RegisterDownload(params (string Name, string Data)[] files)
     {
         await using var tmpFile = TemporaryFileManager.CreateFile();
-        using (var zip = new ZipArchive(tmpFile.Path.Create(), ZipArchiveMode.Create, false))
+        using var memoryStream = new MemoryStream();
+        using (var zip = new ZipArchive(memoryStream, ZipArchiveMode.Create, true))
         {
             foreach (var (name, data) in files)
             {

--- a/tests/NexusMods.DataModel.Tests/Harness/ADataModelTest.cs
+++ b/tests/NexusMods.DataModel.Tests/Harness/ADataModelTest.cs
@@ -117,13 +117,16 @@ public abstract class ADataModelTest<T> : IDisposable, IAsyncLifetime
         {
             foreach (var (name, data) in files)
             {
-                var entry = zip.CreateEntry(name);
+                var entry = zip.CreateEntry(name, CompressionLevel.Fastest);
                 await using var stream = entry.Open();
                 await using var writer = new StreamWriter(stream);
                 await writer.WriteAsync(data);
             }
         }
 
+        memoryStream.Position = 0;
+        await using var fileStream = tmpFile.Path.Create();
+        await memoryStream.CopyToAsync(fileStream, Token);
         return await FileOriginRegistry.RegisterDownload(tmpFile.Path, new FilePathMetadata {OriginalName = tmpFile.Path.FileName, Quality = Quality.Low}, CancellationToken.None);
     }
 


### PR DESCRIPTION
This is a small set of patches that improve performance of writes by a few orders of magnitude.
It's around 10x faster on an NVMe SSD, maybe a bit more on slower mediums, not a big deal.

-------

The jist of these patches is adding bulk INSERT operations into our data store.

Previously, when we wrote items to the data store, each write would be its own separate transaction, i.e. on every write, for safety, the DB would synchronize with disk, so in the event of a data loss, things won't commit total complete annihilation. 

Unfortunately that's a tiiiiiny bit slow.
Anyway, this PR adds some bulk add operations to the DataStore, and uses them whenever it's known we need to insert a bunch of items at once in some places previously bottlenecked.

------

Note: Don't think too hard about this PR. This is more of a temporary measure to make performance under the existing system bearable. Most of the code touched here will be rewritten or non-existent once EventSourcing kicks in. 

I'll do more proper optimization around that point, such as having non-enumerable APIs.
This is the bare minimum to make things bearable for now.

For now I extracted these from my benchmarks branch, to make review easier down the road.