### PR TITLE
Fix nxm downloads not opening the App if app is closed

### DIFF
--- a/src/Networking/NexusMods.Networking.NexusWebApi/Services.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/Services.cs
@@ -46,6 +46,7 @@ public static class Services
         
         return collection
             .AddAllSingleton<ILoginManager, LoginManager>()
+            .AddHostedService(s => (LoginManager)s.GetRequiredService<ILoginManager>())
             .AddAllSingleton<INexusApiClient, NexusApiClient>()
             .AddNexusApiVerbs();
     }

--- a/src/NexusMods.App/Program.cs
+++ b/src/NexusMods.App/Program.cs
@@ -61,6 +61,10 @@ public class Program
 
         // Okay to do wait here, as we are in the main process thread.
         host.StartAsync().Wait(timeout: TimeSpan.FromMinutes(5));
+        
+        // Start the CLI server if we are the main process.
+        var cliServer = services.GetService<CliServer>();
+        cliServer?.StartCliServerAsync().Wait(timeout: TimeSpan.FromSeconds(5));
 
         _logger = services.GetRequiredService<ILogger<Program>>();
         LogMessages.RuntimeInformation(_logger, RuntimeInformation.OSDescription, RuntimeInformation.FrameworkDescription);

--- a/src/NexusMods.App/Services.cs
+++ b/src/NexusMods.App/Services.cs
@@ -93,7 +93,8 @@ public static class Services
             services.AddFileSystem()
                 .AddCrossPlatform()
                 .AddDefaultRenderers()
-                .AddSettingsManager();
+                .AddSettingsManager()
+                .AddSettings<LoggingSettings>();
             
             if (!startupMode.IsAvaloniaDesigner)
                 services.AddSingleProcess(Mode.Client);

--- a/src/NexusMods.SingleProcess/CliServer.cs
+++ b/src/NexusMods.SingleProcess/CliServer.cs
@@ -1,9 +1,7 @@
 using System.Net;
 using System.Net.Sockets;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using NexusMods.Abstractions.GameLocators;
 using NexusMods.Abstractions.Settings;
 using NexusMods.ProxyConsole;
 using NexusMods.SingleProcess.Exceptions;
@@ -48,6 +46,19 @@ public class CliServer : IHostedService, IDisposable
         _syncFile = syncFile;
 
         _settings = settingsManager.Get<CliSettings>();
+    }
+    
+    /// <summary>
+    /// Starts the CLI server, listening for incoming connections.
+    /// This method needs to be called explicitly to start the server.
+    /// </summary>
+    public async Task StartCliServerAsync()
+    {
+        if (!_started)
+        {
+            _started = true;
+            await StartTcpListenerAsync();
+        }
     }
 
     private Task StartTcpListenerAsync()
@@ -135,19 +146,11 @@ public class CliServer : IHostedService, IDisposable
                 _runningClients.Remove(task);
         }
     }
-
+    
     /// <inheritdoc />
-    public async Task StartAsync(CancellationToken cancellationToken)
+    public Task StartAsync(CancellationToken cancellationToken)
     {
-        // Bit of a hack, but works for now till we get better startup logic with DI
-        var registry = _serviceProvider.GetRequiredService<IGameRegistry>();
-        await ((IHostedService)registry).StartAsync(cancellationToken);
-        
-        if (!_started && _settings.StartCliBackend)
-        {
-            _started = true;
-            await StartTcpListenerAsync();
-        }
+        return Task.CompletedTask;
     }
 
     /// <inheritdoc />

--- a/src/NexusMods.SingleProcess/NexusMods.SingleProcess.csproj
+++ b/src/NexusMods.SingleProcess/NexusMods.SingleProcess.csproj
@@ -13,6 +13,7 @@
     <ItemGroup>
       <ProjectReference Include="..\Abstractions\NexusMods.Abstractions.GameLocators\NexusMods.Abstractions.GameLocators.csproj" />
       <ProjectReference Include="..\Abstractions\NexusMods.Abstractions.Settings\NexusMods.Abstractions.Settings.csproj" />
+      <ProjectReference Include="..\NexusMods.CrossPlatform\NexusMods.CrossPlatform.csproj" />
       <ProjectReference Include="..\NexusMods.ProxyConsole\NexusMods.ProxyConsole.csproj" />
     </ItemGroup>
     <Import Project="$([MSBuild]::GetPathOfFileAbove('NuGet.Build.props', '$(MSBuildThisFileDirectory)../'))" />

