### PR TITLE
Cleanup: Toolbars in App no longer include unused nesting.

### DIFF
--- a/src/NexusMods.App.UI/Pages/Diff/ApplyDiff/ApplyDiffView.axaml
+++ b/src/NexusMods.App.UI/Pages/Diff/ApplyDiff/ApplyDiffView.axaml
@@ -15,16 +15,14 @@
     
     <Grid RowDefinitions="Auto, *">
         <Border Classes="Toolbar" Grid.Row="0">
-            <Grid ColumnDefinitions="Auto, *">
-                <StackPanel Grid.Column="0" Orientation="Horizontal">
-                    <Button x:Name="RefreshButton">
-                        <StackPanel>
-                            <icons:UnifiedIcon Classes="Refresh" />
-                            <TextBlock Text="{x:Static resources:Language.ApplyDiff_Refresh}" />
-                        </StackPanel>
-                    </Button>
-                </StackPanel>
-            </Grid>
+            <StackPanel>
+                <Button x:Name="RefreshButton">
+                    <StackPanel>
+                        <icons:UnifiedIcon Classes="Refresh" />
+                        <TextBlock Text="{x:Static resources:Language.ApplyDiff_Refresh}" />
+                    </StackPanel>
+                </Button>
+            </StackPanel>
         </Border>
         
         <reactiveUi:ViewModelViewHost Grid.Row="1" x:Name="TreeViewHost"/>

--- a/src/NexusMods.App.UI/Pages/Downloads/InProgressView.axaml
+++ b/src/NexusMods.App.UI/Pages/Downloads/InProgressView.axaml
@@ -19,54 +19,52 @@
     <Grid RowDefinitions="Auto, *">
         <!-- ToolBar -->
         <Border Classes="Toolbar" Grid.Row="0">
-            <Grid ColumnDefinitions="*, Auto">
-                <StackPanel Grid.Column="1">
-                    <Button x:Name="CancelButton">
-                        <StackPanel>
-                            <icons:UnifiedIcon Classes="RemoveCircleOutline" />
-                            <TextBlock Text="{x:Static resources:Language.DownloadInProgressView__Cancel}" />
-                        </StackPanel>
-                    </Button>
-                    <Button x:Name="PauseButton">
-                        <StackPanel>
-                            <icons:UnifiedIcon Classes="PauseCircleOutline" />
-                            <TextBlock Text="{x:Static resources:Language.DownloadInProgressView__Pause}" />
-                        </StackPanel>
-                    </Button>
-                    <Button x:Name="ResumeButton">
-                        <StackPanel>
-                            <icons:UnifiedIcon Classes="PlayCircleOutline" />
-                            <TextBlock Text="{x:Static resources:Language.DownloadInProgressView__Resume}" />
-                        </StackPanel>
-                    </Button>
-                    <Line />
-                    <Button x:Name="ResumeAllButton">
-                        <StackPanel>
-                            <icons:UnifiedIcon Classes="PlayCircleFilled" />
-                            <TextBlock Text="{x:Static resources:Language.DownloadInProgressView__Resume_All}" />
-                        </StackPanel>
-                    </Button>
-                    <Button x:Name="PauseAllButton">
-                        <StackPanel>
-                            <icons:UnifiedIcon Classes="PauseCircleFilled" />
-                            <TextBlock Text="{x:Static resources:Language.DownloadInProgressView__Pause_All}" />
-                        </StackPanel>
-                    </Button>
-                    <Line />
-                    <Button x:Name="ClearButton">
-                        <StackPanel>
-                            <icons:UnifiedIcon Classes="Close" />
-                            <TextBlock Text="{x:Static resources:Language.DownloadInProgressView__Clear}" />
-                        </StackPanel>
-                    </Button>
-                    <Button x:Name="ClearAllButton">
-                        <StackPanel>
-                            <icons:UnifiedIcon Classes="ClearAll" />
-                            <TextBlock Text="{x:Static resources:Language.DownloadInProgressView__Clear_completed}" />
-                        </StackPanel>
-                    </Button>
-                </StackPanel>
-            </Grid>
+           <StackPanel>
+                <Button x:Name="CancelButton">
+                    <StackPanel>
+                        <icons:UnifiedIcon Classes="RemoveCircleOutline" />
+                        <TextBlock Text="{x:Static resources:Language.DownloadInProgressView__Cancel}" />
+                    </StackPanel>
+                </Button>
+                <Button x:Name="PauseButton">
+                    <StackPanel>
+                        <icons:UnifiedIcon Classes="PauseCircleOutline" />
+                        <TextBlock Text="{x:Static resources:Language.DownloadInProgressView__Pause}" />
+                    </StackPanel>
+                </Button>
+                <Button x:Name="ResumeButton">
+                    <StackPanel>
+                        <icons:UnifiedIcon Classes="PlayCircleOutline" />
+                        <TextBlock Text="{x:Static resources:Language.DownloadInProgressView__Resume}" />
+                    </StackPanel>
+                </Button>
+                <Line />
+                <Button x:Name="ResumeAllButton">
+                    <StackPanel>
+                        <icons:UnifiedIcon Classes="PlayCircleFilled" />
+                        <TextBlock Text="{x:Static resources:Language.DownloadInProgressView__Resume_All}" />
+                    </StackPanel>
+                </Button>
+                <Button x:Name="PauseAllButton">
+                    <StackPanel>
+                        <icons:UnifiedIcon Classes="PauseCircleFilled" />
+                        <TextBlock Text="{x:Static resources:Language.DownloadInProgressView__Pause_All}" />
+                    </StackPanel>
+                </Button>
+                <Line />
+                <Button x:Name="ClearButton">
+                    <StackPanel>
+                        <icons:UnifiedIcon Classes="Close" />
+                        <TextBlock Text="{x:Static resources:Language.DownloadInProgressView__Clear}" />
+                    </StackPanel>
+                </Button>
+                <Button x:Name="ClearAllButton">
+                    <StackPanel>
+                        <icons:UnifiedIcon Classes="ClearAll" />
+                        <TextBlock Text="{x:Static resources:Language.DownloadInProgressView__Clear_completed}" />
+                    </StackPanel>
+                </Button>
+            </StackPanel>
         </Border>
 
         <!-- Page Content -->

