### PR TITLE
Fixed: Race Condition in early App Logic & CLI Commands

### DIFF
--- a/src/NexusMods.App/Commandline/CleanupVerbs.cs
+++ b/src/NexusMods.App/Commandline/CleanupVerbs.cs
@@ -34,10 +34,6 @@ internal static class CleanupVerbs
         [Injected] ISettingsManager settingsManager,
         [Injected] IFileSystem fileSystem)
     {
-        // Prevent a race condition where `IRepository` is not fully done initializing.
-        // https://github.com/Nexus-Mods/NexusMods.App/issues/1396
-        Thread.Sleep(1000);
-        
         // Step 1: Revert the managed games to their original state
         using var db = conn.Db;
         var managedInstallations = db.Loadouts()

--- a/src/NexusMods.DataModel/GameRegistry/Registry.cs
+++ b/src/NexusMods.DataModel/GameRegistry/Registry.cs
@@ -142,9 +142,23 @@ public class Registry : IGameRegistry, IHostedService
     
     private void WaitUntilInitialized()
     {
-        // This is an IHostedService.
-        // It will be initialized in a background threadpool thread.
+        /*
+            Note(sewer)
+            
+            This is an IHostedService.
+            It will be initialized in a background threadpool thread.
+            
+            Sleeping current thread is OK as this can't be called from
+            the thread initializing this.
+            
+            Extra Note:
+            
+            On Windows the Timer Resolution means we can only sleep
+            at minimum 15.6ms increments unless we request a lower one.
+            
+            So expect ~16ms sleeps there.
+        */
         while (!_isInitialized)
-            Thread.Sleep(100);
+            Thread.Sleep(8);
     }
 }

--- a/src/NexusMods.DataModel/GameRegistry/Registry.cs
+++ b/src/NexusMods.DataModel/GameRegistry/Registry.cs
@@ -133,7 +133,11 @@ public class Registry : IGameRegistry, IHostedService
     }
 
     /// <inheritdoc />
-    public EntityId GetId(GameInstallation installation) => _byInstall[GetKey(installation)];
+    public EntityId GetId(GameInstallation installation)
+    {
+        WaitUntilInitialized();
+        return _byInstall[GetKey(installation)];
+    }
 
     /// <inheritdoc />
     public async Task StartAsync(CancellationToken cancellationToken)

--- a/src/NexusMods.DataModel/GameRegistry/Registry.cs
+++ b/src/NexusMods.DataModel/GameRegistry/Registry.cs
@@ -26,10 +26,7 @@ public class Registry : IGameRegistry, IHostedService
     private readonly ILogger<Registry> _logger;
     private readonly IEnumerable<ILocatableGame> _games;
     private bool _isInitialized;
-    
-#if DEBUG
     private int _initThreadId;
-#endif
 
     /// <inheritdoc />
     public ReadOnlyObservableCollection<GameInstallation> InstalledGames => _installedGames;
@@ -52,9 +49,7 @@ public class Registry : IGameRegistry, IHostedService
 
     private async Task Startup(IEnumerable<ILocatableGame> games)
     {
-#if DEBUG
         _initThreadId = Environment.CurrentManagedThreadId;
-#endif
         var allInstalls = from game in games
             let igame = (IGame)game
             from install in igame.Installations
@@ -170,9 +165,7 @@ public class Registry : IGameRegistry, IHostedService
             
             So expect ~16ms sleeps there.
         */
-#if DEBUG
         Debug.Assert(_initThreadId != Environment.CurrentManagedThreadId, "WaitUntilInitialized called from initialization thread");
-#endif
         while (!_isInitialized)
             Thread.Sleep(8);
     }


### PR DESCRIPTION
fixes #1396

This PR is trivial code wise but warrants an explanation.

This fixes a race condition that can be experienced when running certain CLI commands and App startup logic that accesses the current set of game installs.

To explain concisely:

- App starts `IGameRegistry` in the background thread as an `IHostedService`.
- `IGameRegistry` requires initialization via `StartAsync` method (part of `IHostedService`).
- Access to some parts of `IGameRegistry` before `StartAsync` terminates is invalid.
    - Because `IGameRegistry` is initialized asynchronously.

Some parts of the app may request `IGameRegistry` directly or indirectly via DI.
For example running `db.Loadouts().Select(loadout => loadout.Installation)` is one easy way to trigger the error.

------

## Fundamental Issue

Fundamentally the issue is that items that inherit from `IHostedService` are started in the background.
Therefore it was crucial to evaluate whether other parts of the app may also exhibit from the same issues.

I was considering looking for a more general purpose solution. However, after I had a look around at all the current implementations of `IHostedService`, I concluded that this is the only component that needed patching.

The other `IHostedService` components don't rely on state that's silently initialized in the background, so they are not affected. Most of them just access the DB or something else that's already initialized which is totally ok.

Outside of that, performance was also crucial to consider. The API we're touching here thankfully is not one that is a super hot path. Therefore adding a single additional almost never taken branch to 2 `get` calls has no measurable impact.

This is why I'm comfortable with going for a simple solution.