### PR TITLE
Main UI layouts for Settings page and setting entry

### DIFF
--- a/src/NexusMods.App.UI/Controls/Settings/SettingEntries/ISettingEntryViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/Settings/SettingEntries/ISettingEntryViewModel.cs
@@ -1,0 +1,10 @@
+namespace NexusMods.App.UI.Controls.Settings.SettingEntries;
+
+public interface ISettingEntryViewModel : IViewModelInterface
+{
+    string DisplayName { get; }
+    string Description { get; }
+    bool RequiresRestart { get; }
+    
+    IViewModelInterface InteractionControlViewModel { get; }
+}

--- a/src/NexusMods.App.UI/Controls/Settings/SettingEntries/SettingEntryDesignViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/Settings/SettingEntries/SettingEntryDesignViewModel.cs
@@ -1,0 +1,12 @@
+using NexusMods.App.UI.Controls.Settings.SettingEntries.SettingInteractionControls;
+
+namespace NexusMods.App.UI.Controls.Settings.SettingEntries;
+
+public class SettingEntryDesignViewModel : AViewModel<ISettingEntryViewModel>, ISettingEntryViewModel
+{
+    public string DisplayName { get; } = "Enable Telemetry";
+    public string Description { get; } = "Send anonymous analytics information and usage data to Nexus Mods.";
+    public bool RequiresRestart { get; } = true;
+    
+    public IViewModelInterface InteractionControlViewModel { get; } = new SettingToggleViewModel();
+}

--- a/src/NexusMods.App.UI/Controls/Settings/SettingEntries/SettingEntryView.axaml
+++ b/src/NexusMods.App.UI/Controls/Settings/SettingEntries/SettingEntryView.axaml
@@ -1,0 +1,55 @@
+<reactiveUi:ReactiveUserControl x:TypeArguments="settingEntries:ISettingEntryViewModel" xmlns="https://github.com/avaloniaui"
+                                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                                xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                                xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                                xmlns:reactiveUi="http://reactiveui.net"
+                                xmlns:settingEntries="clr-namespace:NexusMods.App.UI.Controls.Settings.SettingEntries"
+                                xmlns:icons="clr-namespace:NexusMods.Icons;assembly=NexusMods.Icons"
+                                xmlns:resources="clr-namespace:NexusMods.App.UI.Resources"
+                                mc:Ignorable="d" d:DesignWidth="1232" 
+                                x:Class="NexusMods.App.UI.Controls.Settings.SettingEntries.SettingEntryView">
+    <Design.DataContext>
+        <settingEntries:SettingEntryDesignViewModel />
+    </Design.DataContext>
+
+    <Border Classes="Mid Rounded-lg"
+            Padding="24,12">
+        <Grid RowDefinitions="Auto, Auto">
+            <Grid Grid.Row="0" 
+                ColumnDefinitions="*, Auto">
+                <StackPanel Grid.Column="0"
+                            Orientation="Vertical">
+                    <TextBlock x:Name="EntryName"
+                               Classes="BodyXLNormal" />
+                    <TextBlock x:Name="EntryDescription"
+                               Classes="BodyMDNormal ForegroundSubdued" />
+                </StackPanel>
+
+                <Border Grid.Column="1"
+                        Margin="8,0,0,0">
+                    <reactiveUi:ViewModelViewHost x:Name="InteractionControl" />
+                </Border>
+            </Grid>
+
+            <Border Grid.Row="1" 
+                    Classes="Rounded-lg"
+                    x:Name="RequiresRestartBanner"
+                    Padding="12"
+                    Margin="0,6,0,0">
+                <Border.Background>
+                    <SolidColorBrush Color="{StaticResource WarningStrong}"
+                                     Opacity="{StaticResource OpacityWeak}" />
+                </Border.Background>
+
+                <StackPanel Orientation="Horizontal"
+                            Classes="Spacing-2">
+
+                    <icons:UnifiedIcon Classes="Alert ForegroundWarningStrong" />
+                    <TextBlock Classes="BodyMDBold ForegroundWarningStrong"
+                               Text="{x:Static resources:Language.SettingEntryView_NeedRestartMessage}" />
+                </StackPanel>
+
+            </Border>
+        </Grid>
+    </Border>
+</reactiveUi:ReactiveUserControl>

