### PR TITLE
Delete empty folder structures on Apply

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <!-- Custom Packages -->
     <PackageVersion Include="LinqGen" Version="0.3.1" />
     <PackageVersion Include="NexusMods.Hashing.xxHash64" Version="2.0.0" />
-    <PackageVersion Include="NexusMods.Paths" Version="0.9.0" />
+    <PackageVersion Include="NexusMods.Paths" Version="0.9.2" />
     <PackageVersion Include="NexusMods.Paths.TestingHelpers" Version="0.8.0" />
     <PackageVersion Include="NexusMods.Archives.Nx" Version="0.3.8" />
     <PackageVersion Include="NexusMods.ProxyConsole.Abstractions" Version="0.6.0" />

--- a/tests/NexusMods.DataModel.Tests/ALoadoutSynchronizerTests.cs
+++ b/tests/NexusMods.DataModel.Tests/ALoadoutSynchronizerTests.cs
@@ -112,25 +112,32 @@ public class ALoadoutSynchronizerTests : ADataModelTest<ALoadoutSynchronizerTest
         var originalMods = BaseList.Value.Mods;
         await _synchronizer.Apply(BaseList.Value);
         
-        var file = new GamePath(LocationId.Game, "DeleteMeDir/deleteMeFile");
-        var path = Install.LocationsRegister.GetResolvedPath(file);
+        var file1 = new GamePath(LocationId.Game, "deleteMeMod/deleteMeDir1/deleteMeFile.txt");
+        var path1 = Install.LocationsRegister.GetResolvedPath(file1);
+        var file2 = new GamePath(LocationId.Game, "deleteMeMod/deleteMeDir2/deleteMeFile.txt");
+        var path2 = Install.LocationsRegister.GetResolvedPath(file2);
         
         // Add mod that will be deleted
         await AddMod("DeleteMe",
             (_texturePath.Path, "texture.dds"),
-            (file.Path, "deleteMeContents"));
+            (file1.Path, "deleteMeContents"),
+            (file2.Path, "deleteMeContents"));
         
         await _synchronizer.Apply(BaseList.Value);
         
-        path.FileExists.Should().BeTrue("the file should exist");
+        path1.FileExists.Should().BeTrue("the file should exist");
         
         // Delete the mod
         BaseList.Alter("Delete the mod", l => l with { Mods = originalMods });
         
         await _synchronizer.Apply(BaseList.Value);
         
-        path.FileExists.Should().BeFalse("the file should not exist");
-        path.Parent.DirectoryExists().Should().BeFalse("the directory should not exist");
+        path1.FileExists.Should().BeFalse("the file should not exist");
+        path1.Parent.DirectoryExists().Should().BeFalse("the directory should not exist");
+        path1.Parent.Parent.DirectoryExists().Should().BeFalse("the directory should not exist");
+        
+        path2.FileExists.Should().BeFalse("the file should not exist");
+        path2.Parent.DirectoryExists().Should().BeFalse("the directory should not exist");
         
         var textureAbsPath = Install.LocationsRegister.GetResolvedPath(_texturePath.Parent);
         textureAbsPath.DirectoryExists().Should().BeTrue("the texture folder should still exist");


### PR DESCRIPTION
- Fixes #981 
- Added a test to check if empty folder structures are deleted correctly
- Cleaned up the `FileTreeToDisk` code a bit (inverted an if and added comments)
- Bumped Paths version

This adds a check in the apply code for each file to be deleted to see whether the parent folders are now empty and should be cleaned up. It is a bit convoluted to make sure to only do one recursive delete of the top level directory of the empty structure.

The code could be a lot worse, but it still might not be the most efficient thing. If there are suggestions I would be happy to try to implement them.


