### PR TITLE
Update logging

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -23,3 +23,10 @@ _(What did you expect to happen instead?)_
 
 ## Other information
 _(Logs, screenshots, possible fixes, expected behaviour, etc.)_
+
+Log files can be found in these locations:
+
+- Windows: `%LOCALAPPDATA%\NexusMods.App\Logs`
+- Linux: `~/.local/state/NexusMods.App/Logs`
+
+Please attach both `nexusmods.app.main` and `nexusmods.app.slim` log files with the most recent dates.

--- a/NexusMods.App.sln.DotSettings
+++ b/NexusMods.App.sln.DotSettings
@@ -56,6 +56,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=hardcoding/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Loadout/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Loadouts/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=nexusmods/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Projektanker/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Resizers/@EntryIndexedValue">True</s:Boolean>
 	</wpf:ResourceDictionary>

--- a/src/NexusMods.App/AppConfig.cs
+++ b/src/NexusMods.App/AppConfig.cs
@@ -64,12 +64,30 @@ public class AppConfig
 
 public interface ILoggingSettings
 {
+    /// <summary>
+    /// Gets the path to the current log file for the main process.
+    /// </summary>
     public ConfigurationPath MainProcessLogFilePath { get; }
 
+    /// <summary>
+    /// Gets the template path to the archive log file for the main process.
+    /// </summary>
+    /// <remarks>
+    /// For details, see https://nlog-project.org/documentation/v5.0.0/html/P_NLog_Targets_FileTarget_ArchiveFileName.htm
+    /// </remarks>
     public ConfigurationPath MainProcessArchiveFilePath { get; }
 
+    /// <summary>
+    /// Gets the path to the current log file for the slim process.
+    /// </summary>
     public ConfigurationPath SlimProcessLogFilePath { get; }
 
+    /// <summary>
+    /// Gets the template path to the archive log file for the slim process.
+    /// </summary>
+    /// <remarks>
+    /// For details, see https://nlog-project.org/documentation/v5.0.0/html/P_NLog_Targets_FileTarget_ArchiveFileName.htm
+    /// </remarks>
     public ConfigurationPath SlimProcessArchiveFilePath { get; }
 
     /// <summary>

--- a/src/NexusMods.App/AppConfig.json
+++ b/src/NexusMods.App/AppConfig.json
@@ -18,8 +18,10 @@
     "CancelSpeedFraction": 0.66
   },
   "LoggingSettings": {
-    "FilePath": "",
-    "ArchiveFilePath": "",
+    "MainProcessLogFilePath": "",
+    "MainProcessArchiveFilePath": "",
+    "SlimProcessLogFilePath": "",
+    "SlimProcessArchiveFilePath": "",
     "MaxArchivedFiles": 10
   },
   "LauncherSettings": {

--- a/src/NexusMods.App/LogMessages.cs
+++ b/src/NexusMods.App/LogMessages.cs
@@ -1,0 +1,52 @@
+using Microsoft.Extensions.Logging;
+
+namespace NexusMods.App;
+
+internal static partial class LogMessages
+{
+    [LoggerMessage(
+        EventId = 0, EventName = nameof(StartingProcess),
+        Level = LogLevel.Information,
+        Message = "Starting process with PID `{pid}` and `{count}` argument(s): `{executable}` `{args}`"
+    )]
+    public static partial void StartingProcess(
+        ILogger logger,
+        string? executable,
+        int pid,
+        int count,
+        string[] args
+    );
+
+    [LoggerMessage(
+        EventId = 1, EventName = nameof(RuntimeInformation),
+        Level = LogLevel.Information,
+        Message = "Operating System is `{os}` running `{framework}`"
+    )]
+    public static partial void RuntimeInformation(
+        ILogger logger,
+        string os,
+        string framework
+    );
+
+    [LoggerMessage(
+        EventId = 2, EventName = nameof(UnobservedTaskException),
+        Level = LogLevel.Error,
+        Message = "Encountered an unobserved task exception in the Task Scheduler from sender of type `{senderType}`: `{sender}`"
+    )]
+    public static partial void UnobservedTaskException(
+        ILogger logger,
+        Exception e,
+        object? sender,
+        Type? senderType
+    );
+
+    [LoggerMessage(
+        EventId = 3, EventName = nameof(UnobservedReactiveThrownException),
+        Level = LogLevel.Error,
+        Message = "Encountered an exception published to an object with an unobserved ThrownExceptions property"
+    )]
+    public static partial void UnobservedReactiveThrownException(
+        ILogger logger,
+        Exception e
+    );
+}


### PR DESCRIPTION
- Improved logging messages containing more information
- We're now using two logging files:
  - `nexusmods.app.main` for the main process only
  - `nexusmods.app.slim` for the "slim" process only
- Updates the "bug" issue template to prompt the user to upload log files.

Having two logging files fixes the issue where both the main and slim process try to write to the same file. While we didn't have any corruptions of log files, we did have an issue where a slim process will move the current main log to an archive log while the main process would continue writing to the archive log. It made debugging and viewing logs difficult, this PR fixes that issue by clearly separating the two logs.