### PR TITLE
Add minimum game/api version diagnostics

### DIFF
--- a/src/Games/NexusMods.Games.StardewValley/Diagnostics.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Diagnostics.cs
@@ -223,7 +223,7 @@ You can download the latest supported SMAPI version {LatestSMAPIVersion} for you
         .WithSummary("The minimum supported SMAPI version of {ModName} is {MinimumAPIVersion}")
         .WithDetails("""
 Mod {Mod} requires the SMAPI version to be at least {MinimumAPIVersion}.
-The current game version is {CurrentSMAPIVersion}.
+The current SMAPI version is {CurrentSMAPIVersion}.
 
 You can solve this issue by either updating SMAPI or download an older version
 of the mod from {NexusModsLink}.

--- a/src/Games/NexusMods.Games.StardewValley/Diagnostics.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Diagnostics.cs
@@ -226,7 +226,8 @@ Mod {Mod} requires the SMAPI version to be at least {MinimumAPIVersion}.
 The current SMAPI version is {CurrentSMAPIVersion}.
 
 You can solve this issue by either updating SMAPI or download an older version
-of the mod from {NexusModsLink}.
+of the mod from {NexusModsLink}. The latest SMAPI version can be downloaded
+from {SMAPINexusModsLink}.
 """)
         .WithMessageData(messageBuilder => messageBuilder
             .AddDataReference<ModReference>("Mod")
@@ -234,6 +235,7 @@ of the mod from {NexusModsLink}.
             .AddValue<string>("MinimumAPIVersion")
             .AddValue<string>("CurrentSMAPIVersion")
             .AddValue<NamedLink>("NexusModsLink")
+            .AddValue<NamedLink>("SMAPINexusModsLink")
         )
         .Finish();
 

--- a/src/Games/NexusMods.Games.StardewValley/Diagnostics.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Diagnostics.cs
@@ -204,11 +204,60 @@ SMAPI is the mod loader for Stardew Valley. The majority of mods require SMAPI t
 
 You can download the latest supported SMAPI version {LatestSMAPIVersion} for your game version
 {CurrentGameVersion} from {SMAPINexusModsLink}.
-""")
+"""
+        )
         .WithMessageData(messageBuilder => messageBuilder
             .AddValue<string>("LatestSMAPIVersion")
             .AddValue<string>("CurrentGameVersion")
             .AddValue<NamedLink>("SMAPINexusModsLink")
+        )
+        .Finish();
+
+    [DiagnosticTemplate]
+    [UsedImplicitly]
+    internal static IDiagnosticTemplate SMAPIVersionOlderThanMinimumAPIVersion = DiagnosticTemplateBuilder
+        .Start()
+        .WithId(new DiagnosticId(Source, number: 11))
+        .WithTitle("SMAPI Version newer than supported Mod")
+        .WithSeverity(DiagnosticSeverity.Warning)
+        .WithSummary("The minimum supported SMAPI version of {ModName} is {MinimumAPIVersion}")
+        .WithDetails("""
+Mod {Mod} requires the SMAPI version to be at least {MinimumAPIVersion}.
+The current game version is {CurrentSMAPIVersion}.
+
+You can solve this issue by either updating SMAPI or download an older version
+of the mod from {NexusModsLink}.
+""")
+        .WithMessageData(messageBuilder => messageBuilder
+            .AddDataReference<ModReference>("Mod")
+            .AddValue<string>("ModName")
+            .AddValue<string>("MinimumAPIVersion")
+            .AddValue<string>("CurrentSMAPIVersion")
+            .AddValue<NamedLink>("NexusModsLink")
+        )
+        .Finish();
+
+    [DiagnosticTemplate]
+    [UsedImplicitly]
+    internal static IDiagnosticTemplate GameVersionOlderThanModMinimumGameVersionTemplate = DiagnosticTemplateBuilder
+        .Start()
+        .WithId(new DiagnosticId(Source, number: 12))
+        .WithTitle("Game Version newer than supported by Mod")
+        .WithSeverity(DiagnosticSeverity.Warning)
+        .WithSummary("The minimum supported game version of {ModName} is {MinimumGameVersion}")
+        .WithDetails("""
+Mod {Mod} requires the game version to be at least {MinimumGameVersion}.
+The current game version is {CurrentGameVersion}.
+
+You can solve this issue by either updating your game or download an older version
+of the mod from {NexusModsLink}.
+""")
+        .WithMessageData(messageBuilder => messageBuilder
+            .AddDataReference<ModReference>("Mod")
+            .AddValue<string>("ModName")
+            .AddValue<string>("MinimumGameVersion")
+            .AddValue<string>("CurrentGameVersion")
+            .AddValue<NamedLink>("NexusModsLink")
         )
         .Finish();
 }

