### PR TITLE
Finish Mod Library

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.FileStore/ArchiveMetadata/NestedArchiveMetadata.cs
+++ b/src/Abstractions/NexusMods.Abstractions.FileStore/ArchiveMetadata/NestedArchiveMetadata.cs
@@ -1,0 +1,16 @@
+using NexusMods.MnemonicDB.Abstractions.Attributes;
+
+namespace NexusMods.Abstractions.FileStore.ArchiveMetadata;
+
+/// <summary>
+/// DownloadAnalysis metadata for a download that was registered from a stream.
+/// </summary>
+public static class NestedArchiveMetadata
+{
+    private const string Namespace = "NexusMods.Abstractions.FileStore.ArchiveMetadata";
+    
+    /// <summary>
+    /// If present, this archive was originated from a stream, likely a nested archive.
+    /// </summary>
+    public static readonly MarkerAttribute NestedArchive = new(Namespace, nameof(NestedArchive));
+}

--- a/src/Abstractions/NexusMods.Abstractions.FileStore/ArchiveMetadata/StreamBasedFileOriginMetadata.cs
+++ b/src/Abstractions/NexusMods.Abstractions.FileStore/ArchiveMetadata/StreamBasedFileOriginMetadata.cs
@@ -5,12 +5,12 @@ namespace NexusMods.Abstractions.FileStore.ArchiveMetadata;
 /// <summary>
 /// DownloadAnalysis metadata for a download that was registered from a stream.
 /// </summary>
-public static class NestedArchiveMetadata
+public static class StreamBasedFileOriginMetadata
 {
     private const string Namespace = "NexusMods.Abstractions.FileStore.ArchiveMetadata";
     
     /// <summary>
     /// If present, this archive was originated from a stream, likely a nested archive.
     /// </summary>
-    public static readonly MarkerAttribute NestedArchive = new(Namespace, nameof(NestedArchive));
+    public static readonly MarkerAttribute StreamBasedOrigin = new(Namespace, nameof(StreamBasedOrigin));
 }

--- a/src/Abstractions/NexusMods.Abstractions.FileStore/Downloads/DownloadAnalysis.cs
+++ b/src/Abstractions/NexusMods.Abstractions.FileStore/Downloads/DownloadAnalysis.cs
@@ -6,6 +6,7 @@ using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.MnemonicDB.Abstractions.Attributes;
 using NexusMods.MnemonicDB.Abstractions.IndexSegments;
 using NexusMods.MnemonicDB.Abstractions.Models;
+using NexusMods.MnemonicDB.Storage;
 using NexusMods.Paths;
 using ModFileTreeNode = NexusMods.Paths.Trees.KeyedBox<NexusMods.Paths.RelativePath, NexusMods.Abstractions.FileStore.Trees.ModFileTree>;
 
@@ -100,6 +101,21 @@ public static class DownloadAnalysis
         public ModFileTreeNode GetFileTree(IFileStore? fs = null)
         {
             return TreeCreator.Create(Contents, fs);
+        }
+        
+        /// <summary>
+        /// The timestamp of the creation of this <see cref="DownloadAnalysis"/> entity
+        /// Download start time or first manual installation time
+        /// </summary>
+        public DateTime CreatedAt
+        {
+            get
+            {
+                // Get the lowest transaction id, then get the timestamp of that transaction
+                var t = this.Select(d => d.T).Min();
+                var txEntity = Db.Get<Entity>(EntityId.From(t.Value));
+                return BuiltInAttributes.TxTimestanp.Get(txEntity);
+            }
         }
     }
 }

--- a/src/Abstractions/NexusMods.Abstractions.FileStore/Downloads/DownloadAnalysis.cs
+++ b/src/Abstractions/NexusMods.Abstractions.FileStore/Downloads/DownloadAnalysis.cs
@@ -102,20 +102,17 @@ public static class DownloadAnalysis
         {
             return TreeCreator.Create(Contents, fs);
         }
-        
+
         /// <summary>
         /// The timestamp of the creation of this <see cref="DownloadAnalysis"/> entity
         /// Download start time or first manual installation time
         /// </summary>
-        public DateTime CreatedAt
+        public DateTime GetCreatedAt()
         {
-            get
-            {
-                // Get the lowest transaction id, then get the timestamp of that transaction
-                var t = this.Select(d => d.T).Min();
-                var txEntity = Db.Get<Entity>(EntityId.From(t.Value));
-                return BuiltInAttributes.TxTimestanp.Get(txEntity);
-            }
+            // Get the lowest transaction id, then get the timestamp of that transaction
+            var t = this.Select(d => d.T).Min();
+            var txEntity = Db.Get<Entity>(EntityId.From(t.Value));
+            return BuiltInAttributes.TxTimestanp.Get(txEntity);
         }
     }
 }

