### PR TITLE
More SMAPI diagnostics

### DIFF
--- a/NexusMods.App.sln.DotSettings
+++ b/NexusMods.App.sln.DotSettings
@@ -36,6 +36,7 @@
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_BEFORE_INVOCATION_RPAR/@EntryValue">True</s:Boolean>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LIMIT/@EntryValue">200</s:Int64>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=DI/@EntryIndexedValue">DI</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=DTO/@EntryIndexedValue">DTO</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=EA/@EntryIndexedValue">EA</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=GOG/@EntryIndexedValue">GOG</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=JWT/@EntryIndexedValue">JWT</s:String>

--- a/src/Games/NexusMods.Games.StardewValley/Diagnostics.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Diagnostics.cs
@@ -150,7 +150,7 @@ The current game version is {CurrentGameVersion}.
 Due to this version mismatch, the game will **crash** on startup.
 You can solve this issue by either updating your game or downgrading SMAPI.
 
-The last supported SMAPI version for game version {CurrentGameVersion} is {LastSupportedSMAPIVersionForCurrentGameVersion}.
+The newest supported SMAPI version for game version {CurrentGameVersion} is {LastSupportedSMAPIVersionForCurrentGameVersion}.
 You can download this SMAPI version from {SMAPINexusModsLink}.
 """)
         .WithMessageData(messageBuilder => messageBuilder

--- a/src/Games/NexusMods.Games.StardewValley/Diagnostics.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Diagnostics.cs
@@ -134,4 +134,32 @@ The compatibility status was extracted from the internal SMAPI metadata file.
             .AddValue<string>("ModVersion")
         )
         .Finish();
+
+    [DiagnosticTemplate]
+    [UsedImplicitly]
+    internal static IDiagnosticTemplate GameVersionOlderThanMinimumGameVersionTemplate = DiagnosticTemplateBuilder
+        .Start()
+        .WithId(new DiagnosticId(Source, number: 8))
+        .WithTitle("Game Version older than supported by SMAPI")
+        .WithSeverity(DiagnosticSeverity.Critical)
+        .WithSummary("The minimum supported game version of SMAPI {SMAPIVersion} is {MinimumGameVersion}")
+        .WithDetails("""
+SMAPI version {SMAPIVersion} requires the game version to be at least {MinimumGameVersion}.
+The current game version is {CurrentGameVersion}.
+
+Due to this version mismatch, the game will **crash** on startup.
+You can solve this issue by either updating your game or downgrading SMAPI.
+
+The last supported SMAPI version for game version {CurrentGameVersion} is {LastSupportedSMAPIVersionForCurrentGameVersion}.
+You can download this SMAPI version from {SMAPINexusModsLink}.
+""")
+        .WithMessageData(messageBuilder => messageBuilder
+            .AddDataReference<ModReference>("SMAPIMod")
+            .AddValue<string>("SMAPIVersion")
+            .AddValue<string>("MinimumGameVersion")
+            .AddValue<string>("CurrentGameVersion")
+            .AddValue<string>("LastSupportedSMAPIVersionForCurrentGameVersion")
+            .AddValue<NamedLink>("SMAPINexusModsLink")
+        )
+        .Finish();
 }

--- a/src/Games/NexusMods.Games.StardewValley/Diagnostics.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Diagnostics.cs
@@ -190,4 +190,25 @@ You can download this SMAPI version from {SMAPINexusModsLink}.
             .AddValue<NamedLink>("SMAPINexusModsLink")
         )
         .Finish();
+
+    [DiagnosticTemplate]
+    [UsedImplicitly]
+    internal static IDiagnosticTemplate SuggestSMAPIVersionTemplate = DiagnosticTemplateBuilder
+        .Start()
+        .WithId(new DiagnosticId(Source, number: 10))
+        .WithTitle("Install SMAPI to get started with modding Stardew Valley")
+        .WithSeverity(DiagnosticSeverity.Suggestion)
+        .WithSummary("Install SMAPI to get started with modding Stardew Valley")
+        .WithDetails("""
+SMAPI is the mod loader for Stardew Valley. The majority of mods require SMAPI to be installed.
+
+You can download the latest supported SMAPI version {LatestSMAPIVersion} for your game version
+{CurrentGameVersion} from {SMAPINexusModsLink}.
+""")
+        .WithMessageData(messageBuilder => messageBuilder
+            .AddValue<string>("LatestSMAPIVersion")
+            .AddValue<string>("CurrentGameVersion")
+            .AddValue<NamedLink>("SMAPINexusModsLink")
+        )
+        .Finish();
 }

--- a/src/Games/NexusMods.Games.StardewValley/Diagnostics.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Diagnostics.cs
@@ -150,7 +150,7 @@ The current game version is {CurrentGameVersion}.
 Due to this version mismatch, the game will **crash** on startup.
 You can solve this issue by either updating your game or downgrading SMAPI.
 
-The newest supported SMAPI version for game version {CurrentGameVersion} is {LastSupportedSMAPIVersionForCurrentGameVersion}.
+The newest supported SMAPI version for game version {CurrentGameVersion} is {NewestSupportedSMAPIVersionForCurrentGameVersion}.
 You can download this SMAPI version from {SMAPINexusModsLink}.
 """)
         .WithMessageData(messageBuilder => messageBuilder
@@ -158,7 +158,7 @@ You can download this SMAPI version from {SMAPINexusModsLink}.
             .AddValue<string>("SMAPIVersion")
             .AddValue<string>("MinimumGameVersion")
             .AddValue<string>("CurrentGameVersion")
-            .AddValue<string>("LastSupportedSMAPIVersionForCurrentGameVersion")
+            .AddValue<string>("NewestSupportedSMAPIVersionForCurrentGameVersion")
             .AddValue<NamedLink>("SMAPINexusModsLink")
         )
         .Finish();

