### PR TITLE
Add left menu badges

### DIFF
--- a/src/NexusMods.App.UI/LeftMenu/Items/IIconViewModel.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Items/IIconViewModel.cs
@@ -9,5 +9,6 @@ public interface IIconViewModel : ILeftMenuItemViewModel
 {
     public string Name { get; set; }
     public IconValue Icon { get; set; }
+    public string[] Badges { get; set; }
     public ReactiveCommand<NavigationInformation, Unit> NavigateCommand { get; set; }
 }

--- a/src/NexusMods.App.UI/LeftMenu/Items/IconView.axaml
+++ b/src/NexusMods.App.UI/LeftMenu/Items/IconView.axaml
@@ -11,28 +11,45 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:reactiveUi="http://reactiveui.net"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:navigation="clr-namespace:NexusMods.App.UI.Controls.Navigation">
+    xmlns:navigation="clr-namespace:NexusMods.App.UI.Controls.Navigation"
+    xmlns:system="clr-namespace:System;assembly=System.Runtime">
+
     <Design.DataContext>
-        <items:IconViewModel Icon="News" Name="Some Text" />
+        <items:IconViewModel Icon="{x:Static icons:IconValues.ModLibrary}" Name="Some Text" />
     </Design.DataContext>
 
-    <navigation:NavigationControl Classes="Invisible" x:Name="ItemButton">
-        <Grid
-            ColumnDefinitions="38, *"
-            Height="40"
-            Width="184">
-            <icons:UnifiedIcon
-                Size="18"
-                Grid.Column="0"
-                Height="18"
-                Width="18"
-                x:Name="LeftIcon" />
+    <navigation:NavigationControl Classes="Invisible" x:Name="ItemButton" Width="184" Height="37">
+        <Grid ColumnDefinitions="Auto, *, *" Margin="8">
+            <icons:UnifiedIcon Grid.Column="0" Size="18" x:Name="LeftIcon" />
             <TextBlock
-                Classes="BodyMDBold"
+                Margin="6 0 0 0"
                 Grid.Column="1"
+                Classes="BodyMDBold"
                 HorizontalAlignment="Left"
                 VerticalAlignment="Center"
                 x:Name="NameText" />
+
+            <ItemsControl Grid.Column="2" x:Name="Badges">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel Spacing="6" Orientation="Horizontal" HorizontalAlignment="Right"/>
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate DataType="{x:Type system:String}">
+                        <Border Width="20" Height="20" CornerRadius="{StaticResource Rounded-full}" Background="{StaticResource PrimaryModerate}">
+                            <TextBlock
+                                x:Name="TextBlock"
+                                TextAlignment="Center"
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                Classes="BodySMBold"
+                                Foreground="{StaticResource NeutralInverted}"
+                                Text="{CompiledBinding }"/>
+                        </Border>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
         </Grid>
     </navigation:NavigationControl>
 

--- a/src/NexusMods.App.UI/LeftMenu/Items/IconView.axaml.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Items/IconView.axaml.cs
@@ -1,9 +1,11 @@
 using System.Reactive.Disposables;
 using Avalonia.ReactiveUI;
+using JetBrains.Annotations;
 using ReactiveUI;
 
 namespace NexusMods.App.UI.LeftMenu.Items;
 
+[UsedImplicitly]
 public partial class IconView : ReactiveUserControl<IIconViewModel>
 {
     public IconView()
@@ -20,6 +22,9 @@ public partial class IconView : ReactiveUserControl<IIconViewModel>
                 .DisposeWith(d);
 
             this.BindCommand(ViewModel, vm => vm.NavigateCommand, view => view.ItemButton)
+                .DisposeWith(d);
+
+            this.OneWayBind(ViewModel, vm => vm.Badges, view => view.Badges.ItemsSource)
                 .DisposeWith(d);
         });
     }

--- a/src/NexusMods.App.UI/LeftMenu/Items/IconViewModel.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Items/IconViewModel.cs
@@ -13,6 +13,7 @@ public class IconViewModel : AViewModel<IIconViewModel>, IIconViewModel
 
     [Reactive] public IconValue Icon { get; set; } = new();
 
-    [Reactive] public ReactiveCommand<NavigationInformation, Unit> NavigateCommand { get; set; } =
-        ReactiveCommand.Create<NavigationInformation>(_ => { }, Observable.Return(false));
+    [Reactive] public string[] Badges { get; set; } = [];
+
+    [Reactive] public ReactiveCommand<NavigationInformation, Unit> NavigateCommand { get; set; } = ReactiveCommand.Create<NavigationInformation>(_ => { }, Observable.Return(false));
 }

