### PR TITLE
Fix command expected Unit, but received bool exception

### DIFF
--- a/src/Games/NexusMods.Games.FOMOD.UI/Step/GuidedInstallerStepViewModel.cs
+++ b/src/Games/NexusMods.Games.FOMOD.UI/Step/GuidedInstallerStepViewModel.cs
@@ -8,6 +8,7 @@ using NexusMods.Abstractions.Activities;
 using NexusMods.Abstractions.GuidedInstallers;
 using NexusMods.Abstractions.GuidedInstallers.ValueObjects;
 using NexusMods.App.UI;
+using NexusMods.App.UI.Extensions;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
 
@@ -166,12 +167,12 @@ public class GuidedInstallerStepViewModel : AViewModel<IGuidedInstallerStepViewM
 
             // GoToNext
             this.WhenAnyObservable(vm => vm.FooterStepperViewModel.GoToNextCommand)
-                .InvokeCommand(goToNextCommand)
+                .InvokeReactiveCommand(goToNextCommand)
                 .DisposeWith(disposables);
 
             // GoToPrev
             this.WhenAnyObservable(vm => vm.FooterStepperViewModel.GoToPrevCommand)
-                .InvokeCommand(goToPrevCommand)
+                .InvokeReactiveCommand(goToPrevCommand)
                 .DisposeWith(disposables);
 
             this.WhenAnyValue(vm => vm.Progress)

--- a/src/NexusMods.App.UI/Controls/MarkdownRenderer/MarkdownRendererViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/MarkdownRenderer/MarkdownRendererViewModel.cs
@@ -2,11 +2,11 @@ using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using Avalonia.Media;
-using Avalonia.Media.Imaging;
 using JetBrains.Annotations;
 using Markdown.Avalonia.Plugins;
 using Markdown.Avalonia.Utils;
 using Microsoft.Extensions.Logging;
+using NexusMods.App.UI.Extensions;
 using NexusMods.CrossPlatform.Process;
 using NexusMods.Hashing.xxHash64;
 using ReactiveUI;
@@ -60,7 +60,7 @@ public class MarkdownRendererViewModel : AViewModel<IMarkdownRendererViewModel>,
                 .Do(ParseGitHubUri)
                 .WhereNotNull()
                 .OffUi()
-                .InvokeCommand(fetchMarkdownCommand)
+                .InvokeReactiveCommand(fetchMarkdownCommand)
                 .DisposeWith(disposables);
 
             fetchMarkdownCommand

--- a/src/NexusMods.App.UI/Extensions/ReactiveExtensions.cs
+++ b/src/NexusMods.App.UI/Extensions/ReactiveExtensions.cs
@@ -1,8 +1,10 @@
 ﻿using System.Linq.Expressions;
 using System.Reactive.Linq;
+using System.Windows.Input;
 using Avalonia;
 using DynamicData;
 using DynamicData.Alias;
+using ReactiveUI;
 
 namespace NexusMods.App.UI.Extensions;
 
@@ -73,4 +75,49 @@ public static class ReactiveExtensions
     {
         return obs.BindToClasses(target, "Active");
     }
+
+
+    /// <summary>
+    /// Prefer this over `InvokeCommand` for better type checking.
+    /// A utility method that will pipe an Observable to an ICommand (i.e.
+    /// it will first call its CanExecute with the provided value, then if
+    /// the command can be executed, Execute() will be called).
+    /// </summary>
+    /// <typeparam name="T">The type.</typeparam>
+    /// <typeparam name="TResult">The result type.</typeparam>
+    /// <param name="item">The source observable to pipe into the command.</param>
+    /// <param name="command">The command to be executed.</param>
+    /// <returns>An object that when disposes, disconnects the Observable
+    /// from the command.</returns>
+    public static IDisposable InvokeReactiveCommand<T, TResult>(
+        this IObservable<T> item,
+        ReactiveCommandBase<T, TResult>? command)
+    {
+        return item.InvokeCommand(command, cmd => cmd);
+    }
+    
+    
+    /// <summary>
+    /// Prefer this over `InvokeCommand` for better type checking.
+    /// A utility method that will pipe an Observable to an ICommand (i.e.
+    /// it will first call its CanExecute with the provided value, then if
+    /// the command can be executed, Execute() will be called).
+    /// </summary>
+    /// <typeparam name="T">The type.</typeparam>
+    /// <typeparam name="TResult">The result type.</typeparam>
+    /// <typeparam name="TTarget">The target type.</typeparam>
+    /// <param name="item">The source observable to pipe into the command.</param>
+    /// <param name="target">The root object which has the Command.</param>
+    /// <param name="commandProperty">The expression to reference the Command.</param>
+    /// <returns>An object that when disposes, disconnects the Observable
+    /// from the command.</returns>
+    public static IDisposable InvokeReactiveCommand<T, TResult, TTarget>(
+        this IObservable<T> item, 
+        TTarget? target, 
+        Expression<Func<TTarget, ReactiveCommandBase<T, TResult>?>> commandProperty)
+        where TTarget : class
+    {
+        return item.InvokeCommand(target, commandProperty);
+    }
+        
 }

--- a/src/NexusMods.App.UI/Extensions/ReactiveExtensions.cs
+++ b/src/NexusMods.App.UI/Extensions/ReactiveExtensions.cs
@@ -103,6 +103,8 @@ public static class ReactiveExtensions
     /// A utility method that will pipe an Observable to an ICommand (i.e.
     /// it will first call its CanExecute with the provided value, then if
     /// the command can be executed, Execute() will be called).
+    /// This will set up a subscription to the (potentially reactive) command property,
+    /// and should be used when a view needs to invoke a command on a ViewModel.
     /// </summary>
     /// <typeparam name="T">The type.</typeparam>
     /// <typeparam name="TResult">The result type.</typeparam>

