### PR TITLE
Add GameWidget functionality and show loading while managing a new game

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ILoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ILoadoutSynchronizer.cs
@@ -40,6 +40,6 @@ public interface ILoadoutSynchronizer
     /// </summary>
     /// <param name="installation"></param>
     /// <returns></returns>
-    Task<Loadout> Manage(GameInstallation installation);
+    Task<Loadout> Manage(GameInstallation installation, string? suggestedName=null);
     #endregion
 }

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/IStandardizedLoadoutSyncronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/IStandardizedLoadoutSyncronizer.cs
@@ -80,9 +80,6 @@ public interface IStandardizedLoadoutSynchronizer : ILoadoutSynchronizer
     /// <summary>
     /// Backs up any new files in the file tree.
     /// </summary>
-    /// <param name="loadout"></param>
-    /// <param name="fileTree"></param>
-    /// <returns></returns>
-    Task BackupNewFiles(Loadout loadout, FileTree fileTree);
+    Task BackupNewFiles(GameInstallation installation, FileTree fileTree);
     #endregion
 }

--- a/src/Games/NexusMods.Games.BethesdaGameStudios/BethesdaLoadoutSynchronizer.cs
+++ b/src/Games/NexusMods.Games.BethesdaGameStudios/BethesdaLoadoutSynchronizer.cs
@@ -10,9 +10,9 @@ public class BethesdaLoadoutSynchronizer : ALoadoutSynchronizer
 {
     public BethesdaLoadoutSynchronizer(IServiceProvider provider) : base(provider) { }
 
-    public override async Task<Loadout> Manage(GameInstallation installation)
+    public override async Task<Loadout> Manage(GameInstallation installation, string? suggestedName = null)
     {
-        var loadout = await base.Manage(installation);
+        var loadout = await base.Manage(installation, suggestedName);
         return FixupLoadout(loadout);
     }
 

--- a/src/NexusMods.App.UI/Controls/GameWidget/GameWidget.axaml.cs
+++ b/src/NexusMods.App.UI/Controls/GameWidget/GameWidget.axaml.cs
@@ -42,7 +42,7 @@ public partial class GameWidget : ReactiveUserControl<IGameWidgetViewModel>
                 this.OneWayBind(ViewModel, vm => vm.Name, v => v.NameTextBlock.Text)
                     .DisposeWith(d);
 
-                this.BindCommand(ViewModel, vm => vm.PrimaryButton, v => v.AddGameButton)
+                this.BindCommand(ViewModel, vm => vm.AddGameCommand, v => v.AddGameButton)
                     .DisposeWith(d);
                 
             }

--- a/src/NexusMods.App.UI/Controls/GameWidget/GameWidget.axaml.cs
+++ b/src/NexusMods.App.UI/Controls/GameWidget/GameWidget.axaml.cs
@@ -45,6 +45,12 @@ public partial class GameWidget : ReactiveUserControl<IGameWidgetViewModel>
                 this.BindCommand(ViewModel, vm => vm.AddGameCommand, v => v.AddGameButton)
                     .DisposeWith(d);
                 
+                this.BindCommand(ViewModel, vm => vm.ViewGameCommand, v => v.ViewGameButton)
+                    .DisposeWith(d);
+                
+                // Adding a game is same as adding a loadout for now
+                this.BindCommand(ViewModel, vm => vm.AddGameCommand, v => v.AddLoadoutButton)
+                    .DisposeWith(d);
             }
         );
     }

--- a/src/NexusMods.App.UI/Controls/GameWidget/GameWidgetDesignViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/GameWidget/GameWidgetDesignViewModel.cs
@@ -14,7 +14,8 @@ public class GameWidgetDesignViewModel : AViewModel<IGameWidgetViewModel>, IGame
     public string Name { get; } = "SOME CYBERPUNK GAME WITH A LONG NAME";
     public Bitmap Image { get; }
     public ReactiveCommand<Unit,Unit> AddGameCommand { get; set; } = ReactiveCommand.Create(() => { });
-    
+    public ReactiveCommand<Unit, Unit> ViewGameCommand { get; set; } = ReactiveCommand.Create(() => { });
+
     [Reactive]
     public GameWidgetState State { get; set; }
 

--- a/src/NexusMods.App.UI/Controls/GameWidget/GameWidgetDesignViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/GameWidget/GameWidgetDesignViewModel.cs
@@ -1,4 +1,4 @@
-using System.Windows.Input;
+using System.Reactive;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
 using NexusMods.Abstractions.GameLocators;
@@ -13,8 +13,7 @@ public class GameWidgetDesignViewModel : AViewModel<IGameWidgetViewModel>, IGame
     public GameInstallation Installation { get; set; } = GameInstallation.Empty;
     public string Name { get; } = "SOME CYBERPUNK GAME WITH A LONG NAME";
     public Bitmap Image { get; }
