### PR TITLE
Fix DataGrid sorting

### DIFF
--- a/src/NexusMods.App.UI/Pages/Downloads/InProgressView.axaml
+++ b/src/NexusMods.App.UI/Pages/Downloads/InProgressView.axaml
@@ -165,7 +165,8 @@
                                   Width="1">
                             <DataGrid.Columns>
                                 <DataGridTemplateColumn Header="{x:Static resources:Language.Helpers_GenerateHeader_MOD_NAME}" 
-                                                        Width="*"> 
+                                                        Width="*"
+                                                        SortMemberPath="Name"> 
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate DataType="viewModels:IDownloadTaskViewModel">
                                             <TextBlock Classes="BodyMDNormal"
@@ -175,7 +176,8 @@
                                     </DataGridTemplateColumn.CellTemplate>
                                 </DataGridTemplateColumn>
 
-                                <DataGridTemplateColumn Header="{x:Static resources:Language.Helpers_GenerateHeader_VERSION}"> 
+                                <DataGridTemplateColumn Header="{x:Static resources:Language.Helpers_GenerateHeader_VERSION}"
+                                                        SortMemberPath="Version"> 
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate DataType="viewModels:IDownloadTaskViewModel">
                                             <TextBlock Classes="BodyMDNormal"
@@ -185,7 +187,8 @@
                                     </DataGridTemplateColumn.CellTemplate>
                                 </DataGridTemplateColumn>
                                 
-                                <DataGridTemplateColumn Header="{x:Static resources:Language.Helpers_GenerateHeader_GAME}"> 
+                                <DataGridTemplateColumn Header="{x:Static resources:Language.Helpers_GenerateHeader_GAME}"
+                                                        SortMemberPath="Game"> 
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate DataType="viewModels:IDownloadTaskViewModel">
                                             <TextBlock Classes="BodyMDNormal"
@@ -195,7 +198,8 @@
                                     </DataGridTemplateColumn.CellTemplate>
                                 </DataGridTemplateColumn>
                                 
-                                <DataGridTemplateColumn Header="{x:Static resources:Language.Helpers_GenerateHeader_SIZE}"> 
+                                <DataGridTemplateColumn Header="{x:Static resources:Language.Helpers_GenerateHeader_SIZE}"
+                                                        SortMemberPath="SizeBytes"> 
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate DataType="viewModels:IDownloadTaskViewModel">
                                             <TextBlock Classes="BodyMDNormal"
@@ -205,7 +209,8 @@
                                     </DataGridTemplateColumn.CellTemplate>
                                 </DataGridTemplateColumn>
                                 
-                                <DataGridTemplateColumn Header="{x:Static resources:Language.DownloadCompleted_COMPLETED}"> 
+                                <DataGridTemplateColumn Header="{x:Static resources:Language.DownloadCompleted_COMPLETED}"
+                                                        SortMemberPath="CompletedTime"> 
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate DataType="viewModels:IDownloadTaskViewModel">
                                             <TextBlock Classes="BodyMDNormal"

--- a/src/NexusMods.App.UI/Pages/Downloads/ViewModels/DownloadTaskDesignViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/Downloads/ViewModels/DownloadTaskDesignViewModel.cs
@@ -14,6 +14,7 @@ public class DownloadTaskDesignViewModel : AViewModel<IDownloadTaskViewModel>, I
     public string Version { get; set; } = "1.0.0";
     public string Game { get; set; } = "Unknown Game";
     public string HumanizedSize => ByteSize.FromBytes(SizeBytes).ToString();
+    public DateTime CompletedTime { get; }
     public string HumanizedCompletedTime { get; } = "-";
     public DownloadTaskStatus Status { get; set; } = DownloadTaskStatus.Idle;
     public EntityId TaskId { get; set; } = EntityId.From(1024);

--- a/src/NexusMods.App.UI/Pages/Downloads/ViewModels/IDownloadTaskViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/Downloads/ViewModels/IDownloadTaskViewModel.cs
@@ -1,4 +1,5 @@
 using System.Reactive;
