### PR TITLE
Fix mod library styling

### DIFF
--- a/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginsPageView.axaml
+++ b/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginsPageView.axaml
@@ -22,18 +22,53 @@
                   x:DataType="fileOriginEntry:IFileOriginEntryViewModel"
                   Width="1">
             <DataGrid.Columns>
-                <DataGridTextColumn Header="{x:Static resources:Language.FileOriginsPageView_NameHeader}" 
-                                    Binding="{CompiledBinding Name}"
-                                    Width="*" />
-                <DataGridTextColumn Header="{x:Static resources:Language.FileOriginsPageView_VersionHeader}" 
-                                    Binding="{CompiledBinding Version}"/>
-                <DataGridTextColumn Header="{x:Static resources:Language.FileOriginsPageView_SizeHeader}" 
-                                    Binding="{CompiledBinding Size}"/>
-                <DataGridTextColumn Header="{x:Static resources:Language.FileOriginsPageView_DownloadedHeader}" 
-                                    Binding="{CompiledBinding DisplayArchiveDate}"/>
-                <DataGridTextColumn Header="{x:Static resources:Language.FileOriginsPageView_AddedHeader}" 
-                                    Binding="{CompiledBinding DisplayLastInstalledDate}"/>
-                <DataGridTemplateColumn Header="{x:Static resources:Language.FileOriginsPageView_ActionHeader}">
+                <DataGridTemplateColumn Header="{x:Static resources:Language.FileOriginsPageView_NameHeader}" 
+                                        Width="*">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate DataType="fileOriginEntry:IFileOriginEntryViewModel">
+                            <TextBlock Classes="BodyMDNormal" 
+                                       VerticalAlignment="Center"
+                                       Text="{CompiledBinding Name}" />
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+                <DataGridTemplateColumn Header="{x:Static resources:Language.FileOriginsPageView_VersionHeader}">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate DataType="fileOriginEntry:IFileOriginEntryViewModel">
+                            <TextBlock Classes="BodyMDNormal" 
+                                       VerticalAlignment="Center"
+                                       Text="{CompiledBinding Version}" />
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+                <DataGridTemplateColumn Header="{x:Static resources:Language.FileOriginsPageView_SizeHeader}">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate DataType="fileOriginEntry:IFileOriginEntryViewModel">
+                            <TextBlock Classes="BodyMDNormal" 
+                                       VerticalAlignment="Center"
+                                       Text="{CompiledBinding Size}" />
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+                <DataGridTemplateColumn Header="{x:Static resources:Language.FileOriginsPageView_DownloadedHeader}">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate DataType="fileOriginEntry:IFileOriginEntryViewModel">
+                            <TextBlock Classes="BodyMDNormal" 
+                                       VerticalAlignment="Center"
+                                       Text="{CompiledBinding DisplayArchiveDate}" />
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+                <DataGridTemplateColumn Header="{x:Static resources:Language.FileOriginsPageView_AddedHeader}">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate DataType="fileOriginEntry:IFileOriginEntryViewModel">
+                            <TextBlock Classes="BodyMDNormal" 
+                                       VerticalAlignment="Center"
+                                       Text="{CompiledBinding DisplayLastInstalledDate}" />
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+                <DataGridTemplateColumn Header="{x:Static resources:Language.FileOriginsPageView_ActionHeader}" Width="175">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate DataType="fileOriginEntry:IFileOriginEntryViewModel">
                             <Button x:Name="AddButton"


### PR DESCRIPTION
Fixes #1378

Old Mod Library text looked like this:
![bad_font](https://github.com/Nexus-Mods/NexusMods.App/assets/654621/6171cfb3-df5f-46c9-b08c-a7a1232a8ba3)

When it should look like this:
![compare](https://github.com/Nexus-Mods/NexusMods.App/assets/654621/733c56c5-8e1c-4191-91c1-349ad2676ef4)

Updated the grid to use template cells with custom styles on the text blocks

Now looks like this:

![good_font](https://github.com/Nexus-Mods/NexusMods.App/assets/654621/ee35b4e6-1f16-4a82-95a4-a849a68779a2)

Also fixed the strange padding on the actions buttons by widening the column a bit:

![actions space](https://github.com/Nexus-Mods/NexusMods.App/assets/654621/772b97ca-e770-4046-bd8c-973ff7025f71)
