### PR TITLE
Settings Backend

### DIFF
--- a/NexusMods.App.sln
+++ b/NexusMods.App.sln
@@ -219,6 +219,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NexusMods.Icons", "src\Nexu
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NexusMods.Abstractions.Settings", "src\Abstractions\NexusMods.Abstractions.Settings\NexusMods.Abstractions.Settings.csproj", "{F8E762B4-185E-4DC5-9651-B8EAF6139488}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NexusMods.Settings", "src\NexusMods.Settings\NexusMods.Settings.csproj", "{2F642097-B510-4E0E-8467-8BD288C47DC3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -569,6 +571,10 @@ Global
 		{F8E762B4-185E-4DC5-9651-B8EAF6139488}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F8E762B4-185E-4DC5-9651-B8EAF6139488}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F8E762B4-185E-4DC5-9651-B8EAF6139488}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2F642097-B510-4E0E-8467-8BD288C47DC3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2F642097-B510-4E0E-8467-8BD288C47DC3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2F642097-B510-4E0E-8467-8BD288C47DC3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2F642097-B510-4E0E-8467-8BD288C47DC3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -669,6 +675,7 @@ Global
 		{FB0DA053-CA8D-4235-9501-9D6F1A244B56} = {E7BAE287-D505-4D6D-A090-665A64309B2D}
 		{B4C27B72-5C31-4045-B840-DD0CC44E4680} = {E7BAE287-D505-4D6D-A090-665A64309B2D}
 		{F8E762B4-185E-4DC5-9651-B8EAF6139488} = {0CB73565-1207-4A56-A79F-6A8E9BBD795C}
+		{2F642097-B510-4E0E-8467-8BD288C47DC3} = {E7BAE287-D505-4D6D-A090-665A64309B2D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9F9F8352-34DD-42C0-8564-EE9AF34A3501}

--- a/NexusMods.App.sln
+++ b/NexusMods.App.sln
@@ -217,6 +217,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Examples", "src\Examples\Ex
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NexusMods.Icons", "src\NexusMods.Icons\NexusMods.Icons.csproj", "{B4C27B72-5C31-4045-B840-DD0CC44E4680}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NexusMods.Abstractions.Settings", "src\Abstractions\NexusMods.Abstractions.Settings\NexusMods.Abstractions.Settings.csproj", "{F8E762B4-185E-4DC5-9651-B8EAF6139488}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -563,6 +565,10 @@ Global
 		{B4C27B72-5C31-4045-B840-DD0CC44E4680}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B4C27B72-5C31-4045-B840-DD0CC44E4680}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B4C27B72-5C31-4045-B840-DD0CC44E4680}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F8E762B4-185E-4DC5-9651-B8EAF6139488}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F8E762B4-185E-4DC5-9651-B8EAF6139488}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F8E762B4-185E-4DC5-9651-B8EAF6139488}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F8E762B4-185E-4DC5-9651-B8EAF6139488}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -662,6 +668,7 @@ Global
 		{674E8B0A-8F77-4DDE-BFCD-618F030DE01B} = {70D38D24-79AE-4600-8E83-17F3C11BA81F}
 		{FB0DA053-CA8D-4235-9501-9D6F1A244B56} = {E7BAE287-D505-4D6D-A090-665A64309B2D}
 		{B4C27B72-5C31-4045-B840-DD0CC44E4680} = {E7BAE287-D505-4D6D-A090-665A64309B2D}
+		{F8E762B4-185E-4DC5-9651-B8EAF6139488} = {0CB73565-1207-4A56-A79F-6A8E9BBD795C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9F9F8352-34DD-42C0-8564-EE9AF34A3501}

--- a/src/Abstractions/NexusMods.Abstractions.Settings/ISettings.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Settings/ISettings.cs
@@ -2,8 +2,14 @@ using JetBrains.Annotations;
 
 namespace NexusMods.Abstractions.Settings;
 
+/// <summary>
+/// Interface for settings.
+/// </summary>
 [PublicAPI]
 public interface ISettings
 {
+    /// <summary>
+    /// Configuration method for this type.
+    /// </summary>
     static abstract ISettingsBuilder Configure(ISettingsBuilder settingsBuilder);
 }

