### PR TITLE
CliServer DI fix

### DIFF
--- a/src/NexusMods.SingleProcess/Services.cs
+++ b/src/NexusMods.SingleProcess/Services.cs
@@ -34,7 +34,7 @@ public static class Services
         {
             case Mode.Main:
                 services.AddSingleton<CliServer>();
-                services.AddHostedService<CliServer>();
+                services.AddHostedService(s => s.GetRequiredService<CliServer>());
                 break;
             case Mode.Client:
                 services.AddTransient<CliClient>();


### PR DESCRIPTION
Something was nagging at me that I was forgetting something and I remembered this morning in the shower.

- Changed the `AddHostedService` call to reuse the existing `CliServer` singleton rather than creating a new one.

Concretely I think what actually changed is that `StopAsync` was getting called on a `CliServer` that was never started, and the actual started version was not getting properly closed at shutdown. 

Probably no actual user impact