--- a/src/NexusMods.App.UI/Controls/Settings/SettingEntries/SettingEntryView.axaml.cs
+++ b/src/NexusMods.App.UI/Controls/Settings/SettingEntries/SettingEntryView.axaml.cs
@@ -1,0 +1,37 @@
+using System.Reactive.Disposables;
+using Avalonia.ReactiveUI;
+using ReactiveUI;
+
+namespace NexusMods.App.UI.Controls.Settings.SettingEntries;
+
+public partial class SettingEntryView : ReactiveUserControl<ISettingEntryViewModel>
+{
+    public SettingEntryView()
+    {
+        InitializeComponent();
+
+        this.WhenActivated(disposables =>
+            {
+                this.OneWayBind(ViewModel,
+                        viewModel => viewModel.DisplayName,
+                        view => view.EntryName.Text)
+                    .DisposeWith(disposables);
+                
+                this.OneWayBind(ViewModel,
+                        viewModel => viewModel.Description,
+                        view => view.EntryDescription.Text)
+                    .DisposeWith(disposables);
+                
+                this.OneWayBind(ViewModel,
+                        viewModel => viewModel.InteractionControlViewModel,
+                        view => view.InteractionControl.ViewModel)
+                    .DisposeWith(disposables);
+
+                this.OneWayBind(ViewModel,
+                        viewModel => viewModel.RequiresRestart,
+                        view => view.RequiresRestartBanner.IsVisible)
+                    .DisposeWith(disposables);
+            }
+        );
+    }
+}

--- a/src/NexusMods.App.UI/Controls/Settings/SettingEntries/SettingInteractionControls/ISettingToggleViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/Settings/SettingEntries/SettingInteractionControls/ISettingToggleViewModel.cs
@@ -1,0 +1,6 @@
+namespace NexusMods.App.UI.Controls.Settings.SettingEntries.SettingInteractionControls;
+
+public interface ISettingToggleViewModel : IViewModelInterface
+{
+    
+}

--- a/src/NexusMods.App.UI/Controls/Settings/SettingEntries/SettingInteractionControls/SettingToggleControl.axaml
+++ b/src/NexusMods.App.UI/Controls/Settings/SettingEntries/SettingInteractionControls/SettingToggleControl.axaml
@@ -1,0 +1,18 @@
+<reactiveUi:ReactiveUserControl x:TypeArguments="settingInteractionControls:ISettingToggleViewModel" xmlns="https://github.com/avaloniaui"
+                                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                                xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                                xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                                xmlns:reactiveUi="http://reactiveui.net"
+                                xmlns:settingInteractionControls="clr-namespace:NexusMods.App.UI.Controls.Settings.SettingEntries.SettingInteractionControls"
+                                mc:Ignorable="d"
+                                x:Class="NexusMods.App.UI.Controls.Settings.SettingEntries.SettingInteractionControls.SettingToggleControl">
+    <ToggleSwitch HorizontalAlignment="Center" x:Name="ToggleSwitch">
+        <ToggleSwitch.OnContent>
+            <ContentControl />
+        </ToggleSwitch.OnContent>
+        <ToggleSwitch.OffContent>
+            <ContentControl />
+        </ToggleSwitch.OffContent>
+    </ToggleSwitch>
+</reactiveUi:ReactiveUserControl>
+

--- a/src/NexusMods.App.UI/Controls/Settings/SettingEntries/SettingInteractionControls/SettingToggleControl.axaml.cs
+++ b/src/NexusMods.App.UI/Controls/Settings/SettingEntries/SettingInteractionControls/SettingToggleControl.axaml.cs
@@ -1,0 +1,13 @@
+
+using Avalonia.ReactiveUI;
+
+namespace NexusMods.App.UI.Controls.Settings.SettingEntries.SettingInteractionControls;
+
+public partial class SettingToggleControl : ReactiveUserControl<ISettingToggleViewModel>
+{
+    public SettingToggleControl()
+    {
+        InitializeComponent();
+    }
+}
+

--- a/src/NexusMods.App.UI/Controls/Settings/SettingEntries/SettingInteractionControls/SettingToggleViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/Settings/SettingEntries/SettingInteractionControls/SettingToggleViewModel.cs
@@ -1,0 +1,6 @@
+namespace NexusMods.App.UI.Controls.Settings.SettingEntries.SettingInteractionControls;
+
+public class SettingToggleViewModel : AViewModel<ISettingToggleViewModel>, ISettingToggleViewModel
+{
+    
+}

--- a/src/NexusMods.App.UI/NexusMods.App.UI.csproj
+++ b/src/NexusMods.App.UI/NexusMods.App.UI.csproj
@@ -496,6 +496,12 @@
         <Compile Update="Pages\Settings\SettingsDesignViewModel.cs">
           <DependentUpon>ISettingsViewModel.cs</DependentUpon>
         </Compile>
+        <Compile Update="Controls\Settings\SettingEntries\SettingEntryDesignViewModel.cs">
+          <DependentUpon>ISettingEntryViewModel.cs</DependentUpon>
+        </Compile>
+        <Compile Update="Controls\Settings\SettingEntries\SettingInteractionControls\SettingToggleViewModel.cs">
+          <DependentUpon>ISettingToggleViewModel.cs</DependentUpon>
+        </Compile>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NexusMods.App.UI/NexusMods.App.UI.csproj
+++ b/src/NexusMods.App.UI/NexusMods.App.UI.csproj
@@ -493,6 +493,9 @@
         <Compile Update="Controls\MarkdownRenderer\MarkdownRendererDesignViewModel.cs">
           <DependentUpon>IMarkdownRendererViewModel.cs</DependentUpon>
         </Compile>
