### PR TITLE
Moved: Setting `SuggestedName` into Analyze Step instead of Add Mod Step

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.FileStore/IFileOriginRegistry.cs
+++ b/src/Abstractions/NexusMods.Abstractions.FileStore/IFileOriginRegistry.cs
@@ -17,37 +17,38 @@ public interface IFileOriginRegistry
     /// <summary>
     /// Register a download with the registry, sourced from a stream, returns a download id that can be used to retrieve the download later.
     /// </summary>
-    public ValueTask<DownloadId> RegisterDownload(IStreamFactory factory, MetadataFn metaDataFn, CancellationToken token = default);
+    public ValueTask<DownloadId> RegisterDownload(IStreamFactory factory, MetadataFn metaDataFn, string modName, CancellationToken token = default);
 
     /// <summary>
     /// Register a download with the registry, returns a download id that can be used to retrieve the download later.
     /// </summary>
-    public ValueTask<DownloadId> RegisterDownload(AbsolutePath path, MetadataFn metaDataFn, CancellationToken token = default);
+    public ValueTask<DownloadId> RegisterDownload(AbsolutePath path, MetadataFn metaDataFn, string modName, CancellationToken token = default);
     
     /// <summary>
     /// Register a download with the registry, using the given entity id as the download id.
     /// </summary>
-    public ValueTask<DownloadId> RegisterDownload(AbsolutePath path, EntityId downloadId, CancellationToken token = default);
+    public ValueTask<DownloadId> RegisterDownload(AbsolutePath path, EntityId downloadId, string modName, CancellationToken token = default);
 
     /// <summary>
     /// Register a download with the registry, returns a download id that can be used to retrieve the download later,
     /// the name and source information are inferred from the path.
     /// </summary>
     /// <param name="path"></param>
+    /// <param name="modName"></param>
     /// <param name="token"></param>
     /// <returns></returns>
-    public ValueTask<DownloadId> RegisterDownload(AbsolutePath path, CancellationToken token = default)
+    public ValueTask<DownloadId> RegisterDownload(AbsolutePath path, string modName, CancellationToken token = default)
     {
         return RegisterDownload(path, (tx, id) =>
         {
             tx.Add(id, FilePathMetadata.OriginalName, path.FileName);
-        }, token);
+        }, modName,token);
     }
 
     /// <summary>
     /// Indexes an already extracted download, returns a download id that can be used to retrieve the download later.
     /// </summary>
-    public ValueTask<DownloadId> RegisterFolder(AbsolutePath path, MetadataFn metaDataFn, CancellationToken token = default);
+    public ValueTask<DownloadId> RegisterFolder(AbsolutePath path, MetadataFn metaDataFn, string modName, CancellationToken token = default);
 
     /// <summary>
     /// Get the analysis of a download

--- a/src/Abstractions/NexusMods.Abstractions.Installers/IArchiveInstaller.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Installers/IArchiveInstaller.cs
@@ -21,11 +21,11 @@ public interface IArchiveInstaller
     /// standard way to "install" a mod. If the installer is not provided, the installers on the loadout's game
     /// will be tried, in the order they are defined, otherwise the provided installer will be used.
     /// </summary>
-    public Task<ModId[]> AddMods(LoadoutId loadoutId, DownloadId downloadId, string? defaultModName = null, IModInstaller? installer = null, CancellationToken token = default);
+    public Task<ModId[]> AddMods(LoadoutId loadoutId, DownloadId downloadId, IModInstaller? installer = null, CancellationToken token = default);
 
     /// <summary>
     /// Installs a <see cref="DownloadAnalysis.Model"/> to a loadout, potentially adding one or more mods.
     /// If the installer is not provided, the installers on the loadout's game will be tried, in the order they are defined.
     /// </summary>
-    public Task<ModId[]> AddMods(LoadoutId loadoutId, DownloadAnalysis.Model downloadAnalysis, string? defaultModName = null, IModInstaller? installer = null, CancellationToken token = default);
+    public Task<ModId[]> AddMods(LoadoutId loadoutId, DownloadAnalysis.Model downloadAnalysis, IModInstaller? installer = null, CancellationToken token = default);
 }