--- a/src/NexusMods.App.UI/LeftMenu/Loadout/LoadoutLeftMenuViewModel.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Loadout/LoadoutLeftMenuViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using System.Reactive.Disposables;
+using System.Reactive.Linq;
 using DynamicData.Kernel;
 using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.Diagnostics;
@@ -107,11 +108,18 @@ public class LoadoutLeftMenuViewModel : AViewModel<ILoadoutLeftMenuViewModel>, I
             diagnosticManager
                 .CountDiagnostics(loadoutContext.LoadoutId)
                 .OnUI()
-                .Subscribe(counts =>
+                .Select(counts =>
                 {
-                    var totalCount = counts.NumSuggestions + counts.NumWarnings + counts.NumCritical;
-                    diagnosticItem.Name = $"{Language.LoadoutLeftMenuViewModel_LoadoutLeftMenuViewModel_Diagnostics} ({totalCount})";
+                    var badges = new List<string>(capacity: 3);
+                    if (counts.NumCritical != 0)
+                        badges.Add(counts.NumCritical.ToString());
+                    if (counts.NumWarnings != 0)
+                        badges.Add(counts.NumWarnings.ToString());
+                    if (counts.NumSuggestions != 0)
+                        badges.Add(counts.NumSuggestions.ToString());
+                    return badges.ToArray();
                 })
+                .BindToVM(diagnosticItem, vm => vm.Badges)
                 .DisposeWith(disposable);
         });
     }

--- a/src/NexusMods.App.UI/LeftMenu/Loadout/LoadoutLeftMenuViewModel.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Loadout/LoadoutLeftMenuViewModel.cs
@@ -1,9 +1,13 @@
 using System.Collections.ObjectModel;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
+using DynamicData;
+using DynamicData.Binding;
 using DynamicData.Kernel;
 using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.Diagnostics;
+using NexusMods.Abstractions.FileStore.Downloads;
+using NexusMods.Abstractions.MnemonicDB.Attributes;
 using NexusMods.App.UI.Controls.Navigation;
 using NexusMods.App.UI.LeftMenu.Items;
 using NexusMods.App.UI.Pages.Diagnostics;
@@ -12,7 +16,9 @@ using NexusMods.App.UI.Pages.ModLibrary;
 using NexusMods.App.UI.Resources;
 using NexusMods.App.UI.WorkspaceSystem;
 using NexusMods.Icons;
+using NexusMods.MnemonicDB.Abstractions;
 using ReactiveUI;
+using ReactiveUI.Fody.Helpers;
 
 namespace NexusMods.App.UI.LeftMenu.Loadout;
 
@@ -23,6 +29,8 @@ public class LoadoutLeftMenuViewModel : AViewModel<ILoadoutLeftMenuViewModel>, I
     public ReadOnlyObservableCollection<ILeftMenuItemViewModel> Items { get; }
     public WorkspaceId WorkspaceId { get; }
 
+    [Reactive] private int NewDownloadModelCount { get; set; }
+
     public LoadoutLeftMenuViewModel(
         LoadoutContext loadoutContext,
         WorkspaceId workspaceId,
@@ -30,6 +38,11 @@ public class LoadoutLeftMenuViewModel : AViewModel<ILoadoutLeftMenuViewModel>, I
         IServiceProvider serviceProvider)
     {
         var diagnosticManager = serviceProvider.GetRequiredService<IDiagnosticManager>();
+        var downloadAnalysisRepository = serviceProvider.GetRequiredService<IRepository<DownloadAnalysis.Model>>();
+        var conn = serviceProvider.GetRequiredService<IConnection>();
+
+        var loadout = conn.Db.Get<Abstractions.Loadouts.Loadout.Model>(loadoutContext.LoadoutId.Value);
+        var game = loadout.Installation.Game;
 
         WorkspaceId = workspaceId;
         ApplyControlViewModel = new ApplyControlViewModel(loadoutContext.LoadoutId, serviceProvider);
@@ -57,20 +70,21 @@ public class LoadoutLeftMenuViewModel : AViewModel<ILoadoutLeftMenuViewModel>, I
             Name = Language.FileOriginsPageTitle,
             Icon = IconValues.ModLibrary,
             NavigateCommand = ReactiveCommand.Create<NavigationInformation>(info =>
-                {
-                    var pageData = new PageData
-                    {
-                        FactoryId = FileOriginsPageFactory.StaticId,
-                        Context = new FileOriginsPageContext
-                        {
-                            LoadoutId = loadoutContext.LoadoutId,
-                        },
-                    };
+            {
+                NewDownloadModelCount = 0;
 
-                    var behavior = workspaceController.GetOpenPageBehavior(pageData, info, Optional<PageIdBundle>.None);
-                    workspaceController.OpenPage(WorkspaceId, pageData, behavior);
-                }
-            ),
+                var pageData = new PageData
+                {
+                    FactoryId = FileOriginsPageFactory.StaticId,
+                    Context = new FileOriginsPageContext
+                    {
+                        LoadoutId = loadoutContext.LoadoutId,
+                    },
+                };
+
+                var behavior = workspaceController.GetOpenPageBehavior(pageData, info, Optional<PageIdBundle>.None);
+                workspaceController.OpenPage(WorkspaceId, pageData, behavior);
+            }),
         };
 
         var diagnosticItem = new IconViewModel