--- a/src/Games/NexusMods.Games.StardewValley/Emitters/Helpers.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/Helpers.cs
@@ -1,0 +1,60 @@
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Logging;
+using NexusMods.Abstractions.Diagnostics.Values;
+using NexusMods.Abstractions.IO;
+using NexusMods.Abstractions.Loadouts;
+using NexusMods.Abstractions.Loadouts.Mods;
+using StardewModdingAPI.Toolkit.Serialization.Models;
+
+namespace NexusMods.Games.StardewValley.Emitters;
+
+internal static class Helpers
+{
+    public static readonly NamedLink NexusModsLink = new("Nexus Mods", new Uri("https://nexusmods.com/stardewvalley"));
+
+    public static async IAsyncEnumerable<ValueTuple<Mod, Manifest>> GetAllManifestsAsync(
+        ILogger logger,
+        IFileStore fileStore,
+        Loadout loadout,
+        bool onlyEnabledMods,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var asyncEnumerable = loadout.Mods.Values
+            .Where(mod => !onlyEnabledMods || mod.Enabled)
+            .ToAsyncEnumerable()
+            .ConfigureAwait(continueOnCapturedContext: false)
+            .WithCancellation(cancellationToken);
+
+        await using var enumerator = asyncEnumerable.GetAsyncEnumerator();
+        while (await enumerator.MoveNextAsync())
+        {
+            var mod = enumerator.Current;
+            var manifest = await GetManifest(logger, fileStore, mod, cancellationToken);
+
+            if (manifest is null) continue;
+            yield return (mod, manifest);
+        }
+    }
+
+    private static async ValueTask<Manifest?> GetManifest(
+        ILogger logger,
+        IFileStore fileStore,
+        Mod mod,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await Interop.GetManifest(fileStore, mod, cancellationToken);
+        }
+        catch (TaskCanceledException)
+        {
+            // ignored
+            return null;
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "Exception trying to get manifest for mod {Mod}", mod.Name);
+            return null;
+        }
+    }
+}