--- a/src/Games/NexusMods.Games.StardewValley/Installers/SMAPIInstaller.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Installers/SMAPIInstaller.cs
@@ -120,6 +120,7 @@ public class SMAPIInstaller : AModInstaller
                 installDataFile.Item.StreamFactory!,
                 (tx, id) => 
                     tx.Add(id, FilePathMetadata.OriginalName, installDataFile.Item.FileName),
+                "SMAPI: Stardew Modding API",
                 cancellationToken);
         }
         else

--- a/src/Games/NexusMods.Games.TestHarness/Verbs/StressTest.cs
+++ b/src/Games/NexusMods.Games.TestHarness/Verbs/StressTest.cs
@@ -93,7 +93,7 @@ public class StressTest
                         var list = await game.Synchronizer.CreateLoadout(install);
                         var downloadId = await fileOriginRegistry.RegisterDownload(tmpPath, 
                             (tx, id) => tx.Add(id, FilePathMetadata.OriginalName, tmpPath.Path.Name),
-                            token);
+                            tmpPath.Path.Name, token);
                         await archiveInstaller.AddMods(LoadoutId.From(list.Id), downloadId, token: token);
 
                         results.Add((file.FileName, mod.ModId, file.FileId, hash, true, null));

--- a/src/Networking/NexusMods.Networking.Downloaders/Tasks/ADownloadTask.cs
+++ b/src/Networking/NexusMods.Networking.Downloaders/Tasks/ADownloadTask.cs
@@ -204,12 +204,7 @@ public abstract class ADownloadTask : ReactiveObject, IDownloadTask
     {
         try
         {
-            // Set the download's name for the mod library
-            using var tx = Connection.BeginTransaction();
-            tx.Add(PersistentState.Id, DownloadAnalysis.SuggestedName, PersistentState.FriendlyName);
-            await tx.Commit();
-            
-            await FileOriginRegistry.RegisterDownload(DownloadLocation, PersistentState.Id);
+            await FileOriginRegistry.RegisterDownload(DownloadLocation, PersistentState.Id, PersistentState.FriendlyName);
         }
         catch (Exception ex)
         {

--- a/src/NexusMods.App.Cli/ProtocolVerbs.cs
+++ b/src/NexusMods.App.Cli/ProtocolVerbs.cs
@@ -65,13 +65,13 @@ public static class ProtocolVerbs
             await httpDownloader.DownloadAsync(new[] { new HttpRequestMessage(HttpMethod.Get, uri) },
                 temporaryPath, null, null, token);
 
+            var nameToSet = string.IsNullOrWhiteSpace(modName) ? "Unknown" : modName;
             var downloadId = await fileOriginRegistry.RegisterDownload(temporaryPath,
                 (tx, id) =>
             {
                 tx.Add(id, FilePathMetadata.OriginalName, temporaryPath.Path.Name);
-            }, token);
-            await archiveInstaller.AddMods(loadout.LoadoutId, downloadId,
-                string.IsNullOrWhiteSpace(modName) ? null : modName, token: token);
+            }, nameToSet, token);
+            await archiveInstaller.AddMods(loadout.LoadoutId, downloadId, token: token);
             return 0;
         });
     }

--- a/src/NexusMods.App.Cli/Types/DownloadHandlers/NxmDownloadProtocolHandler.cs
+++ b/src/NexusMods.App.Cli/Types/DownloadHandlers/NxmDownloadProtocolHandler.cs
@@ -58,7 +58,7 @@ public class NxmDownloadProtocolHandler : IDownloadProtocolHandler
             (tx, id) =>
             {
                 tx.Add(id, FilePathMetadata.OriginalName, tempPath.Path.Name);
-            }, token);
-        await _archiveInstaller.AddMods(loadout.LoadoutId, downloadId, modName, token:token);
+            }, modName, token);
+        await _archiveInstaller.AddMods(loadout.LoadoutId, downloadId, token:token);
     }
 }