@@ -120,6 +134,23 @@ public class LoadoutLeftMenuViewModel : AViewModel<ILoadoutLeftMenuViewModel>, I
                     return badges.ToArray();
                 })
                 .BindToVM(diagnosticItem, vm => vm.Badges)
+                .DisposeWith(disposable);
+
+            downloadAnalysisRepository.Observable
+                .ToObservableChangeSet()
+                .OnUI()
+                .WhereReasonsAre(ListChangeReason.Add, ListChangeReason.AddRange)
+                .Filter(model => FileOriginsPageViewModel.FilterDownloadAnalysisModel(model, game.Domain))
+                .Subscribe(changeSet => NewDownloadModelCount += changeSet.Adds)
+                .DisposeWith(disposable);
+
+            // NOTE(erri120): No new downloads when the Left Menu gets loaded. Must be set here because the observable stream
+            // above will count all existing downloads, which we want to ignore.
+            NewDownloadModelCount = 0;
+
+            this.WhenAnyValue(vm => vm.NewDownloadModelCount)
+                .Select(count => count == 0 ? [] : new[] { count.ToString() })
+                .BindToVM(modLibraryItem, vm => vm.Badges)
                 .DisposeWith(disposable);
         });
     }

--- a/src/NexusMods.App.UI/NexusMods.App.UI.csproj
+++ b/src/NexusMods.App.UI/NexusMods.App.UI.csproj
@@ -571,6 +571,7 @@
       <UpToDateCheckInput Remove="Controls\Buttons\RoundedButton\RoundedButton.axaml" />
       <UpToDateCheckInput Remove="Controls\Buttons\StandardButtonTheme.axaml" />
       <UpToDateCheckInput Remove="RightContent\Home\HomeView.axaml" />
+      <UpToDateCheckInput Remove="Controls\Badge\Badge.axaml" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NexusMods.App.UI/Pages/LoadoutGrid/LoadoutGridViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutGrid/LoadoutGridViewModel.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.FileStore;
 using NexusMods.Abstractions.FileStore.ArchiveMetadata;
+using NexusMods.Abstractions.Games.DTO;
 using NexusMods.Abstractions.Installers;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Loadouts.Ids;
@@ -31,6 +32,7 @@ using NexusMods.App.UI.WorkspaceSystem;
 using NexusMods.Extensions.DynamicData;
 using NexusMods.Icons;
 using NexusMods.MnemonicDB.Abstractions;
+using NexusMods.Networking.Downloaders.Tasks.State;
 using NexusMods.Paths;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
@@ -58,6 +60,7 @@ public class LoadoutGridViewModel : APageViewModel<ILoadoutGridViewModel>, ILoad
 
     [Reactive] public LoadoutId LoadoutId { get; set; }
     [Reactive] public string LoadoutName { get; set; } = "";
+    public GameDomain _gameDomain = GameDomain.DefaultValue;
 
     [Reactive] public ModId[] SelectedItems { get; set; } = Array.Empty<ModId>();
     public ReactiveCommand<NavigationInformation, Unit> ViewModContentsCommand { get; }
@@ -143,6 +146,8 @@ public class LoadoutGridViewModel : APageViewModel<ILoadoutGridViewModel>, ILoad
                 .SelectMany(id => loadoutRepository.Revisions(id.Value))
                 .Select(loadout =>
                 {
+                    _gameDomain = loadout.Installation.Game.Domain;
+
                     var settings = settingsManager.Get<LoadoutGridSettings>();
                     var showGameFiles = settings.ShowGameFiles;
                     var showOverride = settings.ShowOverride;
@@ -166,44 +171,29 @@ public class LoadoutGridViewModel : APageViewModel<ILoadoutGridViewModel>, ILoad
         });
     }
 
