### PR TITLE
Apply diff backend

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/Diff/DiskDiffEntry.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/Diff/DiskDiffEntry.cs
@@ -1,0 +1,31 @@
+using NexusMods.Abstractions.GameLocators;
+using NexusMods.Hashing.xxHash64;
+using NexusMods.Paths;
+
+namespace NexusMods.Abstractions.Loadouts.Synchronizers;
+
+/// <summary>
+/// A file diff entry
+/// </summary>
+public record struct DiskDiffEntry
+{
+    /// <summary>
+    /// The game path of the file
+    /// </summary>
+    public required GamePath GamePath { get; init; }
+    
+    /// <summary>
+    /// The size of the file (newest if modified)
+    /// </summary>
+    public required Size Size { get; init; }
+    
+    /// <summary>
+    /// The hash of the file (newest if modified)
+    /// </summary>
+    public required Hash Hash { get; init; }
+    
+    /// <summary>
+    /// The type of change that occurred to the file path
+    /// </summary>
+    public required FileChangeType ChangeType { get; init; }
+}

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/Diff/FileChangeType.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/Diff/FileChangeType.cs
@@ -1,0 +1,30 @@
+namespace NexusMods.Abstractions.Loadouts.Synchronizers;
+
+/// <summary>
+/// The type of change of a file at a specific path
+/// </summary>
+public enum FileChangeType
+{
+    /// <summary>
+    /// No change
+    /// </summary>
+    None,
+    
+    /// <summary>
+    /// This file path was added and was not present before
+    /// </summary>
+    Added,
+    
+    /// <summary>
+    /// This file path was removed and was present before
+    /// </summary>
+    Removed,
+    
+    /// <summary>
+    /// The contents of the file at this path were modified, hash is different
+    /// </summary>
+    /// <remarks>
+    /// A renamed file is not considered modified, but rather a Removed and an Added file
+    /// </remarks>
+    Modified,
+}

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/Diff/FileDiffTree.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/Diff/FileDiffTree.cs
@@ -1,0 +1,17 @@
+using NexusMods.Abstractions.GameLocators;
+using NexusMods.Abstractions.GameLocators.Trees;
+
+namespace NexusMods.Abstractions.Loadouts.Synchronizers;
+
+/// <summary>
+/// A tree that files and their change states
+/// </summary>
+public class FileDiffTree : AGamePathNodeTree<DiskDiffEntry>
+{
+    private FileDiffTree(IEnumerable<KeyValuePair<GamePath, DiskDiffEntry>> tree) : base(tree) { }
+    
+    /// <summary>
+    /// Creates a diff tree from a list of files and change states
+    /// </summary>
+    public static FileDiffTree Create(IEnumerable<KeyValuePair<GamePath, DiskDiffEntry>> items) => new(items);
+}

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/Diff/LoadoutDiskSateDiffUtils.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/Diff/LoadoutDiskSateDiffUtils.cs
@@ -1,0 +1,124 @@
+using System.Diagnostics;
+using NexusMods.Abstractions.DiskState;
+using NexusMods.Abstractions.GameLocators;
+using NexusMods.Abstractions.Games.DTO;
+using NexusMods.Abstractions.Games.Trees;
+using NexusMods.Abstractions.Loadouts.Files;
+
+namespace NexusMods.Abstractions.Loadouts.Synchronizers;
+
+/// <summary>
+/// Provides utility methods for diffing DiskStates and loadouts
+/// </summary>
+public static class LoadoutSynchronizerDiffExtensions
+{
+    /// <summary>
+    /// Computes the difference between a loadout and a disk state, assuming the loadout to be the newer state.
+    /// </summary>
+    /// <param name="loadout">Newer state, e.g. unapplied loadout</param>
+    /// <param name="diskState">The old state, e.g. last applied DiskState</param>
+    /// <returns>A tree of all the files with associated <see cref="FileChangeType"/></returns>
+    public static async ValueTask<FileDiffTree> LoadoutToDiskDiff(
+        this IStandardizedLoadoutSynchronizer loadoutSynchronizer,
+        Loadout loadout,
+        DiskStateTree diskState)
+    {
+        var flattenedLoadout = await loadoutSynchronizer.LoadoutToFlattenedLoadout(loadout);
+        return await FlattenedLoadoutToDiskDiff(flattenedLoadout, diskState);
+    }
+
+    private static ValueTask<FileDiffTree> FlattenedLoadoutToDiskDiff(FlattenedLoadout flattenedLoadout, DiskStateTree diskState)
+    {
+        var loadoutFiles = flattenedLoadout.GetAllDescendentFiles();
+        var diskStateEntries = diskState.GetAllDescendentFiles();
+
+        Dictionary<GamePath, DiskDiffEntry> resultingItems = new();
+
+        // Add all the disk state entries to the result, checking for changes
+        foreach (var diskItem in diskStateEntries)
+        {
+            var gamePath = diskItem.GamePath();
+            if (flattenedLoadout.TryGetValue(gamePath, out var loadoutFileEntry))
+            {
+                switch (loadoutFileEntry.Item.Value.File)
+                {
+                    case StoredFile sf:
+                        if (sf.Hash != diskItem.Item.Value.Hash)
+                        {
+                            resultingItems.Add(gamePath,
+                                new DiskDiffEntry
+                                {
+                                    GamePath = gamePath,
+                                    Hash = sf.Hash,
+                                    Size = sf.Size,
+                                    ChangeType = FileChangeType.Modified,
+                                }
+                            );
+                        }
+                        else
+                        {
+                            resultingItems.Add(gamePath,
+                                new DiskDiffEntry
+                                {
+                                    GamePath = gamePath,
+                                    Hash = sf.Hash,
+                                    Size = sf.Size,
+                                    ChangeType = FileChangeType.None,
+                                }
+                            );
+                        }
+
+                        break;
+                    case IGeneratedFile gf and IToFile:
+                        // TODO: Implement change detection for generated files
+                        break;
+                    default:
+                        throw new UnreachableException("No way to handle this file");
+                }
+            }
+            else
+            {
+                resultingItems.Add(gamePath,
+                    new DiskDiffEntry
+                    {
+                        GamePath = gamePath,
+                        Hash = diskItem.Item.Value.Hash,
+                        Size = diskItem.Item.Value.Size,
+                        ChangeType = FileChangeType.Removed,
+                    }
+                );
+            }
+        }
+
+        // Add all the new files to the result
+        foreach (var loadoutFile in loadoutFiles)
+        {
+            var gamePath = loadoutFile.GamePath();
+            switch (loadoutFile.Item.Value.File)
+            {
+                case StoredFile sf:
+                    if (!resultingItems.TryGetValue(gamePath, out _))
+                    {
+                        resultingItems.Add(gamePath,
+                            new DiskDiffEntry
+                            {
+                                GamePath = gamePath,
+                                Hash = sf.Hash,
+                                Size = sf.Size,
+                                ChangeType = FileChangeType.Added,
+                            }
+                        );
+                    }
+
+                    break;
+                case IGeneratedFile gf and IToFile:
+                    // TODO: Implement change detection for generated files
+                    break;
+                default:
+                    throw new UnreachableException("No way to handle this file");
+            }
+        }
+
+        return ValueTask.FromResult(FileDiffTree.Create(resultingItems));
+    }
+}

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/NexusMods.Abstractions.Loadouts.Synchronizers.csproj.DotSettings
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/NexusMods.Abstractions.Loadouts.Synchronizers.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=diff/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/tests/NexusMods.DataModel.Tests/ALoadoutSynchronizerTests.CanLoadoutToDiskDiff.verified.txt
+++ b/tests/NexusMods.DataModel.Tests/ALoadoutSynchronizerTests.CanLoadoutToDiskDiff.verified.txt
@@ -1,0 +1,121 @@
+﻿[
+  {
+    GamePath: {Saves}/saves/save.dat,
+    Size: 9,
+    Hash: 7255076076215846327,
+    ChangeType: Added
+  },
+  {
+    GamePath: {Preferences}/preferences/prefs.dat,
+    Size: 10,
+    Hash: 7911229197178386601,
+    ChangeType: Added
+  },
+  {
+    GamePath: {Game}/textures/a.dds,
+    Size: 12,
+    Hash: 12717109700637925136,
+    ChangeType: Added
+  },
+  {
+    GamePath: {Game}/StubbedGame.exe,
+    Size: 15,
+    Hash: 6574561706971262377,
+    ChangeType: Removed
+  },
+  {
+    GamePath: {Game}/perMod/9.dat,
+    Size: 11,
+    Hash: 15866111760882168537,
+    ChangeType: Added
+  },
+  {
+    GamePath: {Game}/perMod/8.dat,
+    Size: 11,
+    Hash: 5713662867142214122,
+    ChangeType: Added
+  },
+  {
+    GamePath: {Game}/perMod/7.dat,
+    Size: 11,
+    Hash: 13572409453822864702,
+    ChangeType: Added
+  },
+  {
+    GamePath: {Game}/perMod/6.dat,
+    Size: 11,
+    Hash: 17066504409269385112,
+    ChangeType: Added
+  },
+  {
+    GamePath: {Game}/perMod/5.dat,
+    Size: 11,
+    Hash: 16516738792654349155,
+    ChangeType: Added
+  },
+  {
+    GamePath: {Game}/perMod/4.dat,
+    Size: 11,
+    Hash: 16561016665659418969,
+    ChangeType: Added
+  },
+  {
+    GamePath: {Game}/perMod/3.dat,
+    Size: 11,
+    Hash: 623130015850055267,
+    ChangeType: Added
+  },
+  {
+    GamePath: {Game}/perMod/2.dat,
+    Size: 11,
+    Hash: 6818945102336093139,
+    ChangeType: Added
+  },
+  {
+    GamePath: {Game}/perMod/1.dat,
+    Size: 11,
+    Hash: 8370123012883808105,
+    ChangeType: Added
+  },
+  {
+    GamePath: {Game}/perMod/0.dat,
+    Size: 11,
+    Hash: 3438294227629774439,
+    ChangeType: Added
+  },
+  {
+    GamePath: {Game}/Models/model.3ds,
+    Size: 9,
+    Hash: 13553311955458940840,
+    ChangeType: Removed
+  },
+  {
+    GamePath: {Game}/meshes/b.nif,
+    Size: 9,
+    Hash: 1881667485528595586,
+    ChangeType: Added
+  },
+  {
+    GamePath: {Game}/Data/image.dds,
+    Size: 17,
+    Hash: 14634740297144163787,
+    ChangeType: Modified
+  },
+  {
+    GamePath: {Game}/config.ini,
+    Size: 10,
+    Hash: 13606612902462422414
+  },
+  {
+    GamePath: {Game}/bin/script.sh,
+    Size: 10,
+    Hash: 1449236998273414814,
+    ChangeType: Added
+  },
+  {
+    GamePath: {Game}/bin/binary,
+    Size: 7,
+    Hash: 3566539263998845450,
+    ChangeType: Added
+  }
+]