--- a/src/Abstractions/NexusMods.Abstractions.Settings/ISettings.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Settings/ISettings.cs
@@ -1,0 +1,9 @@
+using JetBrains.Annotations;
+
+namespace NexusMods.Abstractions.Settings;
+
+[PublicAPI]
+public interface ISettings
+{
+    static abstract ISettingsBuilder Configure(ISettingsBuilder settingsBuilder);
+}

--- a/src/Abstractions/NexusMods.Abstractions.Settings/ISettingsManager.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Settings/ISettingsManager.cs
@@ -1,0 +1,25 @@
+using JetBrains.Annotations;
+
+namespace NexusMods.Abstractions.Settings;
+
+/// <summary>
+/// Represents a settings manager.
+/// </summary>
+[PublicAPI]
+public interface ISettingsManager
+{
+    /// <summary>
+    /// Sets the current value of <typeparamref name="T"/>.
+    /// </summary>
+    void Set<T>(T value) where T : ISettings;
+
+    /// <summary>
+    /// Gets the current value for <typeparamref name="T"/>.
+    /// </summary>
+    T Get<T>() where T : ISettings;
+
+    /// <summary>
+    /// Gets an observable stream to be notified about changes to <typeparamref name="T"/>.
+    /// </summary>
+    IObservable<T> GetChanges<T>() where T : ISettings;
+}

--- a/src/Abstractions/NexusMods.Abstractions.Settings/ISettingsManager.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Settings/ISettingsManager.cs
@@ -11,15 +11,15 @@ public interface ISettingsManager
     /// <summary>
     /// Sets the current value of <typeparamref name="T"/>.
     /// </summary>
-    void Set<T>(T value) where T : ISettings;
+    void Set<T>(T value) where T : class, ISettings, new();
 
     /// <summary>
     /// Gets the current value for <typeparamref name="T"/>.
     /// </summary>
-    T Get<T>() where T : ISettings;
+    T Get<T>() where T : class, ISettings, new();
 
     /// <summary>
     /// Gets an observable stream to be notified about changes to <typeparamref name="T"/>.
     /// </summary>
-    IObservable<T> GetChanges<T>() where T : ISettings;
+    IObservable<T> GetChanges<T>() where T : class, ISettings, new();
 }

--- a/src/Abstractions/NexusMods.Abstractions.Settings/NexusMods.Abstractions.Settings.csproj
+++ b/src/Abstractions/NexusMods.Abstractions.Settings/NexusMods.Abstractions.Settings.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+    <ItemGroup>
+        <PackageReference Include="OneOf" />
+        <PackageReference Include="System.Reactive" />
+        <PackageReference Include="DynamicData" />
+
+        <PackageReference Include="TransparentValueObjects" PrivateAssets="all" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    </ItemGroup>
+</Project>

--- a/src/Abstractions/NexusMods.Abstractions.Settings/NexusMods.Abstractions.Settings.csproj
+++ b/src/Abstractions/NexusMods.Abstractions.Settings/NexusMods.Abstractions.Settings.csproj
@@ -1,9 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
         <PackageReference Include="OneOf" />
         <PackageReference Include="System.Reactive" />
         <PackageReference Include="DynamicData" />
 
         <PackageReference Include="TransparentValueObjects" PrivateAssets="all" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <InternalsVisibleTo Include="NexusMods.Settings" />
     </ItemGroup>
 </Project>

--- a/src/Abstractions/NexusMods.Abstractions.Settings/NexusMods.Abstractions.Settings.csproj.DotSettings
+++ b/src/Abstractions/NexusMods.Abstractions.Settings/NexusMods.Abstractions.Settings.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=settingsbuilder/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Abstractions/NexusMods.Abstractions.Settings/SectionId.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Settings/SectionId.cs
@@ -1,0 +1,17 @@
+using JetBrains.Annotations;
+using TransparentValueObjects;
+
+namespace NexusMods.Abstractions.Settings;
+
+/// <summary>
+/// Represents the unique ID of a section of settings.
+/// </summary>
+[ValueObject<Guid>]
+[PublicAPI]
+public readonly partial struct SectionId : IAugmentWith<DefaultValueAugment>
+{
+    /// <summary>
+    /// Gets the default value (empty GUID).
+    /// </summary>
+    public static SectionId DefaultValue { get; } = From(Guid.Empty);
+}

