### PR TITLE
Remove transform scale on left menu button click

### DIFF
--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Button/BareIconStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Button/BareIconStyles.axaml
@@ -43,11 +43,6 @@
             <Setter Property="Size" Value="24" />
         </Style>
 
-        <Style Selector="^:pressed">
-            <!-- Accentuate the pressed animation -->
-            <Setter Property="RenderTransform" Value="scale(0.9)" />
-        </Style>
-
         <Style Selector="^:disabled">
             <Setter Property="Opacity" Value="{StaticResource OpacityDisabledElement}" />
         </Style>

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Button/BareIconStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Button/BareIconStyles.axaml
@@ -41,8 +41,21 @@
 
         <Style Selector="^ /template/ icons|UnifiedIcon">
             <Setter Property="Size" Value="24" />
+            <Setter Property="Foreground" Value="{StaticResource NeutralTranslucentModerateBrush}" />
         </Style>
-
+                       
+        <Style Selector="^:pointerover">
+            <Style Selector="^ /template/ icons|UnifiedIcon">
+                <Setter Property="Foreground" Value="{StaticResource NeutralStrongBrush}" />
+            </Style>
+        </Style>
+        
+        <Style Selector="^:pressed">
+            <Style Selector="^ /template/ icons|UnifiedIcon">
+                <Setter Property="Foreground" Value="{StaticResource NeutralTranslucentModerateBrush}" />
+            </Style>
+        </Style>
+        
         <Style Selector="^:disabled">
             <Setter Property="Opacity" Value="{StaticResource OpacityDisabledElement}" />
         </Style>

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Button/ButtonStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Button/ButtonStyles.axaml
@@ -14,7 +14,8 @@
                 <Button Classes="Avatar" HorizontalAlignment="Center">
                     <icons:UnifiedIcon>
                         <icons:UnifiedIcon.Value>
-                            <icons:IconValue ImageSetter="avares://NexusMods.Themes.NexusFluentDark/Assets/DesignTime/cyberpunk_game.png" />
+                            <icons:IconValue
+                                ImageSetter="avares://NexusMods.Themes.NexusFluentDark/Assets/DesignTime/cyberpunk_game.png" />
                         </icons:UnifiedIcon.Value>
                     </icons:UnifiedIcon>
                 </Button>
@@ -34,7 +35,7 @@
         </Border>
     </Design.PreviewWith>
 
-    <!--  Style Definitions -->
+    <!-- blanket removal of pressed scale transform. we will add to specific styles when we need it i.e. spine buttons -->
     <Style Selector=":is(Button):pressed">
         <Setter Property="RenderTransform" Value="none" />
     </Style>
@@ -83,43 +84,50 @@
         <Setter Property="CornerRadius" Value="{StaticResource Rounded-lg}" />
         <Setter Property="HorizontalAlignment" Value="Stretch" />
         <Setter Property="Background" Value="{StaticResource SurfaceTransparentBrush}" />
-        
+
 
         <Style Selector="^ TextBlock#NameText">
             <Setter Property="Theme" Value="{StaticResource BodyMDNormalTheme}" />
             <Setter Property="Foreground" Value="{StaticResource NeutralSubduedBrush}" />
         </Style>
-        
+
         <Style Selector="^ icons|UnifiedIcon#LeftIcon">
             <Setter Property="Foreground" Value="{StaticResource NeutralSubduedBrush}" />
         </Style>
-        
-        
+
+
         <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
             <Setter Property="Background" Value="{StaticResource SurfaceMidBrush}" />
         </Style>
-        
+
         <Style Selector="^:pointerover TextBlock#NameText">
             <Setter Property="Foreground" Value="{StaticResource NeutralStrongBrush}" />
         </Style>
-        
+
         <Style Selector="^:pointerover icons|UnifiedIcon#LeftIcon">
             <Setter Property="Foreground" Value="{StaticResource NeutralStrongBrush}" />
         </Style>
-        
+
+
         <Style Selector="^:pressed /template/ ContentPresenter#PART_ContentPresenter">
-            <Setter Property="Background" Value="{StaticResource SurfaceTopBrush}" />
+            <Setter Property="Background" Value="{StaticResource SurfaceLowBrush}" />
         </Style>
