### PR TITLE
Fixed: Avatar Icon Not Disappearing on Logout

### DIFF
--- a/src/Networking/NexusMods.Networking.NexusWebApi/LoginManager.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/LoginManager.cs
@@ -147,8 +147,8 @@ public sealed class LoginManager : IDisposable, ILoginManager
     /// </summary>
     public async Task Logout()
     {
-        await _jwtTokenRepository.Delete(_jwtTokenRepository.All.First());
         _cachedUserInfo.Evict();
+        await _jwtTokenRepository.Delete(_jwtTokenRepository.All.First());
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
fixes #1406 

Because we deleted first from `_jwtTokenRepository`, this would cause `_jwtTokenRepository.Observable` to be invoked.
When this calls `Verify`, the item would not be expired because we haven't actually called evict first.

Changing the order of events so we first invalidate the `CachedObject<UserInfo>` fixes the issue.