### PR TITLE
Protocol registration fixes on Linux

### DIFF
--- a/NexusMods.App.sln.DotSettings
+++ b/NexusMods.App.sln.DotSettings
@@ -50,6 +50,7 @@
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=APPIMAGE/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Avalonia/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ctxt/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=FOMOD/@EntryIndexedValue">True</s:Boolean>

--- a/src/NexusMods.CrossPlatform/NexusMods.CrossPlatform.csproj
+++ b/src/NexusMods.CrossPlatform/NexusMods.CrossPlatform.csproj
@@ -5,6 +5,7 @@
     <ItemGroup>
         <PackageReference Include="CliWrap" />
         <PackageReference Include="NexusMods.Paths" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NexusMods.CrossPlatform/Process/ProcessFactory.cs
+++ b/src/NexusMods.CrossPlatform/Process/ProcessFactory.cs
@@ -1,4 +1,5 @@
 using CliWrap;
+using Microsoft.Extensions.Logging;
 
 namespace NexusMods.CrossPlatform.Process;
 
@@ -7,10 +8,21 @@ namespace NexusMods.CrossPlatform.Process;
 /// </summary>
 public class ProcessFactory : IProcessFactory
 {
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    public ProcessFactory(ILogger<ProcessFactory> logger)
+    {
+        _logger = logger;
+    }
+
     /// <inheritdoc />
     public async Task<CommandResult> ExecuteAsync(Command command,
         CancellationToken cancellationToken = default)
     {
+        _logger.LogInformation("Executing command `{Command}`", command.ToString());
         return await command.ExecuteAsync(cancellationToken);
     }
 }

--- a/src/NexusMods.CrossPlatform/ProtocolRegistration/ProtocolRegistrationLinux.cs
+++ b/src/NexusMods.CrossPlatform/ProtocolRegistration/ProtocolRegistrationLinux.cs
@@ -35,9 +35,10 @@ public class ProtocolRegistrationLinux : IProtocolRegistration
 
         return await Register(
             protocol,
-            $"{BaseId}-{protocol}.desktop",
-            Path.GetDirectoryName(executable)!,
-            $"\"{executable}\" protocol-invoke --url %u");
+            friendlyName: $"{BaseId}-{protocol}.desktop",
+            workingDirectory: FixWhitespace(Path.GetDirectoryName(executable)),
+            commandLine: $"{FixWhitespace(executable)} protocol-invoke --url %u"
+        );
     }
 
     /// <inheritdoc/>
@@ -55,7 +56,7 @@ public class ProtocolRegistrationLinux : IProtocolRegistration
         sb.AppendLine($"Name=NexusMods.App {protocol.ToUpper()} Handler");
         sb.AppendLine("Terminal=false");
         sb.AppendLine("Type=Application");
-        sb.AppendLine($"Path=\"{workingDirectory}\"");
+        sb.AppendLine($"Path={workingDirectory}");
         sb.AppendLine($"Exec={commandLine}");
         sb.AppendLine($"MimeType=x-scheme-handler/{protocol}");
         sb.AppendLine("NoDisplay=true");
@@ -85,5 +86,11 @@ public class ProtocolRegistrationLinux : IProtocolRegistration
 
         // might end with 0xA (LF)
         return stdOut.StartsWith("yes", StringComparison.InvariantCultureIgnoreCase);
+    }
+
+    private static string FixWhitespace(string? input)
+    {
+        if (input is null) return string.Empty;
+        return input.Replace(" ", @"\ ");
     }
 }

--- a/src/NexusMods.CrossPlatform/ProtocolRegistration/ProtocolRegistrationLinux.cs
+++ b/src/NexusMods.CrossPlatform/ProtocolRegistration/ProtocolRegistrationLinux.cs
@@ -31,7 +31,10 @@ public class ProtocolRegistrationLinux : IProtocolRegistration
     /// <inheritdoc/>
     public async Task<string?> RegisterSelf(string protocol)
     {
-        var executable = Environment.ProcessPath;
+        // https://docs.appimage.org/packaging-guide/environment-variables.html#type-2-appimage-runtime
+        // APPIMAGE: (Absolute) path to AppImage file (with symlinks resolved)
+        var appImagePath = Environment.GetEnvironmentVariable("APPIMAGE", EnvironmentVariableTarget.Process);
+        var executable = appImagePath ?? Environment.ProcessPath;
 
         return await Register(
             protocol,

--- a/src/NexusMods.CrossPlatform/ProtocolRegistration/ProtocolRegistrationLinux.cs
+++ b/src/NexusMods.CrossPlatform/ProtocolRegistration/ProtocolRegistrationLinux.cs
@@ -31,13 +31,13 @@ public class ProtocolRegistrationLinux : IProtocolRegistration
     /// <inheritdoc/>
     public async Task<string?> RegisterSelf(string protocol)
     {
-        var executable = System.Diagnostics.Process.GetCurrentProcess().MainModule!.FileName;
+        var executable = Environment.ProcessPath;
 
         return await Register(
             protocol,
             $"{BaseId}-{protocol}.desktop",
             Path.GetDirectoryName(executable)!,
-            $"{executable} protocol-invoke --url %u");
+            $"\"{executable}\" protocol-invoke --url %u");
     }
 
     /// <inheritdoc/>
@@ -55,7 +55,7 @@ public class ProtocolRegistrationLinux : IProtocolRegistration
         sb.AppendLine($"Name=NexusMods.App {protocol.ToUpper()} Handler");
         sb.AppendLine("Terminal=false");
         sb.AppendLine("Type=Application");
-        sb.AppendLine($"Path={workingDirectory}");
+        sb.AppendLine($"Path=\"{workingDirectory}\"");
         sb.AppendLine($"Exec={commandLine}");
         sb.AppendLine($"MimeType=x-scheme-handler/{protocol}");
         sb.AppendLine("NoDisplay=true");


### PR DESCRIPTION
- Logs process execution
- Fixes #1149 by using `APPIMAGE` environment variable instead of `Environment.ProcessPath`. 
- Fixes #1150 by escaping whitespace: `Release 0.4` -> `Release\ 0.4`