### PR TITLE
Perf: Persist ingested files in DiskToFileTree in batch

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -292,7 +292,7 @@ public class ALoadoutSynchronizer : IStandardizedLoadoutSynchronizer
     public async ValueTask<FileTree> DiskToFileTree(DiskStateTree diskState, Loadout prevLoadout, FileTree prevFileTree, DiskStateTree prevDiskState)
     {
         List<KeyValuePair<GamePath, AModFile>> results = new();
-        var file = new List<AModFile>();
+        var newFiles = new List<AModFile>();
         foreach (var item in diskState.GetAllDescendentFiles())
         {
             var gamePath = item.GamePath();
@@ -309,19 +309,19 @@ public class ALoadoutSynchronizer : IStandardizedLoadoutSynchronizer
 
                 // Else, the file has changed, so we need to update it.
                 var newFile = await HandleChangedFile(prevFile, prevEntry.Item.Value, item.Item.Value, gamePath, absPath);
-                file.Add(newFile);
+                newFiles.Add(newFile);
                 results.Add(KeyValuePair.Create(gamePath, newFile));
             }
             else
             {
                 // Else, the file is new, so we need to add it.
                 var newFile = await HandleNewFile(item.Item.Value, gamePath, absPath);
-                file.Add(newFile);
+                newFiles.Add(newFile);
                 results.Add(KeyValuePair.Create(gamePath, newFile));
             }
         }
 
-        CollectionsMarshal.AsSpan(file).EnsureAllPersisted(_store);
+        CollectionsMarshal.AsSpan(newFiles).EnsureAllPersisted(_store);
 
         // Deletes are handled implicitly as we only return files that exist in the new state.
         return FileTree.Create(results);


### PR DESCRIPTION
This fixes a DB bottleneck on ingest when ingesting 60k files.

```
Before: 385.5658 s/op
After: 3.0254 s/op
```

\> 100x improvement.

Tested with `DiskToFileTree` benchmark in `loadoutsynchronizer-benchmarks` branch.