### PR TITLE
Bugfix: Directory Cleanup on Unix should be Recursive

### DIFF
--- a/src/NexusMods.App/Commandline/CleanupVerbs.cs
+++ b/src/NexusMods.App/Commandline/CleanupVerbs.cs
@@ -149,7 +149,7 @@ internal static class CleanupVerbs
 
             try
             {
-                directory.DeleteDirectory();
+                directory.DeleteDirectory(true);
                 await renderer.Text("Deleted directory: {0}", directory);
             }
             catch (Exception e)

--- a/src/NexusMods.App/Commandline/CleanupVerbs.cs
+++ b/src/NexusMods.App/Commandline/CleanupVerbs.cs
@@ -149,7 +149,7 @@ internal static class CleanupVerbs
 
             try
             {
-                directory.DeleteDirectory(true);
+                directory.DeleteDirectory(recursive: true);
                 await renderer.Text("Deleted directory: {0}", directory);
             }
             catch (Exception e)


### PR DESCRIPTION
This deletion should be recursive, or else it may fail depending on the order of directories obtained from code.

I forgot to set this to recursive when applying PR feedback.
And it slipped past review too.