--- a/src/Abstractions/NexusMods.Abstractions.Settings/ServiceExtensions.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Settings/ServiceExtensions.cs
@@ -1,0 +1,23 @@
+using JetBrains.Annotations;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace NexusMods.Abstractions.Settings;
+
+/// <summary>
+/// Extension methods for <see cref="IServiceCollection"/>
+/// </summary>
+[PublicAPI]
+public static class ServiceExtensions
+{
+    /// <summary>
+    /// Registers a settings type.
+    /// </summary>
+    public static IServiceCollection AddSettings<T>(this IServiceCollection serviceCollection) where T : class, ISettings, new()
+    {
+        return serviceCollection.AddSingleton(new SettingsTypeInformation(
+            ObjectType: typeof(T),
+            DefaultValue: new T(),
+            ConfigureLambda: T.Configure
+        ));
+    }
+}

--- a/src/Abstractions/NexusMods.Abstractions.Settings/SettingsBuilder/IPropertyUIBuilder.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Settings/SettingsBuilder/IPropertyUIBuilder.cs
@@ -1,0 +1,59 @@
+using JetBrains.Annotations;
+
+namespace NexusMods.Abstractions.Settings;
+
+[PublicAPI]
+public interface IPropertyUIBuilder<TSettings, TProperty>
+    where TSettings : class, ISettings, new()
+{
+    /// <summary>
+    /// Sets the display name of the property.
+    /// </summary>
+    /// <remarks>
+    /// This property does not allow for Markdown.
+    /// </remarks>
+    IWithDescriptionStep WithDisplayName(string displayName);
+
+    [PublicAPI]
+    public interface IWithDescriptionStep
+    {
+        /// <summary>
+        /// Sets the description of the property.
+        /// </summary>
+        /// <remarks>
+        /// This property allows for Markdown.
+        /// </remarks>
+        IOptionalStep WithDescription(string description);
+    }
+
+    [PublicAPI]
+    public interface IOptionalStep : IFinishedStep
+    {
+        /// <summary>
+        /// Adds validation to the property.
+        /// </summary>
+        IOptionalStep WithValidation(Func<TProperty, ValidationResult> validator);
+
+        /// <summary>
+        /// Sets the property to require a restart when changed.
+        /// </summary>
+        /// <remarks>
+        /// Use <see cref="RequiresRestart()"/> if you want to use
+        /// a generic message instead of a custom one.
+        /// </remarks>
+        IOptionalStep RequiresRestart(string message);
+
+        /// <summary>
+        /// Sets the property to require a restart when changed.
+        /// </summary>
+        /// <remarks>
+        /// This displays a generic message to the user. Use
+        /// <see cref="RequiresRestart(string)"/> if you want to
+        /// customize the message.
+        /// </remarks>
+        IOptionalStep RequiresRestart();
+    }
+
+    [PublicAPI]
+    public interface IFinishedStep;
+}

--- a/src/Abstractions/NexusMods.Abstractions.Settings/SettingsBuilder/ISettingsBuilder.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Settings/SettingsBuilder/ISettingsBuilder.cs
@@ -16,38 +16,3 @@ public interface ISettingsBuilder
         Func<ISettingsUIBuilder<TSettings>, ISettingsUIBuilder<TSettings>.IFinishedStep> configureUI
     ) where TSettings : class, ISettings, new();
 }
-
-file record MySettings : ISettings
-{
-    public string Name { get; init; } = "Initial Value";
-
-    public static ISettingsBuilder Configure(ISettingsBuilder settingsBuilder)
-    {
-        return settingsBuilder.AddToUI<MySettings>(uiBuilder => uiBuilder
-            .AddToSection(SectionId.DefaultValue)
-            .AddPropertyToUI(x => x.Name, propertyBuilder => propertyBuilder
-                .WithDisplayName("Cool Name")
-                .WithDescription("This is a very cool name that you can change!")
-                .WithValidation(ValidateName)
-                .RequiresRestart("Changing this very cool name requires a restart!")
-            )
-        );
-    }
-
-    private static ValidationResult ValidateName(string name)
-    {
-        const int minLength = 5;
-        const int maxLength = 50;
-
-        if (string.IsNullOrWhiteSpace(name))
-            return ValidationResult.CreateFailed("Name cannot be empty!");
-
-        if (name.Length < minLength)
-            return ValidationResult.CreateFailed($"Name must be at least {minLength} characters long!");
-
-        if (name.Length > maxLength)
-            return ValidationResult.CreateFailed($"Name must be less than {minLength} characters long!");
-
-        return ValidationResult.CreateSuccessful();
-    }
-}

