### PR TITLE
Better `RunThroughSteam`

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Games/RunGameTool.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Games/RunGameTool.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
 using System.Text;
@@ -115,50 +116,52 @@ public class RunGameTool<T> : IRunGameTool
 
     private async Task RunThroughSteam(uint appId, CancellationToken cancellationToken)
     {
-        var existingReaperProcesses = Process.GetProcessesByName("reaper");
+        if (!OSInformation.Shared.IsLinux) throw OSInformation.Shared.CreatePlatformNotSupportedException();
+
+        var timeout = TimeSpan.FromMinutes(1);
+
+        // NOTE(erri120): This should be empty for most of the time. We want to wait until the reaper process for
+        // the current starts, so we ignore every reaper process that already exists.
+        var existingReaperProcesses = Process.GetProcessesByName("reaper").Select(x => x.Id).ToHashSet();
 
         // https://developer.valvesoftware.com/wiki/Steam_browser_protocol
         await _osInterop.OpenUrl(new Uri($"steam://rungameid/{appId.ToString(CultureInfo.InvariantCulture)}"), cancellationToken);
 
-        if (OSInformation.Shared.IsWindows)
-        {
-            // TODO:
-        } else if (OSInformation.Shared.IsLinux)
-        {
-            var steam = await WaitForProcessToStart("steam", Array.Empty<Process>(), TimeSpan.FromMinutes(1), cancellationToken);
-            if (steam is null) return;
+        var steam = await WaitForProcessToStart("steam", timeout, existingProcesses: null, cancellationToken);
+        if (steam is null) return;
 
-            // NOTE(erri120): Reaper is a custom tool for cleaning up child processes
-            // See https://github.com/sonic2kk/steamtinkerlaunch/wiki/Steam-Reaper for details.
-            var reaper = await WaitForProcessToStart("reaper", existingReaperProcesses, TimeSpan.FromMinutes(1), cancellationToken);
-            if (reaper is null) return;
+        // NOTE(erri120): Reaper is a custom tool for cleaning up child processes
+        // See https://github.com/sonic2kk/steamtinkerlaunch/wiki/Steam-Reaper for details.
+        var reaper = await WaitForProcessToStart("reaper", timeout, existingReaperProcesses, cancellationToken);
+        if (reaper is null) return;
 
-            await reaper.WaitForExitAsync(cancellationToken);
-        }
-        else
-        {
-            throw OSInformation.Shared.CreatePlatformNotSupportedException();
-        }
+        await reaper.WaitForExitAsync(cancellationToken);
     }
 
     private async ValueTask<Process?> WaitForProcessToStart(
         string processName,
-        Process[] existingProcesses,
         TimeSpan timeout,
+        HashSet<int>? existingProcesses,
         CancellationToken cancellationToken = default)
     {
+        _logger.LogDebug("Waiting for process `{ProcessName}` to start within `{Timeout:g}` second(s)", processName, timeout);
+
         try
         {
             var start = DateTime.UtcNow;
             while (!cancellationToken.IsCancellationRequested && start + timeout > DateTime.UtcNow)
             {
                 var processes = Process.GetProcessesByName(processName);
-                var target = processes.FirstOrDefault(x => existingProcesses.All(p => p.Id != x.Id));
+                var target = existingProcesses is not null
+                    ? processes.FirstOrDefault(x => !existingProcesses.Contains(x.Id))
+                    : processes.FirstOrDefault();
+
                 if (target is not null) return target;
 
                 await Task.Delay(TimeSpan.FromMilliseconds(300), cancellationToken);
             }
 
+            _logger.LogWarning("Process `{ProcessName}` failed to start within `{Timeout:g}` second(s)", processName, timeout);
             return null;
         }
         catch (TaskCanceledException)
@@ -167,7 +170,7 @@ public class RunGameTool<T> : IRunGameTool
         }
         catch (Exception e)
         {
-            _logger.LogError(e, "Exception while waiting for process \"{Process}\" to start", processName);
+            _logger.LogError(e, "Exception while waiting for process `{Process}` to start", processName);
             return null;
         }
     }

--- a/src/Abstractions/NexusMods.Abstractions.Games/RunGameTool.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Games/RunGameTool.cs
@@ -125,7 +125,7 @@ public class RunGameTool<T> : IRunGameTool
         var existingReaperProcesses = Process.GetProcessesByName("reaper").Select(x => x.Id).ToHashSet();
 
         // https://developer.valvesoftware.com/wiki/Steam_browser_protocol
-        await _osInterop.OpenUrl(new Uri($"steam://rungameid/{appId.ToString(CultureInfo.InvariantCulture)}"), cancellationToken);
+        await _osInterop.OpenUrl(new Uri($"steam://rungameid/{appId.ToString(CultureInfo.InvariantCulture)}"), fireAndForget: true, cancellationToken: cancellationToken);
 
         var steam = await WaitForProcessToStart("steam", timeout, existingProcesses: null, cancellationToken);
         if (steam is null) return;

