### PR TITLE
Add ability to set mod name in `ArchiveInstaller.AddMods()`

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Installers/IArchiveInstaller.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Installers/IArchiveInstaller.cs
@@ -21,11 +21,21 @@ public interface IArchiveInstaller
     /// standard way to "install" a mod. If the installer is not provided, the installers on the loadout's game
     /// will be tried, in the order they are defined, otherwise the provided installer will be used.
     /// </summary>
-    public Task<ModId[]> AddMods(LoadoutId loadoutId, DownloadId downloadId, IModInstaller? installer = null, CancellationToken token = default);
+    public Task<ModId[]> AddMods(
+        LoadoutId loadoutId, 
+        DownloadId downloadId, 
+        string? name = null, 
+        IModInstaller? installer = null, 
+        CancellationToken token = default);
 
     /// <summary>
     /// Installs a <see cref="DownloadAnalysis.Model"/> to a loadout, potentially adding one or more mods.
     /// If the installer is not provided, the installers on the loadout's game will be tried, in the order they are defined.
     /// </summary>
-    public Task<ModId[]> AddMods(LoadoutId loadoutId, DownloadAnalysis.Model downloadAnalysis, IModInstaller? installer = null, CancellationToken token = default);
+    public Task<ModId[]> AddMods(
+        LoadoutId loadoutId, 
+        DownloadAnalysis.Model downloadAnalysis,
+        string? name = null, 
+        IModInstaller? installer = null, 
+        CancellationToken token = default);
 }

--- a/src/NexusMods.App.Cli/ProtocolVerbs.cs
+++ b/src/NexusMods.App.Cli/ProtocolVerbs.cs
@@ -70,7 +70,7 @@ public static class ProtocolVerbs
             {
                 tx.Add(id, FilePathMetadata.OriginalName, temporaryPath.Path.Name);
             }, name, token);
-            await archiveInstaller.AddMods(loadout.LoadoutId, downloadId, token: token);
+            await archiveInstaller.AddMods(loadout.LoadoutId, downloadId, name, token: token);
             return 0;
         });
     }

--- a/src/NexusMods.App.Cli/Types/DownloadHandlers/NxmDownloadProtocolHandler.cs
+++ b/src/NexusMods.App.Cli/Types/DownloadHandlers/NxmDownloadProtocolHandler.cs
@@ -59,6 +59,6 @@ public class NxmDownloadProtocolHandler : IDownloadProtocolHandler
             {
                 tx.Add(id, FilePathMetadata.OriginalName, tempPath.Path.Name);
             }, modName, token);
-        await _archiveInstaller.AddMods(loadout.LoadoutId, downloadId, token:token);
+        await _archiveInstaller.AddMods(loadout.LoadoutId, downloadId, modName, token:token);
     }
 }

--- a/src/NexusMods.App.UI/Pages/LoadoutGrid/LoadoutGridViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutGrid/LoadoutGridViewModel.cs
@@ -218,7 +218,7 @@ public class LoadoutGridViewModel : APageViewModel<ILoadoutGridViewModel>, ILoad
                     tx.Add(id, DownloaderState.GameDomain, _gameDomain);
                     tx.Add(id, FilePathMetadata.OriginalName, file.FileName);
                 }, file.FileName);
-            await _archiveInstaller.AddMods(LoadoutId, downloadId, token: CancellationToken.None, installer: installer);
+            await _archiveInstaller.AddMods(LoadoutId, downloadId, file.FileName, installer: installer, token: CancellationToken.None);
         });
 
         return Task.CompletedTask;

--- a/src/NexusMods.DataModel/ArchiveInstaller.cs
+++ b/src/NexusMods.DataModel/ArchiveInstaller.cs
@@ -47,7 +47,12 @@ public class ArchiveInstaller : IArchiveInstaller
     }
     
     /// <inheritdoc />
-    public async Task<ModId[]> AddMods(LoadoutId loadoutId, DownloadAnalysis.Model download, IModInstaller? installer = null, CancellationToken token = default)
+    public async Task<ModId[]> AddMods(
+        LoadoutId loadoutId, 
+        DownloadAnalysis.Model download, 
+        string? name = null, 
+        IModInstaller? installer = null, 
+        CancellationToken token = default)
     {
         // Get the loadout and create the mod, so we can use it in the job.
         var useCustomInstaller = installer != null;
@@ -56,7 +61,7 @@ public class ArchiveInstaller : IArchiveInstaller
         // Note(suggestedName) cannot be null here.
         // Because string is non-nullable where it is set (FileOriginRegistry),
         // and using that is a prerequisite to calling this function.
-        download.TryGet(DownloadAnalysis.SuggestedName, out var modName);
+        var modName = name ?? download.Get(DownloadAnalysis.SuggestedName);
         
         ModId modId;
         Mod.Model baseMod;
@@ -211,11 +216,16 @@ public class ArchiveInstaller : IArchiveInstaller
     }
 
     /// <inheritdoc />
