### PR TITLE
Renamed: Key for AdvancedManualInstaller

### DIFF
--- a/src/NexusMods.App.UI/Pages/LoadoutGrid/LoadoutGridViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutGrid/LoadoutGridViewModel.cs
@@ -197,7 +197,7 @@ public class LoadoutGridViewModel : APageViewModel<ILoadoutGridViewModel>, ILoad
 
     public Task AddModAdvanced(string path)
     {
-        var installer = _provider.GetKeyedService<IModInstaller>("AdvancedInstaller");
+        var installer = _provider.GetKeyedService<IModInstaller>("AdvancedManualInstaller");
         return AddMod(path, installer);
     }
 


### PR DESCRIPTION
This fixes the key from `AdvancedInstaller` to `AdvancedManualInstaller`.
The key got renamed alongside the class at some point, but it seems not all cases were renamed.

Fixes
- #1527

In simpler terms, AdvancedInstaller now shows up when you hit `Add Advanced` in the UI