-    public ICommand PrimaryButton { get; set; } = Initializers.ICommand;
-    public ICommand? SecondaryButton { get; set; }
+    public ReactiveCommand<Unit,Unit> AddGameCommand { get; set; } = ReactiveCommand.Create(() => { });
     
     [Reactive]
     public GameWidgetState State { get; set; }
@@ -22,7 +21,6 @@ public class GameWidgetDesignViewModel : AViewModel<IGameWidgetViewModel>, IGame
     public GameWidgetDesignViewModel()
     {
         Image = new Bitmap(AssetLoader.Open(new Uri("avares://NexusMods.App.UI/Assets/DesignTime/cyberpunk_game.png")));
-        SecondaryButton = ReactiveCommand.Create(() => { });
         State = GameWidgetState.DetectedGame;
     }
 }

--- a/src/NexusMods.App.UI/Controls/GameWidget/GameWidgetViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/GameWidget/GameWidgetViewModel.cs
@@ -1,6 +1,6 @@
+using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
-using System.Windows.Input;
 using Avalonia.Media.Imaging;
 using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.GameLocators;
@@ -18,8 +18,7 @@ public class GameWidgetViewModel : AViewModel<IGameWidgetViewModel>, IGameWidget
     {
         _logger = logger;
 
-        PrimaryButton = ReactiveCommand.Create(() => { });
-        SecondaryButton = ReactiveCommand.Create(() => { });
+        AddGameCommand = ReactiveCommand.Create(() => { });
 
         _image = this
             .WhenAnyValue(vm => vm.Installation)
@@ -64,10 +63,8 @@ public class GameWidgetViewModel : AViewModel<IGameWidgetViewModel>, IGameWidget
     public Bitmap Image => _image.Value;
 
     [Reactive]
-    public ICommand PrimaryButton { get; set; }
-
-    [Reactive]
-    public ICommand? SecondaryButton { get; set; }
+    public ReactiveCommand<Unit,Unit> AddGameCommand { get; set; }
+    
 
     [Reactive]
     public GameWidgetState State { get; set; }

--- a/src/NexusMods.App.UI/Controls/GameWidget/GameWidgetViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/GameWidget/GameWidgetViewModel.cs
@@ -19,6 +19,7 @@ public class GameWidgetViewModel : AViewModel<IGameWidgetViewModel>, IGameWidget
         _logger = logger;
 
         AddGameCommand = ReactiveCommand.Create(() => { });
+        ViewGameCommand = ReactiveCommand.Create(() => { });
 
         _image = this
             .WhenAnyValue(vm => vm.Installation)
@@ -64,7 +65,10 @@ public class GameWidgetViewModel : AViewModel<IGameWidgetViewModel>, IGameWidget
 
     [Reactive]
     public ReactiveCommand<Unit,Unit> AddGameCommand { get; set; }
-    
+
+    [Reactive]
+    public ReactiveCommand<Unit, Unit> ViewGameCommand { get; set; }
+
 
     [Reactive]
     public GameWidgetState State { get; set; }

--- a/src/NexusMods.App.UI/Controls/GameWidget/IGameWidgetViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/GameWidget/IGameWidgetViewModel.cs
@@ -11,6 +11,8 @@ public interface IGameWidgetViewModel : IViewModelInterface
     public string Name { get; }
     public Bitmap Image { get; }
     public ReactiveCommand<Unit,Unit> AddGameCommand { get; set; }
+    public ReactiveCommand<Unit,Unit> ViewGameCommand { get; set; }
+    
 
     public GameWidgetState State { get; set; }
 }

--- a/src/NexusMods.App.UI/Controls/GameWidget/IGameWidgetViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/GameWidget/IGameWidgetViewModel.cs
@@ -1,6 +1,7 @@
-using System.Windows.Input;
+using System.Reactive;
 using Avalonia.Media.Imaging;
 using NexusMods.Abstractions.GameLocators;
+using ReactiveUI;
 
 namespace NexusMods.App.UI.Controls.GameWidget;
 
@@ -9,8 +10,7 @@ public interface IGameWidgetViewModel : IViewModelInterface
     public GameInstallation Installation { get; set; }
     public string Name { get; }
     public Bitmap Image { get; }
-    public ICommand PrimaryButton { get; set; }
-    public ICommand? SecondaryButton { get; set; }
+    public ReactiveCommand<Unit,Unit> AddGameCommand { get; set; }
 
     public GameWidgetState State { get; set; }
 }

