### PR TITLE
Fix slow shutdown

### DIFF
--- a/src/NexusMods.SingleProcess/CliServer.cs
+++ b/src/NexusMods.SingleProcess/CliServer.cs
@@ -148,7 +148,11 @@ public class CliServer : IHostedService, IDisposable
     public async Task StopAsync(CancellationToken cancellationToken)
     {
         if (!_started) return; 
-        await _cancellationTokenSource.CancelAsync();
+        
+        // Ditch this value and don't wait on it because it otherwise blocks the shutdown even when *no-one* is 
+        // waiting on the token
+        _ = _cancellationTokenSource.CancelAsync();
+        
         _tcpListener?.Stop();
         await Task.WhenAll(_runningClients);
         _started = false;


### PR DESCRIPTION
The app takes way to long to shutdown. It turns out it's beause we were awaiting a `.CancelAsync()` call. Even when nothing is attached to this, it takes way to long to complete. This PR discards the task instead of awaiting it.