--- a/src/NexusMods.App.UI/Pages/LoadoutGrid/LoadoutGridView.axaml
+++ b/src/NexusMods.App.UI/Pages/LoadoutGrid/LoadoutGridView.axaml
@@ -17,35 +17,33 @@
     xmlns:markdownRenderer="clr-namespace:NexusMods.App.UI.Controls.MarkdownRenderer">
     <Grid RowDefinitions="Auto, *">
         <Border Grid.Row="0" Classes="Toolbar">
-            <Grid ColumnDefinitions="*, Auto">
-                <StackPanel Grid.Column="1">
-                    <Button x:Name="DeleteModsButton">
-                        <StackPanel>
-                            <icons:UnifiedIcon Classes="Close" />
-                            <TextBlock Text="{x:Static resources:Language.LoadoutGridView__Remove}"/>
-                        </StackPanel>
-                    </Button>
-                    <navigation:NavigationControl x:Name="ViewModFilesButton">
-                        <StackPanel>
-                            <icons:UnifiedIcon Classes="FolderOutline" />
-                            <TextBlock Text="{x:Static resources:Language.LoadoutGridView__View_Files}"/>
-                        </StackPanel>
-                    </navigation:NavigationControl>
-                    <Line/>
-                    <Button x:Name="AddModButton">
-                        <StackPanel>
-                            <icons:UnifiedIcon Classes="PlusCircleOutline" />
-                            <TextBlock Text="{x:Static resources:Language.LoadoutGridView__Add_Mod}"/>
-                        </StackPanel>
-                    </Button>
-                    <Button x:Name="AddModAdvancedButton">
-                        <StackPanel>
-                            <icons:UnifiedIcon Classes="PlusCircleOutline" />
-                            <TextBlock Text="{x:Static resources:Language.LoadoutGridView__Add_Mod_Advanced}"/>
-                        </StackPanel>
-                    </Button>
-                </StackPanel>
-            </Grid>
+            <StackPanel>
+                <Button x:Name="DeleteModsButton">
+                    <StackPanel>
+                        <icons:UnifiedIcon Classes="Close" />
+                        <TextBlock Text="{x:Static resources:Language.LoadoutGridView__Remove}"/>
+                    </StackPanel>
+                </Button>
+                <navigation:NavigationControl x:Name="ViewModFilesButton">
+                    <StackPanel>
+                        <icons:UnifiedIcon Classes="FolderOutline" />
+                        <TextBlock Text="{x:Static resources:Language.LoadoutGridView__View_Files}"/>
+                    </StackPanel>
+                </navigation:NavigationControl>
+                <Line/>
+                <Button x:Name="AddModButton">
+                    <StackPanel>
+                        <icons:UnifiedIcon Classes="PlusCircleOutline" />
+                        <TextBlock Text="{x:Static resources:Language.LoadoutGridView__Add_Mod}"/>
+                    </StackPanel>
+                </Button>
+                <Button x:Name="AddModAdvancedButton">
+                    <StackPanel>
+                        <icons:UnifiedIcon Classes="PlusCircleOutline" />
+                        <TextBlock Text="{x:Static resources:Language.LoadoutGridView__Add_Mod_Advanced}"/>
+                    </StackPanel>
+                </Button>
+            </StackPanel>
         </Border>
         
         <DataGrid Grid.Row="1"

