### PR TITLE
ToolTip Styling and Designer preview fix

### DIFF
--- a/src/NexusMods.App.UI/Controls/Spine/Buttons/Download/SpineDownloadButtonView.axaml
+++ b/src/NexusMods.App.UI/Controls/Spine/Buttons/Download/SpineDownloadButtonView.axaml
@@ -8,7 +8,7 @@
     xmlns:reactiveUi="http://reactiveui.net"
     xmlns:download="clr-namespace:NexusMods.App.UI.Controls.Spine.Buttons.Download"
     xmlns:icons="clr-namespace:NexusMods.Icons;assembly=NexusMods.Icons"
-    mc:Ignorable="d" d:DesignWidth="64" d:DesignHeight="64"
+    mc:Ignorable="d" d:DesignWidth="150" d:DesignHeight="104"
     x:Class="NexusMods.App.UI.Controls.Spine.Buttons.Download.SpineDownloadButtonView">
     <Design.DataContext>
         <download:SpineDownloadButtonDesignerViewModel/>
@@ -18,12 +18,12 @@
             <TextBlock x:Name="ToolTipTextBlock"/>
         </ToolTip.Tip>
         <Grid>
-            <Border></Border>
+            <Border x:Name="OuterBorder"/>
             <Arc x:Name="ProgressArc"></Arc>
-            <icons:UnifiedIcon Size="24" Classes="Download"/>
-            <StackPanel>
-                <TextBlock Classes="Number" x:Name="NumberTextBlock"/>
-                <TextBlock Classes="Units" x:Name="UnitsTextBlock"/>
+            <icons:UnifiedIcon Size="24" Classes="Download" x:Name="Icon"/>
+            <StackPanel x:Name="StackPanel">
+                <TextBlock Classes="SpineDownloadButtonTextBlock Number" x:Name="NumberTextBlock"/>
+                <TextBlock Classes="SpineDownloadButtonTextBlock Units" x:Name="UnitsTextBlock"/>
             </StackPanel>
         </Grid>
     </Button>

--- a/src/NexusMods.App.UI/Controls/Spine/Buttons/Icon/IconButton.axaml
+++ b/src/NexusMods.App.UI/Controls/Spine/Buttons/Icon/IconButton.axaml
@@ -17,7 +17,7 @@
     </Design.DataContext>
 
     <Button
-        Classes="Spine Icon Add"
+        Classes="IconButton Add"
         Height="64"
         Width="64"
         x:Name="Button">
@@ -27,7 +27,8 @@
         <Button.Template>
             <ControlTemplate>
                 <Grid>
-                    <icons:UnifiedIcon Classes="HelpCircle"
+                    <icons:UnifiedIcon x:Name="Icon"
+                                       Classes="HelpCircle"
                                        Size="20"
                                        HorizontalAlignment="Center"
                                        Margin="0"

--- a/src/NexusMods.App.UI/Controls/Spine/Buttons/Icon/IconButtonDesignViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/Spine/Buttons/Icon/IconButtonDesignViewModel.cs
@@ -7,6 +7,7 @@ public class IconButtonDesignViewModel : IconButtonViewModel
     public IconButtonDesignViewModel()
     {
         Click = ReactiveCommand.Create(() => { IsActive = !IsActive; });
+        Name = "Home";
     }
 
 }

--- a/src/NexusMods.App/Program.cs
+++ b/src/NexusMods.App/Program.cs
@@ -205,8 +205,7 @@ public class Program
         TelemetrySettings telemetrySettings,
         LoggingSettings loggingSettings,
         ExperimentalSettings experimentalSettings,