+        <Compile Update="Pages\Settings\SettingsDesignViewModel.cs">
+          <DependentUpon>ISettingsViewModel.cs</DependentUpon>
+        </Compile>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NexusMods.App.UI/Pages/Settings/ISettingsViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/Settings/ISettingsViewModel.cs
@@ -1,8 +1,20 @@
+using System.Collections.ObjectModel;
+using System.Reactive;
+using NexusMods.App.UI.Controls.Settings.SettingEntries;
 using NexusMods.App.UI.WorkspaceSystem;
+using ReactiveUI;
 
 namespace NexusMods.App.UI.Pages.Settings;
 
 public interface ISettingsViewModel : IPageViewModelInterface
 {
+    ReactiveCommand<Unit, Unit> SaveCommand { get; }
+    ReactiveCommand<Unit, Unit> CancelCommand { get; }
     
+    /// <summary>
+    /// X button in the top right corner of the window.
+    /// </summary>
+    ReactiveCommand<Unit, Unit> CloseCommand { get; }
+    
+    ReadOnlyObservableCollection<ISettingEntryViewModel> SettingEntries { get; }
 }

--- a/src/NexusMods.App.UI/Pages/Settings/ISettingsViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/Settings/ISettingsViewModel.cs
@@ -1,0 +1,8 @@
+using NexusMods.App.UI.WorkspaceSystem;
+
+namespace NexusMods.App.UI.Pages.Settings;
+
+public interface ISettingsViewModel : IPageViewModelInterface
+{
+    
+}

--- a/src/NexusMods.App.UI/Pages/Settings/SettingsDesignViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/Settings/SettingsDesignViewModel.cs
@@ -1,0 +1,11 @@
+using NexusMods.App.UI.Windows;
+using NexusMods.App.UI.WorkspaceSystem;
+
+namespace NexusMods.App.UI.Pages.Settings;
+
+public class SettingsDesignViewModel : APageViewModel<ISettingsViewModel>, ISettingsViewModel
+{
+    public SettingsDesignViewModel() : base(new DesignWindowManager())
+    {
+    }
+}

--- a/src/NexusMods.App.UI/Pages/Settings/SettingsDesignViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/Settings/SettingsDesignViewModel.cs
@@ -1,11 +1,29 @@
+using System.Collections.ObjectModel;
+using System.Reactive;
+using NexusMods.App.UI.Controls.Settings.SettingEntries;
 using NexusMods.App.UI.Windows;
 using NexusMods.App.UI.WorkspaceSystem;
+using ReactiveUI;
 
 namespace NexusMods.App.UI.Pages.Settings;
 
 public class SettingsDesignViewModel : APageViewModel<ISettingsViewModel>, ISettingsViewModel
 {
+    public ReactiveCommand<Unit, Unit> SaveCommand { get; } = ReactiveCommand.Create(() => { });
+    public ReactiveCommand<Unit, Unit> CancelCommand { get; } = ReactiveCommand.Create(() => { });
+    public ReactiveCommand<Unit, Unit> CloseCommand { get; } = ReactiveCommand.Create(() => { });
+    public ReadOnlyObservableCollection<ISettingEntryViewModel> SettingEntries { get; }
+
     public SettingsDesignViewModel() : base(new DesignWindowManager())
     {
+        SettingEntries = new ReadOnlyObservableCollection<ISettingEntryViewModel>([
+                new SettingEntryDesignViewModel(),
+                new SettingEntryDesignViewModel(),
+                new SettingEntryDesignViewModel(),
+                new SettingEntryDesignViewModel(),
+            ]
+        );
     }
+
+
 }

--- a/src/NexusMods.App.UI/Pages/Settings/SettingsPage.cs
+++ b/src/NexusMods.App.UI/Pages/Settings/SettingsPage.cs
@@ -1,0 +1,23 @@
+using JetBrains.Annotations;
+using Microsoft.Extensions.DependencyInjection;
+using NexusMods.Abstractions.Serialization.Attributes;
+using NexusMods.App.UI.WorkspaceSystem;
+
+namespace NexusMods.App.UI.Pages.Settings;
+
+[JsonName("NexusMods.App.UI.Pages.SettingsPageContext")]
+public record SettingsPageContext : IPageFactoryContext;
+
+[UsedImplicitly]
+public class SettingsPageFactory : APageFactory<ISettingsViewModel, SettingsPageContext>
+{
+    public SettingsPageFactory(IServiceProvider serviceProvider) : base(serviceProvider) { }
+
+    public static readonly PageFactoryId StaticId = PageFactoryId.From(Guid.Parse("3DE311A0-0AB0-4191-9CA5-5CE8EA76C393"));
+    public override PageFactoryId Id => StaticId;
+
+    public override ISettingsViewModel CreateViewModel(SettingsPageContext context)
+    {
+        return ServiceProvider.GetRequiredService<ISettingsViewModel>();
+    }
+}