--- a/src/NexusMods.App.UI/Pages/MyGames/MyGamesViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/MyGames/MyGamesViewModel.cs
@@ -64,9 +64,10 @@ public class MyGamesViewModel : APageViewModel<IMyGamesViewModel>, IMyGamesViewM
                         {
                             var vm = _provider.GetRequiredService<IGameWidgetViewModel>();
                             vm.Installation = install;
-                            vm.PrimaryButton = ReactiveCommand.CreateFromTask(
+                            vm.AddGameCommand = ReactiveCommand.CreateFromTask(
                                 async () => { await Task.Run(async () => await ManageGame(install)); }
                             );
+                            vm.State = GameWidgetState.ManagedGame;
                             return vm;
                         }
                     )
@@ -80,9 +81,10 @@ public class MyGamesViewModel : APageViewModel<IMyGamesViewModel>, IMyGamesViewM
                         {
                             var vm = _provider.GetRequiredService<IGameWidgetViewModel>();
                             vm.Installation = install;
-                            vm.PrimaryButton = ReactiveCommand.CreateFromTask(
+                            vm.AddGameCommand = ReactiveCommand.CreateFromTask(
                                 async () => { await Task.Run(async () => await ManageGame(install)); }
                             );
+                            vm.State = GameWidgetState.DetectedGame;
                             return vm;
                         }
                     )

--- a/src/NexusMods.App.UI/Pages/MyGames/MyGamesViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/MyGames/MyGamesViewModel.cs
@@ -72,7 +72,12 @@ public class MyGamesViewModel : APageViewModel<IMyGamesViewModel>, IMyGamesViewM
                             var vm = _provider.GetRequiredService<IGameWidgetViewModel>();
                             vm.Installation = install;
                             vm.AddGameCommand = ReactiveCommand.CreateFromTask(
-                                async () => { await Task.Run(async () => await ManageGame(install)); }
+                                async () =>
+                                {
+                                    vm.State = GameWidgetState.AddingGame;
+                                    await Task.Run(async () => await ManageGame(install));
+                                    vm.State = GameWidgetState.ManagedGame;
+                                }
                             );
                             vm.ViewGameCommand = ReactiveCommand.Create(
                                 () => { NavigateToLoadout(install); }
@@ -92,7 +97,12 @@ public class MyGamesViewModel : APageViewModel<IMyGamesViewModel>, IMyGamesViewM
                             var vm = _provider.GetRequiredService<IGameWidgetViewModel>();
                             vm.Installation = install;
                             vm.AddGameCommand = ReactiveCommand.CreateFromTask(
-                                async () => { await Task.Run(async () => await ManageGame(install)); }
+                                async () =>
+                                {
+                                    vm.State = GameWidgetState.AddingGame;
+                                    await Task.Run(async () => await ManageGame(install));
+                                    vm.State = GameWidgetState.ManagedGame;
+                                }
                             );
                             vm.State = GameWidgetState.DetectedGame;
                             return vm;
@@ -154,9 +164,9 @@ public class MyGamesViewModel : APageViewModel<IMyGamesViewModel>, IMyGamesViewM
             _logger.LogError("Unable to find loadout for revision {RevId}", revId);
             return;
         }
-        
+
         var loadoutId = loadout.LoadoutId;