--- a/src/Abstractions/NexusMods.Abstractions.Games/RunGameTool.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Games/RunGameTool.cs
@@ -118,7 +118,7 @@ public class RunGameTool<T> : IRunGameTool
     {
         if (!OSInformation.Shared.IsLinux) throw OSInformation.Shared.CreatePlatformNotSupportedException();
 
-        var timeout = TimeSpan.FromMinutes(1);
+        var timeout = TimeSpan.FromMinutes(5);
 
         // NOTE(erri120): This should be empty for most of the time. We want to wait until the reaper process for
         // the current starts, so we ignore every reaper process that already exists.

--- a/src/Networking/NexusMods.Networking.NexusWebApi/Auth/OAuth.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/Auth/OAuth.cs
@@ -87,7 +87,7 @@ public class OAuth
         using var job = CreateJob(url);
 
         // see https://www.rfc-editor.org/rfc/rfc7636#section-4.3
-        await _os.OpenUrl(url, cancellationToken);
+        await _os.OpenUrl(url, cancellationToken: cancellationToken);
 
         cts.CancelAfter(TimeSpan.FromMinutes(3));
         var code = await codeTask;

--- a/src/NexusMods.CrossPlatform/Helper.cs
+++ b/src/NexusMods.CrossPlatform/Helper.cs
@@ -1,0 +1,22 @@
+namespace NexusMods.CrossPlatform;
+
+internal static class Helper
+{
+    private static void FireAndForget(this Task task, CancellationToken cancellationToken = default)
+    {
+        _ = Task.Run(async () => await task, cancellationToken: cancellationToken);
+    }
+
+    public static Task AwaitOrForget(this Task task, bool fireAndForget, CancellationToken cancellationToken = default)
+    {
+        if (fireAndForget)
+        {
+            task.FireAndForget(cancellationToken: cancellationToken);
+            return Task.CompletedTask;
+        }
+        else
+        {
+            return task;
+        }
+    }
+}

--- a/src/NexusMods.CrossPlatform/Process/IOSInterop.cs
+++ b/src/NexusMods.CrossPlatform/Process/IOSInterop.cs
@@ -9,7 +9,8 @@ public interface IOSInterop
     /// <summary>
     /// open a url in the default application based on the protocol
     /// </summary>
-    /// <param name="url">url to open</param>
+    /// <param name="url">URI to open</param>
+    /// <param name="fireAndForget">Start the process but don't wait for the completion</param>
     /// <param name="cancellationToken">Cancellation token</param>
-    Task OpenUrl(Uri url, CancellationToken cancellationToken = default);
+    Task OpenUrl(Uri url, bool fireAndForget = false, CancellationToken cancellationToken = default);
 }

--- a/src/NexusMods.CrossPlatform/Process/OSInteropLinux.cs
+++ b/src/NexusMods.CrossPlatform/Process/OSInteropLinux.cs
@@ -23,14 +23,6 @@ public class OSInteropLinux : IOSInterop
     {
         var command = Cli.Wrap("xdg-open").WithArguments(new[] { url.ToString() }, escape: true);
         var task = _processFactory.ExecuteAsync(command, cancellationToken);
-
-        if (fireAndForget)
-        {
-            task.Start(TaskScheduler.Default);
-        }
-        else
-        {
-            await task;
-        }
+        await task.AwaitOrForget(fireAndForget: fireAndForget, cancellationToken: cancellationToken);
     }
 }

--- a/src/NexusMods.CrossPlatform/Process/OSInteropLinux.cs
+++ b/src/NexusMods.CrossPlatform/Process/OSInteropLinux.cs
@@ -19,9 +19,18 @@ public class OSInteropLinux : IOSInterop
     }
 
     /// <inheritdoc/>
-    public async Task OpenUrl(Uri url, CancellationToken cancellationToken = default)
+    public async Task OpenUrl(Uri url, bool fireAndForget = false, CancellationToken cancellationToken = default)
     {
         var command = Cli.Wrap("xdg-open").WithArguments(new[] { url.ToString() }, escape: true);
-        await _processFactory.ExecuteAsync(command, cancellationToken);
+        var task = _processFactory.ExecuteAsync(command, cancellationToken);
+
+        if (fireAndForget)
+        {
+            task.Start(TaskScheduler.Default);
+        }
+        else
+        {
+            await task;
+        }
     }
 }

--- a/src/NexusMods.CrossPlatform/Process/OSInteropOSX.cs
+++ b/src/NexusMods.CrossPlatform/Process/OSInteropOSX.cs
@@ -19,9 +19,18 @@ public class OSInteropOSX : IOSInterop
     }
 
     /// <inheritdoc/>