--- a/src/NexusMods.SingleProcess/NexusMods.SingleProcess.csproj
+++ b/src/NexusMods.SingleProcess/NexusMods.SingleProcess.csproj
@@ -13,7 +13,6 @@
     <ItemGroup>
       <ProjectReference Include="..\Abstractions\NexusMods.Abstractions.GameLocators\NexusMods.Abstractions.GameLocators.csproj" />
       <ProjectReference Include="..\Abstractions\NexusMods.Abstractions.Settings\NexusMods.Abstractions.Settings.csproj" />
-      <ProjectReference Include="..\NexusMods.CrossPlatform\NexusMods.CrossPlatform.csproj" />
       <ProjectReference Include="..\NexusMods.ProxyConsole\NexusMods.ProxyConsole.csproj" />
     </ItemGroup>
     <Import Project="$([MSBuild]::GetPathOfFileAbove('NuGet.Build.props', '$(MSBuildThisFileDirectory)../'))" />

--- a/src/NexusMods.SingleProcess/Services.cs
+++ b/src/NexusMods.SingleProcess/Services.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.Settings;
+using NexusMods.CrossPlatform;
 
 namespace NexusMods.SingleProcess;
 
@@ -30,9 +31,11 @@ public static class Services
     {
         services.AddSingleton<SyncFile>();
         services.AddSettings<CliSettings>();
+        services.AddSettings<LoggingSettings>();
         switch (mode)
         {
             case Mode.Main:
+                services.AddSingleton<CliServer>();
                 services.AddHostedService<CliServer>();
                 break;
             case Mode.Client:

--- a/src/NexusMods.SingleProcess/Services.cs
+++ b/src/NexusMods.SingleProcess/Services.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.Settings;
-using NexusMods.CrossPlatform;
 
 namespace NexusMods.SingleProcess;
 

--- a/src/NexusMods.SingleProcess/Services.cs
+++ b/src/NexusMods.SingleProcess/Services.cs
@@ -31,7 +31,6 @@ public static class Services
     {
         services.AddSingleton<SyncFile>();
         services.AddSettings<CliSettings>();
-        services.AddSettings<LoggingSettings>();
         switch (mode)
         {
             case Mode.Main:

--- a/tests/Games/NexusMods.Games.BethesdaGameStudios.Tests/Startup.cs
+++ b/tests/Games/NexusMods.Games.BethesdaGameStudios.Tests/Startup.cs
@@ -29,7 +29,6 @@ public class Startup
             .AddSingleton<CommandLineConfigurator>()
             .AddBethesdaGameStudios()
             .AddGames()
-            .AddActivityMonitor()
             .AddSerializationAbstractions()
             .AddInstallerTypes()
             .AddGenericGameSupport()
@@ -39,7 +38,6 @@ public class Startup
             .AddCLI()
             .AddSingleton<IGuidedInstaller, NullGuidedInstaller>()
             .AddLogging(builder => builder.AddXunitOutput())
-            .AddCrossPlatform()
             .Validate();
     }
 }

--- a/tests/Games/NexusMods.Games.BladeAndSorcery.Tests/Startup.cs
+++ b/tests/Games/NexusMods.Games.BladeAndSorcery.Tests/Startup.cs
@@ -25,10 +25,8 @@ public class Startup
             .AddGames()
             .AddFileStoreAbstractions()
             .AddLoadoutAbstractions()
-            .AddActivityMonitor()
             .AddSerializationAbstractions()
             .AddInstallerTypes()
-            .AddCrossPlatform()
             .Validate();
     }
 }

--- a/tests/Games/NexusMods.Games.DarkestDungeon.Tests/Startup.cs
+++ b/tests/Games/NexusMods.Games.DarkestDungeon.Tests/Startup.cs
@@ -23,12 +23,10 @@ public class Startup
             .AddDarkestDungeon()
             .AddLogging(builder => builder.AddXUnit())
             .AddGames()
-            .AddActivityMonitor()
             .AddFileStoreAbstractions()
             .AddLoadoutAbstractions()
             .AddSerializationAbstractions()
             .AddInstallerTypes()
-            .AddCrossPlatform()
             .Validate();
     }
 }

--- a/tests/Games/NexusMods.Games.FOMOD.Tests/Startup.cs
+++ b/tests/Games/NexusMods.Games.FOMOD.Tests/Startup.cs
@@ -6,7 +6,6 @@ using NexusMods.Abstractions.Games;
 using NexusMods.Abstractions.Installers;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Serialization;
-using NexusMods.Activities;
 using NexusMods.App.BuildInfo;
 using NexusMods.CrossPlatform;
 using NexusMods.Games.BethesdaGameStudios;
