### PR TITLE
Add a setting to not log to the console, just to log files

### DIFF
--- a/src/NexusMods.App/LoggingSettings.cs
+++ b/src/NexusMods.App/LoggingSettings.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.Settings;
@@ -43,7 +44,11 @@ public record LoggingSettings : ISettings
     /// <summary>
     /// When enabled, logs will be written to the console as well as the log file.
     /// </summary>
+    #if DEBUG
+    public bool LogToConsole { get; init; } = true;
+    #else
     public bool LogToConsole { get; init; } = false;
+    #endif
 
     public static ISettingsBuilder Configure(ISettingsBuilder settingsBuilder)
     {

--- a/src/NexusMods.App/LoggingSettings.cs
+++ b/src/NexusMods.App/LoggingSettings.cs
@@ -40,6 +40,11 @@ public record LoggingSettings : ISettings
     /// </summary>
     public LogLevel MinimumLevel { get; init; } = LogLevel.Debug;
 
+    /// <summary>
+    /// When enabled, logs will be written to the console as well as the log file.
+    /// </summary>
+    public bool LogToConsole { get; init; } = false;
+
     public static ISettingsBuilder Configure(ISettingsBuilder settingsBuilder)
     {
         // TODO: put in some section
@@ -62,6 +67,13 @@ public record LoggingSettings : ISettings
                         ],
                         valueToDisplayString: static logLevel => logLevel.ToString()
                     )
+                    .RequiresRestart()
+                )
+                .AddPropertyToUI(x => x.LogToConsole, propertybuilder => propertybuilder
+                    .AddToSection(sectionId)
+                    .WithDisplayName("Log to Console")
+                    .WithDescription("When enabled, logs will be written to the console as well as the log file.")
+                    .UseBooleanContainer()
                     .RequiresRestart()
                 )
             );

--- a/src/NexusMods.App/Program.cs
+++ b/src/NexusMods.App/Program.cs
@@ -222,13 +222,21 @@ public class Program
         fileTarget.Layout = defaultLayout;
         fileTarget.Header = defaultHeader;
 
-        var consoleTarget = new ConsoleTarget("console")
+        if (settings.LogToConsole)
         {
-            Layout = "${processtime} [${level:uppercase=true}] ${message:withexception=true}",
-        };
+            var consoleTarget = new ConsoleTarget("console")
+            {
+                Layout = "${processtime} [${level:uppercase=true}] ${message:withexception=true}",
+            };
+            config.AddRuleForAllLevels(consoleTarget);
+        }
+        else
+        {
+            
+        }
 
         config.AddRuleForAllLevels(fileTarget);
-        config.AddRuleForAllLevels(consoleTarget);
+
 
         // NOTE(erri120): RemoveLoggerFactoryFilter prevents
         // the global minimum level to take effect.


### PR DESCRIPTION
I've intended to add this for months now. Adds a setting that removes the log to console feature of the app so that logs only go into the log files. Reduces spam on the console and in the pop-up window. The console window still appears on Windows as that's a strange windows thing we need to look into at some point, but likely after we merge #1345 