--- a/tests/NexusMods.DataModel.Tests/Harness/VerifiableFile.cs
+++ b/tests/NexusMods.DataModel.Tests/Harness/VerifiableFile.cs
@@ -1,0 +1,24 @@
+using NexusMods.Abstractions.Loadouts.Synchronizers;
+
+namespace NexusMods.DataModel.Tests.Harness;
+
+public record VerifiableFile
+{
+    public required string GamePath { get; init; }
+    public required ulong Size { get; init; }
+    
+    public required ulong Hash { get; init; }
+    
+    public required FileChangeType ChangeType { get; init; }
+    
+    public static VerifiableFile From(DiskDiffEntry diskDiffEntry)
+    {
+        return new VerifiableFile
+        {
+            GamePath = diskDiffEntry.GamePath.ToString(),
+            Size = diskDiffEntry.Size.Value,
+            Hash = diskDiffEntry.Hash.Value,
+            ChangeType = diskDiffEntry.ChangeType,
+        };
+    }
+}

--- a/tests/NexusMods.DataModel.Tests/NexusMods.DataModel.Tests.csproj
+++ b/tests/NexusMods.DataModel.Tests/NexusMods.DataModel.Tests.csproj
@@ -20,6 +20,10 @@
       </None>
     </ItemGroup>
 
+    <ItemGroup>
+      <PackageReference Include="Verify.Xunit" />
+    </ItemGroup>
+
     <Target Name="CopyResources" AfterTargets="PostBuildEvent">
         <ItemGroup>
             <_Resources Include="Resources\**" />


### PR DESCRIPTION
This adds an extension method to the LoadoutSyncrhonizer to compute a Diff tree between a loadout and a DiskState.
Part of 
- #1113 

Added a test to check if it worked and results seem correct