### PR TITLE
Restored: Navigating away from Deleted Loadout

### DIFF
--- a/src/NexusMods.App.UI/Controls/Spine/SpineViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/Spine/SpineViewModel.cs
@@ -123,8 +123,6 @@ public class SpineViewModel : AViewModel<ISpineViewModel>, ISpineViewModel
                     .DisposeWith(disposables);
 
                 // Navigate away from the Loadout workspace if the Loadout is removed
-                // TODO: Will be fixed along with SPINE in next PR.
-                /*
                 loadoutRepository.Observable
                     .ToObservableChangeSet()
                     .OnUI()
@@ -142,7 +140,7 @@ public class SpineViewModel : AViewModel<ISpineViewModel>, ISpineViewModel
                     }, false)
                     .SubscribeWithErrorLogging()
                     .DisposeWith(disposables);
-                */
+
                 // Update the LeftMenuViewModel when the active workspace changes
                 workspaceController.WhenAnyValue(controller => controller.ActiveWorkspace)
                     .Select(workspace => workspace?.Id)


### PR DESCRIPTION
This PR restores (uncomments) the code that navigates away from the current loadout if the current loadout is the loadout being deleted.

This was previously temporarily commented while the loadout removal detection was being corrected (also Spine bug).
But since @halgari fixed that up at the end of the last week, this is now OK to restore.