### PR TITLE
Fixed: App Uninstallation in Single File Apps & Improve PupNet CI Build Step

### DIFF
--- a/.github/workflows/build-linux-pupnet.yaml
+++ b/.github/workflows/build-linux-pupnet.yaml
@@ -83,9 +83,8 @@ jobs:
           cd ../PupNet
           git clone ${{ inputs.PupNetRepo }} .
           git checkout ${{ inputs.PupNetBranch }}
-          dotnet build -c Release
-          cd PupNet/bin/Release/net8.0
-          dotnet tool install --global --add-source . KuiperZone.PupNet
+          dotnet pack -c Release -o . -p:Version=0.0.0-nma
+          dotnet tool install --global --add-source . KuiperZone.PupNet --version 0.0.0-nma
 
       - name: Create Archive
         if: ${{ inputs.BuildArchive }}

--- a/.github/workflows/build-windows-pupnet.yaml
+++ b/.github/workflows/build-windows-pupnet.yaml
@@ -97,9 +97,8 @@ jobs:
           cd ../PupNet
           git clone ${{ inputs.PupNetRepo }} .
           git checkout ${{ inputs.PupNetBranch }}
-          dotnet build -c Release
-          cd PupNet/bin/Release/net8.0
-          dotnet tool install --global --add-source . KuiperZone.PupNet
+          dotnet pack -c Release -o . -p:Version=0.0.0-nma
+          dotnet tool install --global --add-source . KuiperZone.PupNet --version 0.0.0-nma
 
       - name: Download CodeSignTool
         id: downloadCodeSignTool

--- a/src/NexusMods.App/Commandline/CleanupVerbs.cs
+++ b/src/NexusMods.App/Commandline/CleanupVerbs.cs
@@ -127,7 +127,7 @@ internal static class CleanupVerbs
         await File.WriteAllLinesAsync(directoriesToDeletePath, appDirectories.Select(d => d.ToString()));
 
         // uninstall-helper.ps1 is beside our current EXE.
-        var scriptPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "uninstall-helper.ps1");
+        var scriptPath = Path.Combine(AppContext.BaseDirectory, "uninstall-helper.ps1");
 
         // Execute the PowerShell script
         await Cli.Wrap("powershell")


### PR DESCRIPTION
This is a simple two set of patches:

- Replacing `Assembly.GetExecutingAssembly().Location`
    - Single-File Apps don't have an assembly location. (Breaking change)
    - So we use the folder used for resolving assemblies instead.
- Ensuring CI uses our locally built PupNet
    - Depending on how NuGet is configured on Actions runner, there's a technical possibility it could install a release from `nuget.org`.
    - So to avoid this, we build and install a custom version.

You can find a test CI Run at https://github.com/Sewer56/NexusMods.App/actions/runs/9302098600 . Binary  from that CI run is also on Slack.