### PR TITLE
Telemetry/Vogen: Set Default Download Size

### DIFF
--- a/src/NexusMods.App/TelemetryProvider.cs
+++ b/src/NexusMods.App/TelemetryProvider.cs
@@ -79,7 +79,7 @@ internal sealed class TelemetryProvider : ITelemetryProvider, IDisposable
             .ToArray();
     }
 
-    private Size _downloadSize;
+    private Size _downloadSize = Size.Zero;
     private Size GetDownloadSize() => _downloadSize;
 
     public void Dispose()


### PR DESCRIPTION
Fixes a silent exception under the hood.