-    public async Task OpenUrl(Uri url, CancellationToken cancellationToken = default)
+    public async Task OpenUrl(Uri url, bool fireAndForget = false, CancellationToken cancellationToken = default)
     {
         var command = Cli.Wrap("open").WithArguments(url.ToString());
-        await _processFactory.ExecuteAsync(command, cancellationToken);
+        var task = _processFactory.ExecuteAsync(command, cancellationToken);
+
+        if (fireAndForget)
+        {
+            task.Start(TaskScheduler.Default);
+        }
+        else
+        {
+            await task;
+        }
     }
 }

--- a/src/NexusMods.CrossPlatform/Process/OSInteropOSX.cs
+++ b/src/NexusMods.CrossPlatform/Process/OSInteropOSX.cs
@@ -23,14 +23,6 @@ public class OSInteropOSX : IOSInterop
     {
         var command = Cli.Wrap("open").WithArguments(url.ToString());
         var task = _processFactory.ExecuteAsync(command, cancellationToken);
-
-        if (fireAndForget)
-        {
-            task.Start(TaskScheduler.Default);
-        }
-        else
-        {
-            await task;
-        }
+        await task.AwaitOrForget(fireAndForget: fireAndForget, cancellationToken: cancellationToken);
     }
 }

--- a/src/NexusMods.CrossPlatform/Process/OSInteropWindows.cs
+++ b/src/NexusMods.CrossPlatform/Process/OSInteropWindows.cs
@@ -24,14 +24,6 @@ public class OSInteropWindows : IOSInterop
         // cmd /c start "" "https://google.com"
         var command = Cli.Wrap("cmd.exe").WithArguments($@"/c start """" ""{url}""");
         var task = _processFactory.ExecuteAsync(command, cancellationToken);
-
-        if (fireAndForget)
-        {
-            task.Start(TaskScheduler.Default);
-        }
-        else
-        {
-            await task;
-        }
+        await task.AwaitOrForget(fireAndForget: fireAndForget, cancellationToken: cancellationToken);
     }
 }

--- a/src/NexusMods.CrossPlatform/Process/OSInteropWindows.cs
+++ b/src/NexusMods.CrossPlatform/Process/OSInteropWindows.cs
@@ -19,10 +19,19 @@ public class OSInteropWindows : IOSInterop
     }
 
     /// <inheritdoc/>
-    public async Task OpenUrl(Uri url, CancellationToken cancellationToken = default)
+    public async Task OpenUrl(Uri url, bool fireAndForget = false, CancellationToken cancellationToken = default)
     {
         // cmd /c start "" "https://google.com"
         var command = Cli.Wrap("cmd.exe").WithArguments($@"/c start """" ""{url}""");
-        await _processFactory.ExecuteAsync(command, cancellationToken);
+        var task = _processFactory.ExecuteAsync(command, cancellationToken);
+
+        if (fireAndForget)
+        {
+            task.Start(TaskScheduler.Default);
+        }
+        else
+        {
+            await task;
+        }
     }
 }

--- a/tests/Networking/NexusMods.Networking.NexusWebApi.Tests/OAuthTests.cs
+++ b/tests/Networking/NexusMods.Networking.NexusWebApi.Tests/OAuthTests.cs
@@ -68,7 +68,7 @@ public class OAuthTests
         #region Verification
 
         _ = idGen.Received(2).UUIDv4();
-        _ = os.Received(1).OpenUrl(ExpectedAuthURL, Arg.Any<CancellationToken>());
+        _ = os.Received(1).OpenUrl(ExpectedAuthURL, cancellationToken: Arg.Any<CancellationToken>());
         result.Should().BeEquivalentTo(ReplyToken);
         #endregion
     }
@@ -104,7 +104,7 @@ public class OAuthTests
         #region Verification
 
         _ = idGen.DidNotReceive().UUIDv4();
-        _ = os.DidNotReceive().OpenUrl(Arg.Any<Uri>(), Arg.Any<CancellationToken>());
+        _ = os.DidNotReceive().OpenUrl(Arg.Any<Uri>(), cancellationToken: Arg.Any<CancellationToken>());
         token.Should().BeEquivalentTo(ReplyToken);
 
         #endregion


### PR DESCRIPTION
I don't know if this will fix issue #1151, but it will definitely allow us to debug the issue better.

Changes:

- `IOSInterop.OpenUrl` add a `fireAndForget` parameter. Opening Steam on Linux using `xdg-open` blocked the entire task until Steam exited. This was undesired, so we can now opt in to a fire-and-forget-style of task running.
- More logging in `RunThroughSteam` and `WaitForProcessToStart`.
- Increased timeout from 1 minute to 5 minute in case Steam or the game take too long to start.