### PR TITLE
Upgrade Avalonia to 11.1.0 beta2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,18 +31,18 @@
   </ItemGroup>
   <ItemGroup>
     <!-- Avalonia -->
-    <PackageVersion Include="Avalonia" Version="11.0.10" />
-    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.0.10" />
+    <PackageVersion Include="Avalonia" Version="11.1.0-beta2" />
+    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.1.0-beta2" />
     <PackageVersion Include="Avalonia.Controls.TreeDataGrid" Version="11.0.2" />
-    <PackageVersion Include="Avalonia.Desktop" Version="11.0.10" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.0.10" />
-    <PackageVersion Include="Avalonia.Headless" Version="11.0.10" />
-    <PackageVersion Include="Avalonia.ReactiveUI" Version="11.0.10" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.0.10" />
+    <PackageVersion Include="Avalonia.Desktop" Version="11.1.0-beta2" />
+    <PackageVersion Include="Avalonia.Diagnostics" Version="11.1.0-beta2" />
+    <PackageVersion Include="Avalonia.Headless" Version="11.1.0-beta2" />
+    <PackageVersion Include="Avalonia.ReactiveUI" Version="11.1.0-beta2" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.1.0-beta2" />
     <PackageVersion Include="Projektanker.Icons.Avalonia.MaterialDesign" Version="9.1.2" />
-    <PackageVersion Include="Avalonia.Svg.Skia" Version="11.0.0.14" />
+    <PackageVersion Include="Avalonia.Svg.Skia" Version="11.1.0-beta1" />
     <!-- keep this version in sync with Avalonia (https://github.com/whistyun/Markdown.Avalonia?tab=readme-ov-file#nuget) -->
-    <PackageVersion Include="Markdown.Avalonia.Tight" Version="11.0.2" />
+    <PackageVersion Include="Markdown.Avalonia.Tight" Version="11.0.3-a1" />
   </ItemGroup>
   <ItemGroup>
     <!-- System -->

--- a/src/NexusMods.App.UI/Controls/MarkdownRenderer/MarkdownRendererView.axaml.cs
+++ b/src/NexusMods.App.UI/Controls/MarkdownRenderer/MarkdownRendererView.axaml.cs
@@ -16,9 +16,9 @@ public partial class MarkdownRendererView : ReactiveUserControl<IMarkdownRendere
         {
             var viewModel = ViewModel!;
 
-            MarkdownScrollViewer.Engine.HyperlinkCommand = viewModel.OpenLinkCommand;
-            MarkdownScrollViewer.Engine.Plugins.PathResolver = viewModel.PathResolver;
-            MarkdownScrollViewer.Engine.Plugins.Plugins.Add(viewModel.ImageResolverPlugin);
+            MarkdownScrollViewer.Plugins.HyperlinkCommand = viewModel.OpenLinkCommand;
+            MarkdownScrollViewer.Plugins.PathResolver = viewModel.PathResolver;
+            MarkdownScrollViewer.Plugins.Plugins.Add(viewModel.ImageResolverPlugin);
 
             this.OneWayBind(ViewModel, vm => vm.Contents, view => view.MarkdownScrollViewer.Markdown)
                 .DisposeWith(disposables);


### PR DESCRIPTION
Resolves #1270. Note that this also upgrades `Markdown.Avalonia.Tight` to `11.0.3-a1` which we use for rendering Markdown. This version upgrade breaks our styling for links, see https://github.com/whistyun/Markdown.Avalonia/issues/145 for more details.

Before:

![2024-04-25_12-18-27](https://github.com/Nexus-Mods/NexusMods.App/assets/16577545/1393eb45-bac9-4208-bda5-97eaa060297f)

After:

![2024-04-25_12-22-29](https://github.com/Nexus-Mods/NexusMods.App/assets/16577545/404607f9-671f-4830-a42b-7ac2f7beb4aa)