@@ -23,7 +22,6 @@ public class Startup
     public void ConfigureServices(IServiceCollection container)
     {
         container
-            .AddCrossPlatform()
             .AddLoadoutAbstractions()
             .AddDefaultServicesForTesting()
             .AddBethesdaGameStudios()
@@ -34,7 +32,6 @@ public class Startup
             .AddSingleton<ICoreDelegates, MockDelegates>()
             .AddLogging(builder => builder.AddXunitOutput().SetMinimumLevel(LogLevel.Debug))
             .AddGames()
-            .AddActivityMonitor()
             .AddSerializationAbstractions()
             .AddInstallerTypes()
             .Validate();

--- a/tests/Games/NexusMods.Games.MountAndBlade2Bannerlord.Tests/Startup.cs
+++ b/tests/Games/NexusMods.Games.MountAndBlade2Bannerlord.Tests/Startup.cs
@@ -23,12 +23,10 @@ public class Startup
             .AddMountAndBladeBannerlord()
             .AddLogging(builder => builder.AddXunitOutput())
             .AddGames()
-            .AddActivityMonitor()
             .AddSerializationAbstractions()
             .AddFileStoreAbstractions()
             .AddLoadoutAbstractions()
             .AddInstallerTypes()
-            .AddCrossPlatform()
             .Validate();
     }
 }

--- a/tests/Games/NexusMods.Games.RedEngine.Tests/Startup.cs
+++ b/tests/Games/NexusMods.Games.RedEngine.Tests/Startup.cs
@@ -23,12 +23,10 @@ public class Startup
             .AddRedEngineGames()
             .AddLogging(builder => builder.AddXUnit())
             .AddGames()
-            .AddActivityMonitor()
             .AddSerializationAbstractions()
             .AddLoadoutAbstractions()
             .AddFileStoreAbstractions()
             .AddInstallerTypes()
-            .AddCrossPlatform()
             .Validate();
     }
 }

--- a/tests/Games/NexusMods.Games.Sifu.Tests/Startup.cs
+++ b/tests/Games/NexusMods.Games.Sifu.Tests/Startup.cs
@@ -23,12 +23,10 @@ public class Startup
             .AddSifu()
             .AddLogging(builder => builder.AddXUnit())
             .AddGames()
-            .AddActivityMonitor()
             .AddFileStoreAbstractions()
             .AddLoadoutAbstractions()
             .AddSerializationAbstractions()
             .AddInstallerTypes()
-            .AddCrossPlatform()
             .Validate();
     }
 }

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/Startup.cs
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/Startup.cs
@@ -29,12 +29,10 @@ public class Startup
             .AddStardewValley()
             .AddLogging(builder => builder.AddXUnit())
             .AddGames()
-            .AddActivityMonitor()
             .AddFileStoreAbstractions()
             .AddLoadoutAbstractions()
             .AddSerializationAbstractions()
             .AddInstallerTypes()
-            .AddCrossPlatform()
             .Validate();
     }
 }

--- a/tests/Games/NexusMods.Games.TestFramework/DependencyInjectionHelper.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/DependencyInjectionHelper.cs
@@ -2,9 +2,11 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using NexusMods.Abstractions.Activities;
 using NexusMods.Abstractions.HttpDownloader;
 using NexusMods.Abstractions.Loadouts.Synchronizers;
 using NexusMods.Abstractions.Settings;
+using NexusMods.Activities;
 using NexusMods.CrossPlatform;
 using NexusMods.DataModel;
 using NexusMods.FileExtractor;
@@ -52,6 +54,9 @@ public static class DependencyInjectionHelper
             .AddSingleton<HttpClient>()
             .AddSingleton<TestModDownloader>()
             .AddNexusWebApi(true)
+            .AddCrossPlatform()
+            .AddActivityMonitor()
+            .AddSettings<LoggingSettings>()
             .AddHttpDownloader()
             .AddDataModel()
             .AddLoadoutsSynchronizers()

--- a/tests/Games/NexusMods.Games.TestFramework/NexusMods.Games.TestFramework.csproj
+++ b/tests/Games/NexusMods.Games.TestFramework/NexusMods.Games.TestFramework.csproj
@@ -3,6 +3,7 @@
         <ProjectReference Include="..\..\..\src\ArchiveManagement\NexusMods.FileExtractor\NexusMods.FileExtractor.csproj" />
         <ProjectReference Include="..\..\..\src\Networking\NexusMods.Networking.HttpDownloader\NexusMods.Networking.HttpDownloader.csproj" />
         <ProjectReference Include="..\..\..\src\Networking\NexusMods.Networking.NexusWebApi\NexusMods.Networking.NexusWebApi.csproj" />
+        <ProjectReference Include="..\..\..\src\NexusMods.Activities\NexusMods.Activities.csproj" />
         <ProjectReference Include="..\..\..\src\NexusMods.DataModel\NexusMods.DataModel.csproj" />
         <ProjectReference Include="..\..\..\src\NexusMods.Settings\NexusMods.Settings.csproj" />
         <ProjectReference Include="..\..\NexusMods.StandardGameLocators.TestHelpers\NexusMods.StandardGameLocators.TestHelpers.csproj" />

