### PR TITLE
Fix flakey tests

### DIFF
--- a/tests/NexusMods.UI.Tests/AVmTest.cs
+++ b/tests/NexusMods.UI.Tests/AVmTest.cs
@@ -13,7 +13,7 @@ using NexusMods.StandardGameLocators.TestHelpers.StubbedGames;
 
 namespace NexusMods.UI.Tests;
 
-public class AVmTest<TVm> : AUiTest, IAsyncLifetime
+public class AVmTest<TVm> : AUiTest
 where TVm : IViewModelInterface
 {
     protected AbsolutePath DataZipLzma => FileSystem.GetKnownPath(KnownPath.EntryDirectory).Combine("Resources/data_zip_lzma.zip");
@@ -32,7 +32,15 @@ where TVm : IViewModelInterface
     protected IFileOriginRegistry FileOriginRegistry { get; }
 
     private Loadout.Model? _loadout;
-    protected Loadout.Model Loadout => _loadout!;
+    protected Loadout.Model Loadout
+    {
+        get
+        {
+            if (_loadout == null)
+                throw new Exception("Must call CreateLoadout before accessing Loadout.");
+            return _loadout!;
+        }
+    }
 
     public AVmTest(IServiceProvider provider) : base(provider)
     {
@@ -47,7 +55,7 @@ where TVm : IViewModelInterface
 
     protected TVm Vm => _vmWrapper.VM;
 
-    public async Task InitializeAsync()
+    public async Task CreateLoadout()
     {
         _loadout = await ((IGame)Install.Game).Synchronizer.CreateLoadout(Install, "Test");
     }
@@ -67,15 +75,4 @@ where TVm : IViewModelInterface
         _vmWrapper.Dispose();
         return Task.CompletedTask;
     }
-}
-
-public class AVmTest<TVm, TVmInterface> : AVmTest<TVmInterface> where TVmInterface : IViewModelInterface
-where TVm : TVmInterface
-{
-    public AVmTest(IServiceProvider provider) : base(provider) { }
-
-    /// <summary>
-    /// The concrete view model, not the interface.
-    /// </summary>
-    public TVm ConcreteVm => (TVm) Vm;
 }

--- a/tests/NexusMods.UI.Tests/RightContent/LoadoutGridViewModelTests.cs
+++ b/tests/NexusMods.UI.Tests/RightContent/LoadoutGridViewModelTests.cs
@@ -10,6 +10,7 @@ public class LoadoutGridViewModelTests(IServiceProvider provider) : AVmTest<ILoa
     [Fact]
     public async Task AddingModUpdatesTheModSource()
     {
+        await CreateLoadout();
         Vm.LoadoutId = Loadout.LoadoutId;
 
         var ids = await InstallMod(DataZipLzma);
@@ -25,6 +26,7 @@ public class LoadoutGridViewModelTests(IServiceProvider provider) : AVmTest<ILoa
     [Fact]
     public async Task CanDeleteMods()
     {
+        await CreateLoadout();
         Vm.LoadoutId = Loadout.LoadoutId;
         
         var ids = new List<ModId>();


### PR DESCRIPTION
This should fix the flakey tests. In the past we were managing the StubbedGame on every single test. Since the stubbed game was created via DI all the tests in the process were sharing the same stubbed game, and that was somehow causing issues. I made this part of the test framework optional and we only ever use it in two tests, so we may be fine now?