--- a/src/Games/NexusMods.Games.StardewValley/Diagnostics.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Diagnostics.cs
@@ -162,4 +162,32 @@ You can download this SMAPI version from {SMAPINexusModsLink}.
             .AddValue<NamedLink>("SMAPINexusModsLink")
         )
         .Finish();
+
+    [DiagnosticTemplate]
+    [UsedImplicitly]
+    internal static IDiagnosticTemplate GameVersionNewerThanMaximumGameVersionTemplate = DiagnosticTemplateBuilder
+        .Start()
+        .WithId(new DiagnosticId(Source, number: 9))
+        .WithTitle("Game Version newer than supported by SMAPI")
+        .WithSeverity(DiagnosticSeverity.Critical)
+        .WithSummary("The maximum supported game version of SMAPI {SMAPIVersion} is {MaximumGameVersion}")
+        .WithDetails("""
+SMAPI version {SMAPIVersion} requires the game version to be lower than {MaximumGameVersion}.
+The current game version is {CurrentGameVersion}.
+
+Due to this version mismatch, the game will **crash** on startup.
+You can solve this issue by either downgrading your game to {MaximumGameVersion} or updating SMAPI.
+
+The newest supported SMAPI version for game version {CurrentGameVersion} is {NewestSupportedSMAPIVersionForCurrentGameVersion}.
+You can download this SMAPI version from {SMAPINexusModsLink}.
+""")
+        .WithMessageData(messageBuilder => messageBuilder
+            .AddDataReference<ModReference>("SMAPIMod")
+            .AddValue<string>("SMAPIVersion")
+            .AddValue<string>("MaximumGameVersion")
+            .AddValue<string>("CurrentGameVersion")
+            .AddValue<string>("NewestSupportedSMAPIVersionForCurrentGameVersion")
+            .AddValue<NamedLink>("SMAPINexusModsLink")
+        )
+        .Finish();
 }

