### PR TITLE
Mark tests as Flakey

### DIFF
--- a/tests/NexusMods.UI.Tests/Controls/LaunchButtonViewTests.cs
+++ b/tests/NexusMods.UI.Tests/Controls/LaunchButtonViewTests.cs
@@ -61,6 +61,8 @@ public class LaunchButtonViewTests : AViewTest<LaunchButtonView, LaunchButtonDes
     }
 
     [Fact]
+    // Seems to very seldom stall CI, could be made to fail if run un repeat for enough times locally
+    [Trait("FlakeyTest", "True")]
     public async Task ProgressAffectsProgressBar()
     {
         ViewModel.Progress = Percent.CreateClamped(0.25);

--- a/tests/NexusMods.UI.Tests/Overlays/OverlayViewModelTests.cs
+++ b/tests/NexusMods.UI.Tests/Overlays/OverlayViewModelTests.cs
@@ -86,6 +86,8 @@ public class OverlayViewModelTests
     }
     
     [Fact]
+    // intermittent failures on CI but not locally
+    [Trait("FlakeyTest", "True")]
     public async Task SetOverlayViewModel_WhenActiveIsFalse_TaskIsCompleted()
     {
         // Arrange


### PR DESCRIPTION
Failures are too random and slowing down PRs getting merged as well as neutering CI effectiveness.
Tried looking into both tests, but apart from weird timing shenanigans with UI threads I didn't find possible causes for the failures.