--- a/src/NexusMods.App.UI/Pages/Settings/SettingsView.axaml
+++ b/src/NexusMods.App.UI/Pages/Settings/SettingsView.axaml
@@ -5,6 +5,7 @@
                                 xmlns:reactiveUi="http://reactiveui.net"
                                 xmlns:settings="clr-namespace:NexusMods.App.UI.Pages.Settings"
                                 xmlns:icons="clr-namespace:NexusMods.Icons;assembly=NexusMods.Icons"
+                                xmlns:resources="clr-namespace:NexusMods.App.UI.Resources"
                                 mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
                                 x:Class="NexusMods.App.UI.Pages.Settings.SettingsView">
     <Design.DataContext>
@@ -24,9 +25,9 @@
                                 Orientation="Horizontal"
                                 Spacing="{StaticResource Spacing-2}">
 
-                        <icons:UnifiedIcon Classes="Cog" />
-                        <TextBlock Text="Settings"
-                                   Classes="Header" />
+                        <icons:UnifiedIcon Classes="Cog ForegroundSubdued" Size="24" />
+                        <TextBlock Classes="BodyLGBold ForegroundSubdued"
+                                   Text="{x:Static resources:Language.SettingsView_Title}"/>
 
                     </StackPanel>
 
@@ -34,8 +35,6 @@
                             Classes="BareIcon WindowClose ForegroundSubdued">
                     </Button>
                 </Grid>
-
-
             </Border>
 
 
@@ -56,10 +55,10 @@
 
                     <Border Grid.Column="1"
                             x:Name="ContentBorder">
-                        
-                        
+                        <ScrollViewer>
+                            <!-- Add setting items here -->
+                        </ScrollViewer>
                     </Border>
-
                 </Grid>
             </Border>
 
@@ -70,12 +69,12 @@
                 <StackPanel>
                     <Button Classes="Standard Tertiary">
                         <StackPanel Orientation="Horizontal">
-                            <TextBlock Text="CANCEL" />
+                            <TextBlock Text="{x:Static resources:Language.DialogButton_CANCEL}" />
                         </StackPanel>
                     </Button>
                     <Button Classes="Standard Primary">
                         <StackPanel Orientation="Horizontal">
-                            <TextBlock Text="SAVE" />
+                            <TextBlock Text="{x:Static resources:Language.DialogButton_SAVE}" />
                         </StackPanel>
                     </Button>
                 </StackPanel>

--- a/src/NexusMods.App.UI/Pages/Settings/SettingsView.axaml
+++ b/src/NexusMods.App.UI/Pages/Settings/SettingsView.axaml
@@ -1,0 +1,45 @@
+<reactiveUi:ReactiveUserControl x:TypeArguments="settings:ISettingsViewModel" xmlns="https://github.com/avaloniaui"
+                                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                                xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                                xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                                xmlns:reactiveUi="http://reactiveui.net"
+                                xmlns:settings="clr-namespace:NexusMods.App.UI.Pages.Settings"
+                                mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+                                x:Class="NexusMods.App.UI.Pages.Settings.SettingsView">
+    <Design.DataContext>
+        <settings:SettingsDesignViewModel />
+    </Design.DataContext>
+
+    <Grid RowDefinitions="*, Auto">
+
+        <Border Grid.Row="0"
+                x:Name="TopSectionBorder"
+                Classes="Base">
+
+            <Grid ColumnDefinitions="Auto, *">
+                <Border Grid.Column="0"
+                        x:Name="SideBarBorder">
+                </Border>
+
+                <Border Grid.Column="1"
+                        x:Name="ContentBorder">
+                </Border>
+
+            </Grid>
+        </Border>
+
+
+        <Border Grid.Row="1"
+                x:Name="FooterBorder"
+                Classes="Mid">
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button Classes="Standard Tertiary">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="CANCEL" />
+                    </StackPanel>
+                </Button>
+            </StackPanel>
+        </Border>
+    </Grid>
+
+</reactiveUi:ReactiveUserControl>

--- a/src/NexusMods.App.UI/Pages/Settings/SettingsView.axaml
+++ b/src/NexusMods.App.UI/Pages/Settings/SettingsView.axaml
@@ -4,35 +4,67 @@
                                 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                                 xmlns:reactiveUi="http://reactiveui.net"
                                 xmlns:settings="clr-namespace:NexusMods.App.UI.Pages.Settings"
+                                xmlns:icons="clr-namespace:NexusMods.Icons;assembly=NexusMods.Icons"
                                 mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
                                 x:Class="NexusMods.App.UI.Pages.Settings.SettingsView">
     <Design.DataContext>
         <settings:SettingsDesignViewModel />
     </Design.DataContext>
 
-    <Border Classes="Rounded-lg">
-        <Grid RowDefinitions="*, Auto">
-
+    <Border Classes="Rounded-lg Low">
+        <Grid RowDefinitions="Auto, *, Auto">
             <Border Grid.Row="0"