--- a/src/NexusMods.App.UI/Pages/LoadoutGrid/LoadoutGridViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutGrid/LoadoutGridViewModel.cs
@@ -217,8 +217,8 @@ public class LoadoutGridViewModel : APageViewModel<ILoadoutGridViewModel>, ILoad
                 {
                     tx.Add(id, DownloaderState.GameDomain, _gameDomain);
                     tx.Add(id, FilePathMetadata.OriginalName, file.FileName);
-                });
-            await _archiveInstaller.AddMods(LoadoutId, downloadId, file.FileName, token: CancellationToken.None, installer: installer);
+                }, file.FileName);
+            await _archiveInstaller.AddMods(LoadoutId, downloadId, token: CancellationToken.None, installer: installer);
         });
 
         return Task.CompletedTask;

--- a/src/NexusMods.DataModel/ArchiveInstaller.cs
+++ b/src/NexusMods.DataModel/ArchiveInstaller.cs
@@ -10,10 +10,8 @@ using NexusMods.Abstractions.IO;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Loadouts.Ids;
 using NexusMods.Abstractions.Loadouts.Mods;
-using NexusMods.Abstractions.NexusWebApi.DTOs;
 using NexusMods.Extensions.BCL;
 using NexusMods.MnemonicDB.Abstractions;
-using NexusMods.MnemonicDB.Abstractions.Models;
 using File = NexusMods.Abstractions.Loadouts.Files.File;
 
 namespace NexusMods.DataModel;
@@ -49,7 +47,7 @@ public class ArchiveInstaller : IArchiveInstaller
     }
     
     /// <inheritdoc />
-    public async Task<ModId[]> AddMods(LoadoutId loadoutId, DownloadAnalysis.Model download, string? defaultModName = null, IModInstaller? installer = null, CancellationToken token = default)
+    public async Task<ModId[]> AddMods(LoadoutId loadoutId, DownloadAnalysis.Model download, IModInstaller? installer = null, CancellationToken token = default)
     {
         // Get the loadout and create the mod, so we can use it in the job.
         var useCustomInstaller = installer != null;
@@ -57,13 +55,7 @@ public class ArchiveInstaller : IArchiveInstaller
 
         var archiveName = download.TryGet(FilePathMetadata.OriginalName, out var originalName) ? originalName.ToString() : null;
         var suggestedName = download.TryGet(DownloadAnalysis.SuggestedName, out var outSuggestedName) ? outSuggestedName : null;
-
-        var modName = defaultModName ?? suggestedName ?? archiveName ?? "<unknown>";
-        {
-            using var dlTx = _conn.BeginTransaction();
-            dlTx.Add(download.Id, DownloadAnalysis.SuggestedName, modName);
-            await dlTx.Commit();
-        }
+        var modName = suggestedName ?? archiveName ?? "Unknown";
         
         ModId modId;
         Mod.Model baseMod;
@@ -218,12 +210,11 @@ public class ArchiveInstaller : IArchiveInstaller
     }
 
     /// <inheritdoc />
-    public async Task<ModId[]> AddMods(LoadoutId loadoutId, DownloadId downloadId, string? defaultModName = null, 
-        IModInstaller? installer = null, CancellationToken token = default)
+    public async Task<ModId[]> AddMods(LoadoutId loadoutId, DownloadId downloadId, IModInstaller? installer = null, CancellationToken token = default)
     {
         var download = _fileOriginRegistry.Get(downloadId);
         
-        return await AddMods(loadoutId, download, defaultModName, installer, token);
+        return await AddMods(loadoutId, download, installer, token);
     }
 
 }

--- a/src/NexusMods.DataModel/CommandLine/Verbs/ArchiveVerbs.cs
+++ b/src/NexusMods.DataModel/CommandLine/Verbs/ArchiveVerbs.cs
@@ -26,7 +26,8 @@ internal static class ArchiveVerbs
                 (tx, id) =>
                 {
                     tx.Add(id, FilePathMetadata.OriginalName, inputFile.Name);
-                }, token);
+                }, 
+                inputFile.FileName, token);
             var metadata = fileOriginRegistry.Get(downloadId);
             return metadata.Contents.Select(kv =>
             {

--- a/src/NexusMods.DataModel/CommandLine/Verbs/LoadoutManagementVerbs.cs
+++ b/src/NexusMods.DataModel/CommandLine/Verbs/LoadoutManagementVerbs.cs
@@ -129,9 +129,9 @@ public static class LoadoutManagementVerbs
         return await renderer.WithProgress(token, async () =>
         {
             var downloadId = await fileOriginRegistry.RegisterDownload(file, 
-            (tx, id) => tx.Add(id, FilePathMetadata.OriginalName, file.FileName), token);
+            (tx, id) => tx.Add(id, FilePathMetadata.OriginalName, file.FileName), name, token);
 
-            await archiveInstaller.AddMods(loadout.LoadoutId, downloadId, name, token: token);
+            await archiveInstaller.AddMods(loadout.LoadoutId, downloadId, token: token);
             return 0;
         });
     }

