### PR TITLE
Fix Design Preview process accessing and locking the database

### DIFF
--- a/src/NexusMods.App/Program.cs
+++ b/src/NexusMods.App/Program.cs
@@ -41,8 +41,7 @@ public class Program
         var host = BuildHost(
             slimMode: !isMain,
             telemetrySettings,
-            loggingSettings,
-            isAvaloniaDesigner: true
+            loggingSettings
         );
 
         // Okay to do wait here, as we are in the main process thread.

--- a/src/NexusMods.App/Program.cs
+++ b/src/NexusMods.App/Program.cs
@@ -256,9 +256,6 @@ public class Program
             LoggingSettings.CreateDefault(OSInformation.Shared),
             isAvaloniaDesigner: true);
         
-        // We have to initialize async services here, waiting is bad, but we don't have many alternatives
-        host.StartAsync().Wait(timeout: TimeSpan.FromMinutes(5));
-        
         DesignerUtils.Activate(host.Services);
         
         return Startup.BuildAvaloniaApp(host.Services);


### PR DESCRIPTION
This prevents the Design Preview process from locking the database, blocking actually running the app on windows after opening any xaml file in the IDE.

This makes it use the inMemoryDatabase.