--- a/src/Games/NexusMods.Games.StardewValley/Emitters/Helpers.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/Helpers.cs
@@ -11,6 +11,7 @@ namespace NexusMods.Games.StardewValley.Emitters;
 internal static class Helpers
 {
     public static readonly NamedLink NexusModsLink = new("Nexus Mods", new Uri("https://nexusmods.com/stardewvalley"));
+    public static readonly NamedLink SMAPILink = new("Nexus Mods", new Uri("https://nexusmods.com/stardewvalley/mods/2400"));
 
     public static async IAsyncEnumerable<ValueTuple<Mod, Manifest>> GetAllManifestsAsync(
         ILogger logger,

--- a/src/Games/NexusMods.Games.StardewValley/Emitters/MissingSMAPIEmitter.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/MissingSMAPIEmitter.cs
@@ -10,8 +10,6 @@ namespace NexusMods.Games.StardewValley.Emitters;
 
 public class MissingSMAPIEmitter : ILoadoutDiagnosticEmitter
 {
-    private static readonly NamedLink NexusModsSMAPILink = new("Nexus Mods", new Uri("https://nexusmods.com/stardewvalley/mods/2400"));
-
     public async IAsyncEnumerable<Diagnostic> Diagnose(Loadout loadout, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         await Task.Yield();
@@ -24,7 +22,7 @@ public class MissingSMAPIEmitter : ILoadoutDiagnosticEmitter
         {
             yield return Diagnostics.CreateSMAPIRequiredButNotInstalled(
                 ModCount: smapiModCount,
-                NexusModsSMAPIUri: NexusModsSMAPILink
+                NexusModsSMAPIUri: Helpers.SMAPILink
             );
 
             yield break;

--- a/src/Games/NexusMods.Games.StardewValley/Emitters/SMAPIGameVersionDiagnosticEmitter.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/SMAPIGameVersionDiagnosticEmitter.cs
@@ -7,7 +7,6 @@ using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.Diagnostics;
 using NexusMods.Abstractions.Diagnostics.Emitters;
 using NexusMods.Abstractions.Diagnostics.References;
-using NexusMods.Abstractions.Diagnostics.Values;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Loadouts.Extensions;
 using NexusMods.Abstractions.Loadouts.Mods;
@@ -25,8 +24,6 @@ public class SMAPIGameVersionDiagnosticEmitter : ILoadoutDiagnosticEmitter
 {
     private readonly ILogger _logger;
     private readonly HttpClient _client;
-
-    private static readonly NamedLink NexusModsSMAPILink = new("Nexus Mods", new Uri("https://nexusmods.com/stardewvalley/mods/2400"));
 
     public SMAPIGameVersionDiagnosticEmitter(
         ILogger<SMAPIGameVersionDiagnosticEmitter> logger,
@@ -101,7 +98,7 @@ public class SMAPIGameVersionDiagnosticEmitter : ILoadoutDiagnosticEmitter
         return Diagnostics.CreateSuggestSMAPIVersion(
             LatestSMAPIVersion: supportedSMAPIVersion.ToString(),
             CurrentGameVersion: gameVersion.ToString(),
-            SMAPINexusModsLink: NexusModsSMAPILink
+            SMAPINexusModsLink: Helpers.SMAPILink
         );
     }
 
@@ -131,7 +128,7 @@ public class SMAPIGameVersionDiagnosticEmitter : ILoadoutDiagnosticEmitter
             MaximumGameVersion: maximumGameVersion.ToString(),
             CurrentGameVersion: gameVersion.ToString(),
             NewestSupportedSMAPIVersionForCurrentGameVersion: supportedSMAPIVersion.ToString(),
-            SMAPINexusModsLink: NexusModsSMAPILink
+            SMAPINexusModsLink: Helpers.SMAPILink
         );
     }
 
@@ -161,7 +158,7 @@ public class SMAPIGameVersionDiagnosticEmitter : ILoadoutDiagnosticEmitter
             MinimumGameVersion: minimumGameVersion.ToString(),
             CurrentGameVersion: gameVersion.ToString(),
             NewestSupportedSMAPIVersionForCurrentGameVersion: supportedSMAPIVersion.ToString(),
-            SMAPINexusModsLink: NexusModsSMAPILink
+            SMAPINexusModsLink: Helpers.SMAPILink
         );
     }
 

--- a/src/Games/NexusMods.Games.StardewValley/Emitters/VersionDiagnosticEmitter.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/VersionDiagnosticEmitter.cs
@@ -70,7 +70,8 @@ public class VersionDiagnosticEmitter : ILoadoutDiagnosticEmitter
                     ModName: mod.Name,
                     MinimumAPIVersion: minimumApiVersion.ToString(),
                     CurrentSMAPIVersion: smapiVersion.ToString(),
-                    NexusModsLink: modPageUrls.GetValueOrDefault(manifest.UniqueID, Helpers.NexusModsLink)
+                    NexusModsLink: modPageUrls.GetValueOrDefault(manifest.UniqueID, Helpers.NexusModsLink),
+                    SMAPINexusModsLink: Helpers.SMAPILink
                 );
             }
 

