### PR TITLE
Re-added: A minimal dummy Design VM for LoadoutGrid Toolbar Support

### DIFF
--- a/src/NexusMods.App.UI/NexusMods.App.UI.csproj
+++ b/src/NexusMods.App.UI/NexusMods.App.UI.csproj
@@ -556,6 +556,9 @@
         <Compile Update="Overlays\AlphaWarning\AlphaWarningViewModel.cs">
           <DependentUpon>IAlphaWarningViewModel.cs</DependentUpon>
         </Compile>
+        <Compile Update="Pages\LoadoutGrid\LoadoutGridDesignViewModel.cs">
+          <DependentUpon>ILoadoutGridViewModel.cs</DependentUpon>
+        </Compile>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NexusMods.App.UI/Pages/LoadoutGrid/LoadoutGridDesignViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutGrid/LoadoutGridDesignViewModel.cs
@@ -1,0 +1,33 @@
+using System.Collections.ObjectModel;
+using System.Reactive;
+using JetBrains.Annotations;
+using NexusMods.Abstractions.Loadouts.Ids;
+using NexusMods.App.UI.Controls.DataGrid;
+using NexusMods.App.UI.Controls.MarkdownRenderer;
+using NexusMods.App.UI.Controls.Navigation;
+using NexusMods.App.UI.Windows;
+using NexusMods.App.UI.WorkspaceSystem;
+using ReactiveUI;
+
+namespace NexusMods.App.UI.Pages.LoadoutGrid;
+
+/// <summary>
+///     This is a dummy VM to allow for basic designer functionality.
+/// </summary>
+[UsedImplicitly]
+public class LoadoutGridDesignViewModel(IWindowManager windowManager) : APageViewModel<ILoadoutGridViewModel>(windowManager), ILoadoutGridViewModel
+{
+    public ReadOnlyObservableCollection<ModId> Mods { get; } = new([]);
+    public LoadoutId LoadoutId { get; set; }
+    public string LoadoutName { get; } = "Design Loadout";
+    public IMarkdownRendererViewModel MarkdownRendererViewModel { get; } = new MarkdownRendererDesignViewModel();
+    public ReadOnlyObservableCollection<IDataGridColumnFactory<LoadoutColumn>> Columns { get; } = new([]);
+    public ModId[] SelectedItems { get; set; } = [];
+    public ReactiveCommand<NavigationInformation, Unit> ViewModContentsCommand { get; } = ReactiveCommand.Create<NavigationInformation, Unit>(_ => Unit.Default);
+
+    public LoadoutGridDesignViewModel() : this(new DesignWindowManager()) { }
+
+    public Task AddMod(string path) => throw new NotImplementedException();
+    public Task AddModAdvanced(string path) => throw new NotImplementedException();
+    public Task DeleteMods(IEnumerable<ModId> modsToDelete, string commitMessage) => throw new NotImplementedException();
+}

--- a/src/NexusMods.App.UI/Pages/LoadoutGrid/LoadoutGridView.axaml
+++ b/src/NexusMods.App.UI/Pages/LoadoutGrid/LoadoutGridView.axaml
@@ -15,6 +15,9 @@
     xmlns:navigation="clr-namespace:NexusMods.App.UI.Controls.Navigation"
     xmlns:ui="clr-namespace:NexusMods.App.UI"
     xmlns:markdownRenderer="clr-namespace:NexusMods.App.UI.Controls.MarkdownRenderer">
+    <Design.DataContext>
+        <loadoutGrid:LoadoutGridDesignViewModel />
+    </Design.DataContext>
     <Grid RowDefinitions="Auto, *">
         <Border Grid.Row="0" Classes="Toolbar">
             <Grid ColumnDefinitions="*, Auto">


### PR DESCRIPTION
This re-adds a very minimal design VM for LoadoutGrid

![image](https://github.com/Nexus-Mods/NexusMods.App/assets/6697380/17a8ddeb-97f7-4273-92b9-6ba822658640)

The intent here is to have a preview of the toolbar.
In its current state, on the main branch the preview is completely broken, which makes edits more tedious.

----------

Note: When adding this, I kinda thought that there ought to be a better way to do this.

We still haven't had that talk about redundancy of Design ViewModels after standup, but when working on this, I kinda started to think to myself: `Can't we just DI Inject and use the standard ViewModel?`. I haven't yet tried to find out; but maybe that's worth investigating.