### PR TITLE
Fix reified deletes in Apply

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -182,7 +182,8 @@ public class ALoadoutSynchronizer : IStandardizedLoadoutSynchronizer
                 var file = newEntry.Item.Value!;
                 if (file.TryGetAsDeletedFile(out _))
                 {
-                    // File is deleted in the new tree, so nothing to do
+                    // File is deleted in the new tree, so add it toDelete and we're done
+                    toDelete.Add(KeyValuePair.Create(gamePath, entry));
                     continue;
                 }
                 else if (file.Contains(StoredFile.Hash))


### PR DESCRIPTION
Fixes #1357 

Turns out, in my coding binge a few weeks ago, I missed that we store the deletes that need to be performed in a `toDelete` collection then run through later in that method and delete everything. I wasn't adding reified deletes to this list so the deletes were never executed. 

Example using the replication case from #1357 

![explorer_sm3fv3XyEm](https://github.com/Nexus-Mods/NexusMods.App/assets/654621/ad681a5c-4b15-4df4-b82f-f97c5a157a9b)