--- a/src/Games/NexusMods.Games.StardewValley/Emitters/VersionDiagnosticEmitter.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/VersionDiagnosticEmitter.cs
@@ -1,0 +1,89 @@
+using System.Runtime.CompilerServices;
+using JetBrains.Annotations;
+using Microsoft.Extensions.Logging;
+using NexusMods.Abstractions.Diagnostics;
+using NexusMods.Abstractions.Diagnostics.Emitters;
+using NexusMods.Abstractions.Diagnostics.References;
+using NexusMods.Abstractions.IO;
+using NexusMods.Abstractions.Loadouts;
+using NexusMods.Abstractions.Loadouts.Extensions;
+using NexusMods.Games.StardewValley.Models;
+using NexusMods.Games.StardewValley.WebAPI;
+using NexusMods.Paths;
+using StardewModdingAPI.Toolkit;
+
+namespace NexusMods.Games.StardewValley.Emitters;
+
+[UsedImplicitly]
+public class VersionDiagnosticEmitter : ILoadoutDiagnosticEmitter
+{
+    private readonly ILogger _logger;
+    private readonly IFileStore _fileStore;
+    private readonly IOSInformation _os;
+    private readonly ISMAPIWebApi _smapiWebApi;
+
+    public VersionDiagnosticEmitter(
+        ILogger<VersionDiagnosticEmitter> logger,
+        IFileStore fileStore,
+        IOSInformation os,
+        ISMAPIWebApi smapiWebApi)
+    {
+        _logger = logger;
+        _fileStore = fileStore;
+        _os = os;
+        _smapiWebApi = smapiWebApi;
+    }
+
+    public async IAsyncEnumerable<Diagnostic> Diagnose(Loadout loadout, [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var gameVersion = new SemanticVersion(loadout.Installation.Version);
+        // var gameVersion = new SemanticVersion("1.5.6");
+
+        var optionalSMAPIMod = loadout.GetFirstModWithMetadata<SMAPIMarker>();
+        if (!optionalSMAPIMod.HasValue) yield break;
+
+        var (_, smapiMarker) = optionalSMAPIMod.Value;
+        if (!smapiMarker.TryParse(out var smapiVersion)) yield break;
+
+        var smapiMods = await Helpers
+            .GetAllManifestsAsync(_logger, _fileStore, loadout, onlyEnabledMods: true, cancellationToken)
+            .ToArrayAsync(cancellationToken);
+
+        var modPageUrls = await _smapiWebApi.GetModPageUrls(
+            _os,
+            gameVersion,
+            smapiVersion,
+            smapiMods.Select(tuple => tuple.Item2.UniqueID).ToArray()
+        );
+
+        foreach (var tuple in smapiMods)
+        {
+            var (mod, manifest) = tuple;
+
+            var minimumApiVersion = manifest.MinimumApiVersion;
+            var minimumGameVersion = manifest.MinimumGameVersion;
+
+            if (minimumApiVersion is not null && smapiVersion.IsOlderThan(minimumApiVersion))
+            {
+                yield return Diagnostics.CreateSMAPIVersionOlderThanMinimumAPIVersion(
+                    Mod: mod.ToReference(loadout),
+                    ModName: mod.Name,
+                    MinimumAPIVersion: minimumApiVersion.ToString(),
+                    CurrentSMAPIVersion: smapiVersion.ToString(),
+                    NexusModsLink: modPageUrls.GetValueOrDefault(manifest.UniqueID, Helpers.NexusModsLink)
+                );
+            }
+
+            if (minimumGameVersion is not null && gameVersion.IsOlderThan(minimumGameVersion))
+            {
+                yield return Diagnostics.CreateGameVersionOlderThanModMinimumGameVersion(
+                    Mod: mod.ToReference(loadout),
+                    ModName: mod.Name,
+                    MinimumGameVersion: minimumGameVersion.ToString(),
+                    CurrentGameVersion: gameVersion.ToString(),
+                    NexusModsLink: modPageUrls.GetValueOrDefault(manifest.UniqueID, Helpers.NexusModsLink)
+                );
+            }
+        }
+    }
+}

--- a/src/Games/NexusMods.Games.StardewValley/Installers/SMAPIInstaller.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Installers/SMAPIInstaller.cs
@@ -162,7 +162,7 @@ public class SMAPIInstaller : AModInstaller
                     }
 
                     var fvi = tempFile.Path.FileInfo.GetFileVersionInfo();
-                    version = fvi.FileVersionString;
+                    version = fvi.FileVersion.ToString(fieldCount: 3);
                 }
                 catch (Exception e)
                 {

--- a/src/Games/NexusMods.Games.StardewValley/Services.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Services.cs
@@ -26,6 +26,7 @@ public static class Services
             .AddSingleton<MissingSMAPIEmitter>()
             .AddSingleton<SMAPIModDatabaseCompatibilityDiagnosticEmitter>()
             .AddSingleton<SMAPIGameVersionDiagnosticEmitter>()
+            .AddSingleton<VersionDiagnosticEmitter>()
 
             // Misc
             .AddSingleton<ISMAPIWebApi, SMAPIWebApi>()

--- a/src/Games/NexusMods.Games.StardewValley/StardewValley.cs
+++ b/src/Games/NexusMods.Games.StardewValley/StardewValley.cs
@@ -105,6 +105,7 @@ public class StardewValley : AGame, ISteamGame, IGogGame, IXboxGame
         _serviceProvider.GetRequiredService<DependencyDiagnosticEmitter>(),
         _serviceProvider.GetRequiredService<MissingSMAPIEmitter>(),
         _serviceProvider.GetRequiredService<SMAPIModDatabaseCompatibilityDiagnosticEmitter>(),
+        _serviceProvider.GetRequiredService<VersionDiagnosticEmitter>(),
     ];
 
     public override List<IModInstallDestination> GetInstallDestinations(IReadOnlyDictionary<LocationId, AbsolutePath> locations) => ModInstallDestinationHelpers.GetCommonLocations(locations);


### PR DESCRIPTION
Resolves #1265.

- Fixes an issue with SMAPI versions, again.
- Upgrades the SMAPI submodule to `4.0.7`
- Adds two new diagnostics:

![2024-04-24_12-22-47](https://github.com/Nexus-Mods/NexusMods.App/assets/16577545/8e07024f-3ac5-42ea-9d12-8994c35ef711)
![2024-04-24_12-17-15](https://github.com/Nexus-Mods/NexusMods.App/assets/16577545/80931077-95c6-4dfd-9670-5eeb395827f8)