--- a/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginsPageView.axaml
+++ b/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginsPageView.axaml
@@ -7,11 +7,41 @@
                                 xmlns:icons="clr-namespace:NexusMods.Icons;assembly=NexusMods.Icons"
                                 xmlns:resources="clr-namespace:NexusMods.App.UI.Resources"
                                 xmlns:fileOriginEntry="clr-namespace:NexusMods.App.UI.Pages.ModLibrary.FileOriginEntry"
+                                xmlns:navigation="clr-namespace:NexusMods.App.UI.Controls.Navigation"
                                 mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
                                 x:Class="NexusMods.App.UI.Pages.ModLibrary.FileOriginsPageView"
                                 x:CompileBindings="True">
     <Grid RowDefinitions="Auto, *">
+        <!-- Toolbar -->
         <Border Grid.Row="0" Classes="Toolbar">
+            <StackPanel Orientation="Horizontal">
+                <!-- Add Buttons Section -->
+                <Button x:Name="DeleteModsButton">
+                    <StackPanel>
+                        <icons:UnifiedIcon Classes="Close" />
+                        <TextBlock Text="{x:Static resources:Language.LoadoutGridView__Remove}"/>
+                    </StackPanel>
+                </Button>
+                <navigation:NavigationControl x:Name="ViewModFilesButton">
+                    <StackPanel>
+                        <icons:UnifiedIcon Classes="FolderOutline" />
+                        <TextBlock Text="{x:Static resources:Language.LoadoutGridView__View_Files}"/>
+                    </StackPanel>
+                </navigation:NavigationControl>
+                <Line/>
+                <Button x:Name="AddModButton">
+                    <StackPanel>
+                        <icons:UnifiedIcon Classes="PlusCircleOutline" />
+                        <TextBlock Text="{x:Static resources:Language.LoadoutGridView__Add_Mod}"/>
+                    </StackPanel>
+                </Button>
+                <Button x:Name="AddModAdvancedButton">
+                    <StackPanel>
+                        <icons:UnifiedIcon Classes="PlusCircleOutline" />
+                        <TextBlock Text="{x:Static resources:Language.LoadoutGridView__Add_Mod_Advanced}"/>
+                    </StackPanel>
+                </Button>
+            </StackPanel>
         </Border>
 
         <DataGrid Grid.Row="1"

--- a/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginsPageView.axaml
+++ b/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginsPageView.axaml
@@ -14,34 +14,6 @@
     <Grid RowDefinitions="Auto, *">
         <!-- Toolbar -->
         <Border Grid.Row="0" Classes="Toolbar">
-            <StackPanel Orientation="Horizontal">
-                <!-- Add Buttons Section -->
-                <Button x:Name="DeleteModsButton">
-                    <StackPanel>
-                        <icons:UnifiedIcon Classes="Close" />
-                        <TextBlock Text="{x:Static resources:Language.LoadoutGridView__Remove}"/>
-                    </StackPanel>
-                </Button>
-                <navigation:NavigationControl x:Name="ViewModFilesButton">
-                    <StackPanel>
-                        <icons:UnifiedIcon Classes="FolderOutline" />
-                        <TextBlock Text="{x:Static resources:Language.LoadoutGridView__View_Files}"/>
-                    </StackPanel>
-                </navigation:NavigationControl>
-                <Line/>
-                <Button x:Name="AddModButton">
-                    <StackPanel>
-                        <icons:UnifiedIcon Classes="PlusCircleOutline" />
-                        <TextBlock Text="{x:Static resources:Language.LoadoutGridView__Add_Mod}"/>
-                    </StackPanel>
-                </Button>
-                <Button x:Name="AddModAdvancedButton">
-                    <StackPanel>
-                        <icons:UnifiedIcon Classes="PlusCircleOutline" />
-                        <TextBlock Text="{x:Static resources:Language.LoadoutGridView__Add_Mod_Advanced}"/>
-                    </StackPanel>
-                </Button>
-            </StackPanel>
         </Border>
 
         <DataGrid Grid.Row="1"