--- a/tests/Games/NexusMods.Games.FOMOD.Tests/FomodXmlInstallerTests.cs
+++ b/tests/Games/NexusMods.Games.FOMOD.Tests/FomodXmlInstallerTests.cs
@@ -24,7 +24,7 @@ public class FomodXmlInstallerTests : AModInstallerTest<SkyrimSpecialEdition, Fo
         var relativePath = $"TestCasesPacked/{testCase}.fomod";
         var fullPath = FileSystem.GetKnownPath(KnownPath.EntryDirectory)
             .Combine(relativePath);
-        var downloadId = await FileOriginRegistry.RegisterDownload(fullPath);
+        var downloadId = await FileOriginRegistry.RegisterDownload(fullPath, "");
 
         var analysis = FileOriginRegistry.Get(downloadId);
         var installer = FomodXmlInstaller.Create(ServiceProvider, new GamePath(LocationId.Game, ""));

--- a/tests/Games/NexusMods.Games.TestFramework/AModInstallerTest.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/AModInstallerTest.cs
@@ -86,9 +86,9 @@ public abstract class AModInstallerTest<TGame, TModInstaller> : AGameTest<TGame>
         AbsolutePath archivePath,
         CancellationToken cancellationToken = default)
     {
-        var downloadId = await FileOriginRegistry.RegisterDownload(archivePath, cancellationToken);
+        var downloadId = await FileOriginRegistry.RegisterDownload(archivePath, "test", cancellationToken);
         
-        var ids = await ArchiveInstaller.AddMods(Loadout.LoadoutId, downloadId, "test", ModInstaller, cancellationToken);
+        var ids = await ArchiveInstaller.AddMods(Loadout.LoadoutId, downloadId, ModInstaller, cancellationToken);
         var db = Connection.Db;
         return ids.Select(id => db.Get<Mod.Model>((EntityId)id)).ToArray();
     }

--- a/tests/NexusMods.DataModel.Tests/FileOriginRegistryTests.cs
+++ b/tests/NexusMods.DataModel.Tests/FileOriginRegistryTests.cs
@@ -28,7 +28,7 @@ public class FileOriginRegistryTests(IServiceProvider provider)
             ServiceProvider.GetRequiredService<IFileHashCache>());
         
         // Act
-        var result = await sut.RegisterDownload(DataZipLzma, CancellationToken.None);
+        var result = await sut.RegisterDownload(DataZipLzma, "data.zip.lzma", CancellationToken.None);
 
         // Assert
         var analysis = FileOriginRegistry.Get(result);
@@ -61,8 +61,8 @@ public class FileOriginRegistryTests(IServiceProvider provider)
 
         
         // Act
-        await sut.RegisterDownload(DataZipLzma, CancellationToken.None);
-        await sut.RegisterDownload(DataZipLzma, CancellationToken.None);
+        await sut.RegisterDownload(DataZipLzma, "Mod V1", CancellationToken.None);
+        await sut.RegisterDownload(DataZipLzma, "Mod V1", CancellationToken.None);
 
         // BackupFiles should only have been called once if all files were duplicate.
         await fileStore.Received(1)
@@ -99,10 +99,10 @@ public class FileOriginRegistryTests(IServiceProvider provider)
             }),
             Arg.Any<CancellationToken>());
 
-        await sut.RegisterDownload(DataZipLzma, CancellationToken.None);
+        await sut.RegisterDownload(DataZipLzma, "Mod V1", CancellationToken.None);
 
         // Act: We now add Mod V2