-    public async Task<ModId[]> AddMods(LoadoutId loadoutId, DownloadId downloadId, IModInstaller? installer = null, CancellationToken token = default)
+    public async Task<ModId[]> AddMods(
+        LoadoutId loadoutId, 
+        DownloadId downloadId, 
+        string? name = null,
+        IModInstaller? installer = null, 
+        CancellationToken token = default)
     {
         var download = _fileOriginRegistry.Get(downloadId);
         
-        return await AddMods(loadoutId, download, installer, token);
+        return await AddMods(loadoutId, download, name, installer, token);
     }
 
 }

--- a/src/NexusMods.DataModel/CommandLine/Verbs/LoadoutManagementVerbs.cs
+++ b/src/NexusMods.DataModel/CommandLine/Verbs/LoadoutManagementVerbs.cs
@@ -131,7 +131,7 @@ public static class LoadoutManagementVerbs
             var downloadId = await fileOriginRegistry.RegisterDownload(file, 
             (tx, id) => tx.Add(id, FilePathMetadata.OriginalName, file.FileName), name, token);
 
-            await archiveInstaller.AddMods(loadout.LoadoutId, downloadId, token: token);
+            await archiveInstaller.AddMods(loadout.LoadoutId, downloadId, name, token: token);
             return 0;
         });
     }

--- a/tests/Games/NexusMods.Games.TestFramework/AModInstallerTest.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/AModInstallerTest.cs
@@ -88,7 +88,7 @@ public abstract class AModInstallerTest<TGame, TModInstaller> : AGameTest<TGame>
     {
         var downloadId = await FileOriginRegistry.RegisterDownload(archivePath, "test", cancellationToken);
         
-        var ids = await ArchiveInstaller.AddMods(Loadout.LoadoutId, downloadId, ModInstaller, cancellationToken);
+        var ids = await ArchiveInstaller.AddMods(Loadout.LoadoutId, downloadId, "test", ModInstaller, cancellationToken);
         var db = Connection.Db;
         return ids.Select(id => db.Get<Mod.Model>((EntityId)id)).ToArray();
     }

--- a/tests/NexusMods.DataModel.Tests/Harness/ADataModelTest.cs
+++ b/tests/NexusMods.DataModel.Tests/Harness/ADataModelTest.cs
@@ -118,7 +118,7 @@ public abstract class ADataModelTest<T> : IDisposable, IAsyncLifetime
     protected async Task<ModId[]> AddMods(LoadoutId loadoutId, AbsolutePath path, string? name = null)
     {
         var downloadId = await FileOriginRegistry.RegisterDownload(path, name ?? path.FileName, Token);
-        var result = await ArchiveInstaller.AddMods(loadoutId, downloadId, token: Token);
+        var result = await ArchiveInstaller.AddMods(loadoutId, downloadId,name ?? path.FileName, token: Token);
         // Refresh the loadout to get the new mods, as a convenience.
         Refresh(ref BaseLoadout);
         return result;
@@ -166,7 +166,7 @@ public abstract class ADataModelTest<T> : IDisposable, IAsyncLifetime
     protected async Task<ModId> AddMod(string modName, params (string Name, string Data)[] files)
     {
         var downloadId = await RegisterDownload(modName, files);
-        var modIds = await ArchiveInstaller.AddMods(LoadoutId.From(BaseLoadout.Id), downloadId, token: Token);
+        var modIds = await ArchiveInstaller.AddMods(LoadoutId.From(BaseLoadout.Id), downloadId, modName, token: Token);
         return modIds.First();
     }
 

--- a/tests/NexusMods.UI.Tests/AVmTest.cs
+++ b/tests/NexusMods.UI.Tests/AVmTest.cs
@@ -71,7 +71,7 @@ where TVm : IViewModelInterface
             {
                 tx.Add(id, FilePathMetadata.OriginalName, path.FileName);
             }, path.FileName);
-        return await ArchiveInstaller.AddMods(Loadout.LoadoutId, downloadId);
+        return await ArchiveInstaller.AddMods(Loadout.LoadoutId, downloadId, path.FileName);
     }
 
     public async Task InitializeAsync()


### PR DESCRIPTION
This should hopefully
- fix #1541 

fingers crossed

## Details
There are two reasons that test is failing on the CI:
- If an archive is installed multiple times, we were using the previous name, so the test was expecting a mod with a specific name, but wouldn't find it.
- Other problem is that the archive is not supposed to be installed multiple times, so this test is sharing the DataStore with other concurrent tests, which are also installing the same file concurrently, which should not be happening.

This PR only fixes the first problem, which is also a UX problem for normal users.
The sharing db in the tests is an issue that we also need to fix but outside the scope for this. 