-        
+
         Dispatcher.UIThread.Invoke(() =>
             {
                 if (!_windowManager.TryGetActiveWindow(out var window)) return;

--- a/src/NexusMods.App.UI/Pages/MyGames/MyGamesViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/MyGames/MyGamesViewModel.cs
@@ -4,6 +4,7 @@ using Avalonia.Threading;
 using DynamicData;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.GameLocators;
 using NexusMods.Abstractions.Games;
 using NexusMods.Abstractions.Loadouts;
@@ -23,6 +24,8 @@ public class MyGamesViewModel : APageViewModel<IMyGamesViewModel>, IMyGamesViewM
     private readonly ILoadoutRegistry _loadoutRegistry;
     private readonly IServiceProvider _provider;
     private readonly IWindowManager _windowManager;
+    private readonly ILogger<MyGamesViewModel> _logger;
+    private readonly IApplyService _applyService;
     private ReadOnlyObservableCollection<IGameWidgetViewModel> _managedGames = new([]);
     private ReadOnlyObservableCollection<IGameWidgetViewModel> _detectedGames = new([]);
 
@@ -33,11 +36,15 @@ public class MyGamesViewModel : APageViewModel<IMyGamesViewModel>, IMyGamesViewM
         IWindowManager windowManager,
         IServiceProvider serviceProvider,
         ILoadoutRegistry loadoutRegistry,
+        ILogger<MyGamesViewModel> logger,
+        IApplyService applyService,
         IEnumerable<IGame> games) : base(windowManager)
     {
         _provider = serviceProvider;
         _loadoutRegistry = loadoutRegistry;
+        _applyService = applyService;
         _windowManager = windowManager;
+        _logger = logger;
 
         var gamesList = games.ToList();
         var installations = gamesList
@@ -66,6 +73,9 @@ public class MyGamesViewModel : APageViewModel<IMyGamesViewModel>, IMyGamesViewM
                             vm.Installation = install;
                             vm.AddGameCommand = ReactiveCommand.CreateFromTask(
                                 async () => { await Task.Run(async () => await ManageGame(install)); }
+                            );
+                            vm.ViewGameCommand = ReactiveCommand.Create(
+                                () => { NavigateToLoadout(install); }
                             );
                             vm.State = GameWidgetState.ManagedGame;
                             return vm;
@@ -102,6 +112,51 @@ public class MyGamesViewModel : APageViewModel<IMyGamesViewModel>, IMyGamesViewM
 
         var loadoutId = marker.Id;
 
+        Dispatcher.UIThread.Invoke(() =>
+            {
+                if (!_windowManager.TryGetActiveWindow(out var window)) return;
+                var workspaceController = window.WorkspaceController;
+
+                workspaceController.ChangeOrCreateWorkspaceByContext(
+                    context => context.LoadoutId == loadoutId,
+                    () => new PageData
+                    {
+                        FactoryId = LoadoutGridPageFactory.StaticId,
+                        Context = new LoadoutGridContext
+                        {
+                            LoadoutId = loadoutId
+                        }
+                    },
+                    () => new LoadoutContext
+                    {
+                        LoadoutId = loadoutId
+                    }
+                );
+            }
+        );
+    }
+
+    private void NavigateToLoadout(GameInstallation installation)
+    {
+        var revId = _applyService.GetLastAppliedLoadout(installation);
+        if (revId is null)
+        {
+            _logger.LogError("Unable to find active loadout for  {GameName} : {InstallPath}",
+                installation.Game.Name,
+                installation.LocationsRegister[LocationId.Game]
+            );
+            return;
+        }
+
+        var loadout = _loadoutRegistry.GetLoadout(revId);
+        if (loadout is null)
+        {
+            _logger.LogError("Unable to find loadout for revision {RevId}", revId);
+            return;
+        }
+        
+        var loadoutId = loadout.LoadoutId;
+        
         Dispatcher.UIThread.Invoke(() =>
             {
                 if (!_windowManager.TryGetActiveWindow(out var window)) return;

--- a/src/NexusMods.DataModel/Loadouts/LoadoutRegistry.cs
+++ b/src/NexusMods.DataModel/Loadouts/LoadoutRegistry.cs
@@ -442,14 +442,8 @@ public class LoadoutRegistry : IDisposable, ILoadoutRegistry
         if (string.IsNullOrWhiteSpace(name))
             name = SuggestName(installation);
 
-        var result = await installation.GetGame().Synchronizer.Manage(installation);
-        result = Alter(result.LoadoutId, $"Manage new instance of {installation.Game.Name} as {name}",
-            _ => result with
-        {
-            Name = name
-        });
-        var withExtraFiles = await installation.GetGame().Synchronizer.Ingest(result);
-        Alter(result.LoadoutId, $"Adding extra files found in game folder", _ => withExtraFiles);
+        var result = await installation.GetGame().Synchronizer.Manage(installation, name);
+
         return GetMarker(result.LoadoutId);
     }
 

--- a/tests/NexusMods.DataModel.Tests/ALoadoutSynchronizerTests.cs
+++ b/tests/NexusMods.DataModel.Tests/ALoadoutSynchronizerTests.cs
@@ -501,7 +501,7 @@ public class ALoadoutSynchronizerTests : ADataModelTest<ALoadoutSynchronizerTest
 
         flattenedAgain[deletedFile].Should().BeNull("the file should have been deleted");
 
-        await _synchronizer.BackupNewFiles(loadout, fileTree);
+        await _synchronizer.BackupNewFiles(loadout.Installation, fileTree);
 
         (await FileStore.HaveFile(new byte[] { 0x04, 0x05, 0x06 }.XxHash64()))
             .Should().BeTrue("the file should have been backed up");


### PR DESCRIPTION
closes #1138

Handles all the remaining items on the issue:
- [x] Show ManagedGame ui state for managed games, show DetectedGame ui state for detected games
- [x] Implement navigating to the last Applied loadout when pressing "View" button
- [x] Show loading ui state while a new game is being setup
    - [x] Only add the new loadout to the `LoadoutRegistry` after all files have been backed up, instead of before ingest step.
- [x] Do nothing on Remove button for now, see #1106 for the that part

## Notes:
This changes how Mange game works. 
Before we were indexing the game folder, creating a loaodut with a mod with all the entries and adding that to the LoadoutRegistry. Then we would run an ingest on that loadout to backup all those files.

This created a loadout that was in a precarious state without all the game files backup up in it, something not desirable for other systems like diagnostics as well as the loadout popping up in the UI before it was supposed to be interacted with by the user.

We changed that here by running a Backup operation on the files directly after they are indexed, creating the loadout a single time with all the files already backed up and added.