--- a/src/NexusMods.App.UI/Pages/TextEdit/TextEditorPageView.axaml
+++ b/src/NexusMods.App.UI/Pages/TextEdit/TextEditorPageView.axaml
@@ -14,48 +14,46 @@
 
     <Grid RowDefinitions="Auto, *">
         <Border Grid.Row="0" Classes="Toolbar" BorderThickness="0 0 0 1" BorderBrush="{StaticResource StrokeTranslucentWeakBrush}">
-            <Grid ColumnDefinitions="*, Auto" Margin="24 0">
-                <StackPanel Grid.Column="1">
-                    <TextBlock x:Name="LanguageNameText" Classes="BodyMDNormal ForegroundSubdued" HorizontalAlignment="Right" TextAlignment="Right" VerticalAlignment="Center"/>
+            <StackPanel>
+                <TextBlock x:Name="LanguageNameText" Classes="BodyMDNormal ForegroundSubdued" HorizontalAlignment="Right" TextAlignment="Right" VerticalAlignment="Center"/>
 
-                    <Line/>
+                <Line/>
 
-                    <ComboBox x:Name="ThemeSelector">
-                        <ComboBox.ItemTemplate>
-                            <DataTemplate DataType="{x:Type grammars:ThemeName}">
-                                <ComboBoxItem>
-                                    <TextBlock Text="{CompiledBinding}"/>
-                                </ComboBoxItem>
-                            </DataTemplate>
-                        </ComboBox.ItemTemplate>
-                    </ComboBox>
+                <ComboBox x:Name="ThemeSelector">
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate DataType="{x:Type grammars:ThemeName}">
+                            <ComboBoxItem>
+                                <TextBlock Text="{CompiledBinding}"/>
+                            </ComboBoxItem>
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
 
-                    <Line/>
+                <Line/>
 
-                    <Button x:Name="CopyButton">
-                        <StackPanel>
-                            <icons:UnifiedIcon Classes="Copy" />
-                            <TextBlock Text="Copy"/>
-                        </StackPanel>
-                    </Button>
+                <Button x:Name="CopyButton">
+                    <StackPanel>
+                        <icons:UnifiedIcon Classes="Copy" />
+                        <TextBlock Text="Copy"/>
+                    </StackPanel>
+                </Button>
 
-                    <Button x:Name="PasteButton">
-                        <StackPanel>
-                            <icons:UnifiedIcon Classes="Paste" />
-                            <TextBlock Text="Paste"/>
-                        </StackPanel>
-                    </Button>
+                <Button x:Name="PasteButton">
+                    <StackPanel>
+                        <icons:UnifiedIcon Classes="Paste" />
+                        <TextBlock Text="Paste"/>
+                    </StackPanel>
+                </Button>
 
-                    <Line/>
+                <Line/>
 
-                    <Button x:Name="SaveButton">
-                        <StackPanel>
-                            <icons:UnifiedIcon Classes="Save" />
-                            <TextBlock Text="Save"/>
-                        </StackPanel>
-                    </Button>
-                </StackPanel>
-            </Grid>
+                <Button x:Name="SaveButton">
+                    <StackPanel>
+                        <icons:UnifiedIcon Classes="Save" />
+                        <TextBlock Text="Save"/>
+                    </StackPanel>
+                </Button>
+            </StackPanel>
         </Border>
 
         <avaloniaEdit:TextEditor Grid.Row="1" x:Name="TextEditor"

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Border/Toolbar.xaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Border/Toolbar.xaml
@@ -5,6 +5,7 @@
 
     <Design.PreviewWith >
         <StackPanel Width="920">
+            <!-- With Header -->
             <Border Classes="Toolbar">
                 <Grid ColumnDefinitions="*, Auto">
                     <TextBlock Grid.Column="0" Text="TOOL BAR HEADER"/>