--- a/tests/Networking/NexusMods.Networking.Downloaders.Tests/Startup.cs
+++ b/tests/Networking/NexusMods.Networking.Downloaders.Tests/Startup.cs
@@ -28,7 +28,6 @@ public class Startup
             .AddDefaultServicesForTesting()
             .AddUniversalGameLocator<Cyberpunk2077>(new Version("1.61"))
             .AddUniversalGameLocator<SkyrimSpecialEdition>(new Version("1.6.659.0"))
-            .AddActivityMonitor()
             .AddStubbedGameLocators()
             .AddBethesdaGameStudios()
             .AddGenericGameSupport()
@@ -37,8 +36,6 @@ public class Startup
             .AddFomod()
             .AddDownloaders()
             .AddSingleton<LocalHttpServer>()
-            .AddCrossPlatform()
-            .AddSettings<LoggingSettings>()
             .Validate();
     }
 }

--- a/tests/Networking/NexusMods.Networking.Downloaders.Tests/Startup.cs
+++ b/tests/Networking/NexusMods.Networking.Downloaders.Tests/Startup.cs
@@ -2,8 +2,10 @@ using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.GuidedInstallers;
 using NexusMods.Abstractions.Serialization;
 using NexusMods.Abstractions.Serialization.ExpressionGenerator;
+using NexusMods.Abstractions.Settings;
 using NexusMods.Activities;
 using NexusMods.App.BuildInfo;
+using NexusMods.CrossPlatform;
 using NexusMods.Extensions.DependencyInjection;
 using NexusMods.Games.BethesdaGameStudios;
 using NexusMods.Games.BethesdaGameStudios.SkyrimSpecialEdition;
@@ -35,6 +37,8 @@ public class Startup
             .AddFomod()
             .AddDownloaders()
             .AddSingleton<LocalHttpServer>()
+            .AddCrossPlatform()
+            .AddSettings<LoggingSettings>()
             .Validate();
     }
 }

--- a/tests/Networking/NexusMods.Networking.NexusWebApi.Tests/Startup.cs
+++ b/tests/Networking/NexusMods.Networking.NexusWebApi.Tests/Startup.cs
@@ -1,8 +1,10 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.Loadouts;
+using NexusMods.Abstractions.Settings;
 using NexusMods.Activities;
 using NexusMods.App.BuildInfo;
+using NexusMods.CrossPlatform;
 using NexusMods.CrossPlatform.Process;
 using NexusMods.DataModel;
 using NexusMods.Networking.HttpDownloader;
@@ -23,10 +25,11 @@ public class Startup
             .AddSingleton<HttpClient>()
             .AddHttpDownloader()
             .AddSingleton<TemporaryFileManager>()
-            .AddSingleton<IProcessFactory, ProcessFactory>()
             .AddSingleton<LocalHttpServer>()
             .AddNexusWebApi(true)
             .AddActivityMonitor()
+            .AddCrossPlatform()
+            .AddSettings<LoggingSettings>()
             .AddLoadoutAbstractions()
             .AddDataModel() // this is required because we're also using NMA integration
             .AddLogging(builder => builder.AddXunitOutput()

--- a/tests/NexusMods.CLI.Tests/Startup.cs
+++ b/tests/NexusMods.CLI.Tests/Startup.cs
@@ -49,6 +49,7 @@ public class Startup
                 .AddGames()
                 .AddInstallerTypes()
                 .AddCrossPlatform()
+                .AddSettings<LoggingSettings>()
                 .AddLogging(builder => builder.AddXunitOutput().SetMinimumLevel(LogLevel.Trace))
                 .AddSingleton<LocalHttpServer>()
                 .AddLogging(builder => builder.AddXUnit())


### PR DESCRIPTION
- fixes #515


### Recap:
- Slim process was not spawning new main process due to missing `LoggingSetting` in DI for `ProcessFactory`
- Fixed that, the DL was being skipped due to login check returning false
- `LoginManger` wouldn't have data until DB was initialized
- Had to make the `LoginManger` into a `HostedService` and await in `StartAsync()` on the db to be ready.
- This initialized the UserData from DB, but `CliServer.StartAsync()` started listening before that.
- Changed `CliServer` to require explicit `StartCliServerAsync` call in `Program.cs`
- `CliServer` is only started after all the other `HostedServices` have initialized.
- Removed hack workaround where `CliServer` was waiting for `GameRegistry` to initialize in `StartAsync`.
- Fixed DI for all serviced that used either `PrcessFactory` or `CrossPlatform` that also required `LoggingSettings`