-                    x:Name="TopSectionBorder"
-                    Classes="Low Rounded-t-lg">
+                    x:Name="HeaderSectionBorder"
+                    Padding="24"
+                    HorizontalAlignment="Stretch">
+
+                <Grid ColumnDefinitions="Auto, *, Auto">
+
+                    <StackPanel Grid.Column="0"
+                                Orientation="Horizontal"
+                                Spacing="{StaticResource Spacing-2}">
+
+                        <icons:UnifiedIcon Classes="Cog" />
+                        <TextBlock Text="Settings"
+                                   Classes="Header" />
+
+                    </StackPanel>
+
+                    <Button Grid.Column="2"
+                            Classes="BareIcon WindowClose ForegroundSubdued">
+                    </Button>
+                </Grid>
+
+
+            </Border>
+
+
+            <Border Grid.Row="1"
+                    x:Name="BodySectionBorder"
+                    Classes="Rounded-t-lg">
 
                 <Grid ColumnDefinitions="Auto, *">
                     <Border Grid.Column="0"
                             x:Name="SideBarBorder"
-                            Classes="Top"
                             Width="216">
+
+                        <!-- Add Filter Box here -->
+                        <ScrollViewer>
+                            <!-- Add category items here -->
+                        </ScrollViewer>
                     </Border>
 
                     <Border Grid.Column="1"
                             x:Name="ContentBorder">
+                        
+                        
                     </Border>
 
                 </Grid>
             </Border>
 
 
-            <Border Grid.Row="1"
+            <Border Grid.Row="2"
                     x:Name="FooterBorder"
                     Classes="Footer">
                 <StackPanel>

--- a/src/NexusMods.App.UI/Pages/Settings/SettingsView.axaml
+++ b/src/NexusMods.App.UI/Pages/Settings/SettingsView.axaml
@@ -6,7 +6,8 @@
                                 xmlns:settings="clr-namespace:NexusMods.App.UI.Pages.Settings"
                                 xmlns:icons="clr-namespace:NexusMods.Icons;assembly=NexusMods.Icons"
                                 xmlns:resources="clr-namespace:NexusMods.App.UI.Resources"
-                                mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+                                xmlns:settingEntries="clr-namespace:NexusMods.App.UI.Controls.Settings.SettingEntries"
+                                mc:Ignorable="d" d:DesignWidth="1232" d:DesignHeight="550"
                                 x:Class="NexusMods.App.UI.Pages.Settings.SettingsView">
     <Design.DataContext>
         <settings:SettingsDesignViewModel />
@@ -27,12 +28,13 @@
 
                         <icons:UnifiedIcon Classes="Cog ForegroundSubdued" Size="24" />
                         <TextBlock Classes="BodyLGBold ForegroundSubdued"
-                                   Text="{x:Static resources:Language.SettingsView_Title}"/>
+                                   Text="{x:Static resources:Language.SettingsView_Title}" />
 
                     </StackPanel>
 
                     <Button Grid.Column="2"
-                            Classes="BareIcon WindowClose ForegroundSubdued">
+                            Classes="BareIcon WindowClose ForegroundSubdued"
+                            x:Name="CloseButton">
                     </Button>
                 </Grid>
             </Border>
@@ -40,7 +42,8 @@
 
             <Border Grid.Row="1"
                     x:Name="BodySectionBorder"
-                    Classes="Rounded-t-lg">
+                    Classes="Rounded-t-lg"
+                    Margin="0,0,12,0">
 
                 <Grid ColumnDefinitions="Auto, *">
                     <Border Grid.Column="0"
@@ -55,8 +58,22 @@
 
                     <Border Grid.Column="1"
                             x:Name="ContentBorder">
+                        
                         <ScrollViewer>
-                            <!-- Add setting items here -->
+                            <ItemsControl x:Name="SettingEntriesItemsControl"
+                                          Margin="0,0,12,0">
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <StackPanel Classes="Spacing-1_5" />
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate DataType="{x:Type settingEntries:ISettingEntryViewModel}">
+                                        <reactiveUi:ViewModelViewHost ViewModel="{CompiledBinding .}"/>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
                         </ScrollViewer>
                     </Border>
                 </Grid>
@@ -67,12 +84,14 @@
                     x:Name="FooterBorder"
                     Classes="Footer">
                 <StackPanel>
-                    <Button Classes="Standard Tertiary">
+                    <Button Classes="Standard Tertiary"
+                            x:Name="CancelButton">
                         <StackPanel Orientation="Horizontal">
                             <TextBlock Text="{x:Static resources:Language.DialogButton_CANCEL}" />
                         </StackPanel>
                     </Button>
-                    <Button Classes="Standard Primary">
+                    <Button Classes="Standard Primary"
+                            x:Name="SaveButton">
                         <StackPanel Orientation="Horizontal">
                             <TextBlock Text="{x:Static resources:Language.DialogButton_SAVE}" />
                         </StackPanel>