-        await sut.RegisterDownload(DataZipLzmaWithExtraFile, CancellationToken.None);
+        await sut.RegisterDownload(DataZipLzmaWithExtraFile, "Mod V2", CancellationToken.None);
 
         // Assert
         // Ensure there were at least two calls

--- a/tests/NexusMods.DataModel.Tests/Harness/ADataModelTest.cs
+++ b/tests/NexusMods.DataModel.Tests/Harness/ADataModelTest.cs
@@ -117,8 +117,8 @@ public abstract class ADataModelTest<T> : IDisposable, IAsyncLifetime
 
     protected async Task<ModId[]> AddMods(LoadoutId loadoutId, AbsolutePath path, string? name = null)
     {
-        var downloadId = await FileOriginRegistry.RegisterDownload(path, Token);
-        var result = await ArchiveInstaller.AddMods(loadoutId, downloadId, name, token: Token);
+        var downloadId = await FileOriginRegistry.RegisterDownload(path, name ?? path.FileName, Token);
+        var result = await ArchiveInstaller.AddMods(loadoutId, downloadId, token: Token);
         // Refresh the loadout to get the new mods, as a convenience.
         Refresh(ref BaseLoadout);
         return result;
@@ -134,8 +134,9 @@ public abstract class ADataModelTest<T> : IDisposable, IAsyncLifetime
     /// returning the download id.
     /// </summary>
     /// <param name="files"></param>
+    /// <param name="modName"></param>
     /// <returns></returns>
-    protected async Task<DownloadId> RegisterDownload(params (string Name, string Data)[] files)
+    protected async Task<DownloadId> RegisterDownload(string modName, params (string Name, string Data)[] files)
     {
         await using var tmpFile = TemporaryFileManager.CreateFile(KnownExtensions.Zip);
         using var memoryStream = new MemoryStream();
@@ -156,7 +157,7 @@ public abstract class ADataModelTest<T> : IDisposable, IAsyncLifetime
             await memoryStream.CopyToAsync(fileStream, Token);
         }
 
-        return await FileOriginRegistry.RegisterDownload(tmpFile.Path, Token);
+        return await FileOriginRegistry.RegisterDownload(tmpFile.Path, modName, Token);
     }
 
     /// <summary>
@@ -164,8 +165,8 @@ public abstract class ADataModelTest<T> : IDisposable, IAsyncLifetime
     /// </summary>
     protected async Task<ModId> AddMod(string modName, params (string Name, string Data)[] files)
     {
-        var downloadId = await RegisterDownload(files);
-        var modIds = await ArchiveInstaller.AddMods(LoadoutId.From(BaseLoadout.Id), downloadId, modName, token: Token);
+        var downloadId = await RegisterDownload(modName, files);
+        var modIds = await ArchiveInstaller.AddMods(LoadoutId.From(BaseLoadout.Id), downloadId, token: Token);
         return modIds.First();
     }
 

--- a/tests/NexusMods.UI.Tests/AVmTest.cs
+++ b/tests/NexusMods.UI.Tests/AVmTest.cs
@@ -70,7 +70,7 @@ where TVm : IViewModelInterface
             (tx, id) =>
             {
                 tx.Add(id, FilePathMetadata.OriginalName, path.FileName);
-            });
+            }, path.FileName);
         return await ArchiveInstaller.AddMods(Loadout.LoadoutId, downloadId);
     }
 


### PR DESCRIPTION
This is a change required for the new library design

https://www.figma.com/design/Ntr9PttR5VrqpTRwwZHzLu/%F0%9F%93%B1-Mod-list---adding%2Fremoving-mods?node-id=3474-29727&t=ac9JhBPo7ATUddi9-1

Previously, a Downloaded File would only become valid once it has been added to a loadout. This is because its `SuggestedName` property has not yet been set, thus the `Repository`'s `IsValid` method would fail, as not all attributes are available.

In simpler words: `Registering a file would not show it in Mod Library`.

This PR moves the logic to set the `SuggestedName` from the `Add Mod to Loadout` step to the `Register Download` step.
This way, registering a file shows it in mod library.