--- a/src/Abstractions/NexusMods.Abstractions.Settings/SettingsBuilder/ISettingsBuilder.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Settings/SettingsBuilder/ISettingsBuilder.cs
@@ -1,0 +1,53 @@
+using JetBrains.Annotations;
+
+namespace NexusMods.Abstractions.Settings;
+
+/// <summary>
+/// Configuration builder for types that implement <see cref="ISettings"/>.
+/// </summary>
+[PublicAPI]
+public interface ISettingsBuilder
+{
+    /// <summary>
+    /// Configures the settings type <typeparamref name="TSettings"/> to be
+    /// exposed in the UI.
+    /// </summary>
+    ISettingsBuilder AddToUI<TSettings>(
+        Func<ISettingsUIBuilder<TSettings>, ISettingsUIBuilder<TSettings>.IFinishedStep> configureUI
+    ) where TSettings : class, ISettings, new();
+}
+
+file record MySettings : ISettings
+{
+    public string Name { get; init; } = "Initial Value";
+
+    public static ISettingsBuilder Configure(ISettingsBuilder settingsBuilder)
+    {
+        return settingsBuilder.AddToUI<MySettings>(uiBuilder => uiBuilder
+            .AddToSection(SectionId.DefaultValue)
+            .AddPropertyToUI(x => x.Name, propertyBuilder => propertyBuilder
+                .WithDisplayName("Cool Name")
+                .WithDescription("This is a very cool name that you can change!")
+                .WithValidation(ValidateName)
+                .RequiresRestart("Changing this very cool name requires a restart!")
+            )
+        );
+    }
+
+    private static ValidationResult ValidateName(string name)
+    {
+        const int minLength = 5;
+        const int maxLength = 50;
+
+        if (string.IsNullOrWhiteSpace(name))
+            return ValidationResult.CreateFailed("Name cannot be empty!");
+
+        if (name.Length < minLength)
+            return ValidationResult.CreateFailed($"Name must be at least {minLength} characters long!");
+
+        if (name.Length > maxLength)
+            return ValidationResult.CreateFailed($"Name must be less than {minLength} characters long!");
+
+        return ValidationResult.CreateSuccessful();
+    }
+}

--- a/src/Abstractions/NexusMods.Abstractions.Settings/SettingsBuilder/ISettingsUIBuilder.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Settings/SettingsBuilder/ISettingsUIBuilder.cs
@@ -1,0 +1,29 @@
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+
+namespace NexusMods.Abstractions.Settings;
+
+/// <summary>
+/// Configuration builder for <typeparamref name="TSettings"/> that gets exposed in the UI.
+/// </summary>
+[PublicAPI]
+public interface ISettingsUIBuilder<TSettings>
+    where TSettings : class, ISettings, new()
+{
+    IAddPropertyToUIStep AddToSection(SectionId id);
+
+    [PublicAPI]
+    public interface IAddPropertyToUIStep : IFinishedStep
+    {
+        /// <summary>
+        /// Adds the selected property to the UI.
+        /// </summary>
+        IAddPropertyToUIStep AddPropertyToUI<TProperty>(
+            Expression<Func<TSettings, TProperty>> selectProperty,
+            Func<IPropertyUIBuilder<TSettings, TProperty>, IPropertyUIBuilder<TSettings, TProperty>.IFinishedStep> configureProperty
+        );
+    }
+
+    [PublicAPI]
+    public interface IFinishedStep;
+}

