### PR TITLE
Feat: Bring Window to Foreground on Login

### DIFF
--- a/src/NexusMods.App.UI/Windows/IMainWindowViewModel.cs
+++ b/src/NexusMods.App.UI/Windows/IMainWindowViewModel.cs
@@ -16,5 +16,5 @@ public interface IMainWindowViewModel : IViewModelInterface, IWorkspaceWindow
     ///     Normally this would go into something like <see cref="IWorkspaceWindow"/>,
     ///     however there aren't enough use cases yet to justify this.
     /// </remarks>
-    ReactiveCommand<Unit, Unit> ActivateCommand { get; }
+    ReactiveCommand<Unit, Unit> ActivateWindowCommand { get; }
 }

--- a/src/NexusMods.App.UI/Windows/IMainWindowViewModel.cs
+++ b/src/NexusMods.App.UI/Windows/IMainWindowViewModel.cs
@@ -1,8 +1,20 @@
+using System.Reactive;
 using NexusMods.App.UI.Overlays;
+using ReactiveUI;
 
 namespace NexusMods.App.UI.Windows;
 
 public interface IMainWindowViewModel : IViewModelInterface, IWorkspaceWindow
 {
     IOverlayViewModel? CurrentOverlay { get; }
+
+    /// <summary>
+    ///     This command is used to bring the window to front.
+    /// </summary>
+    /// <remarks>
+    ///     Note(sewer)
+    ///     Normally this would go into something like <see cref="IWorkspaceWindow"/>,
+    ///     however there aren't enough use cases yet to justify this.
+    /// </remarks>
+    ReactiveCommand<Unit, Unit> ActivateCommand { get; }
 }

--- a/src/NexusMods.App.UI/Windows/MainWindow.axaml.cs
+++ b/src/NexusMods.App.UI/Windows/MainWindow.axaml.cs
@@ -66,7 +66,9 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
                 .BindTo(this, view => view.ViewModel!.IsActive)
                 .DisposeWith(disposables);
 
-            ViewModel!.ActivateCommand.Subscribe(_ =>
+            ViewModel!.ActivateCommand
+                .OnUI()
+                .Subscribe(_ =>
             {
                 Activate();
             }).DisposeWith(disposables);

--- a/src/NexusMods.App.UI/Windows/MainWindow.axaml.cs
+++ b/src/NexusMods.App.UI/Windows/MainWindow.axaml.cs
@@ -66,7 +66,7 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
                 .BindTo(this, view => view.ViewModel!.IsActive)
                 .DisposeWith(disposables);
 
-            ViewModel!.ActivateCommand
+            ViewModel!.ActivateWindowCommand
                 .OnUI()
                 .Subscribe(_ =>
             {

--- a/src/NexusMods.App.UI/Windows/MainWindow.axaml.cs
+++ b/src/NexusMods.App.UI/Windows/MainWindow.axaml.cs
@@ -65,6 +65,11 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
             this.WhenAnyValue(view => view.IsActive)
                 .BindTo(this, view => view.ViewModel!.IsActive)
                 .DisposeWith(disposables);
+
+            ViewModel!.ActivateCommand.Subscribe(_ =>
+            {
+                Activate();
+            }).DisposeWith(disposables);
         });
     }
 

--- a/src/NexusMods.App.UI/Windows/MainWindowViewModel.cs
+++ b/src/NexusMods.App.UI/Windows/MainWindowViewModel.cs
@@ -25,7 +25,7 @@ public class MainWindowViewModel : AViewModel<IMainWindowViewModel>, IMainWindow
 {
     private readonly IWindowManager _windowManager;
     
-    public ReactiveCommand<Unit, Unit> ActivateCommand { get; } = ReactiveCommand.Create(() => { });
+    public ReactiveCommand<Unit, Unit> ActivateWindowCommand { get; } = ReactiveCommand.Create(() => { });
 
     public MainWindowViewModel(
         IServiceProvider serviceProvider,

--- a/src/NexusMods.App.UI/Windows/MainWindowViewModel.cs
+++ b/src/NexusMods.App.UI/Windows/MainWindowViewModel.cs
@@ -1,3 +1,4 @@
+using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using Microsoft.Extensions.DependencyInjection;
@@ -23,6 +24,8 @@ namespace NexusMods.App.UI.Windows;
 public class MainWindowViewModel : AViewModel<IMainWindowViewModel>, IMainWindowViewModel
 {
     private readonly IWindowManager _windowManager;
+    
+    public ReactiveCommand<Unit, Unit> ActivateCommand { get; } = ReactiveCommand.Create(() => { });
 
     public MainWindowViewModel(
         IServiceProvider serviceProvider,
@@ -69,6 +72,14 @@ public class MainWindowViewModel : AViewModel<IMainWindowViewModel>, IMainWindow
                 var updaterViewModel = serviceProvider.GetRequiredService<IUpdaterViewModel>();
                 updaterViewModel.MaybeShow();
             }
+            
+            loginManager.IsLoggedInObservable
+                .Subscribe(isSignedIn =>
+                {
+                    if (isSignedIn)
+                        ActivateCommand.Execute().Subscribe();
+                })
+                .DisposeWith(d);
             
             var loginMessageVM = serviceProvider.GetRequiredService<ILoginMessageBoxViewModel>();
             loginMessageVM.Controller = overlayController;


### PR DESCRIPTION
This is a basic implementation for:
- #1507

Although this PR is fairly simple, and adheres to UI Guidelines... it feels, weird.
If you have any better ideas for implementing this, please let me know.

I could integrate this sort of functionality into the workspace system, and persist the window that started the login request in a global location. However, I've decided to keep things simple for now. Let me know how far you want me to go with this.