### PR TITLE
Fix LoginManager requiring API key for unrelated tests and increasing load times

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.NexusWebApi/ILoginManager.cs
+++ b/src/Abstractions/NexusMods.Abstractions.NexusWebApi/ILoginManager.cs
@@ -7,15 +7,6 @@ namespace NexusMods.Abstractions.NexusWebApi;
 /// </summary>
 public interface ILoginManager
 {
-    /// <summary>
-    /// The current user information, null if not logged in
-    /// </summary>
-    UserInfo? UserInfo { get; }
-    
-    /// <summary>
-    /// True if logged in
-    /// </summary>
-    bool IsLoggedIn { get; }
     
     /// <summary>
     /// Allows you to subscribe to notifications of when the user information changes.
@@ -42,6 +33,11 @@ public interface ILoginManager
     /// </summary>
     /// <param name="token"></param>
     Task LoginAsync(CancellationToken token = default);
+    
+    /// <summary>
+    /// Returns the user's information
+    /// </summary>
+    Task<UserInfo?> GetUserInfoAsync(CancellationToken token = default);
 
     /// <summary>
     ///  Log out of Nexus Mods

--- a/src/Networking/NexusMods.Networking.NexusWebApi/Services.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/Services.cs
@@ -46,7 +46,6 @@ public static class Services
         
         return collection
             .AddAllSingleton<ILoginManager, LoginManager>()
-            .AddHostedService(s => (LoginManager)s.GetRequiredService<ILoginManager>())
             .AddAllSingleton<INexusApiClient, NexusApiClient>()
             .AddNexusApiVerbs();
     }

--- a/src/NexusMods.App.Cli/Types/IpcHandlers/NxmIpcProtocolHandler.cs
+++ b/src/NexusMods.App.Cli/Types/IpcHandlers/NxmIpcProtocolHandler.cs
@@ -48,7 +48,8 @@ public class NxmIpcProtocolHandler : IIpcProtocolHandler
                 break;
             case NXMModUrl modUrl:
                 // Check if the user is logged in
-                if (_loginManager.IsLoggedIn)
+                var userInfo = await _loginManager.GetUserInfoAsync(cancel);
+                if (userInfo is not null)
                 {
                     var task = await _downloadService.AddTask(modUrl);
                     _ = task.StartAsync();

--- a/src/NexusMods.App.UI/Controls/TopBar/TopBarViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/TopBar/TopBarViewModel.cs
@@ -128,7 +128,7 @@ public class TopBarViewModel : AViewModel<ITopBarViewModel>, ITopBarViewModel
 
         OpenNexusModsProfileCommand = ReactiveCommand.CreateFromTask(async () =>
         {
-            var userInfo = _loginManager.UserInfo;
+            var userInfo = await _loginManager.GetUserInfoAsync();
             if (userInfo is null) return;
 
             var userId = userInfo.UserId.Value;

--- a/src/NexusMods.App.UI/Overlays/Login/StartupMessageBox/LoginMessageBoxViewModel.cs
+++ b/src/NexusMods.App.UI/Overlays/Login/StartupMessageBox/LoginMessageBoxViewModel.cs
@@ -35,11 +35,6 @@ public class LoginMessageBoxViewModel : AOverlayViewModel<ILoginMessageBoxViewMo
         if (_settingsManager.Get<LoginSettings>().HasShownModal) return false;
         _settingsManager.Update<LoginSettings>(settings => settings with { HasShownModal = true });
         
-        if (_loginManager.IsLoggedIn)
-        {
-            return false;
-        }
-        
         _overlayController.Enqueue(this);
         return true;
     }


### PR DESCRIPTION
- reverted `LoginManager` to not be `IHostedService`
- removed property accessors that only worked if there was a subscription active
- added `GetUserInfoAsync` method to call verify directly