--- a/src/NexusMods.App.UI/Extensions/ReactiveExtensions.cs
+++ b/src/NexusMods.App.UI/Extensions/ReactiveExtensions.cs
@@ -93,7 +93,8 @@ public static class ReactiveExtensions
         this IObservable<T> item,
         ReactiveCommandBase<T, TResult>? command)
     {
-        return item.InvokeCommand(command, cmd => cmd);
+        // ReSharper disable once InvokeAsExtensionMethod
+        return ReactiveCommandMixins.InvokeCommand(item, command);
     }
     
     

--- a/src/NexusMods.App.UI/Pages/TextEdit/TextEditorPageViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/TextEdit/TextEditorPageViewModel.cs
@@ -11,6 +11,7 @@ using NexusMods.Abstractions.Loadouts.Files;
 using NexusMods.Abstractions.MnemonicDB.Attributes;
 using NexusMods.Abstractions.MnemonicDB.Attributes.Extensions;
 using NexusMods.Abstractions.Settings;
+using NexusMods.App.UI.Extensions;
 using NexusMods.App.UI.Settings;
 using NexusMods.App.UI.Windows;
 using NexusMods.App.UI.WorkspaceSystem;
@@ -131,11 +132,11 @@ public class TextEditorPageViewModel : APageViewModel<ITextEditorPageViewModel>,
                     serialDisposable.Disposable = repository.Revisions(context.FileId.Value, includeCurrent: false)
                         .Select(_ => context)
                         .OffUi()
-                        .InvokeCommand(_loadFileCommand);
+                        .InvokeReactiveCommand(_loadFileCommand);
                 })
                 .WhereNotNull()
                 .OffUi()
-                .InvokeCommand(_loadFileCommand)
+                .InvokeReactiveCommand(_loadFileCommand)
                 .DisposeWith(disposables);
 
             this.WhenAnyObservable(vm => vm._loadFileCommand)

--- a/src/NexusMods.App.UI/Windows/MainWindowViewModel.cs
+++ b/src/NexusMods.App.UI/Windows/MainWindowViewModel.cs
@@ -6,6 +6,7 @@ using NexusMods.Abstractions.NexusWebApi;
 using NexusMods.App.UI.Controls.DevelopmentBuildBanner;
 using NexusMods.App.UI.Controls.Spine;
 using NexusMods.App.UI.Controls.TopBar;
+using NexusMods.App.UI.Extensions;
 using NexusMods.App.UI.LeftMenu;
 using NexusMods.App.UI.Overlays;
 using NexusMods.App.UI.Overlays.AlphaWarning;
@@ -72,7 +73,7 @@ public class MainWindowViewModel : AViewModel<IMainWindowViewModel>, IMainWindow
             loginManager.IsLoggedInObservable
                 .Where(isSignedIn => isSignedIn)
                 .Select(_ => Unit.Default)
-                .InvokeCommand(BringWindowToFront)
+                .InvokeReactiveCommand(BringWindowToFront)
                 .DisposeWith(d);
             
             var loginMessageVM = serviceProvider.GetRequiredService<ILoginMessageBoxViewModel>();

--- a/src/NexusMods.App.UI/Windows/MainWindowViewModel.cs
+++ b/src/NexusMods.App.UI/Windows/MainWindowViewModel.cs
@@ -71,6 +71,7 @@ public class MainWindowViewModel : AViewModel<IMainWindowViewModel>, IMainWindow
             
             loginManager.IsLoggedInObservable
                 .Where(isSignedIn => isSignedIn)
+                .Select(_ => Unit.Default)
                 .InvokeCommand(BringWindowToFront)
                 .DisposeWith(d);
             

--- a/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelViewModel.cs
@@ -75,7 +75,7 @@ public class PanelViewModel : AViewModel<IPanelViewModel>, IPanelViewModel
                 .Count()
                 .Where(count => count == 0)
                 .Select(_ => Unit.Default)
-                .InvokeCommand(CloseCommand)
+                .InvokeReactiveCommand(CloseCommand)
                 .DisposeWith(disposables);
 
             // change the header when the panel only has a single tab vs multiple tabs

--- a/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerView.axaml.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerView.axaml.cs
@@ -4,6 +4,7 @@ using System.Reactive.Linq;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.ReactiveUI;
+using NexusMods.App.UI.Extensions;
 using ReactiveUI;
 
 namespace NexusMods.App.UI.WorkspaceSystem;
@@ -95,7 +96,7 @@ public partial class PanelResizerView : ReactiveUserControl<IPanelResizerViewMod
                     _isPressed = false;
                 })
                 .Select(_ => Unit.Default)
-                .InvokeCommand(this, view => view.ViewModel!.DragEndCommand)
+                .InvokeReactiveCommand(this, view => view.ViewModel!.DragEndCommand)
                 .DisposeWith(disposables);
 
             // drag
@@ -112,7 +113,7 @@ public partial class PanelResizerView : ReactiveUserControl<IPanelResizerViewMod
 
                     return ViewModel.IsHorizontal ? currentPos.Y : currentPos.X;
                 })
-                .InvokeCommand(this, view => view.ViewModel!.DragStartCommand)
+                .InvokeReactiveCommand(this, view => view.ViewModel!.DragStartCommand)
                 .DisposeWith(disposables);
         });
     }


### PR DESCRIPTION
Was tricky to pin down since stack trace didn't help. 
In the end I noticed it happened right after login and after a code search for `InvokeCommand` I found it.

Following @erri120 advice I added a couple of wrapper extensions for `InvokeCommand` that would not accept `ICommand`, resulting in better static type checking, which should prevent a similar issue from happening in the future. 