+using JetBrains.Annotations;
 using NexusMods.App.UI.Controls.Navigation;
 using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.Networking.Downloaders.Interfaces;
@@ -33,6 +34,13 @@ public interface IDownloadTaskViewModel : IViewModelInterface
     /// Total size in humanized string format.
     /// </summary>
     public string HumanizedSize { get; }
+    
+    /// <summary>
+    /// The DateTime when the download was completed
+    /// Used for sorting and filtering.
+    /// </summary>
+    [UsedImplicitly]
+    public DateTime CompletedTime { get; }
     
     /// <summary>
     /// The DateTime when the download was completed in humanized string format.

--- a/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginsPageView.axaml
+++ b/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginsPageView.axaml
@@ -84,7 +84,8 @@
                 </DataGrid.Resources>
                 <DataGrid.Columns>
                     <DataGridTemplateColumn Header="{x:Static resources:Language.FileOriginsPageView_NameHeader}" 
-                                            Width="*">
+                                            Width="*"
+                                            SortMemberPath="Name">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate DataType="fileOriginEntry:IFileOriginEntryViewModel">
                                 <TextBlock Classes="BodyMDNormal" 
@@ -93,7 +94,8 @@
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
-                    <DataGridTemplateColumn Header="{x:Static resources:Language.FileOriginsPageView_VersionHeader}">
+                    <DataGridTemplateColumn Header="{x:Static resources:Language.FileOriginsPageView_VersionHeader}"
+                                            SortMemberPath="Version">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate DataType="fileOriginEntry:IFileOriginEntryViewModel">
                                 <TextBlock Classes="BodyMDNormal" 
@@ -102,7 +104,8 @@
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
-                    <DataGridTemplateColumn Header="{x:Static resources:Language.FileOriginsPageView_SizeHeader}">
+                    <DataGridTemplateColumn Header="{x:Static resources:Language.FileOriginsPageView_SizeHeader}"
+                                            SortMemberPath="Size">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate DataType="fileOriginEntry:IFileOriginEntryViewModel">
                                 <TextBlock Classes="BodyMDNormal" 
@@ -111,7 +114,8 @@
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
-                    <DataGridTemplateColumn Header="{x:Static resources:Language.FileOriginsPageView_DownloadedHeader}">
+                    <DataGridTemplateColumn Header="{x:Static resources:Language.FileOriginsPageView_DownloadedHeader}"
+                                            SortMemberPath="DisplayArchiveDate">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate DataType="fileOriginEntry:IFileOriginEntryViewModel">
                                 <TextBlock Classes="BodyMDNormal" 
@@ -120,7 +124,8 @@
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
-                    <DataGridTemplateColumn Header="{x:Static resources:Language.FileOriginsPageView_InstalledHeader}">
+                    <DataGridTemplateColumn Header="{x:Static resources:Language.FileOriginsPageView_InstalledHeader}"
+                                            SortMemberPath="DisplayLastInstalledDate">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate DataType="fileOriginEntry:IFileOriginEntryViewModel">
                                 <TextBlock Classes="BodyMDNormal" 
@@ -129,7 +134,9 @@
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
-                    <DataGridTemplateColumn Header="{x:Static resources:Language.FileOriginsPageView_ActionHeader}" MinWidth="102">
+                    <DataGridTemplateColumn Header="{x:Static resources:Language.FileOriginsPageView_ActionHeader}" 
+                                            MinWidth="102"
+                                            SortMemberPath="IsModAddedToLoadout">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate DataType="fileOriginEntry:IFileOriginEntryViewModel">
                                 <Grid>


### PR DESCRIPTION
- fix #1616 

Fixes sorting for Mod Library and Completed Downloads section.

`DataGridTemplateColumn` needs `SortMemberPath` to know which property to use for sorting.
The ugly part is that it takes a string rather than a binding or something Type checkable.