--- a/src/NexusMods.App.UI/Pages/Settings/SettingsView.axaml
+++ b/src/NexusMods.App.UI/Pages/Settings/SettingsView.axaml
@@ -10,36 +10,45 @@
         <settings:SettingsDesignViewModel />
     </Design.DataContext>
 
-    <Grid RowDefinitions="*, Auto">
+    <Border Classes="Rounded-lg">
+        <Grid RowDefinitions="*, Auto">
 
-        <Border Grid.Row="0"
-                x:Name="TopSectionBorder"
-                Classes="Base">
+            <Border Grid.Row="0"
+                    x:Name="TopSectionBorder"
+                    Classes="Low Rounded-t-lg">
 
-            <Grid ColumnDefinitions="Auto, *">
-                <Border Grid.Column="0"
-                        x:Name="SideBarBorder">
-                </Border>
+                <Grid ColumnDefinitions="Auto, *">
+                    <Border Grid.Column="0"
+                            x:Name="SideBarBorder"
+                            Classes="Top"
+                            Width="216">
+                    </Border>
 
-                <Border Grid.Column="1"
-                        x:Name="ContentBorder">
-                </Border>
+                    <Border Grid.Column="1"
+                            x:Name="ContentBorder">
+                    </Border>
 
-            </Grid>
-        </Border>
+                </Grid>
+            </Border>
 
 
-        <Border Grid.Row="1"
-                x:Name="FooterBorder"
-                Classes="Mid">
-            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                <Button Classes="Standard Tertiary">
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="CANCEL" />
-                    </StackPanel>
-                </Button>
-            </StackPanel>
-        </Border>
-    </Grid>
+            <Border Grid.Row="1"
+                    x:Name="FooterBorder"
+                    Classes="Footer">
+                <StackPanel>
+                    <Button Classes="Standard Tertiary">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="CANCEL" />
+                        </StackPanel>
+                    </Button>
+                    <Button Classes="Standard Primary">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="SAVE" />
+                        </StackPanel>
+                    </Button>
+                </StackPanel>
+            </Border>
+        </Grid>
+    </Border>
 
 </reactiveUi:ReactiveUserControl>

--- a/src/NexusMods.App.UI/Pages/Settings/SettingsView.axaml.cs
+++ b/src/NexusMods.App.UI/Pages/Settings/SettingsView.axaml.cs
@@ -1,4 +1,6 @@
+using System.Reactive.Disposables;
 using Avalonia.ReactiveUI;
+using ReactiveUI;
 
 namespace NexusMods.App.UI.Pages.Settings;
 
@@ -7,6 +9,30 @@ public partial class SettingsView : ReactiveUserControl<ISettingsViewModel>
     public SettingsView()
     {
         InitializeComponent();
+
+        this.WhenActivated(d =>
+            {
+                this.BindCommand(ViewModel,
+                        viewModel => viewModel.SaveCommand,
+                        view => view.SaveButton)
+                    .DisposeWith(d);
+
+                this.BindCommand(ViewModel,
+                        viewModel => viewModel.CancelCommand,
+                        view => view.CancelButton)
+                    .DisposeWith(d);
+
+                this.BindCommand(ViewModel,
+                        viewModel => viewModel.CloseCommand,
+                        view => view.CloseButton)
+                    .DisposeWith(d);
+
+                this.OneWayBind(ViewModel,
+                        viewModel => viewModel.SettingEntries,
+                        view => view.SettingEntriesItemsControl.ItemsSource)
+                    .DisposeWith(d);
+            }
+        );
     }
 }
 

--- a/src/NexusMods.App.UI/Pages/Settings/SettingsView.axaml.cs
+++ b/src/NexusMods.App.UI/Pages/Settings/SettingsView.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.ReactiveUI;
+
+namespace NexusMods.App.UI.Pages.Settings;
+
+public partial class SettingsView : ReactiveUserControl<ISettingsViewModel>
+{
+    public SettingsView()
+    {
+        InitializeComponent();
+    }
+}
+