-    public Task AddMod(string path)
-    {
-        var file = _fileSystem.FromUnsanitizedFullPath(path);
-        if (!_fileSystem.FileExists(file))
-        {
-            _logger.LogError("File {File} does not exist, not installing mod", file);
-            return Task.CompletedTask;
-        }
-
-        var _ = Task.Run(async () =>
-        {
-            var downloadId = await _fileOriginRegistry.RegisterDownload(file,
-                (tx, id) =>
-                {
-                    tx.Add(id, FilePathMetadata.OriginalName, file.FileName);
-                });
-            await _archiveInstaller.AddMods(LoadoutId, downloadId, file.FileName, token: CancellationToken.None);
-        });
-
-        return Task.CompletedTask;
-    }
+    public Task AddMod(string path) => AddMod(path, installer: null);
 
     public Task AddModAdvanced(string path)
     {
+        var installer = _provider.GetKeyedService<IModInstaller>("AdvancedInstaller");
+        return AddMod(path, installer);
+    }
+
+    private Task AddMod(string path, IModInstaller? installer)
+    {
         var file = _fileSystem.FromUnsanitizedFullPath(path);
         if (!_fileSystem.FileExists(file))
         {
             _logger.LogError("File {File} does not exist, not installing mod", file);
             return Task.CompletedTask;
         }
-        
-        var installer = _provider.GetRequiredKeyedService<IModInstaller>("AdvancedManualInstaller");
 
         var _ = Task.Run(async () =>
         {
             var downloadId = await _fileOriginRegistry.RegisterDownload(file,
                 (tx, id) =>
                 {
+                    tx.Add(id, DownloaderState.GameDomain, _gameDomain);
                     tx.Add(id, FilePathMetadata.OriginalName, file.FileName);
                 });
             await _archiveInstaller.AddMods(LoadoutId, downloadId, file.FileName, token: CancellationToken.None, installer: installer);

--- a/src/NexusMods.App.UI/Pages/LoadoutGrid/LoadoutGridViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutGrid/LoadoutGridViewModel.cs
@@ -146,7 +146,14 @@ public class LoadoutGridViewModel : APageViewModel<ILoadoutGridViewModel>, ILoad
                 .SelectMany(id => loadoutRepository.Revisions(id.Value))
                 .Select(loadout =>
                 {
-                    _gameDomain = loadout.Installation.Game.Domain;
+                    try
+                    {
+                        _gameDomain = loadout.Installation.Game.Domain;
+                    }
+                    catch (Exception)
+                    {
+                        _gameDomain = GameDomain.DefaultValue;
+                    }
 
                     var settings = settingsManager.Get<LoadoutGridSettings>();
                     var showGameFiles = settings.ShowGameFiles;

--- a/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginsPageViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginsPageViewModel.cs
@@ -73,8 +73,12 @@ public class FileOriginsPageViewModel : APageViewModel<IFileOriginsPageViewModel
 
     public static bool FilterDownloadAnalysisModel(DownloadAnalysis.Model model, GameDomain currentGameDomain)
     {
-        if (!model.TryGet(DownloaderState.GameDomain, out var domain)) return false;
-        if (domain != currentGameDomain) return false;
+        // NOTE(erri120, Al12rs): Manually added archives don't have a game domain.
+        if (model.TryGet(DownloaderState.GameDomain, out var domain))
+        {
+            if (domain != currentGameDomain) return false;
+        }
+
         if (model.Contains(StreamBasedFileOriginMetadata.StreamBasedOrigin)) return false;
         return true;
     }

--- a/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginsPageViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginsPageViewModel.cs
@@ -73,12 +73,8 @@ public class FileOriginsPageViewModel : APageViewModel<IFileOriginsPageViewModel
 
     public static bool FilterDownloadAnalysisModel(DownloadAnalysis.Model model, GameDomain currentGameDomain)
     {
-        // NOTE(erri120, Al12rs): Manually added archives don't have a game domain.
-        if (model.TryGet(DownloaderState.GameDomain, out var domain))
-        {
-            if (domain != currentGameDomain) return false;
-        }
-
+        if (!model.TryGet(DownloaderState.GameDomain, out var domain)) return false;
+        if (domain != currentGameDomain) return false;
         if (model.Contains(StreamBasedFileOriginMetadata.StreamBasedOrigin)) return false;
         return true;
     }


### PR DESCRIPTION
Resolves #1424.

Also adds badges for diagnostics instead of using `(count)` as before. Since the left menu doesn't know if the mod library page is currently open and visible, the badge will only be removed if the user actually clicks on the item.