-        GameLocatorSettings? gameLocatorSettings = null,
-        bool isAvaloniaDesigner = false)
+        GameLocatorSettings? gameLocatorSettings = null)
     {
         var host = new HostBuilder().ConfigureServices(services =>
         {
@@ -216,7 +215,7 @@ public class Program
                 experimentalSettings: experimentalSettings,
                 gameLocatorSettings: gameLocatorSettings).Validate();
 
-            if (isAvaloniaDesigner)
+            if (startupMode.IsAvaloniaDesigner)
             {
                 s.OverrideSettingsForTests<DataModelSettings>(settings => settings with { UseInMemoryDataModel = true, });
             }
@@ -294,6 +293,8 @@ public class Program
         {
             RunAsMain = true,
             ShowUI = false,
+            ExecuteCli = false,
+            IsAvaloniaDesigner = true,
             Args = [],
             OriginalArgs = [],
         };
@@ -301,9 +302,10 @@ public class Program
         var host = BuildHost(startupMode, 
             telemetrySettings: new TelemetrySettings(), 
             LoggingSettings.CreateDefault(OSInformation.Shared),
-            isAvaloniaDesigner: true,
             experimentalSettings: new ExperimentalSettings()
         );
+        
+        host.StartAsync().GetAwaiter().GetResult();
         
         DesignerUtils.Activate(host.Services);
         

--- a/src/NexusMods.App/Services.cs
+++ b/src/NexusMods.App/Services.cs
@@ -48,7 +48,6 @@ public static class Services
                 .AddSettings<TelemetrySettings>()
                 .AddSettings<LoggingSettings>()
                 .AddSettings<ExperimentalSettings>()
-                .AddSingleProcess(Mode.Main)
                 .AddDefaultRenderers()
 
                 .AddSingleton<ITelemetryProvider, TelemetryProvider>()
@@ -83,6 +82,9 @@ public static class Services
                 .AddDownloaders()
                 .AddCleanupVerbs();
 
+            if (!startupMode.IsAvaloniaDesigner)
+                services.AddSingleProcess(Mode.Main);
+
             if (addStandardGameLocators)
                 services.AddStandardGameLocators(settings: gameLocatorSettings);
         }
@@ -90,9 +92,11 @@ public static class Services
         {
             services.AddFileSystem()
                 .AddCrossPlatform()
-                .AddSingleProcess(Mode.Client)
                 .AddDefaultRenderers()
                 .AddSettingsManager();
+            
+            if (!startupMode.IsAvaloniaDesigner)
+                services.AddSingleProcess(Mode.Client);
         }
 
         return services;

--- a/src/NexusMods.App/StartupMode.cs
+++ b/src/NexusMods.App/StartupMode.cs
@@ -27,6 +27,8 @@ public class StartupMode
     /// </summary>
     public bool ShowUI { get; set; } = true;
     
+    public bool IsAvaloniaDesigner { get; set; } = false;
+    
     public static StartupMode Parse(string[] args)
     {
         var mode = new StartupMode

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Button/SpineButtonStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Button/SpineButtonStyles.axaml
@@ -2,32 +2,33 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:icons="clr-namespace:NexusMods.Icons;assembly=NexusMods.Icons"
         xmlns:extensions="clr-namespace:NexusMods.Themes.NexusFluentDark.Extensions"
-        xmlns:icon="clr-namespace:NexusMods.App.UI.Controls.Spine.Buttons.Icon;assembly=NexusMods.App.UI">
+        xmlns:icon="clr-namespace:NexusMods.App.UI.Controls.Spine.Buttons.Icon;assembly=NexusMods.App.UI"
+        xmlns:image="clr-namespace:NexusMods.App.UI.Controls.Spine.Buttons.Image;assembly=NexusMods.App.UI">
     <Design.PreviewWith>
         <WrapPanel Width="500">
-            <Button Classes="Spine Icon Inactive Add IconTemplate" Margin="10" />
-            <Button Classes="Spine Icon Active Add IconTemplate" Margin="10" />
-            <Button Classes="Spine Icon Inactive Home IconTemplate" Margin="10" />
-            <Button Classes="Spine Icon Active Home IconTemplate" Margin="10" />
+            <Button Classes="IconButton Inactive Add IconTemplate" Margin="10" />
+            <Button Classes="IconButton Active Add IconTemplate" Margin="10" />
+            <Button Classes="IconButton Inactive Home IconTemplate" Margin="10" />
+            <Button Classes="IconButton Active Home IconTemplate" Margin="10" />
             <Button Classes="ImageButton Inactive ImageTemplate" Margin="10" />
             <Button Classes="ImageButton Active ImageTemplate" Margin="10" />
-            <icon:IconButton/>
+            <icon:IconButton />
+            <image:ImageButton />
         </WrapPanel>
     </Design.PreviewWith>
 
     <!-- Styles Definitions-->
 
-    <Style Selector="Button.Spine">
+    <Style Selector="Button.IconButton">
         <Setter Property="HorizontalAlignment" Value="Center" />
         <Setter Property="ClipToBounds" Value="False" />
         <Setter Property="Background" Value="{StaticResource SurfaceTransparentBrush}" />
-
 
         <Style Selector="^:pressed">
             <Setter Property="RenderTransform" Value="scale(0.9)" />
         </Style>
 
-        <Style Selector="^.Inactive Border">
+        <Style Selector="^.Inactive Border#IconButtonInnerBorder">
             <Setter Property="BorderBrush" Value="{StaticResource StrokeTranslucentWeakBrush}" />
             <Setter Property="Background" Value="{StaticResource SurfaceTransparentBrush}" />
             <Setter Property="BorderThickness" Value="2" />
@@ -42,7 +43,7 @@
             </Setter>
         </Style>
 
-        <Style Selector="^.Inactive:pointerover Border">
+        <Style Selector="^.Inactive:pointerover Border#IconButtonInnerBorder">
             <Setter Property="Background">
                 <SolidColorBrush Color="{StaticResource NeutralStrong}"
                                  Opacity="{StaticResource OpacityModerate}" />
@@ -51,7 +52,7 @@
             <Setter Property="BorderThickness" Value="2" />
         </Style>
 
-        <Style Selector="^.Active Border">
+        <Style Selector="^.Active Border#IconButtonInnerBorder">
             <Setter Property="Background" Value="{StaticResource SurfaceTransparentBrush}" />
             <Setter Property="BorderBrush" Value="{StaticResource NeutralStrongBrush}" />
             <Setter Property="BorderThickness" Value="2" />
@@ -60,7 +61,7 @@
             </Setter>
         </Style>
 
-        <Style Selector="^.Active:pointerover Border">
+        <Style Selector="^.Active:pointerover Border#IconButtonInnerBorder">
             <Setter Property="Background">
                 <SolidColorBrush Color="{StaticResource NeutralStrong}"
                                  Opacity="{StaticResource Alpha50}" />
@@ -69,51 +70,49 @@
             <Setter Property="BorderThickness" Value="2" />
         </Style>
 
-        <!-- IconButton Styles -->
-        <Style Selector="^.Icon">
 
-            <!-- Set the template of the button for preview purposes, actual template is defined in `IconButton.axaml` -->
-            <Style Selector="^.IconTemplate">
-                <Setter Property="Template">
-                    <ControlTemplate>
-                        <Grid>
-                            <icons:UnifiedIcon Classes="HelpCircle"
-                                               Size="20"
-                                               HorizontalAlignment="Center"
-                                               Margin="0"
-                                               Padding="0"
-                                               VerticalAlignment="Center" />
-                            <Border Classes="Rounded-full"
-                                    Height="50"
-                                    Width="50">
-                            </Border>
-                        </Grid>
-                    </ControlTemplate>
-                </Setter>
-            </Style>
+        <!-- Set the template of the button for preview purposes, actual template is defined in `IconButton.axaml` -->
+        <Style Selector="^.IconTemplate">
+            <Setter Property="Template">
+                <ControlTemplate>
+                    <Grid>
+                        <icons:UnifiedIcon x:Name="Icon"
+                                           Classes="HelpCircle"
+                                           Size="20"
+                                           HorizontalAlignment="Center"
+                                           Margin="0"
+                                           Padding="0"
+                                           VerticalAlignment="Center" />
+                        <Border x:Name="IconButtonInnerBorder" 
+                                Classes="Rounded-full"
+                                Height="50"
+                                Width="50">
+                        </Border>
+                    </Grid>
+                </ControlTemplate>
+            </Setter>
+        </Style>
 
-            <Setter Property="CornerRadius" Value="{StaticResource Rounded-full}" />
+        <Setter Property="CornerRadius" Value="{StaticResource Rounded-full}" />
 
-            <Style Selector="^.Add /template/ icons|UnifiedIcon">
-                <Setter Property="Value">
-                    <icons:IconValue MdiValueSetter="mdi-plus" />
-                </Setter>
-            </Style>
+        <Style Selector="^.Add /template/ icons|UnifiedIcon#Icon">
+            <Setter Property="Value">
+                <icons:IconValue MdiValueSetter="mdi-plus" />
+            </Setter>
+        </Style>
 
-            <Style Selector="^.Home /template/ icons|UnifiedIcon">
-                <Setter Property="Value">
-                    <icons:IconValue MdiValueSetter="mdi-home" />
-                </Setter>
-            </Style>
+        <Style Selector="^.Home /template/ icons|UnifiedIcon#Icon">
+            <Setter Property="Value">
+                <icons:IconValue MdiValueSetter="mdi-home" />
+            </Setter>
+        </Style>
 
-            <Style Selector="^.Inactive icons|UnifiedIcon">
-                <Setter Property="Foreground" Value="{StaticResource NeutralSubduedBrush}" />
-            </Style>
+        <Style Selector="^.Inactive icons|UnifiedIcon#Icon">
+            <Setter Property="Foreground" Value="{StaticResource NeutralSubduedBrush}" />
+        </Style>
 
-            <Style Selector="^.Active icons|UnifiedIcon">
-                <Setter Property="Foreground" Value="{StaticResource NeutralStrongBrush}" />
-            </Style>
-
+        <Style Selector="^.Active icons|UnifiedIcon#Icon">
+            <Setter Property="Foreground" Value="{StaticResource NeutralStrongBrush}" />
         </Style>
 
     </Style>
@@ -127,7 +126,7 @@
         <Setter Property="Width" Value="48" />
         <Setter Property="Padding" Value="0" />
         <Setter Property="ClipToBounds" Value="False" />
-        
+
         <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
             <Setter Property="Transitions">
                 <Transitions>
@@ -149,7 +148,7 @@
             <Setter Property="Width" Value="48" />
             <Setter Property="ClipToBounds" Value="True" />
         </Style>
-        
+
         <Style Selector="^ icons|UnifiedIcon#Image">
             <Setter Property="VerticalAlignment" Value="Stretch" />
             <Setter Property="HorizontalAlignment" Value="Stretch" />
@@ -161,7 +160,7 @@
             <Setter Property="HorizontalAlignment" Value="Stretch" />
             <Setter Property="Height" Value="48" />
             <Setter Property="Width" Value="48" />
-            
+
             <Setter Property="Transitions">
                 <Transitions>
                     <BrushTransition Duration="0:0:0.2" Property="Fill" />
@@ -176,7 +175,7 @@
             <!-- NOTE(Al12rs): Add 1px to workaround image edges showing past the decoration border -->
             <Setter Property="Height" Value="49" />
             <Setter Property="Width" Value="49" />
-            
+
             <Setter Property="Transitions">
                 <Transitions>
                     <BrushTransition Duration="0:0:0.2" Property="BorderBrush" />
@@ -184,26 +183,26 @@
                 </Transitions>
             </Setter>
         </Style>
-        
+
 
         <Style Selector="^:pressed">
             <Setter Property="RenderTransform" Value="scale(0.9)" />
         </Style>
 
-        
+
         <Style Selector="^.Inactive">
-            
+
             <Style Selector="^ Rectangle#Mask">
                 <Setter Property="Fill" Value="{StaticResource BrandTranslucentDark200Brush}" />
             </Style>
-            
+
             <Style Selector="^ Border#DecorationBorder">
                 <!-- Border is 1px thicker than design to account that it is 1px larger -->
                 <Setter Property="BorderThickness" Value="2" />
                 <Setter Property="BorderBrush" Value="{StaticResource StrokeTranslucentWeakBrush}" />
             </Style>
-            
-            
+
+
             <Style Selector="^:pointerover Rectangle#Mask">
                 <Setter Property="Fill" Value="{StaticResource SurfaceTranslucentHighBrush}" />
             </Style>
@@ -213,24 +212,24 @@
                 <Setter Property="BorderThickness" Value="3" />
                 <Setter Property="BorderBrush" Value="{StaticResource StrokeTranslucentModerateBrush}" />
             </Style>
-            
+
         </Style>
 
         <Style Selector="^.Active">
-            
+
             <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
                 <Setter Property="BoxShadow">
                     <extensions:BoxShadow BlurRadius="10" SpreadRadius="0" ShadowColor="{StaticResource NeutralTranslucentWeak}" />
                 </Setter>
             </Style>
-            
+
             <Style Selector="^ Border#DecorationBorder">
                 <!-- Border is 1px thicker than design to account that it is 1px larger -->
                 <Setter Property="BorderThickness" Value="3" />
                 <Setter Property="BorderBrush" Value="{StaticResource NeutralStrongBrush}" />
             </Style>
-            
-            
+
+
             <Style Selector="^:pointerover Rectangle#Mask">
                 <Setter Property="Fill" Value="{StaticResource SurfaceTranslucentHighBrush}" />
             </Style>
@@ -240,7 +239,7 @@
                 <Setter Property="BorderThickness" Value="3" />
                 <Setter Property="BorderBrush" Value="{StaticResource NeutralStrongBrush}" />
             </Style>
-            
+
         </Style>
 
 

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Button/SpineButtonStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Button/SpineButtonStyles.axaml
@@ -1,7 +1,8 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:icons="clr-namespace:NexusMods.Icons;assembly=NexusMods.Icons"
-        xmlns:extensions="clr-namespace:NexusMods.Themes.NexusFluentDark.Extensions">
+        xmlns:extensions="clr-namespace:NexusMods.Themes.NexusFluentDark.Extensions"
+        xmlns:icon="clr-namespace:NexusMods.App.UI.Controls.Spine.Buttons.Icon;assembly=NexusMods.App.UI">
     <Design.PreviewWith>
         <WrapPanel Width="500">
             <Button Classes="Spine Icon Inactive Add IconTemplate" Margin="10" />
@@ -10,6 +11,7 @@
             <Button Classes="Spine Icon Active Home IconTemplate" Margin="10" />
             <Button Classes="ImageButton Inactive ImageTemplate" Margin="10" />
             <Button Classes="ImageButton Active ImageTemplate" Margin="10" />
+            <icon:IconButton/>
         </WrapPanel>
     </Design.PreviewWith>
 

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Button/SpineDownloadButtonStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Button/SpineDownloadButtonStyles.axaml
@@ -8,81 +8,6 @@
     <Design.PreviewWith>
         <StackPanel Orientation="Horizontal" Margin="24" Classes="Spacing-2">
             <ui:SpineDownloadButtonView />
-            <StackPanel Orientation="Vertical" Classes="Spacing-2">
-                <Button Classes="SpineDownloadButton Idle">
-                    <Grid>
-                        <Border></Border>
-                        <Arc></Arc>
-                        <icons:UnifiedIcon Classes="Download" />
-                        <StackPanel>
-                            <TextBlock Text="8.6" Classes="Number" />
-                            <TextBlock Text="MB/s" Classes="Units" />
-                        </StackPanel>
-                    </Grid>
-                </Button>
-                <Button Classes="SpineDownloadButton Idle Active">
-                    <Grid>
-                        <Border></Border>
-                        <Arc></Arc>
-                        <icons:UnifiedIcon Classes="Download" />
-                        <StackPanel>
-                            <TextBlock Text="8.6" Classes="Number" />
-                            <TextBlock Text="MB/s" Classes="Units" />
-                        </StackPanel>
-                    </Grid>
-                </Button>
-            </StackPanel>
-
-            <StackPanel Orientation="Vertical" Classes="Spacing-2">
-                <Button Classes="SpineDownloadButton Progress">
-                    <Grid>
-                        <Border></Border>
-                        <Arc SweepAngle="270"></Arc>
-                        <icons:UnifiedIcon Classes="Download" />
-                        <StackPanel>
-                            <TextBlock Text="18.6" Classes="Number" />
-                            <TextBlock Text="MB/s" Classes="Units" />
-                        </StackPanel>
-                    </Grid>
-                </Button>
-                <Button Classes="SpineDownloadButton Progress Active">
-                    <Grid>
-                        <Border></Border>
-                        <Arc SweepAngle="90"></Arc>
-                        <icons:UnifiedIcon Classes="Download" />
-                        <StackPanel>
-                            <TextBlock Text="18.6" Classes="Number" />
-                            <TextBlock Text="MB/s" Classes="Units" />
-                        </StackPanel>
-                    </Grid>
-                </Button>
-            </StackPanel>
-
-            <StackPanel Orientation="Vertical" Classes="Spacing-2">
-                <Button Classes="SpineDownloadButton Progress">
-                    <Grid>
-                        <Border></Border>
-                        <Arc SweepAngle="180"></Arc>
-                        <icons:UnifiedIcon Classes="Download" />
-                        <StackPanel>
-                            <TextBlock Text="48" Classes="Number" />
-                            <TextBlock Text="MINS" Classes="Units" />
-                        </StackPanel>
-                    </Grid>
-                </Button>
-                <Button Classes="SpineDownloadButton Progress Active">
-                    <Grid>
-                        <Border></Border>
-                        <Arc SweepAngle="90"></Arc>
-                        <icons:UnifiedIcon Classes="Download" />
-                        <StackPanel>
-                            <TextBlock Text="48" Classes="Number" />
-                            <TextBlock Text="MINS" Classes="Units" />
-                        </StackPanel>
-                    </Grid>
-                </Button>
-            </StackPanel>
-
         </StackPanel>
     </Design.PreviewWith>
 
@@ -107,7 +32,7 @@
         <Setter Property="Background" Value="{StaticResource SurfaceTransparentBrush}" />
 
         <!-- Border -->
-        <Style Selector="^ Border">
+        <Style Selector="^ Border#OuterBorder">
             <Setter Property="Width" Value="50" />
             <Setter Property="Height" Value="50" />
             <Setter Property="CornerRadius" Value="{StaticResource Rounded-full}" />
@@ -118,14 +43,14 @@
         </Style>
 
         <!-- Icon -->
-        <Style Selector="^ icons|UnifiedIcon">
+        <Style Selector="^ icons|UnifiedIcon#Icon">
             <Setter Property="Size" Value="24" />
             <Setter Property="Margin" Value="12" />
             <Setter Property="Foreground" Value="{DynamicResource NeutralStrongBrush}" />
         </Style>
 
         <!-- StackPanel -->
-        <Style Selector="^ > Grid > StackPanel">
+        <Style Selector="^ > Grid > StackPanel#StackPanel">
             <Setter Property="Spacing" Value="{StaticResource Spacing-none}" />
             <Setter Property="Orientation" Value="Vertical" />
             <Setter Property="HorizontalAlignment" Value="Center" />
@@ -134,7 +59,7 @@
         </Style>
 
         <!-- TextBlock -->
-        <Style Selector="^ TextBlock">
+        <Style Selector="^ TextBlock.SpineDownloadButtonTextBlock">
             <Setter Property="Margin" Value="0" />
             <Setter Property="Padding" Value="0" />
             <Setter Property="VerticalAlignment" Value="Center" />
@@ -164,7 +89,7 @@
             </Style>
 
             <!-- Border -->
-            <Style Selector="^ Border">
+            <Style Selector="^ Border#OuterBorder">
                 <Setter Property="BorderBrush" Value="{DynamicResource NeutralModerateBrush}" />
                 <Setter Property="Background">
                     <SolidColorBrush Color="{StaticResource NeutralStrong}"
@@ -173,7 +98,7 @@
             </Style>
 
             <!-- Icon -->
-            <Style Selector="^ icons|UnifiedIcon">
+            <Style Selector="^ icons|UnifiedIcon#Icon">
                 <Setter Property="Foreground" Value="{DynamicResource NeutralStrongBrush}" />
             </Style>
 
@@ -183,12 +108,12 @@
         <!-- Progress variation -->
         <Style Selector="^.Progress">
 
-            <Style Selector="^ Border">
+            <Style Selector="^ Border#OuterBorder">
                 <Setter Property="BorderThickness" Value="2" />
                 <Setter Property="CornerRadius" Value="{StaticResource Rounded-full}" />
             </Style>
 
-            <Style Selector="^ Arc">
+            <Style Selector="^ Arc#ProgressArc">
                 <Setter Property="Width" Value="50" />
                 <Setter Property="Height" Value="50" />
                 <Setter Property="StrokeThickness" Value="3" />
@@ -196,16 +121,16 @@
                 <Setter Property="Stroke" Value="{StaticResource InfoWeakBrush}" />
             </Style>
 
-            <Style Selector="^ > Grid > icons|UnifiedIcon">
+            <Style Selector="^ > Grid > icons|UnifiedIcon#Icon">
                 <Setter Property="IsVisible" Value="False" />
             </Style>
 
-            <Style Selector="^ > Grid > StackPanel">
+            <Style Selector="^ > Grid > StackPanel#StackPanel">
                 <Setter Property="IsVisible" Value="True" />
             </Style>
 
             <!-- pointerover color -->
-            <Style Selector="^:pointerover Arc">
+            <Style Selector="^:pointerover Arc#ProgressArc">
                 <Setter Property="Stroke" Value="{StaticResource InfoSubduedBrush}" />
             </Style>
         </Style>
@@ -213,11 +138,11 @@
         <!-- Idle variation -->
         <Style Selector="^.Idle">
 
-            <Style Selector="^ > Grid > icons|UnifiedIcon">
+            <Style Selector="^ > Grid > icons|UnifiedIcon#Icon">
                 <Setter Property="IsVisible" Value="True" />
             </Style>
 
-            <Style Selector="^ > Grid > StackPanel">
+            <Style Selector="^ > Grid > StackPanel#StackPanel">
                 <Setter Property="IsVisible" Value="False" />
             </Style>
         </Style>
@@ -225,7 +150,7 @@
         <!-- Active variation (Selected) -->
         <Style Selector="^.Active">
 
-            <Style Selector="^ Border">
+            <Style Selector="^ Border#OuterBorder">
                 <Setter Property="Background">
                     <SolidColorBrush Color="{StaticResource NeutralStrong}"
                                      Opacity="{StaticResource OpacityWeak}" />
@@ -236,7 +161,7 @@
                 </Setter>
             </Style>
 
-            <Style Selector="^.Progress Border">
+            <Style Selector="^.Progress Border#OuterBorder">
                 <Setter Property="BorderThickness" Value="2" />
                 <Setter Property="CornerRadius" Value="{StaticResource Rounded-full}" />
                 <Setter Property="BorderBrush" Value="{StaticResource NeutralModerateBrush}" />
@@ -246,7 +171,7 @@
                 </Setter>
             </Style>
 
-            <Style Selector="^ icons|UnifiedIcon">
+            <Style Selector="^ icons|UnifiedIcon#Icon">
                 <Setter Property="Foreground" Value="{DynamicResource NeutralStrongBrush}" />
             </Style>
         </Style>

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/ToolTips/ToolTipStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/ToolTips/ToolTipStyles.axaml
@@ -1,0 +1,30 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:extensions="clr-namespace:NexusMods.Themes.NexusFluentDark.Extensions">
+    <Design.PreviewWith>
+        <Border Padding="20">
+            <!-- Add Controls for Previewer Here -->
+            <Button>
+                <ToolTip.Tip>
+                    <TextBlock Text="This is a tooltip" /> 
+                </ToolTip.Tip>
+                <TextBlock Text="Hover over me" />
+            </Button>
+        </Border>
+    </Design.PreviewWith>
+
+    <!-- Add Styles Here -->
+    <Style Selector="ToolTip">
+        <Setter Property="Background" Value="{StaticResource SurfaceMidBrush}" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="CornerRadius" Value="{StaticResource Rounded}" />
+        <Setter Property="Padding" Value="12,8" />
+        <Setter Property="BoxShadow">
+            <extensions:BoxShadow
+                BlurRadius="5" ShadowColor="{StaticResource BrandTranslucentDark500}"
+                VerticalLength1="3" BlurRadius1="4" ShadowColor1="{StaticResource BrandTranslucentDark100}"
+                VerticalLength2="2" BlurRadius2="4" ShadowColor2="{StaticResource BrandTranslucentDark100}" />
+        </Setter>
+    </Style>
+</Styles>
+

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/ToolTips/ToolTipStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/ToolTips/ToolTipStyles.axaml
@@ -15,23 +15,26 @@
 
     <!-- Add Styles Here -->
     <Style Selector="ToolTip">
-        <Setter Property="Background" Value="{StaticResource SurfaceMidBrush}" />
         <Setter Property="BorderThickness" Value="0" />
-        <Setter Property="CornerRadius" Value="{StaticResource Rounded}" />
-        <Setter Property="Padding" Value="12,8" />
-        <Setter Property="ClipToBounds" Value="False" />
+        <!-- NOTE(Al12rs) ClipToBounds doesn't work on ToolTips, make outer container bigger and transparent instead -->
+        <Setter Property="Padding" Value="18" />
+        <Setter Property="Background" Value="{StaticResource SurfaceTransparentBrush}" />
+        
+        <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="ClipToBounds" Value="False" />
+            <Setter Property="Background" Value="{StaticResource SurfaceMidBrush}" />
+            <Setter Property="CornerRadius" Value="{StaticResource Rounded}" />
+            <Setter Property="Padding" Value="12,8" />
 
-        <!-- BoxShadow doesn't is getting clipped, even with ClipToBounds="False" on everything -->
-        <!-- <Style Selector="^ /template/  Border#PART_LayoutRoot"> -->
-        <!--     <Setter Property="ClipToBounds" Value="False" /> -->
-        <!--     <Setter Property="BoxShadow"> -->
-        <!--         <extensions:BoxShadow -->
-        <!--             BlurRadius="5" VerticalLength="3" ShadowColor="{StaticResource BrandTranslucentDark500}" -->
-        <!--             VerticalLength1="1" BlurRadius1="18" ShadowColor1="{StaticResource BrandTranslucentDark100}" -->
-        <!--             VerticalLength2="6" BlurRadius2="10" ShadowColor2="{StaticResource BrandTranslucentDark100}" /> -->
-        <!--     </Setter> -->
-        <!-- </Style> -->
+            <Setter Property="BoxShadow">
+                <extensions:BoxShadow
+                    VerticalLength="3"  BlurRadius="5"   ShadowColor="{StaticResource BrandTranslucentDark500}"
+                    VerticalLength1="1" BlurRadius1="18" ShadowColor1="{StaticResource BrandTranslucentDark100}"
+                    VerticalLength2="6" BlurRadius2="10" ShadowColor2="{StaticResource BrandTranslucentDark100}" />
+            </Setter>
+
+        </Style>
     </Style>
-    
-    
+
+
 </Styles>

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/ToolTips/ToolTipStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/ToolTips/ToolTipStyles.axaml
@@ -2,9 +2,9 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:extensions="clr-namespace:NexusMods.Themes.NexusFluentDark.Extensions">
     <Design.PreviewWith>
-        <Border Padding="20">
+        <Border Padding="20" Classes="Mid">
             <!-- Add Controls for Previewer Here -->
-            <Button>
+            <Button ClipToBounds="False">
                 <ToolTip.Tip>
                     <TextBlock Text="This is a tooltip" />
                 </ToolTip.Tip>
@@ -19,14 +19,19 @@
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="CornerRadius" Value="{StaticResource Rounded}" />
         <Setter Property="Padding" Value="12,8" />
+        <Setter Property="ClipToBounds" Value="False" />
 
-        <Style Selector="^ /template/  Border#PART_LayoutRoot">
-            <Setter Property="BoxShadow">
-                <extensions:BoxShadow
-                    BlurRadius="5" ShadowColor="{StaticResource BrandTranslucentDark500}"
-                    VerticalLength1="3" BlurRadius1="4" ShadowColor1="{StaticResource BrandTranslucentDark100}"
-                    VerticalLength2="2" BlurRadius2="4" ShadowColor2="{StaticResource BrandTranslucentDark100}" />
-            </Setter>
-        </Style>
+        <!-- BoxShadow doesn't is getting clipped, even with ClipToBounds="False" on everything -->
+        <!-- <Style Selector="^ /template/  Border#PART_LayoutRoot"> -->
+        <!--     <Setter Property="ClipToBounds" Value="False" /> -->
+        <!--     <Setter Property="BoxShadow"> -->
+        <!--         <extensions:BoxShadow -->
+        <!--             BlurRadius="5" VerticalLength="3" ShadowColor="{StaticResource BrandTranslucentDark500}" -->
+        <!--             VerticalLength1="1" BlurRadius1="18" ShadowColor1="{StaticResource BrandTranslucentDark100}" -->
+        <!--             VerticalLength2="6" BlurRadius2="10" ShadowColor2="{StaticResource BrandTranslucentDark100}" /> -->
+        <!--     </Setter> -->
+        <!-- </Style> -->
     </Style>
+    
+    
 </Styles>

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/ToolTips/ToolTipStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/ToolTips/ToolTipStyles.axaml
@@ -22,9 +22,11 @@
         
         <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
             <Setter Property="ClipToBounds" Value="False" />
+            <Setter Property="BorderThickness" Value="0" />
             <Setter Property="Background" Value="{StaticResource SurfaceMidBrush}" />
             <Setter Property="CornerRadius" Value="{StaticResource Rounded}" />
             <Setter Property="Padding" Value="12,8" />
+            <Setter Property="Margin" Value="0" />
 
             <Setter Property="BoxShadow">
                 <extensions:BoxShadow

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/ToolTips/ToolTipStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/ToolTips/ToolTipStyles.axaml
@@ -6,7 +6,7 @@
             <!-- Add Controls for Previewer Here -->
             <Button>
                 <ToolTip.Tip>
-                    <TextBlock Text="This is a tooltip" /> 
+                    <TextBlock Text="This is a tooltip" />
                 </ToolTip.Tip>
                 <TextBlock Text="Hover over me" />
             </Button>
@@ -19,12 +19,14 @@
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="CornerRadius" Value="{StaticResource Rounded}" />
         <Setter Property="Padding" Value="12,8" />
-        <Setter Property="BoxShadow">
-            <extensions:BoxShadow
-                BlurRadius="5" ShadowColor="{StaticResource BrandTranslucentDark500}"
-                VerticalLength1="3" BlurRadius1="4" ShadowColor1="{StaticResource BrandTranslucentDark100}"
-                VerticalLength2="2" BlurRadius2="4" ShadowColor2="{StaticResource BrandTranslucentDark100}" />
-        </Setter>
+
+        <Style Selector="^ /template/  Border#PART_LayoutRoot">
+            <Setter Property="BoxShadow">
+                <extensions:BoxShadow
+                    BlurRadius="5" ShadowColor="{StaticResource BrandTranslucentDark500}"
+                    VerticalLength1="3" BlurRadius1="4" ShadowColor1="{StaticResource BrandTranslucentDark100}"
+                    VerticalLength2="2" BlurRadius2="4" ShadowColor2="{StaticResource BrandTranslucentDark100}" />
+            </Setter>
+        </Style>
     </Style>
 </Styles>
-


### PR DESCRIPTION
- fix #952 
- Fixed DI related exception in designer preview

Regarding the designer preview, we were not calling `Host.StartAsync()`
After doing that though, I excluded SingleProcess (CLIServer and CLIClient) from being added to the Designer Service collection, to avoid the designer claiming single process lock.


For ToolTip styling, I added the Styles as defined on figma and fixed the SpineDownloadButton and IconButton Styles from bleeding into the ToolTips.

The ToolTip BoxShadow seems to work only in some cases though, there might be a problem with the outer padding value not being respected for some reason. The main issue was that `ClipToBounds=False` didn't work on `ToolTip` control itself, so I had to add the padding. 

![image](https://github.com/Nexus-Mods/NexusMods.App/assets/26797547/6fae7345-b996-4a39-ad95-cd9498ee97af)
![image](https://github.com/Nexus-Mods/NexusMods.App/assets/26797547/de876d95-963b-41a1-8de9-b499767821e1)
![image](https://github.com/Nexus-Mods/NexusMods.App/assets/26797547/a3a9e5d1-8c61-446c-ab24-c0b3dc3cdd45)
![image](https://github.com/Nexus-Mods/NexusMods.App/assets/26797547/864c4d9d-bc7c-475d-a93a-77b3b0551249)