--- a/src/NexusMods.App.UI/Resources/Language.Designer.cs
+++ b/src/NexusMods.App.UI/Resources/Language.Designer.cs
@@ -267,6 +267,24 @@ namespace NexusMods.App.UI.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to CANCEL.
+        /// </summary>
+        public static string DialogButton_CANCEL {
+            get {
+                return ResourceManager.GetString("DialogButton_CANCEL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to SAVE.
+        /// </summary>
+        public static string DialogButton_SAVE {
+            get {
+                return ResourceManager.GetString("DialogButton_SAVE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Apply changes: Adding {0} Modifying {1} Removing {2}.
         /// </summary>
         public static string DiffTreeViewModel_StatusBar__Apply_changes {
@@ -1077,6 +1095,15 @@ namespace NexusMods.App.UI.Resources {
         public static string SearchBox__Search {
             get {
                 return ResourceManager.GetString("SearchBox__Search", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Settings.
+        /// </summary>
+        public static string SettingsView_Title {
+            get {
+                return ResourceManager.GetString("SettingsView_Title", resourceCulture);
             }
         }
         

--- a/src/NexusMods.App.UI/Resources/Language.Designer.cs
+++ b/src/NexusMods.App.UI/Resources/Language.Designer.cs
@@ -1099,6 +1099,15 @@ namespace NexusMods.App.UI.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The app will need to restart to apply this setting.
+        /// </summary>
+        public static string SettingEntryView_NeedRestartMessage {
+            get {
+                return ResourceManager.GetString("SettingEntryView_NeedRestartMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Settings.
         /// </summary>
         public static string SettingsView_Title {

--- a/src/NexusMods.App.UI/Resources/Language.resx
+++ b/src/NexusMods.App.UI/Resources/Language.resx
@@ -425,4 +425,7 @@
     <data name="DialogButton_SAVE" xml:space="preserve">
         <value>SAVE</value>
     </data>
+    <data name="SettingEntryView_NeedRestartMessage" xml:space="preserve">
+        <value>The app will need to restart to apply this setting</value>
+    </data>
 </root>

--- a/src/NexusMods.App.UI/Resources/Language.resx
+++ b/src/NexusMods.App.UI/Resources/Language.resx
@@ -416,4 +416,13 @@
     <data name="ApplyDiffViewModel_PageTitle" xml:space="preserve">
         <value>Preview changes</value>
     </data>
+    <data name="SettingsView_Title" xml:space="preserve">
+        <value>Settings</value>
+    </data>
+    <data name="DialogButton_CANCEL" xml:space="preserve">
+        <value>CANCEL</value>
+    </data>
+    <data name="DialogButton_SAVE" xml:space="preserve">
+        <value>SAVE</value>
+    </data>
 </root>

--- a/src/NexusMods.App.UI/Services.cs
+++ b/src/NexusMods.App.UI/Services.cs
@@ -18,6 +18,7 @@ using NexusMods.App.UI.Controls.MarkdownRenderer;
 using NexusMods.App.UI.Controls.ModInfo.Error;
 using NexusMods.App.UI.Controls.ModInfo.Loading;
 using NexusMods.App.UI.Controls.ModInfo.ModFiles;
+using NexusMods.App.UI.Controls.Settings.SettingEntries;
 using NexusMods.App.UI.Controls.Settings.SettingEntries.SettingInteractionControls;
 using NexusMods.App.UI.Controls.Spine;
 using NexusMods.App.UI.Controls.Spine.Buttons.Download;
@@ -182,6 +183,7 @@ public static class Services
             .AddView<FileTreeView, IFileTreeViewModel>()
             
             .AddView<SettingsView, ISettingsViewModel>()
+            .AddView<SettingEntryView, ISettingEntryViewModel>()
             .AddView<SettingToggleControl, ISettingToggleViewModel>()
 
             .AddView<DiagnosticEntryView, IDiagnosticEntryViewModel>()

--- a/src/NexusMods.App.UI/Services.cs
+++ b/src/NexusMods.App.UI/Services.cs
@@ -18,6 +18,7 @@ using NexusMods.App.UI.Controls.MarkdownRenderer;
 using NexusMods.App.UI.Controls.ModInfo.Error;
 using NexusMods.App.UI.Controls.ModInfo.Loading;
 using NexusMods.App.UI.Controls.ModInfo.ModFiles;
+using NexusMods.App.UI.Controls.Settings.SettingEntries.SettingInteractionControls;
 using NexusMods.App.UI.Controls.Spine;
 using NexusMods.App.UI.Controls.Spine.Buttons.Download;
 using NexusMods.App.UI.Controls.Spine.Buttons.Icon;
@@ -48,6 +49,7 @@ using NexusMods.App.UI.Pages.LoadoutGrid.Columns.ModName;
 using NexusMods.App.UI.Pages.LoadoutGrid.Columns.ModVersion;
 using NexusMods.App.UI.Pages.ModInfo;
 using NexusMods.App.UI.Pages.MyGames;
+using NexusMods.App.UI.Pages.Settings;
 using NexusMods.App.UI.Settings;
 using NexusMods.App.UI.Windows;
 using NexusMods.App.UI.WorkspaceAttachments;
@@ -134,6 +136,9 @@ public static class Services
             .AddViewModel<DummyLoadingViewModel, ILoadingViewModel>()
             .AddViewModel<DummyErrorViewModel, IErrorViewModel>()
             .AddViewModel<ApplyDiffViewModel, IApplyDiffViewModel>()
+            
+            
+            .AddViewModel<SettingToggleViewModel, ISettingToggleViewModel>()
 
             // Views
             .AddView<DevelopmentBuildBannerView, IDevelopmentBuildBannerViewModel>()
@@ -175,6 +180,9 @@ public static class Services
             .AddView<ErrorView, IErrorViewModel>()
             .AddView<ApplyDiffView, IApplyDiffViewModel>()
             .AddView<FileTreeView, IFileTreeViewModel>()
+            
+            .AddView<SettingsView, ISettingsViewModel>()
+            .AddView<SettingToggleControl, ISettingToggleViewModel>()
 
             .AddView<DiagnosticEntryView, IDiagnosticEntryViewModel>()
             .AddViewModel<DiagnosticEntryViewModel, IDiagnosticEntryViewModel>()

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Border/BorderStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Border/BorderStyles.axaml
@@ -50,7 +50,10 @@
                 <TextBlock Text="DANGER moderate" />
             </Border>
             <Border Classes="Rounded-lg DangerStrong" Padding="16">
-                <TextBlock Text="DANGER strong" />
+                <TextBlock Text="DANGER strong"/>
+            </Border>
+            <Border Classes="Rounded-lg WarningStrong" Padding="16">
+                <TextBlock Text="WARNING strong" />
             </Border>
             <Border Classes="LeftPaneTitle" Padding="16">
                 <TextBlock Text="LEFT PANEL TITLE" />

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Border/FooterBorder.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Border/FooterBorder.axaml
@@ -1,8 +1,7 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <!-- Add Styles Here -->
-
-
+    
+    <!-- Preview -->
     <Design.PreviewWith>
         <StackPanel Margin="20" Width="300">
 
@@ -24,6 +23,7 @@
         </StackPanel>
     </Design.PreviewWith>
 
+    <!-- Add Styles Here -->
     <Style Selector="Border.Footer">
         <Setter Property="Background" Value="{StaticResource SurfaceMidBrush}" />
         <Setter Property="CornerRadius" Value="{StaticResource Rounded-b-lg}" />
@@ -35,6 +35,5 @@
             <Setter Property="Spacing" Value="{StaticResource Spacing-2}" />
         </Style>
     </Style>
-
-
+    
 </Styles>

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Border/FooterBorder.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Border/FooterBorder.axaml
@@ -1,0 +1,40 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- Add Styles Here -->
+
+
+    <Design.PreviewWith>
+        <StackPanel Margin="20" Width="300">
+
+            <Border Classes="Footer">
+                <StackPanel>
+                    <Button Classes="Standard Tertiary">
+                        <StackPanel>
+                            <TextBlock Text="CANCEL" />
+                        </StackPanel>
+                    </Button>
+                    <Button Classes="Standard Primary">
+                        <StackPanel>
+                            <TextBlock Text="SAVE" />
+                        </StackPanel>
+                    </Button>
+                </StackPanel>
+            </Border>
+
+        </StackPanel>
+    </Design.PreviewWith>
+
+    <Style Selector="Border.Footer">
+        <Setter Property="Background" Value="{StaticResource SurfaceMidBrush}" />
+        <Setter Property="CornerRadius" Value="{StaticResource Rounded-b-lg}" />
+
+        <Style Selector="^ > StackPanel">
+            <Setter Property="Orientation" Value="Horizontal" />
+            <Setter Property="HorizontalAlignment" Value="Right" />
+            <Setter Property="Margin" Value="24, 24, 24, 24" />
+            <Setter Property="Spacing" Value="{StaticResource Spacing-2}" />
+        </Style>
+    </Style>
+
+
+</Styles>

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Button/BareIconStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Button/BareIconStyles.axaml
@@ -51,6 +51,11 @@
         <Style Selector="^:disabled">
             <Setter Property="Opacity" Value="{StaticResource OpacityDisabledElement}" />
         </Style>
+        
+        <Style Selector="^.ForegroundSubdued">
+            <Setter Property="Foreground" Value="{StaticResource NeutralSubduedBrush}" />
+        </Style>
+        
     </Style>
 
     <!-- Small version -->

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/StylesIndex.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/StylesIndex.axaml
@@ -7,6 +7,7 @@
     <StyleInclude Source="/Styles/Controls/RadioButton/RadioButtonStyles.axaml"/>
     <StyleInclude Source="/Styles/Controls/Border/BorderStyles.axaml"/>
     <StyleInclude Source="/Styles/Controls/Border/Toolbar.xaml"/>
+    <StyleInclude Source="/Styles/Controls/Border/FooterBorder.axaml"/>
     <StyleInclude Source="/Styles/Controls/Button/ButtonStyles.axaml"/>
     <StyleInclude Source="/Styles/Controls/Button/PillStyles.xaml"/>
     <StyleInclude Source="/Styles/Controls/Button/StandardButtonStyles.axaml"/>


### PR DESCRIPTION
- Added `SettingsView` page
- Added `SettingEntryView`: this is a reusable view that shows the name, description and restart requirements of any setting. It contains a ViewModelViewHost for the actual interaction control (e.g. toggleSwitch, ComboBox)
- Different implementations of `ISettingEntryViewModel` can provide different InteractionControls and handle value updates/validations etc.
- Downside is that we need a wrapper for simple controls like ToggleSwitch, just so we can swap them out using different VMs.