--- a/src/Abstractions/NexusMods.Abstractions.FileStore/NexusMods.Abstractions.FileStore.csproj
+++ b/src/Abstractions/NexusMods.Abstractions.FileStore/NexusMods.Abstractions.FileStore.csproj
@@ -6,6 +6,7 @@
       <ProjectReference Include="..\NexusMods.Abstractions.IO\NexusMods.Abstractions.IO.csproj" />
       <ProjectReference Include="..\NexusMods.Abstractions.MnemonicDB.Attributes\NexusMods.Abstractions.MnemonicDB.Attributes.csproj" />
       <ProjectReference Include="..\NexusMods.Abstractions.Serialization\NexusMods.Abstractions.Serialization.csproj" />
+      <PackageReference Include="NexusMods.MnemonicDB.Storage" />
       <PackageReference Include="TransparentValueObjects" PrivateAssets="all" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
     <ItemGroup>

--- a/src/Abstractions/NexusMods.Abstractions.FileStore/TypeFinder.cs
+++ b/src/Abstractions/NexusMods.Abstractions.FileStore/TypeFinder.cs
@@ -17,6 +17,6 @@ internal class TypeFinder : ITypeFinder
         typeof(FilePathMetadata),
         typeof(GameArchiveMetadata),
         typeof(DownloadAnalysis),
-        typeof(NestedArchiveMetadata),
+        typeof(StreamBasedFileOriginMetadata),
     };
 }

--- a/src/Abstractions/NexusMods.Abstractions.FileStore/TypeFinder.cs
+++ b/src/Abstractions/NexusMods.Abstractions.FileStore/TypeFinder.cs
@@ -17,5 +17,6 @@ internal class TypeFinder : ITypeFinder
         typeof(FilePathMetadata),
         typeof(GameArchiveMetadata),
         typeof(DownloadAnalysis),
+        typeof(NestedArchiveMetadata),
     };
 }

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts/Mods/Mod.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts/Mods/Mod.cs
@@ -158,19 +158,16 @@ public static partial class Mod
             get => Mod.Category.Get(this);
             set => Mod.Category.Add(this, value);
         }
-        
+
         /// <summary>
         /// The timestamp of the creation of this mod.
         /// </summary>
-        public DateTime CreatedAt
+        public DateTime GetCreatedAt()
         {
-            get
-            {
-                // Get the lowest transaction id, then get the timestamp of that transaction
-                var t = this.Select(d => d.T).Min();
-                var txEntity = Db.Get<Entity>(EntityId.From(t.Value));
-                return BuiltInAttributes.TxTimestanp.Get(txEntity);
-            }
+            // Get the lowest transaction id, then get the timestamp of that transaction
+            var t = this.Select(d => d.T).Min();
+            var txEntity = Db.Get<Entity>(EntityId.From(t.Value));
+            return BuiltInAttributes.TxTimestanp.Get(txEntity);
         }
 
         public Entities<EntityIds, File.Model> Files => GetReverse<File.Model>(File.Mod);