@@ -31,6 +32,32 @@
                     </StackPanel>
                 </Grid>
             </Border>
+
+            <!-- No Header -->
+            <Border Classes="Toolbar">
+                <StackPanel>
+                    <Button>
+                        <StackPanel>
+                            <icons:UnifiedIcon Classes="RemoveCircleOutline"/>
+                            <TextBlock Text="Remove"/>
+                        </StackPanel>
+                    </Button>
+                    <Line Classes="Separator"/>
+                    <Button>
+                        <StackPanel>
+                            <icons:UnifiedIcon Classes="RemoveCircleOutline"/>
+                            <TextBlock Text="Remove All"/>
+                        </StackPanel>
+                    </Button>
+                    <Button IsEnabled="False">
+                        <StackPanel>
+                            <icons:UnifiedIcon Classes="RemoveCircleOutline"/>
+                            <TextBlock Text="Remove All"/>
+                        </StackPanel>
+                    </Button>
+                </StackPanel>
+            </Border>
+
         </StackPanel>
     </Design.PreviewWith>
 
@@ -45,13 +72,19 @@
     <Style Selector="Border.Toolbar > Grid">
         <Setter Property="Margin" Value="24, 0"/>
     </Style>
+    
+    <!-- Only applied when no grid -->
+    <Style Selector="Border.Toolbar > StackPanel">
+        <Setter Property="Margin" Value="24, 0"/>
+        <Setter Property="HorizontalAlignment" Value="Right"/>
+    </Style>
 
-    <Style Selector="Border.Toolbar > Grid > StackPanel">
+    <Style Selector="Border.Toolbar StackPanel">
         <Setter Property="Orientation" Value="Horizontal"/>
         <Setter Property="Spacing" Value="{StaticResource Spacing-2}"/>
     </Style>
 
-    <Style Selector="Border.Toolbar > Grid > StackPanel > Line">
+    <Style Selector="Border.Toolbar StackPanel Line">
         <Setter Property="Width" Value="12"/>
         <Setter Property="Height" Value="32"/>
         <Setter Property="StrokeThickness" Value="1"/>
@@ -60,7 +93,7 @@
         <Setter Property="Stroke" Value="{StaticResource StrokeTranslucentWeakBrush}"/>
     </Style>
 
-    <Style Selector="Border.Toolbar > Grid > TextBlock">
+    <Style Selector="Border.Toolbar TextBlock">
         <Setter Property="Theme" Value="{StaticResource HeadingXSSemiTheme}"/>
         <Setter Property="Foreground" Value="{StaticResource NeutralSubduedBrush}" />
         <Setter Property="VerticalAlignment" Value="Center"/>
@@ -96,7 +129,13 @@
 
     <Style Selector="Border.Toolbar Button TextBlock">
         <Setter Property="Theme" Value="{StaticResource BodyMDNormalTheme}" />
+        <Setter Property="Foreground" Value="{StaticResource NeutralStrongBrush}" />
         <Setter Property="Margin" Value="0" />
     </Style>
 
+    <!-- Note(Sewer): Apparently declaration order matters, so this will not work if placed
+         above the style for non-disabled button. --> 
+    <Style Selector="Border.Toolbar Button:disabled TextBlock">
+        <Setter Property="Foreground" Value="{StaticResource NeutralSubduedBrush}" />
+    </Style>
 </Styles>


### PR DESCRIPTION
![image](https://github.com/Nexus-Mods/NexusMods.App/assets/6697380/1a1d8cde-336a-4bc3-b2c0-7017cfffe13e)

This PR slightly improves how we present toolbars in the various user interface elements.

Previously, inner contents of every single toolbar was declared as something like:

```xaml
<Grid ColumnDefinitions="Auto, *">
    <StackPanel Grid.Column="0" Orientation="Horizontal">
```

(Note: Some views had `Orientation == Horizontal` and some had `Alignment == Right`, both are redundant with our styles)

The first column of the Grid being reserved to represent the title.
However, ***none of our current views*** actually have a title on the toolbar, therefore this can be simplified to:

```xaml
<StackPanel>
```

Greatly reducing nesting, and making UI work easier.

When I was working with moving some of the buttons over from My Mods to Mod Library, I noticed this, and thus have cleaned up this unneeded nesting.