### PR TITLE
Fix Test_Locators_Windows failing on xboxGamePass since it was disabled

### DIFF
--- a/tests/NexusMods.StandardGameLocators.Tests/BasicTests.cs
+++ b/tests/NexusMods.StandardGameLocators.Tests/BasicTests.cs
@@ -33,16 +33,16 @@ public class BasicTests(IGameRegistry registry)
     {
         Skip.If(!OperatingSystem.IsWindows());
 
-
+        // TODO: Enable XboxGamePass back again when it's supported 
         registry.Installations.Values
-            .Should().HaveCount(6)
+            .Should().HaveCount(5)
             .And.Satisfy(
                 eaInstallation => eaInstallation.Store == GameStore.EADesktop,
                 epicInstallation => epicInstallation.Store == GameStore.EGS,
                 originInstallation => originInstallation.Store == GameStore.Origin,
                 gogInstallation => gogInstallation.Store == GameStore.GOG,
-                steamInstallation => steamInstallation.Store == GameStore.Steam,
-                xboxInstallation => xboxInstallation.Store == GameStore.XboxGamePass
+                steamInstallation => steamInstallation.Store == GameStore.Steam
+                // xboxInstallation => xboxInstallation.Store == GameStore.XboxGamePass
             );
     }
 


### PR DESCRIPTION
In Game Finder
@erri120 Just a heads up that this will need to be enabled back in once we add support for GamePass again