+
+        <!-- NOTE(insomnious): not being used until we have active states implemented
+        <Style Selector="^:pressed TextBlock#NameText">
+            <Setter Property="Theme" Value="{StaticResource BodyMDBoldTheme}" />
+        </Style>
+        -->
 
         <Style Selector="^.Active /template/ ContentPresenter#PART_ContentPresenter">
             <Setter Property="Background" Value="{StaticResource SurfaceLowBrush}" />
         </Style>
-        
+
         <Style Selector="^.Active TextBlock#NameText">
             <Setter Property="Theme" Value="{StaticResource BodyMDBoldTheme}" />
             <Setter Property="Foreground" Value="{StaticResource NeutralModerateBrush}" />
         </Style>
-        
+
         <Style Selector="^.Active icons|UnifiedIcon#LeftIcon">
             <Setter Property="Foreground" Value="{StaticResource NeutralModerateBrush}" />
         </Style>
@@ -152,7 +160,7 @@
         <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
             <Setter Property="Background" Value="{StaticResource SurfaceTopBrush}" />
         </Style>
-        
+
         <Style Selector="^:pressed /template/ ContentPresenter#PART_ContentPresenter">
             <Setter Property="Background" Value="{StaticResource SurfaceMidBrush}" />
         </Style>

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Button/ButtonStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Button/ButtonStyles.axaml
@@ -35,6 +35,9 @@
     </Design.PreviewWith>
 
     <!--  Style Definitions -->
+    <Style Selector=":is(Button):pressed">
+        <Setter Property="RenderTransform" Value="none" />
+    </Style>
 
     <!-- TopBar Action Button -->
     <Style Selector="Button.Action">
@@ -104,6 +107,9 @@
             <Setter Property="Foreground" Value="{StaticResource NeutralStrongBrush}" />
         </Style>
         
+        <Style Selector="^:pressed /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{StaticResource SurfaceTopBrush}" />
+        </Style>
 
         <Style Selector="^.Active /template/ ContentPresenter#PART_ContentPresenter">
             <Setter Property="Background" Value="{StaticResource SurfaceLowBrush}" />
@@ -145,6 +151,10 @@
 
         <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
             <Setter Property="Background" Value="{StaticResource SurfaceTopBrush}" />
+        </Style>
+        
+        <Style Selector="^:pressed /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{StaticResource SurfaceMidBrush}" />
         </Style>
 
         <Style Selector="^ > StackPanel">

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Button/HyperlinkStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Button/HyperlinkStyles.axaml
@@ -35,7 +35,6 @@
         </Style>
 
         <Style Selector="^:pressed">
-            <Setter Property="RenderTransform" Value="scale(1)" />
             <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
                 <Setter Property="Background" Value="{StaticResource SurfaceTransparentBrush}" />
             </Style>

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Button/PillStyles.xaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Button/PillStyles.xaml
@@ -219,8 +219,12 @@
 
     <!-- Pill Label -->
     <!-- Labels should have all interactions disabled, so they don't look interactable -->
-    <!-- NOTE(insomnious): left this empty selector here to make it easier to find in future -->
     <Style Selector="Button.Pill.Label">
+
+        <!--  Disable the scaling found in Fluent buttons when pressing -->
+        <Style Selector="^:pressed">
+            <Setter Property="RenderTransform" Value="scale(1.0)" />
+        </Style>
     </Style>
 
 

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Button/PillStyles.xaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Button/PillStyles.xaml
@@ -219,12 +219,8 @@
 
     <!-- Pill Label -->
     <!-- Labels should have all interactions disabled, so they don't look interactable -->
+    <!-- NOTE(insomnious): left this empty selector here to make it easier to find in future -->
     <Style Selector="Button.Pill.Label">
-
-        <!--  Disable the scaling found in Fluent buttons when pressing -->
-        <Style Selector="^:pressed">
-            <Setter Property="RenderTransform" Value="scale(1.0)" />
-        </Style>
     </Style>
 
 


### PR DESCRIPTION
@captainsandypants is happy with the global  removal of transform scale, and I've commented out the press state as it doesn't make sense until the active state is implemented

Fixes #1609 