--- a/src/Networking/NexusMods.Networking.Downloaders/Tasks/NxmDownloadTask.cs
+++ b/src/Networking/NexusMods.Networking.Downloaders/Tasks/NxmDownloadTask.cs
@@ -97,7 +97,7 @@ public class NxmDownloadTask : ADownloadTask
             {
                 using var tx = Connection.BeginTransaction();
                 if (info.Data.Name is not null)
-                    tx.Add(eid, DownloaderState.FriendlyName, info.Data.Name + " " + file.FileName);
+                    tx.Add(eid, DownloaderState.FriendlyName, info.Data.Name);
                 else
                     tx.Add(eid, DownloaderState.FriendlyName, file.FileName);
                 

--- a/src/NexusMods.App.UI/Pages/LoadoutGrid/Columns/ModInstalled/ModInstalledViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutGrid/Columns/ModInstalled/ModInstalledViewModel.cs
@@ -14,7 +14,7 @@ namespace NexusMods.App.UI.Pages.LoadoutGrid.Columns.ModInstalled;
 internal class ModInstalledViewModel(IConnection connection) : 
     AColumnViewModel<IModInstalledViewModel, DateTime>(connection), IModInstalledViewModel
 {
-    protected override DateTime Selector(Mod.Model model) => model.CreatedAt;
+    protected override DateTime Selector(Mod.Model model) => model.GetCreatedAt();
 
     protected override int Compare(DateTime a, DateTime b) => DateTime.Compare(a, b);
 }

--- a/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginEntry/FileOriginEntryViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginEntry/FileOriginEntryViewModel.cs
@@ -40,14 +40,22 @@ public class FileOriginEntryViewModel : AViewModel<IFileOriginEntryViewModel>, I
         Name = fileOrigin.TryGet(DownloaderState.FriendlyName, out var friendlyName) && friendlyName != "Unknown"
             ? friendlyName
             : fileOrigin.SuggestedName;
-        Size = fileOrigin.TryGet(DownloaderState.Size, out var size) ? size : Size.Zero;
+        
+        Size = fileOrigin.TryGet(DownloadAnalysis.Size, out var analysisSize) 
+            ? analysisSize 
+            : fileOrigin.TryGet(DownloaderState.Size, out var dlStateSize) 
+                ? dlStateSize 
+                : Size.Zero;
+        
         AddToLoadoutCommand = ReactiveCommand.CreateFromTask(async () =>
         {
             await archiveInstaller.AddMods(loadoutId, fileOrigin);
         });
+        
         Version = fileOrigin.TryGet(DownloaderState.Version, out var version) && version != "Unknown"
             ? version
             : "-";
+        
         ArchiveDate = fileOrigin.CreatedAt;
 
         var loadout = conn.Db.Get<Loadout.Model>(loadoutId.Value);

--- a/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginEntry/FileOriginEntryViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginEntry/FileOriginEntryViewModel.cs
@@ -38,8 +38,10 @@ public class FileOriginEntryViewModel : AViewModel<IFileOriginEntryViewModel>, I
             ? friendlyName
             : fileOrigin.SuggestedName;
         Size = fileOrigin.TryGet(DownloaderState.Size, out var size) ? size : Size.Zero;
-        AddToLoadoutCommand = ReactiveCommand.CreateFromTask(async () => { await archiveInstaller.AddMods(loadoutId, fileOrigin); }
-        );
+        AddToLoadoutCommand = ReactiveCommand.CreateFromTask(async () =>
+        {
+            await archiveInstaller.AddMods(loadoutId, fileOrigin);
+        });
         Version = fileOrigin.TryGet(DownloaderState.Version, out var version) && version != "Unknown"
             ? version
             : "-";
@@ -58,8 +60,7 @@ public class FileOriginEntryViewModel : AViewModel<IFileOriginEntryViewModel>, I
         conn.Revisions(loadoutId)
             .StartWith(loadout)
             .Select(rev => rev.Mods.Where(mod => mod.Contains(Mod.Source)
-                                                 && mod.SourceId.Equals(fileOrigin.Id)
-                )
+                                                 && mod.SourceId.Equals(fileOrigin.Id))
                 .Select(mod => mod.CreatedAt)
                 .DefaultIfEmpty(DateTime.MinValue)
                 .Max()

--- a/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginEntry/FileOriginEntryViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginEntry/FileOriginEntryViewModel.cs
@@ -56,7 +56,7 @@ public class FileOriginEntryViewModel : AViewModel<IFileOriginEntryViewModel>, I
             ? version
             : "-";
         
-        ArchiveDate = fileOrigin.CreatedAt;
+        ArchiveDate = fileOrigin.GetCreatedAt();
 
         var loadout = conn.Db.Get<Loadout.Model>(loadoutId.Value);
 
@@ -72,7 +72,7 @@ public class FileOriginEntryViewModel : AViewModel<IFileOriginEntryViewModel>, I
             .StartWith(loadout)
             .Select(rev => rev.Mods.Where(mod => mod.Contains(Mod.Source)
                                                  && mod.SourceId.Equals(fileOrigin.Id))
-                .Select(mod => mod.CreatedAt)
+                .Select(mod => mod.GetCreatedAt())
                 .DefaultIfEmpty(DateTime.MinValue)
                 .Max()
             )

--- a/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginEntry/FileOriginEntryViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginEntry/FileOriginEntryViewModel.cs
@@ -1,6 +1,14 @@
 using System.Reactive;
 using System.Reactive.Linq;
+using DynamicData;
+using DynamicData.Aggregation;
 using Humanizer;
+using NexusMods.Abstractions.FileStore.Downloads;
+using NexusMods.Abstractions.Installers;
+using NexusMods.Abstractions.Loadouts;
+using NexusMods.Abstractions.Loadouts.Ids;
+using NexusMods.MnemonicDB.Abstractions;
+using NexusMods.Networking.Downloaders.Tasks.State;
 using NexusMods.Paths;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
@@ -9,33 +17,58 @@ namespace NexusMods.App.UI.Pages.ModLibrary.FileOriginEntry;
 
 public class FileOriginEntryViewModel : AViewModel<IFileOriginEntryViewModel>, IFileOriginEntryViewModel
 {
-    public required string Name { get; init; } 
-    public string Version { get; init; } = "-";
-    public required Size Size { get; init; }
-    public DateTime ArchiveDate { get; set; } = DateTime.UnixEpoch;
-
+    public string Name { get; } 
+    public string Version { get; }
+    public Size Size { get; }
+    public DateTime ArchiveDate { get; }
+    
     [ObservableAsProperty]
     public string DisplayArchiveDate { get; } = "-";
 
     
-    [Reactive]
-    public DateTime LastInstalledDate { get; set; } = DateTime.UnixEpoch;
+    [ObservableAsProperty]
+    public DateTime LastInstalledDate { get; set; } 
     
     [ObservableAsProperty]
     public string DisplayLastInstalledDate { get; } = "-";
-    public required ReactiveCommand<Unit, Unit> AddToLoadoutCommand { get; init; }
+    public ReactiveCommand<Unit, Unit> AddToLoadoutCommand { get; init; }
     
-    public FileOriginEntryViewModel()
+    public FileOriginEntryViewModel(
+        IConnection conn, 
+        IArchiveInstaller archiveInstaller, 
+        LoadoutId loadoutId, 
+        DownloadAnalysis.Model fileOrigin)
     {
+        Name = fileOrigin.SuggestedName;
+        Size = fileOrigin.Size;
+        AddToLoadoutCommand = ReactiveCommand.CreateFromTask(async () =>
+            {
+                await archiveInstaller.AddMods(loadoutId, fileOrigin);
+            }
+        );
+        Version = fileOrigin.TryGet(DownloaderState.Version, out var version) && version != "Unknown"
+            ? version
+            : "-";
+        ArchiveDate = fileOrigin.CreatedAt;
+        
         var interval = Observable.Interval(TimeSpan.FromSeconds(60)).StartWith(1);
         
         interval.Select(_ => ArchiveDate)
             .Select(date => date.Equals(DateTime.UnixEpoch) ? "-" : date.Humanize())
             .ToPropertyEx(this, vm => vm.DisplayArchiveDate);
+        
+        conn.Revisions(loadoutId)
+            .StartWith(conn.Db.Get<Loadout.Model>(loadoutId.Value))
+            .ToObservableChangeSet()
+            .TransformMany(revision => revision.Mods)
+            .Filter(mod =>  fileOrigin.Id.Equals(mod.SourceId))
+            .Maximum(mod => mod.CreatedAt)
+            .ToPropertyEx(this, vm => vm.LastInstalledDate);
 
         this.WhenAnyValue(vm => vm.LastInstalledDate)
             .Merge(interval.Select(_ => LastInstalledDate))
             .Select(date => date.Equals(DateTime.UnixEpoch) ? "-" : date.Humanize())
             .ToPropertyEx(this, vm => vm.DisplayLastInstalledDate);
+        
     }
 }

--- a/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginEntry/FileOriginEntryViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginEntry/FileOriginEntryViewModel.cs
@@ -16,66 +16,58 @@ namespace NexusMods.App.UI.Pages.ModLibrary.FileOriginEntry;
 
 public class FileOriginEntryViewModel : AViewModel<IFileOriginEntryViewModel>, IFileOriginEntryViewModel
 {
-    public string Name { get; } 
+    public string Name { get; }
     public string Version { get; }
     public Size Size { get; }
     public DateTime ArchiveDate { get; }
-    
-    [ObservableAsProperty]
-    public string DisplayArchiveDate { get; } = "-";
-    
-    [Reactive]
-    public DateTime LastInstalledDate { get; set; } 
-    
-    [ObservableAsProperty]
-    public string DisplayLastInstalledDate { get; } = "-";
     public ReactiveCommand<Unit, Unit> AddToLoadoutCommand { get; init; }
+
+    [ObservableAsProperty] public string DisplayArchiveDate { get; } = "-";
+
+    [ObservableAsProperty] public DateTime LastInstalledDate { get; set; }
+
+    [ObservableAsProperty] public string DisplayLastInstalledDate { get; } = "-";
     
     public FileOriginEntryViewModel(
-        IConnection conn, 
-        IArchiveInstaller archiveInstaller, 
-        LoadoutId loadoutId, 
+        IConnection conn,
+        IArchiveInstaller archiveInstaller,
+        LoadoutId loadoutId,
         DownloadAnalysis.Model fileOrigin)
     {
         Name = fileOrigin.SuggestedName;
         Size = fileOrigin.Size;
-        AddToLoadoutCommand = ReactiveCommand.CreateFromTask(async () =>
-            {
-                await archiveInstaller.AddMods(loadoutId, fileOrigin);
-            }
+        AddToLoadoutCommand = ReactiveCommand.CreateFromTask(async () => { await archiveInstaller.AddMods(loadoutId, fileOrigin); }
         );
         Version = fileOrigin.TryGet(DownloaderState.Version, out var version) && version != "Unknown"
             ? version
             : "-";
         ArchiveDate = fileOrigin.CreatedAt;
-        
+
         var loadout = conn.Db.Get<Loadout.Model>(loadoutId.Value);
-        
+
         var interval = Observable.Interval(TimeSpan.FromSeconds(60)).StartWith(1);
-        
+
         // Update the humanized Archive Date every minute
         interval.Select(_ => ArchiveDate)
             .Select(date => date.Equals(DateTime.MinValue) ? "-" : date.Humanize())
             .ToPropertyEx(this, vm => vm.DisplayArchiveDate);
-        
+
         // Update the LastInstalledDate every time the loadout is updated
         conn.Revisions(loadoutId)
             .StartWith(loadout)
-            .Do(rev =>
-                {
-                    LastInstalledDate = rev.Mods.Where(mod => mod.Contains(Mod.Source)
-                                                              && mod.SourceId.Equals(fileOrigin.Id))
-                        .Select(mod => mod.CreatedAt)
-                        .DefaultIfEmpty(DateTime.MinValue)
-                        .Max();
-                }
-            ).Subscribe();
+            .Select(rev => rev.Mods.Where(mod => mod.Contains(Mod.Source)
+                                                 && mod.SourceId.Equals(fileOrigin.Id)
+                )
+                .Select(mod => mod.CreatedAt)
+                .DefaultIfEmpty(DateTime.MinValue)
+                .Max()
+            )
+            .ToPropertyEx(this, vm => vm.LastInstalledDate);
 
         // Update the humanized LastInstalledDate every minute and when the LastInstalledDate changes
         this.WhenAnyValue(vm => vm.LastInstalledDate)
-            .Merge( interval.Select(_ => LastInstalledDate))
+            .Merge(interval.Select(_ => LastInstalledDate))
             .Select(date => date.Equals(DateTime.MinValue) ? "-" : date.Humanize())
             .ToPropertyEx(this, vm => vm.DisplayLastInstalledDate);
-        
     }
 }

--- a/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginEntry/FileOriginEntryViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginEntry/FileOriginEntryViewModel.cs
@@ -27,15 +27,17 @@ public class FileOriginEntryViewModel : AViewModel<IFileOriginEntryViewModel>, I
     [ObservableAsProperty] public DateTime LastInstalledDate { get; set; }
 
     [ObservableAsProperty] public string DisplayLastInstalledDate { get; } = "-";
-    
+
     public FileOriginEntryViewModel(
         IConnection conn,
         IArchiveInstaller archiveInstaller,
         LoadoutId loadoutId,
         DownloadAnalysis.Model fileOrigin)
     {
-        Name = fileOrigin.SuggestedName;
-        Size = fileOrigin.Size;
+        Name = fileOrigin.TryGet(DownloaderState.FriendlyName, out var friendlyName) && friendlyName != "Unknown"
+            ? friendlyName
+            : fileOrigin.SuggestedName;
+        Size = fileOrigin.TryGet(DownloaderState.Size, out var size) ? size : Size.Zero;
         AddToLoadoutCommand = ReactiveCommand.CreateFromTask(async () => { await archiveInstaller.AddMods(loadoutId, fileOrigin); }
         );
         Version = fileOrigin.TryGet(DownloaderState.Version, out var version) && version != "Unknown"

--- a/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginEntry/IFileOriginEntryViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginEntry/IFileOriginEntryViewModel.cs
@@ -9,9 +9,6 @@ public interface IFileOriginEntryViewModel : IViewModelInterface
     string Name { get;}
     string Version { get; }
     Size Size { get; }    
-    
-    public DateTime LastInstalledDate { get; set; }
-    public DateTime ArchiveDate { get; }
     string DisplayArchiveDate { get; }
     string DisplayLastInstalledDate { get; }
     ReactiveCommand<Unit, Unit> AddToLoadoutCommand { get; }

--- a/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginEntry/IFileOriginEntryViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginEntry/IFileOriginEntryViewModel.cs
@@ -11,7 +11,7 @@ public interface IFileOriginEntryViewModel : IViewModelInterface
     Size Size { get; }    
     
     public DateTime LastInstalledDate { get; set; }
-    public DateTime ArchiveDate { get; set; }
+    public DateTime ArchiveDate { get; }
     string DisplayArchiveDate { get; }
     string DisplayLastInstalledDate { get; }
     ReactiveCommand<Unit, Unit> AddToLoadoutCommand { get; }

--- a/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginsPage.cs
+++ b/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginsPage.cs
@@ -1,10 +1,14 @@
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
-using NexusMods.Abstractions.Loadouts;
+using NexusMods.Abstractions.FileStore.Downloads;
+using NexusMods.Abstractions.Installers;
 using NexusMods.Abstractions.Loadouts.Ids;
+using NexusMods.Abstractions.MnemonicDB.Attributes;
 using NexusMods.Abstractions.Serialization.Attributes;
 using NexusMods.App.UI.Resources;
+using NexusMods.App.UI.Windows;
 using NexusMods.App.UI.WorkspaceSystem;
+using NexusMods.MnemonicDB.Abstractions;
 
 namespace NexusMods.App.UI.Pages.ModLibrary;
 
@@ -27,9 +31,13 @@ public class FileOriginsPageFactory : APageFactory<IFileOriginsPageViewModel, Fi
 
     public override IFileOriginsPageViewModel CreateViewModel(FileOriginsPageContext context)
     {
-        var vm = ServiceProvider.GetRequiredService<IFileOriginsPageViewModel>();
-        vm.Initialize(context.LoadoutId);
-        return vm;
+        return new FileOriginsPageViewModel(
+            context.LoadoutId,
+            ServiceProvider.GetRequiredService<IArchiveInstaller>(),
+            ServiceProvider.GetRequiredService<IRepository<DownloadAnalysis.Model>>(),
+            ServiceProvider.GetRequiredService<IConnection>(),
+            ServiceProvider.GetRequiredService<IWindowManager>()
+        );
     }
 
     public override IEnumerable<PageDiscoveryDetails?> GetDiscoveryDetails(IWorkspaceContext workspaceContext)

--- a/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginsPage.cs
+++ b/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginsPage.cs
@@ -28,7 +28,7 @@ public class FileOriginsPageFactory : APageFactory<IFileOriginsPageViewModel, Fi
     public override IFileOriginsPageViewModel CreateViewModel(FileOriginsPageContext context)
     {
         var vm = ServiceProvider.GetRequiredService<IFileOriginsPageViewModel>();
-        vm.LoadoutId = context.LoadoutId;
+        vm.Initialize(context.LoadoutId);
         return vm;
     }
 

--- a/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginsPageViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginsPageViewModel.cs
@@ -2,9 +2,6 @@ using System.Collections.ObjectModel;
 using System.Reactive.Disposables;
 using DynamicData;
 using DynamicData.Binding;
-using Humanizer.Bytes;
-using NexusMods.Abstractions.FileStore;
-using NexusMods.Abstractions.FileStore.ArchiveMetadata;
 using NexusMods.Abstractions.FileStore.Downloads;
 using NexusMods.Abstractions.Installers;
 using NexusMods.Abstractions.Loadouts;
@@ -15,40 +12,57 @@ using NexusMods.App.UI.Resources;
 using NexusMods.App.UI.Windows;
 using NexusMods.App.UI.WorkspaceSystem;
 using NexusMods.Icons;
-using NexusMods.Paths;
+using NexusMods.MnemonicDB.Abstractions;
+using NexusMods.Networking.Downloaders.Tasks.State;
 using ReactiveUI;
-using ReactiveUI.Fody.Helpers;
 
 namespace NexusMods.App.UI.Pages.ModLibrary;
 
 public class FileOriginsPageViewModel : APageViewModel<IFileOriginsPageViewModel>, IFileOriginsPageViewModel
 {
-    [Reactive] public LoadoutId LoadoutId { get; set; }
-
+    private readonly IConnection _conn;
+    private readonly IRepository<DownloadAnalysis.Model> _dlAnalysisRepo;
+    private readonly IArchiveInstaller _archiveInstaller;
+    
     public ReadOnlyObservableCollection<IFileOriginEntryViewModel> FileOrigins => _fileOrigins;
-    private readonly ReadOnlyObservableCollection<IFileOriginEntryViewModel> _fileOrigins;
+    private ReadOnlyObservableCollection<IFileOriginEntryViewModel> _fileOrigins = new([]);
+    
+    public LoadoutId LoadoutId { get; private set; }
+    
+    
     public FileOriginsPageViewModel(
         IArchiveInstaller archiveInstaller,
-        IFileOriginRegistry fileOriginRegistry,
         IRepository<DownloadAnalysis.Model> downloadAnalysisRepository,
+        IConnection conn,
         IWindowManager windowManager) : base(windowManager)
     {
+        _conn = conn;
+        _archiveInstaller = archiveInstaller;
+        _dlAnalysisRepo = downloadAnalysisRepository;
+        
         TabTitle = Language.FileOriginsPageTitle;
         TabIcon = IconValues.ModLibrary;
+    }
+    
+    public void Initialize(LoadoutId loadoutId)
+    {
+        LoadoutId = loadoutId;
         
-        var downloadAnalyses = downloadAnalysisRepository.Observable;
+        var loadout = _conn.Db.Get<Loadout.Model>(LoadoutId.Value);
+        var game = loadout.Installation.Game;
+        
+        var downloadAnalyses = _dlAnalysisRepo.Observable;
         
         var entriesObservable = downloadAnalyses.ToObservableChangeSet()
-            .Transform(fileOrigin => (IFileOriginEntryViewModel)new FileOriginEntryViewModel
-            {
-                Name = fileOrigin.SuggestedName,
-                Size = fileOrigin.Size,
-                AddToLoadoutCommand = ReactiveCommand.CreateFromTask(async () =>
-                    {
-                        await archiveInstaller.AddMods(LoadoutId, fileOrigin);
-                    }
-                ),
-            })
+            .Filter(downloadAnalysis => 
+                !downloadAnalysis.TryGet(DownloaderState.GameDomain, out var domain) || domain == game.Domain)
+            .Transform(fileOrigin => (IFileOriginEntryViewModel)new FileOriginEntryViewModel(
+                    _conn,
+                    _archiveInstaller,
+                    LoadoutId,
+                    fileOrigin
+                )
+            )
             .OnUI()
             .Bind(out _fileOrigins);
         
@@ -57,8 +71,5 @@ public class FileOriginsPageViewModel : APageViewModel<IFileOriginsPageViewModel
             entriesObservable.Subscribe()
                 .DisposeWith(d);
         });
-
-        
-        
     }
 }

--- a/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginsPageViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginsPageViewModel.cs
@@ -32,6 +32,7 @@ public class FileOriginsPageViewModel : APageViewModel<IFileOriginsPageViewModel
     
     
     public FileOriginsPageViewModel(
+        LoadoutId loadoutId,
         IArchiveInstaller archiveInstaller,
         IRepository<DownloadAnalysis.Model> downloadAnalysisRepository,
         IConnection conn,
@@ -43,10 +44,7 @@ public class FileOriginsPageViewModel : APageViewModel<IFileOriginsPageViewModel
         
         TabTitle = Language.FileOriginsPageTitle;
         TabIcon = IconValues.ModLibrary;
-    }
-    
-    public void Initialize(LoadoutId loadoutId)
-    {
+        
         LoadoutId = loadoutId;
         
         var loadout = _conn.Db.Get<Loadout.Model>(LoadoutId.Value);

--- a/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginsPageViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginsPageViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using System.Reactive.Disposables;
 using DynamicData;
 using DynamicData.Binding;
+using NexusMods.Abstractions.FileStore.ArchiveMetadata;
 using NexusMods.Abstractions.FileStore.Downloads;
 using NexusMods.Abstractions.Installers;
 using NexusMods.Abstractions.Loadouts;
@@ -54,8 +55,10 @@ public class FileOriginsPageViewModel : APageViewModel<IFileOriginsPageViewModel
         var downloadAnalyses = _dlAnalysisRepo.Observable;
         
         var entriesObservable = downloadAnalyses.ToObservableChangeSet()
-            .Filter(downloadAnalysis => 
-                !downloadAnalysis.TryGet(DownloaderState.GameDomain, out var domain) || domain == game.Domain)
+            .Filter(downloadAnalysis => (!downloadAnalysis.TryGet(DownloaderState.GameDomain, out var domain) 
+                                         || domain == game.Domain)
+                                        && !downloadAnalysis.Contains(NestedArchiveMetadata.NestedArchive)
+            )
             .Transform(fileOrigin => (IFileOriginEntryViewModel)new FileOriginEntryViewModel(
                     _conn,
                     _archiveInstaller,

--- a/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginsPageViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginsPageViewModel.cs
@@ -57,7 +57,7 @@ public class FileOriginsPageViewModel : APageViewModel<IFileOriginsPageViewModel
         var entriesObservable = downloadAnalyses.ToObservableChangeSet()
             .Filter(downloadAnalysis => (!downloadAnalysis.TryGet(DownloaderState.GameDomain, out var domain) 
                                          || domain == game.Domain)
-                                        && !downloadAnalysis.Contains(NestedArchiveMetadata.NestedArchive))
+                                        && !downloadAnalysis.Contains(StreamBasedFileOriginMetadata.StreamBasedOrigin))
             .OnUI()
             .Transform(fileOrigin => (IFileOriginEntryViewModel)new FileOriginEntryViewModel(
                     _conn,

--- a/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginsPageViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginsPageViewModel.cs
@@ -57,8 +57,8 @@ public class FileOriginsPageViewModel : APageViewModel<IFileOriginsPageViewModel
         var entriesObservable = downloadAnalyses.ToObservableChangeSet()
             .Filter(downloadAnalysis => (!downloadAnalysis.TryGet(DownloaderState.GameDomain, out var domain) 
                                          || domain == game.Domain)
-                                        && !downloadAnalysis.Contains(NestedArchiveMetadata.NestedArchive)
-            )
+                                        && !downloadAnalysis.Contains(NestedArchiveMetadata.NestedArchive))
+            .OnUI()
             .Transform(fileOrigin => (IFileOriginEntryViewModel)new FileOriginEntryViewModel(
                     _conn,
                     _archiveInstaller,
@@ -66,7 +66,6 @@ public class FileOriginsPageViewModel : APageViewModel<IFileOriginsPageViewModel
                     fileOrigin
                 )
             )
-            .OnUI()
             .Bind(out _fileOrigins);
         
         this.WhenActivated(d =>

--- a/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/IFileOriginsPageViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/IFileOriginsPageViewModel.cs
@@ -1,5 +1,4 @@
 using System.Collections.ObjectModel;
-using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Loadouts.Ids;
 using NexusMods.App.UI.Pages.ModLibrary.FileOriginEntry;
 using NexusMods.App.UI.WorkspaceSystem;
@@ -8,7 +7,9 @@ namespace NexusMods.App.UI.Pages.ModLibrary;
 
 public interface IFileOriginsPageViewModel : IPageViewModelInterface
 {
-    LoadoutId LoadoutId { get; set; }
+    LoadoutId LoadoutId { get; }
     
     ReadOnlyObservableCollection<IFileOriginEntryViewModel> FileOrigins { get; }
+    
+    void Initialize(LoadoutId loadoutId);
 }

--- a/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/IFileOriginsPageViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/IFileOriginsPageViewModel.cs
@@ -10,6 +10,4 @@ public interface IFileOriginsPageViewModel : IPageViewModelInterface
     LoadoutId LoadoutId { get; }
     
     ReadOnlyObservableCollection<IFileOriginEntryViewModel> FileOrigins { get; }
-    
-    void Initialize(LoadoutId loadoutId);
 }

--- a/src/NexusMods.App.UI/Services.cs
+++ b/src/NexusMods.App.UI/Services.cs
@@ -140,7 +140,6 @@ public static class Services
             .AddViewModel<DummyLoadingViewModel, ILoadingViewModel>()
             .AddViewModel<DummyErrorViewModel, IErrorViewModel>()
             .AddViewModel<ApplyDiffViewModel, IApplyDiffViewModel>()
-            .AddViewModel<FileOriginsPageViewModel, IFileOriginsPageViewModel>()
 
             // Views
             .AddView<DevelopmentBuildBannerView, IDevelopmentBuildBannerViewModel>()

--- a/src/NexusMods.DataModel/FileOriginRegistry.cs
+++ b/src/NexusMods.DataModel/FileOriginRegistry.cs
@@ -68,7 +68,7 @@ public class FileOriginRegistry : IFileOriginRegistry
         void AppendNestedArchiveMetadata(ITransaction tx, EntityId id)
         {
             metaData?.Invoke(tx, id);
-            tx.Add(id, NestedArchiveMetadata.NestedArchive, new Null());
+            tx.Add(id, StreamBasedFileOriginMetadata.StreamBasedOrigin, new Null());
         }
     }
 

--- a/src/NexusMods.DataModel/Services.cs
+++ b/src/NexusMods.DataModel/Services.cs
@@ -126,7 +126,7 @@ public static class Services
         coll.AddAttributeCollection(typeof(DownloadAnalysis));
         coll.AddAttributeCollection(typeof(DownloadContentEntry));
         coll.AddAttributeCollection(typeof(FilePathMetadata));
-        coll.AddAttributeCollection(typeof(NestedArchiveMetadata));
+        coll.AddAttributeCollection(typeof(StreamBasedFileOriginMetadata));
         coll.AddAllSingleton<IFileOriginRegistry, FileOriginRegistry>();
         
         // Repositories

--- a/src/NexusMods.DataModel/Services.cs
+++ b/src/NexusMods.DataModel/Services.cs
@@ -1,7 +1,5 @@
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.Settings;
 using NexusMods.Abstractions.Diagnostics;
 using NexusMods.Abstractions.DiskState;
@@ -15,7 +13,6 @@ using NexusMods.Abstractions.IO;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Messaging;
 using NexusMods.Abstractions.MnemonicDB.Attributes;
-using NexusMods.Abstractions.Serialization;
 using NexusMods.Abstractions.Serialization.ExpressionGenerator;
 using NexusMods.DataModel.ArchiveContents;
 using NexusMods.DataModel.Attributes;
@@ -129,6 +126,7 @@ public static class Services
         coll.AddAttributeCollection(typeof(DownloadAnalysis));
         coll.AddAttributeCollection(typeof(DownloadContentEntry));
         coll.AddAttributeCollection(typeof(FilePathMetadata));
+        coll.AddAttributeCollection(typeof(NestedArchiveMetadata));
         coll.AddAllSingleton<IFileOriginRegistry, FileOriginRegistry>();
         
         // Repositories


### PR DESCRIPTION
- Closes #1284
- Closes #1210 
- Closes #1155

This implements the remaining missing features of the Mod Library as current designs.

### Summary:
- Filter entries by Game, if entry has no Game, it is shown.
- Compute and show "Downloaded" DateTime column which is either when a manual archive was first analyzed, or when a download was started.
- Show Version data if available (it is only present on NXM downloads)
- Compute and update "Added" DateTime column by querying the loadout mods for matches and getting the most recent CreatedAt time
- Excluded Nested archives (e.g. SMAPI internal archive) from showing up
- Used Nexus Mod page name if available instead of file name

I'm not completely happy with the subscriptions and the all the attributes shenanigans, but at least everything seems to work now.

![image](https://github.com/Nexus-Mods/NexusMods.App/assets/26797547/2a2152f1-7a62-4139-aa46-5bcbee09c00d)