--- a/src/Games/NexusMods.Games.StardewValley/Emitters/SMAPIGameVersionDiagnosticEmitter.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/SMAPIGameVersionDiagnosticEmitter.cs
@@ -1,0 +1,152 @@
+using System.Collections.Immutable;
+using System.Net.Http.Json;
+using System.Runtime.CompilerServices;
+using JetBrains.Annotations;
+using Microsoft.Extensions.Logging;
+using NexusMods.Abstractions.Diagnostics;
+using NexusMods.Abstractions.Diagnostics.Emitters;
+using NexusMods.Abstractions.Diagnostics.References;
+using NexusMods.Abstractions.Diagnostics.Values;
+using NexusMods.Abstractions.Loadouts;
+using NexusMods.Abstractions.Loadouts.Mods;
+using NexusMods.Games.StardewValley.Models;
+
+namespace NexusMods.Games.StardewValley.Emitters;
+
+using SMAPIToGameMapping = ImmutableDictionary<string, SMAPIGameVersionDiagnosticEmitter.GameVersions>;
+using GameToSMAPIMapping = ImmutableDictionary<string, string[]>;
+
+[UsedImplicitly]
+public class SMAPIGameVersionDiagnosticEmitter : ILoadoutDiagnosticEmitter
+{
+    private readonly ILogger _logger;
+    private readonly HttpClient _client;
+
+    private static readonly NamedLink NexusModsSMAPILink = new("Nexus Mods", new Uri("https://nexusmods.com/stardewvalley/mods/2400"));
+
+    public SMAPIGameVersionDiagnosticEmitter(
+        ILogger<SMAPIGameVersionDiagnosticEmitter> logger,
+        HttpClient client)
+    {
+        _logger = logger;
+        _client = client;
+    }
+
+    public async IAsyncEnumerable<Diagnostic> Diagnose(Loadout loadout, [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var smapiToGameMappings = await FetchSMAPIToGameMappings(cancellationToken);
+        if (smapiToGameMappings is null) yield break;
+
+        var gameToSMAPIMappings = await FetchGameToSMAPIMappings(cancellationToken);
+        if (gameToSMAPIMappings is null) yield break;
+
+        var gameVersion = loadout.Installation.Version;
+        var smapiMod = loadout.Mods
+            .Where(kv => kv.Value.Enabled)
+            .Select(kv => kv.Value)
+            .FirstOrDefault(mod => mod.Metadata.OfType<SMAPIMarker>().Any());
+
+        if (smapiMod is null) yield break;
+        var smapiMarker = smapiMod.Metadata.OfType<SMAPIMarker>().First();
+        var smapiVersion = smapiMarker.Version!;
+
+        var diagnostic1 = GameVersionOlderThanMinimumGameVersion(
+            smapiToGameMappings, gameToSMAPIMappings,
+            loadout, smapiMod,
+            gameVersion, smapiVersion
+        );
+
+        if (diagnostic1 is not null) yield return diagnostic1;
+    }
+
+    private Diagnostic? GameVersionOlderThanMinimumGameVersion(
+        SMAPIToGameMapping smapiToGameMappings,
+        GameToSMAPIMapping gameToSMAPIMappings,
+        Loadout loadout,
+        Mod smapiMod,
+        Version gameVersion,
+        Version smapiVersion)
+    {
+        if (!smapiToGameMappings.TryGetValue(smapiVersion.ToString(), out var supportedGameVersions))
+        {
+            // ReSharper disable once InconsistentLogPropertyNaming
+            _logger.LogWarning("Found no game version information for SMAPI version {SMAPIVersion}", smapiVersion);
+            return null;
+        }
+
+        var (sMinimumGameVersion, _) = supportedGameVersions;
+        if (sMinimumGameVersion is null) return null;
+
+        if (!Version.TryParse(sMinimumGameVersion, out var minimumGameVersion))
+        {
+            _logger.LogWarning("Unable to parse game version string `{VersionString}` as a Version", sMinimumGameVersion);
+            return null;
+        }
+
+        if (minimumGameVersion <= gameVersion) return null;
+
+        if (!gameToSMAPIMappings.TryGetValue(gameVersion.ToString(), out var supportedSMAPIVersions) ||
+            supportedSMAPIVersions.Length == 0)
+        {
+            _logger.LogWarning("Found no supported SMAPI versions for game version {GameVersion}", gameVersion);
+            return null;
+        }
+
+        return Diagnostics.CreateGameVersionOlderThanMinimumGameVersion(
+            SMAPIMod: smapiMod.ToReference(loadout),
+            SMAPIVersion: smapiVersion.ToString(),
+            MinimumGameVersion: sMinimumGameVersion,
+            CurrentGameVersion: gameVersion.ToString(),
+            LastSupportedSMAPIVersionForCurrentGameVersion: supportedSMAPIVersions.First(),
+            SMAPINexusModsLink: NexusModsSMAPILink
+        );
+    }
+
+    private static readonly Uri SMAPIToGameMappingsDataUri = new("https://github.com/erri120/smapi-versions/raw/main/data/smapi-game-versions.json");
+    private static readonly Uri GameToSMAPIMappingsDataUri = new("https://github.com/erri120/smapi-versions/raw/main/data/game-smapi-versions.json");
+
+    private SMAPIToGameMapping? _smapiToGameMappings;
+    private GameToSMAPIMapping? _gameToSMAPIMappings;
+
+    private async Task<SMAPIToGameMapping?> FetchSMAPIToGameMappings(CancellationToken cancellationToken)
+    {
+        return _smapiToGameMappings ??= await FetchData<SMAPIToGameMapping>(GameToSMAPIMappingsDataUri, cancellationToken);
+    }
+
+    private async Task<GameToSMAPIMapping?> FetchGameToSMAPIMappings(CancellationToken cancellationToken)
+    {
+        return _gameToSMAPIMappings ??= await FetchData<GameToSMAPIMapping>(SMAPIToGameMappingsDataUri, cancellationToken);
+    }
+
+    private async Task<T?> FetchData<T>(Uri dataUri, CancellationToken cancellationToken) where T : class
+    {
+        try
+        {
+            var data = await _client.GetFromJsonAsync<T>(dataUri, cancellationToken).ConfigureAwait(false);
+            if (data is not null) return data;
+
+            _logger.LogWarning("Serialization of JSON data at {Uri} failed and returned null", dataUri);
+            return null;
+
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Exception while getting JSON data from {Uri}", dataUri);
+            return null;
+        }
+    }
+
+    [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
+    public record GameVersions
+    {
+        public required string? MinimumGameVersion { get; init; }
+
+        public required string? MaximumGameVersion { get; init; }
+
+        public void Deconstruct(out string? minimumGameVersion, out string? maximumGameVersion)
+        {
+            minimumGameVersion = MinimumGameVersion;
+            maximumGameVersion = MaximumGameVersion;
+        }
+    }
+}

--- a/src/Games/NexusMods.Games.StardewValley/Emitters/SMAPIGameVersionDiagnosticEmitter.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/SMAPIGameVersionDiagnosticEmitter.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http.Json;
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
@@ -13,8 +14,8 @@ using NexusMods.Games.StardewValley.Models;
 
 namespace NexusMods.Games.StardewValley.Emitters;
 
-using SMAPIToGameMapping = ImmutableDictionary<string, SMAPIGameVersionDiagnosticEmitter.GameVersions>;
-using GameToSMAPIMapping = ImmutableDictionary<string, string[]>;
+using SMAPIToGameMapping = ImmutableDictionary<Version, SMAPIGameVersionDiagnosticEmitter.GameVersions>;
+using GameToSMAPIMapping = ImmutableDictionary<Version, Version>;
 
 [UsedImplicitly]
 public class SMAPIGameVersionDiagnosticEmitter : ILoadoutDiagnosticEmitter
@@ -40,7 +41,9 @@ public class SMAPIGameVersionDiagnosticEmitter : ILoadoutDiagnosticEmitter
         var gameToSMAPIMappings = await FetchGameToSMAPIMappings(cancellationToken);
         if (gameToSMAPIMappings is null) yield break;
 
-        var gameVersion = loadout.Installation.Version;
+        // var gameVersion = SimplifyVersion(new Version("1.5.6"));
+        var gameVersion = SimplifyVersion(loadout.Installation.Version);
+
         var smapiMod = loadout.Mods
             .Where(kv => kv.Value.Enabled)
             .Select(kv => kv.Value)
@@ -48,7 +51,7 @@ public class SMAPIGameVersionDiagnosticEmitter : ILoadoutDiagnosticEmitter
 
         if (smapiMod is null) yield break;
         var smapiMarker = smapiMod.Metadata.OfType<SMAPIMarker>().First();
-        var smapiVersion = smapiMarker.Version!;
+        var smapiVersion = SimplifyVersion(smapiMarker.Version!);
 
         var diagnostic1 = GameVersionOlderThanMinimumGameVersion(
             smapiToGameMappings, gameToSMAPIMappings,
@@ -67,26 +70,19 @@ public class SMAPIGameVersionDiagnosticEmitter : ILoadoutDiagnosticEmitter
         Version gameVersion,
         Version smapiVersion)
     {
-        if (!smapiToGameMappings.TryGetValue(smapiVersion.ToString(), out var supportedGameVersions))
+        if (!smapiToGameMappings.TryGetValue(smapiVersion, out var supportedGameVersions))
         {
             // ReSharper disable once InconsistentLogPropertyNaming
             _logger.LogWarning("Found no game version information for SMAPI version {SMAPIVersion}", smapiVersion);
             return null;
         }
 
-        var (sMinimumGameVersion, _) = supportedGameVersions;
-        if (sMinimumGameVersion is null) return null;
-
-        if (!Version.TryParse(sMinimumGameVersion, out var minimumGameVersion))
-        {
-            _logger.LogWarning("Unable to parse game version string `{VersionString}` as a Version", sMinimumGameVersion);
-            return null;
-        }
+        var (minimumGameVersion, _) = supportedGameVersions;
+        if (minimumGameVersion is null) return null;
 
         if (minimumGameVersion <= gameVersion) return null;
 
-        if (!gameToSMAPIMappings.TryGetValue(gameVersion.ToString(), out var supportedSMAPIVersions) ||
-            supportedSMAPIVersions.Length == 0)
+        if (!gameToSMAPIMappings.TryGetValue(gameVersion, out var supportedSMAPIVersion))
         {
             _logger.LogWarning("Found no supported SMAPI versions for game version {GameVersion}", gameVersion);
             return null;
@@ -95,9 +91,9 @@ public class SMAPIGameVersionDiagnosticEmitter : ILoadoutDiagnosticEmitter
         return Diagnostics.CreateGameVersionOlderThanMinimumGameVersion(
             SMAPIMod: smapiMod.ToReference(loadout),
             SMAPIVersion: smapiVersion.ToString(),
-            MinimumGameVersion: sMinimumGameVersion,
+            MinimumGameVersion: minimumGameVersion.ToString(),
             CurrentGameVersion: gameVersion.ToString(),
-            LastSupportedSMAPIVersionForCurrentGameVersion: supportedSMAPIVersions.First(),
+            LastSupportedSMAPIVersionForCurrentGameVersion: supportedSMAPIVersion.ToString(),
             SMAPINexusModsLink: NexusModsSMAPILink
         );
     }
@@ -110,12 +106,82 @@ public class SMAPIGameVersionDiagnosticEmitter : ILoadoutDiagnosticEmitter
 
     private async Task<SMAPIToGameMapping?> FetchSMAPIToGameMappings(CancellationToken cancellationToken)
     {
-        return _smapiToGameMappings ??= await FetchData<SMAPIToGameMapping>(GameToSMAPIMappingsDataUri, cancellationToken);
+        if (_smapiToGameMappings is not null) return _smapiToGameMappings;
+
+        var data = await FetchData<Dictionary<string, GameVersionsDTO>>(SMAPIToGameMappingsDataUri, cancellationToken);
+        if (data is null) return null;
+
+        var res = new Dictionary<Version, GameVersions>();
+        foreach (var kv in data)
+        {
+            var (sVersion, gameVersions) = kv;
+            var (sMinimumGameVersion, sMaximumGameVersion) = gameVersions;
+
+            if (!TryParseVersion(sVersion, out var version)) continue;
+
+            Version? minimumGameVersion = null, maximumGameVersion = null;
+            if (sMinimumGameVersion is not null) if (!TryParseVersion(sMinimumGameVersion, out minimumGameVersion)) continue;
+            if (sMaximumGameVersion is not null) if (!TryParseVersion(sMaximumGameVersion, out maximumGameVersion)) continue;
+
+            res[version] = new GameVersions
+            {
+                MinimumGameVersion = minimumGameVersion,
+                MaximumGameVersion = maximumGameVersion,
+            };
+        }
+
+        _smapiToGameMappings = res.ToImmutableDictionary(keyComparer: VersionComparer.Instance);
+        return _smapiToGameMappings;
+
     }
 
     private async Task<GameToSMAPIMapping?> FetchGameToSMAPIMappings(CancellationToken cancellationToken)
     {
-        return _gameToSMAPIMappings ??= await FetchData<GameToSMAPIMapping>(SMAPIToGameMappingsDataUri, cancellationToken);
+        if (_gameToSMAPIMappings is not null) return _gameToSMAPIMappings;
+
+        var data = await FetchData<Dictionary<string, string[]>>(GameToSMAPIMappingsDataUri, cancellationToken);
+        if (data is null) return null;
+
+        var res = new Dictionary<Version, Version>();
+        foreach (var kv in data)
+        {
+            var (sGameVersion, smapiVersions) = kv;
+            if (smapiVersions.Length == 0) continue;
+
+            if (!TryParseVersion(sGameVersion, out var gameVersion)) continue;
+
+            var sSMAPIVersion = smapiVersions.First();
+            if (!TryParseVersion(sSMAPIVersion, out var smapiVersion)) continue;
+
+            res[gameVersion] = smapiVersion;
+        }
+
+        _gameToSMAPIMappings = res.ToImmutableDictionary(keyComparer: VersionComparer.Instance);
+        return _gameToSMAPIMappings;
+    }
+
+    private bool TryParseVersion(string input, [NotNullWhen(true)] out Version? version)
+    {
+        version = null;
+        if (Version.TryParse(input, out var tmp))
+        {
+            version = SimplifyVersion(tmp);
+            return true;
+        }
+
+        _logger.LogWarning("Unable to parse string `{Input}` as a Version", input);
+        return false;
+    }
+
+    private static Version SimplifyVersion(Version input)
+    {
+        var major = input.Major;
+        var minor = input.Minor;
+        var build = input.Build == -1 ? 0 : input.Build;
+        var revision = input.Revision == 0 ? -1 : input.Revision;
+
+        if (revision != -1) return new Version(major, minor, build, revision);
+        return new Version(major, minor, build);
     }
 
     private async Task<T?> FetchData<T>(Uri dataUri, CancellationToken cancellationToken) where T : class
@@ -136,8 +202,40 @@ public class SMAPIGameVersionDiagnosticEmitter : ILoadoutDiagnosticEmitter
         }
     }
 
+    private class VersionComparer : IEqualityComparer<Version>
+    {
+        public static readonly IEqualityComparer<Version> Instance = new VersionComparer();
+
+        public bool Equals(Version? x, Version? y)
+        {
+            if (ReferenceEquals(x, y)) return true;
+            if (ReferenceEquals(x, null)) return false;
+            if (ReferenceEquals(y, null)) return false;
+            return x.Equals(y);
+        }
+
+        public int GetHashCode(Version version)
+        {
+            return version.GetHashCode();
+        }
+    }
+
     [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
     public record GameVersions
+    {
+        public required Version? MinimumGameVersion { get; init; }
+
+        public required Version? MaximumGameVersion { get; init; }
+
+        public void Deconstruct(out Version? minimumGameVersion, out Version? maximumGameVersion)
+        {
+            minimumGameVersion = MinimumGameVersion;
+            maximumGameVersion = MaximumGameVersion;
+        }
+    }
+
+    [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
+    public record GameVersionsDTO
     {
         public required string? MinimumGameVersion { get; init; }
 

--- a/src/Games/NexusMods.Games.StardewValley/Emitters/SMAPIGameVersionDiagnosticEmitter.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/SMAPIGameVersionDiagnosticEmitter.cs
@@ -11,6 +11,7 @@ using NexusMods.Abstractions.Diagnostics.Values;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Loadouts.Mods;
 using NexusMods.Games.StardewValley.Models;
+using StardewModdingAPI;
 
 namespace NexusMods.Games.StardewValley.Emitters;
 
@@ -307,6 +308,12 @@ public class SMAPIGameVersionDiagnosticEmitter : ILoadoutDiagnosticEmitter
     {
         public static readonly VersionComparer Instance = new();
 
+        public int GetHashCode(Version version)
+        {
+            // NOTE(erri120): used by dictionary lookups
+            return version.GetHashCode();
+        }
+
         public bool Equals(Version? x, Version? y)
         {
             if (ReferenceEquals(x, y)) return true;
@@ -316,15 +323,12 @@ public class SMAPIGameVersionDiagnosticEmitter : ILoadoutDiagnosticEmitter
             if (x.Major != y.Major) return false;
             if (x.Minor != y.Minor) return false;
 
+            // NOTE(erri120): normalize Version and replace -1 with 0
             var xBuild = x.Build == -1 ? 0 : x.Build;
             var yBuild = y.Build == -1 ? 0 : y.Build;
 
-            return x.Build == yBuild;
-        }
-
-        public int GetHashCode(Version version)
-        {
-            return version.GetHashCode();
+            // NOTE(erri120): skipping revision because it's not part of a "semantic version"
+            return xBuild == yBuild;
         }
 
         public int Compare(Version? x, Version? y)
@@ -339,9 +343,11 @@ public class SMAPIGameVersionDiagnosticEmitter : ILoadoutDiagnosticEmitter
             var minorComparison = x.Minor.CompareTo(y.Minor);
             if (minorComparison != 0) return minorComparison;
 
+            // NOTE(erri120): normalize Version and replace -1 with 0
             var xBuild = x.Build == -1 ? 0 : x.Build;
             var yBuild = y.Build == -1 ? 0 : y.Build;
 
+            // NOTE(erri120): skipping revision because it's not part of a "semantic version"
             return xBuild.CompareTo(yBuild);
         }
     }

--- a/src/Games/NexusMods.Games.StardewValley/Emitters/SMAPIGameVersionDiagnosticEmitter.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/SMAPIGameVersionDiagnosticEmitter.cs
@@ -115,7 +115,7 @@ public class SMAPIGameVersionDiagnosticEmitter : ILoadoutDiagnosticEmitter
         var (_, maximumGameVersion) = supportedGameVersions;
         if (maximumGameVersion is null) return null;
 
-        if (maximumGameVersion > gameVersion) return null;
+        if (maximumGameVersion >= gameVersion) return null;
 
         var supportedSMAPIVersion = GetSuggestedSMAPIVersion(gameToSMAPIMappings, gameVersion);
         if (supportedSMAPIVersion is null) return null;

--- a/src/Games/NexusMods.Games.StardewValley/Services.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Services.cs
@@ -26,6 +26,7 @@ public static class Services
             .AddSingleton<DependencyDiagnosticEmitter>()
             .AddSingleton<MissingSMAPIEmitter>()
             .AddSingleton<SMAPIModDatabaseCompatibilityDiagnosticEmitter>()
+            .AddSingleton<SMAPIGameVersionDiagnosticEmitter>()
 
             // Misc
             .AddSingleton<ISMAPIWebApi, SMAPIWebApi>()

--- a/src/Games/NexusMods.Games.StardewValley/StardewValley.cs
+++ b/src/Games/NexusMods.Games.StardewValley/StardewValley.cs
@@ -101,6 +101,7 @@ public class StardewValley : AGame, ISteamGame, IGogGame, IXboxGame
 
     public override IDiagnosticEmitter[] DiagnosticEmitters =>
     [
+        _serviceProvider.GetRequiredService<SMAPIGameVersionDiagnosticEmitter>(),
         _serviceProvider.GetRequiredService<DependencyDiagnosticEmitter>(),
         _serviceProvider.GetRequiredService<MissingSMAPIEmitter>(),
         _serviceProvider.GetRequiredService<SMAPIModDatabaseCompatibilityDiagnosticEmitter>(),

--- a/src/NexusMods.DataModel/Diagnostics/DiagnosticManager.cs
+++ b/src/NexusMods.DataModel/Diagnostics/DiagnosticManager.cs
@@ -111,6 +111,8 @@ internal sealed class DiagnosticManager : IDiagnosticManager
 
             var flattened = nested
                 .SelectMany(many => many)
+                .OrderByDescending(x => x.Severity)
+                .ThenBy(x => x.Id)
                 .ToArray();
 
             return flattened;


### PR DESCRIPTION
Resolves #1168.

Adds three new diagnostics:
- **Critical**: Current game version is lower than the minimum supported version by SMAPI
- **Critical**: Current game version is newer than the maximum supported version by SMAPI
- **Suggestion**: SMAPI and no SMAPI mods are installed, you should install SMAPI to get started with modding Stardew Valley

![2024-04-04_13-58-17](https://github.com/Nexus-Mods/NexusMods.App/assets/16577545/e9456e57-63d1-443f-9b15-3e4244fa1184)
![2024-04-04_14-39-30](https://github.com/Nexus-Mods/NexusMods.App/assets/16577545/8913a8a7-5e6a-4585-a296-ec97166fde38)
![2024-04-04_14-54-19](https://github.com/Nexus-Mods/NexusMods.App/assets/16577545/683b159b-7920-4626-a8a6-a62072aac71a)
