### PR TITLE
Upgrade (almost) all the deps

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,13 +40,13 @@
     <PackageVersion Include="NetEscapades.EnumGenerators" Version="1.0.0-beta07" PrivateAssets="all" ExcludeAssets="compile;runtime" />
     <PackageVersion Include="Avalonia" Version="11.1.0-beta2" />
     <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.1.0-beta2" />
-    <PackageVersion Include="Avalonia.Controls.TreeDataGrid" Version="11.0.2" />
+    <PackageVersion Include="Avalonia.Controls.TreeDataGrid" Version="11.0.10" />
     <PackageVersion Include="Avalonia.Desktop" Version="11.1.0-beta2" />
     <PackageVersion Include="Avalonia.Diagnostics" Version="11.1.0-beta2" />
     <PackageVersion Include="Avalonia.Headless" Version="11.1.0-beta2" />
     <PackageVersion Include="Avalonia.ReactiveUI" Version="11.1.0-beta2" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.1.0-beta2" />
-    <PackageVersion Include="Projektanker.Icons.Avalonia.MaterialDesign" Version="9.1.2" />
+    <PackageVersion Include="Projektanker.Icons.Avalonia.MaterialDesign" Version="9.3.0" />
     <PackageVersion Include="Avalonia.Svg.Skia" Version="11.1.0-beta1" />
     <PackageVersion Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.0-rc2" />
     <!-- keep this version in sync with Avalonia (https://github.com/whistyun/Markdown.Avalonia?tab=readme-ov-file#nuget) -->
@@ -57,21 +57,21 @@
     <PackageVersion Include="System.IO.Hashing" Version="8.0.0" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="System.Reactive" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.3" />
+    <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.5" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="8.0.4" />
+    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="8.0.5" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.1" />
     <PackageVersion Include="AutoFixture" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.Xunit2" Version="4.18.1" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.0">
+    <PackageVersion Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
@@ -91,33 +91,33 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="Verify.Xunit" Version="23.5.0" />
-    <PackageVersion Include="Verify.ImageMagick" Version="3.3.0" />
+    <PackageVersion Include="Verify.Xunit" Version="24.2.0" />
+    <PackageVersion Include="Verify.ImageMagick" Version="3.4.2" />
     <PackageVersion Include="Verify.SourceGenerators" Version="2.2.0" />
-    <PackageVersion Include="xunit" Version="2.7.0" />
-    <PackageVersion Include="Xunit.DependencyInjection" Version="9.2.1" />
+    <PackageVersion Include="xunit" Version="2.8.0" />
+    <PackageVersion Include="Xunit.DependencyInjection" Version="9.3.0" />
     <PackageVersion Include="Xunit.DependencyInjection.Logging" Version="9.0.0" />
     <PackageVersion Include="Xunit.DependencyInjection.SkippableFact" Version="9.0.0" />
     <PackageVersion Include="xunit.extensibility.core" Version="2.6.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7">
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.12" />
-    <PackageVersion Include="BitFaster.Caching" Version="2.4.1" />
+    <PackageVersion Include="BitFaster.Caching" Version="2.5.0" />
     <PackageVersion Include="CliWrap" Version="3.6.6" />
     <PackageVersion Include="DynamicData" Version="8.4.1" />
     <PackageVersion Include="GameFinder" Version="4.2.0" />
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="ini-parser-netstandard" Version="2.5.2" />
-    <PackageVersion Include="Mutagen.Bethesda.Skyrim" Version="0.42.0" />
-    <PackageVersion Include="NLog.Extensions.Logging" Version="5.3.8" />
+    <PackageVersion Include="Mutagen.Bethesda.Skyrim" Version="0.44.0" />
+    <PackageVersion Include="NLog.Extensions.Logging" Version="5.3.11" />
     <PackageVersion Include="OneOf" Version="3.0.263" />
     <PackageVersion Include="ReactiveUI.Fody" Version="19.5.41" />
     <PackageVersion Include="Sewer56.BitStream" Version="1.3.0" />
     <PackageVersion Include="Spectre.Console" Version="0.48.0" />
-    <PackageVersion Include="Splat.Microsoft.Extensions.Logging" Version="14.8.12" />
+    <PackageVersion Include="Splat.Microsoft.Extensions.Logging" Version="15.0.1" />
     <PackageVersion Include="TransparentValueObjects" Version="1.0.1" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -66,8 +66,8 @@
     <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="8.0.5" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.1" />
     <PackageVersion Include="AutoFixture" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.Xunit2" Version="4.18.1" />

--- a/src/Games/NexusMods.Games.BethesdaGameStudios/PluginAnalyzer.cs
+++ b/src/Games/NexusMods.Games.BethesdaGameStudios/PluginAnalyzer.cs
@@ -72,8 +72,8 @@ public class PluginAnalyzer
             var frame = new MutagenFrame(readStream);
             var header = readStream.ReadModHeaderFrame(readSafe: true);
 
-            var isLightMaster = (header.Flags & (int)SkyrimModHeader.HeaderFlag.LightMaster) ==
-                                (int)SkyrimModHeader.HeaderFlag.LightMaster;
+            var isLightMaster = (header.Flags & (int)SkyrimModHeader.HeaderFlag.Light) ==
+                                (int)SkyrimModHeader.HeaderFlag.Light;
 
             var masters = header
                 .Masters()


### PR DESCRIPTION
Upgrades almost all the dependencies in the app that are behind. Does not upgrade a SMAPI dependency (so we stay in sync with SMAPI) or the Bannerlord launcer code (that has a breaking change in a minor release)