### PR TITLE
Remove preprocessor directives

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Telemetry/Counters.ActiveUsers.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Telemetry/Counters.ActiveUsers.cs
@@ -18,15 +18,4 @@ public static partial class Counters
             )
         );
     }
-
-    /// <summary>
-    /// Creates counter for the number of active users.
-    /// </summary>
-    public static void CreateActiveUsersCounter(this IMeterConfig meterConfig)
-    {
-        GetMeter(meterConfig).CreateObservableUpDownCounter(
-            name: InstrumentConstants.NameActiveUsers,
-            observeValue: static () => 1
-        );
-    }
 }

--- a/src/NexusMods.App.BuildInfo/ApplicationConstants.cs
+++ b/src/NexusMods.App.BuildInfo/ApplicationConstants.cs
@@ -19,12 +19,27 @@ public static class ApplicationConstants
                 var sha = GetSha(informationalVersion);
                 CommitHash = sha;
             }
-
-            Version = Assembly.GetExecutingAssembly().GetName().Version!;
         }
         catch (Exception)
         {
-            Version = new Version(0, 0, 1);
+            // ignored
+        }
+
+        var debugVersion = new Version(0, 0, 1);
+        if (CompileConstants.IsDebug)
+        {
+            Version = debugVersion;
+        }
+        else
+        {
+            try
+            {
+                Version = Assembly.GetExecutingAssembly().GetName().Version ?? debugVersion;
+            }
+            catch (Exception)
+            {
+                Version = debugVersion;
+            }
         }
     }
 

--- a/src/NexusMods.App.BuildInfo/CompileConstants.cs
+++ b/src/NexusMods.App.BuildInfo/CompileConstants.cs
@@ -25,12 +25,13 @@ public static class CompileConstants
 #endif
 
     /// <summary>
-    /// True if the app is running with compile settings
+    /// True if the application is running in debug mode.
     /// </summary>
+    public static readonly bool IsDebug =
 #if DEBUG
-    public static readonly bool IsDebug = true;
+    true;
 #else
-    public static readonly bool IsDebug = false;
+    false;
 #endif
 }
 

--- a/src/NexusMods.App.UI/ExperimentalSettings.cs
+++ b/src/NexusMods.App.UI/ExperimentalSettings.cs
@@ -1,4 +1,6 @@
+using JetBrains.Annotations;
 using NexusMods.Abstractions.Settings;
+using NexusMods.App.BuildInfo;
 
 namespace NexusMods.App.UI;
 
@@ -10,18 +12,12 @@ public record ExperimentalSettings : ISettings
     /// <summary>
     /// Enables games that are not enabled by default.
     /// </summary>
-    public bool EnableAllGames { get; init; } 
-#if DEBUG
-        = true;
-#endif
-    
+    public bool EnableAllGames { get; [UsedImplicitly] set; } = CompileConstants.IsDebug;
+
     /// <summary>
     /// Enables the ability to have multiple loadouts within the app.
     /// </summary>
-    public bool EnableMultipleLoadouts { get; init; }
-#if DEBUG
-        = true;
-#endif
+    public bool EnableMultipleLoadouts { get; [UsedImplicitly] set; } = CompileConstants.IsDebug;
 
     public static ISettingsBuilder Configure(ISettingsBuilder settingsBuilder)
     {
@@ -31,22 +27,19 @@ public record ExperimentalSettings : ISettings
         return settingsBuilder
             .ConfigureStorageBackend<ExperimentalSettings>(builder => builder.UseJson())
             .AddToUI<ExperimentalSettings>(builder => builder
-                .AddPropertyToUI(x => x.EnableAllGames, propertybuilder => propertybuilder
+                .AddPropertyToUI(x => x.EnableAllGames, propertyBuilder => propertyBuilder
                     .AddToSection(sectionId)
                     .WithDisplayName("[Unsupported] Enable Unsupported Games")
                     .WithDescription("When set, 'work-in-progress' games that are not yet fully supported will be enabled in the UI.")
                     .UseBooleanContainer()
                     .RequiresRestart()
                 )
-                // Disabled until first Alpha Release ships.
-#if DEBUG
-                .AddPropertyToUI(x => x.EnableMultipleLoadouts, propertybuilder => propertybuilder
+                .AddPropertyToUI(x => x.EnableMultipleLoadouts, propertyBuilder => propertyBuilder
                     .AddToSection(sectionId)
                     .WithDisplayName("(Experimental) Enable Multiple Loadouts")
                     .WithDescription("When set, you will be able to create multiple loadouts for a game.")
                     .UseBooleanContainer()
                 )
-#endif
             );
     }
 }

--- a/src/NexusMods.App/TelemetryProvider.cs
+++ b/src/NexusMods.App/TelemetryProvider.cs
@@ -7,6 +7,7 @@ using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Loadouts.Mods;
 using NexusMods.Abstractions.MnemonicDB.Attributes;
 using NexusMods.Abstractions.Telemetry;
+using NexusMods.App.BuildInfo;
 using NexusMods.App.UI;
 using NexusMods.Networking.NexusWebApi;
 using NexusMods.Paths;
@@ -39,11 +40,7 @@ internal sealed class TelemetryProvider : ITelemetryProvider, IDisposable
 
     public void ConfigureMetrics(IMeterConfig meterConfig)
     {
-#if RELEASE
-        meterConfig.CreateActiveUsersPerVersionCounter(BuildInfo.ApplicationConstants.Version);
-#else
-        meterConfig.CreateActiveUsersCounter();
-#endif
+        meterConfig.CreateActiveUsersPerVersionCounter(ApplicationConstants.Version);
         meterConfig.CreateUsersPerOSCounter();
         meterConfig.CreateUsersPerLanguageCounter();
         meterConfig.CreateUsersPerMembershipCounter(GetMembership);


### PR DESCRIPTION
Also updates the telemetry for active users to always send a version. Using `0.0.1` to mean "debug version".