### PR TITLE
Add diagnostic for mods that overwrite game files

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Loadouts/Extensions/LoadoutExtensions.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts/Extensions/LoadoutExtensions.cs
@@ -14,9 +14,11 @@ public static class LoadoutExtensions
 {
     private static IEnumerable<Mod.Model> GetEnabledMods(this Loadout.Model loadout, bool onlyEnabledMods)
     {
-        return onlyEnabledMods
+        var enumerable = onlyEnabledMods
             ? loadout.Mods.Where(mod => mod.Enabled)
             : loadout.Mods;
+
+        return enumerable.Where(mod => mod.Category == ModCategory.Mod);
     }
 
     /// <summary>

--- a/src/Games/NexusMods.Games.StardewValley/Diagnostics.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Diagnostics.cs
@@ -264,4 +264,27 @@ of the mod from {NexusModsLink}.
             .AddValue<NamedLink>("NexusModsLink")
         )
         .Finish();
+
+    [DiagnosticTemplate]
+    [UsedImplicitly]
+    internal static IDiagnosticTemplate ModOverwritesGameFilesTemplate = DiagnosticTemplateBuilder
+        .Start()
+        .WithId(new DiagnosticId(Source, number: 13))
+        .WithTitle("Mod overwrites game files")
+        .WithSeverity(DiagnosticSeverity.Suggestion)
+        .WithSummary("Mod {ModName} overwrites game files")
+        .WithDetails("""
+Mod {Mod} overwrites game files. This can cause compatibility issues and have other
+unintended side-effects. See the {SMAPIWikiLink} for details.
+
+You can resolve this diagnostic by replacing {Mod} with a SMAPI mod that doesn't
+overwrite game files. See the {SMAPIWikiTableLink} for a list of alternatives.
+""")
+        .WithMessageData(messageBuilder => messageBuilder
+            .AddDataReference<ModReference>("Mod")
+            .AddValue<string>("ModName")
+            .AddValue<NamedLink>("SMAPIWikiLink")
+            .AddValue<NamedLink>("SMAPIWikiTableLink")
+        )
+        .Finish();
 }

--- a/src/Games/NexusMods.Games.StardewValley/Emitters/ModOverwritesGameFilesEmitter.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/ModOverwritesGameFilesEmitter.cs
@@ -1,0 +1,38 @@
+using System.Runtime.CompilerServices;
+using NexusMods.Abstractions.Diagnostics;
+using NexusMods.Abstractions.Diagnostics.Emitters;
+using NexusMods.Abstractions.Diagnostics.References;
+using NexusMods.Abstractions.Diagnostics.Values;
+using NexusMods.Abstractions.GameLocators;
+using NexusMods.Abstractions.Loadouts;
+using NexusMods.Abstractions.Loadouts.Extensions;
+
+namespace NexusMods.Games.StardewValley.Emitters;
+
+public class ModOverwritesGameFilesEmitter : ILoadoutDiagnosticEmitter
+{
+    private static readonly NamedLink SMAPIWikiLink = new("SMAPI Wiki", new Uri("https://stardewvalleywiki.com/Modding:Using_XNB_mods"));
+    private static readonly NamedLink SMAPIWikiTableLink = new("SMAPI Wiki", new Uri("https://stardewvalleywiki.com/Modding:Using_XNB_mods#Alternatives_using_Content_Patcher"));
+
+    private static readonly GamePath ContentDirectoryPath = new(LocationId.Game, "Content");
+
+    public async IAsyncEnumerable<Diagnostic> Diagnose(Loadout.Model loadout, [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        await Task.Yield();
+
+        var mods = loadout
+            .GetEnabledMods()
+            .Where(mod => mod.Files.Any(file => file.To.StartsWith(ContentDirectoryPath)))
+            .ToArray();
+
+        foreach (var mod in mods)
+        {
+            yield return Diagnostics.CreateModOverwritesGameFiles(
+                Mod: mod.ToReference(loadout),
+                ModName: mod.Name,
+                SMAPIWikiLink: SMAPIWikiLink,
+                SMAPIWikiTableLink: SMAPIWikiTableLink
+            );
+        }
+    }
+}

--- a/src/Games/NexusMods.Games.StardewValley/Services.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Services.cs
@@ -29,6 +29,7 @@ public static class Services
             .AddSingleton<SMAPIModDatabaseCompatibilityDiagnosticEmitter>()
             .AddSingleton<SMAPIGameVersionDiagnosticEmitter>()
             .AddSingleton<VersionDiagnosticEmitter>()
+            .AddSingleton<ModOverwritesGameFilesEmitter>()
 
             // Attributes
             .AddAttributeCollection(typeof(SMAPIMarker))

--- a/src/Games/NexusMods.Games.StardewValley/StardewValley.cs
+++ b/src/Games/NexusMods.Games.StardewValley/StardewValley.cs
@@ -96,6 +96,7 @@ public class StardewValley : AGame, ISteamGame, IGogGame, IXboxGame
         _serviceProvider.GetRequiredService<MissingSMAPIEmitter>(),
         _serviceProvider.GetRequiredService<SMAPIModDatabaseCompatibilityDiagnosticEmitter>(),
         _serviceProvider.GetRequiredService<VersionDiagnosticEmitter>(),
+        _serviceProvider.GetRequiredService<ModOverwritesGameFilesEmitter>(),
     ];
 
     public override List<IModInstallDestination> GetInstallDestinations(IReadOnlyDictionary<LocationId, AbsolutePath> locations) => ModInstallDestinationHelpers.GetCommonLocations(locations);


### PR DESCRIPTION
Resolves #1478.

![2024-05-29_09-42-52](https://github.com/Nexus-Mods/NexusMods.App/assets/16577545/b2a4bdbe-79b4-4731-beb5-1691feb20e30)