--- a/src/Abstractions/NexusMods.Abstractions.Settings/SettingsTypeInformation.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Settings/SettingsTypeInformation.cs
@@ -1,0 +1,7 @@
+namespace NexusMods.Abstractions.Settings;
+
+internal record SettingsTypeInformation(
+    Type ObjectType,
+    ISettings DefaultValue,
+    Func<ISettingsBuilder, ISettingsBuilder> ConfigureLambda
+);

--- a/src/Abstractions/NexusMods.Abstractions.Settings/ValidationResult.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Settings/ValidationResult.cs
@@ -1,0 +1,82 @@
+using JetBrains.Annotations;
+using OneOf;
+
+namespace NexusMods.Abstractions.Settings;
+
+/// <summary>
+/// Represents either a failed or successful validation result.
+/// </summary>
+[PublicAPI]
+public readonly struct ValidationResult
+{
+    /// <summary>
+    /// Union between <see cref="Failed"/> and <see cref="Successful"/>.
+    /// </summary>
+    public readonly OneOf<Failed, Successful> Value;
+
+    /// <summary>
+    /// Gets whether the validation failed.
+    /// </summary>
+    public bool IsFailed() => Value.IsT0;
+
+    /// <summary>
+    /// Gets whether the validation was successful.
+    /// </summary>
+    public bool IsSuccessful() => Value.IsT1;
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    public ValidationResult(OneOf<Failed, Successful> value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// Creates a failed result with a reason.
+    /// </summary>
+    public static ValidationResult CreateFailed(string reason)
+    {
+        return new ValidationResult(new Failed(reason));
+    }
+
+    /// <summary>
+    /// Creates a successful result.
+    /// </summary>
+    public static ValidationResult CreateSuccessful()
+    {
+        return new ValidationResult(Successful.Instance);
+    }
+
+    /// <summary>
+    /// Represents a failed validation.
+    /// </summary>
+    [PublicAPI]
+    public readonly struct Failed
+    {
+        /// <summary>
+        /// Reason why the validation failed.
+        /// </summary>
+        public readonly string Reason;
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        public Failed(string reason)
+        {
+            Reason = reason;
+        }
+    }
+
+    /// <summary>
+    /// Represents a successful validation.
+    /// </summary>
+    [PublicAPI]
+    public readonly struct Successful
+    {
+        /// <summary>
+        /// Instance.
+        /// </summary>
+        public static readonly Successful Instance;
+    }
+}

--- a/src/Examples/Examples.csproj
+++ b/src/Examples/Examples.csproj
@@ -15,6 +15,7 @@
     </ItemGroup>
     
     <ItemGroup>
+        <ProjectReference Include="..\Abstractions\NexusMods.Abstractions.Settings\NexusMods.Abstractions.Settings.csproj" />
         <ProjectReference Include="..\NexusMods.App.UI\NexusMods.App.UI.csproj" />
         <ProjectReference Include="..\NexusMods.App\NexusMods.App.csproj" />
         <ProjectReference Include="..\NexusMods.App.Generators.Diagnostics\NexusMods.App.Generators.Diagnostics\NexusMods.App.Generators.Diagnostics.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />

--- a/src/Examples/Settings/AddingSettings.cs
+++ b/src/Examples/Settings/AddingSettings.cs
@@ -1,0 +1,55 @@
+using NexusMods.Abstractions.Settings;
+// ReSharper disable All
+
+namespace Examples.Settings;
+
+// Create a new record class for your settings. The class needs a default constructor!
+file record MySettings : ISettings
+{
+    // Make sure to set a default value for all properties.
+    public string Name { get; init; } = "Initial Value";
+
+    // This is a static method from the interface that you have to implement.
+    public static ISettingsBuilder Configure(ISettingsBuilder settingsBuilder)
+    {
+        // You can use the ISettingsBuilder to expose the properties defined in
+        // this class in the UI.
+        return settingsBuilder.AddToUI<MySettings>(uiBuilder => uiBuilder
+             // TODO: define sections
+            .AddToSection(SectionId.DefaultValue)
+             // You have to configure every property that you want to add to the UI individually.
+            .AddPropertyToUI(x => x.Name, propertyBuilder => propertyBuilder
+                .WithDisplayName("Cool Name")
+                .WithDescription("This is a very cool name that you can change!")
+                // Optionally, you can have validation to prevent users from inputting weird stuff:
+                .WithValidation(ValidateName)
+                // Optionally, you can mark a property to require a restart if it changes.
+                // Example for this is changing the language or other major changes that
+                // can't be applied on the fly.
+                // You can define a custom message:
+                .RequiresRestart("Changing this very cool name requires a restart!")
+                // Or default to a generic message:
+                .RequiresRestart()
+            )
+        );
+    }
+
+    private static ValidationResult ValidateName(string name)
+    {
+        const int minLength = 5;
+        const int maxLength = 50;
+
+        // Validation is done by simply returning a ValidationResult.
+        // Validation can either fail or succeed. If it fails, provide a reason:
+        if (string.IsNullOrWhiteSpace(name))
+            return ValidationResult.CreateFailed("Name cannot be empty!");
+
+        if (name.Length < minLength)
+            return ValidationResult.CreateFailed($"Name must be at least {minLength} characters long!");
+
+        if (name.Length > maxLength)
+            return ValidationResult.CreateFailed($"Name must be less than {minLength} characters long!");
+
+        return ValidationResult.CreateSuccessful();
+    }
+}

--- a/src/Examples/Settings/ConsumingSettings.cs
+++ b/src/Examples/Settings/ConsumingSettings.cs
@@ -1,0 +1,50 @@
+using NexusMods.Abstractions.Settings;
+// ReSharper disable All
+
+namespace Examples.Settings;
+
+file class MyCoolSettings : ISettings
+{
+    public string Name { get; init; } = "Some Name";
+
+    public static ISettingsBuilder Configure(ISettingsBuilder settingsBuilder)
+    {
+        // This settings class doesn't have to appear on the UI, so we don't
+        // have to configure anything and can just return the provided builder:
+        return settingsBuilder;
+    }
+}
+
+file class MyService
+{
+    private readonly ISettingsManager _settingsManager;
+
+    public MyService(ISettingsManager settingsManager)
+    {
+        // Get the ISettingsManager via DI:
+        _settingsManager = settingsManager;
+    }
+
+    public void DoSomething()
+    {
+        // Call Get<TSettings> to get the current values for the provided type.
+        // You shouldn't cache the current settings values, instead, you should
+        // always call Get<TSettings>
+        var name = _settingsManager.Get<MyCoolSettings>().Name;
+
+        Console.WriteLine($"My name is '{name}'");
+    }
+
+    public void ReactToChanges()
+    {
+        // You can also react to changes to the settings. This is very useful
+        // if you're already doing reactive work that depends on the settings.
+        // This allows you to refresh data or re-trigger another observable stream.
+        _settingsManager
+            .GetChanges<MyCoolSettings>()
+            .Subscribe(newValue =>
+            {
+                Console.WriteLine($"Settings changed to {newValue}");
+            });
+    }
+}

--- a/src/Examples/Settings/README.md
+++ b/src/Examples/Settings/README.md
@@ -1,0 +1,4 @@
+# Settings Examples
+
+- [Adding Settings](./AddingSettings.cs)
+- [Consuming Settings](./ConsumingSettings.cs)

--- a/src/NexusMods.App/NexusMods.App.csproj
+++ b/src/NexusMods.App/NexusMods.App.csproj
@@ -30,6 +30,7 @@
         <ProjectReference Include="..\NexusMods.App.UI\NexusMods.App.UI.csproj" />
         <ProjectReference Include="..\NexusMods.App.Cli\NexusMods.App.Cli.csproj" />
         <ProjectReference Include="..\NexusMods.DataModel\NexusMods.DataModel.csproj" />
+        <ProjectReference Include="..\NexusMods.Settings\NexusMods.Settings.csproj" />
         <ProjectReference Include="..\Themes\NexusMods.Themes.NexusFluentDark\NexusMods.Themes.NexusFluentDark.csproj" />
     </ItemGroup>
 

--- a/src/NexusMods.App/Services.cs
+++ b/src/NexusMods.App/Services.cs
@@ -32,6 +32,7 @@ using NexusMods.Networking.HttpDownloader;
 using NexusMods.Networking.NexusWebApi;
 using NexusMods.Paths;
 using NexusMods.ProxyConsole;
+using NexusMods.Settings;
 using NexusMods.SingleProcess;
 using NexusMods.StandardGameLocators;
 using NexusMods.Telemetry;
@@ -63,6 +64,7 @@ public static class Services
                 .AddSingleton<CommandLineConfigurator>()
                 .AddCLI()
                 .AddUI(config.LauncherSettings)
+                .AddSettings()
                 .AddSingleton<App>()
                 .AddGuidedInstallerUi()
                 .AddAdvancedInstaller()

--- a/src/NexusMods.Settings/NexusMods.Settings.csproj
+++ b/src/NexusMods.Settings/NexusMods.Settings.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Abstractions\NexusMods.Abstractions.Settings\NexusMods.Abstractions.Settings.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/NexusMods.Settings/Services.cs
+++ b/src/NexusMods.Settings/Services.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.DependencyInjection;
+using NexusMods.Abstractions.Settings;
+
+namespace NexusMods.Settings;
+
+public static class Services
+{
+    public static IServiceCollection AddSettings(this IServiceCollection serviceCollection)
+    {
+        return serviceCollection
+            .AddSingleton<ISettingsManager, SettingsManager>();
+    }
+}

--- a/src/NexusMods.Settings/SettingsManager.cs
+++ b/src/NexusMods.Settings/SettingsManager.cs
@@ -17,9 +17,12 @@ internal class SettingsManager : ISettingsManager
     {
         _logger = serviceProvider.GetRequiredService<ILogger<SettingsManager>>();
 
+        // TODO:
         var typeInformation = serviceProvider
             .GetServices<SettingsTypeInformation>()
             .ToArray();
+
+        _logger.LogDebug("Found {Count} registered settings", typeInformation.Length);
     }
 
     public void Set<T>(T value) where T : class, ISettings, new()

--- a/src/NexusMods.Settings/SettingsManager.cs
+++ b/src/NexusMods.Settings/SettingsManager.cs
@@ -1,13 +1,26 @@
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.Settings;
 
 namespace NexusMods.Settings;
 
 internal class SettingsManager : ISettingsManager
 {
+    private readonly ILogger _logger;
+
     private readonly Subject<(Type, object)> _subject = new();
     private readonly Dictionary<Type, object> _values = new();
+
+    public SettingsManager(IServiceProvider serviceProvider)
+    {
+        _logger = serviceProvider.GetRequiredService<ILogger<SettingsManager>>();
+
+        var typeInformation = serviceProvider
+            .GetServices<SettingsTypeInformation>()
+            .ToArray();
+    }
 
     public void Set<T>(T value) where T : class, ISettings, new()
     {

--- a/src/NexusMods.Settings/SettingsManager.cs
+++ b/src/NexusMods.Settings/SettingsManager.cs
@@ -1,0 +1,34 @@
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using NexusMods.Abstractions.Settings;
+
+namespace NexusMods.Settings;
+
+internal class SettingsManager : ISettingsManager
+{
+    private readonly Subject<(Type, object)> _subject = new();
+    private readonly Dictionary<Type, object> _values = new();
+
+    public void Set<T>(T value) where T : class, ISettings, new()
+    {
+        _values[typeof(T)] = value;
+        _subject.OnNext((typeof(T), value));
+    }
+
+    public T Get<T>() where T : class, ISettings, new()
+    {
+        if (_values.TryGetValue(typeof(T), out var obj)) return (obj as T)!;
+
+        var value = new T();
+        Set(value);
+
+        return value;
+    }
+
+    public IObservable<T> GetChanges<T>() where T : class, ISettings, new()
+    {
+        return _subject
+            .Where(tuple => tuple.Item1 == typeof(T))
+            .Select(tuple => (tuple.Item2 as T)!);
+    }
+}


### PR DESCRIPTION
Part of #1182, resolves #396.

Initial implementation of the settings backend:

- Adds `ISettings` for all setting types.
- Adds `ISettingsManager` to get or change settings.
- Adds `ISettingsBuilder` to configure how settings appear in the UI.

Missing from this PR that are done in a separate PR as part of #1182:

- Moving existing setting types to the backend
- Persisting and loading the settings
- Allowing the user to change the settings via a UI