### PR TITLE
Move downloads out of Temp and clean up after cancel and complete

### DIFF
--- a/src/Networking/NexusMods.Networking.Downloaders/DownloadService.cs
+++ b/src/Networking/NexusMods.Networking.Downloaders/DownloadService.cs
@@ -1,8 +1,8 @@
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using DynamicData;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using NexusMods.Abstractions.MnemonicDB.Attributes.Extensions;
 using NexusMods.Abstractions.NexusWebApi.Types;
 using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.Networking.Downloaders.Interfaces;
@@ -14,8 +14,7 @@ using DynamicData.Kernel;
 using Microsoft.Extensions.Hosting;
 using NexusMods.Abstractions.Activities;
 using NexusMods.Abstractions.IO;
-using NexusMods.MnemonicDB.Abstractions.DatomIterators;
-using NexusMods.MnemonicDB.Abstractions.Query;
+using NexusMods.Abstractions.Settings;
 using NexusMods.Paths;
 
 namespace NexusMods.Networking.Downloaders;
@@ -25,6 +24,9 @@ public class DownloadService : IDownloadService, IDisposable, IHostedService
 {
     /// <inheritdoc />
     public ReadOnlyObservableCollection<IDownloadTask> Downloads => _downloadsCollection;
+    
+    /// <inheritdoc />
+    public AbsolutePath OngoingDownloadsDirectory => _downloadDirectory;
     private ReadOnlyObservableCollection<IDownloadTask> _downloadsCollection = ReadOnlyObservableCollection<IDownloadTask>.Empty;
 
     private readonly SourceCache<IDownloadTask, EntityId> _downloads = new(t => t.PersistentState.Id);
@@ -34,14 +36,26 @@ public class DownloadService : IDownloadService, IDisposable, IHostedService
     private bool _isDisposed;
     private readonly CompositeDisposable _disposables;
     private readonly IFileStore _fileStore;
+    private AbsolutePath _downloadDirectory;
 
-    public DownloadService(ILogger<DownloadService> logger, IServiceProvider provider, IFileStore fileStore, IConnection conn)
+    public DownloadService(
+        ILogger<DownloadService> logger, 
+        IServiceProvider provider, 
+        IFileStore fileStore, 
+        IConnection conn,
+        IFileSystem fs,
+        ISettingsManager settingsManager)
     {
         _logger = logger;
         _provider = provider;
         _conn = conn;
         _disposables = new CompositeDisposable();
         _fileStore = fileStore;
+        _downloadDirectory = settingsManager.Get<DownloadSettings>().OngoingDownloadLocation.ToPath(fs);
+        if (!_downloadDirectory.DirectoryExists())
+        {
+            _downloadDirectory.CreateDirectory();
+        }
     }
 
     internal IEnumerable<IDownloadTask> GetItemsToResume()
@@ -209,8 +223,17 @@ public class DownloadService : IDownloadService, IDisposable, IHostedService
             // TODO(Al12rs): should Suspend() instead, but only after moving ongoing dl files outside Temp folder,
             // that is otherwise cleaned up on application close, causing exceptions due to file in use,
             // on top of discarding all the progress.
-            .Select(dl => dl.Cancel());
+            .Select(dl => dl.Suspend());
         
         await Task.WhenAll(suspendingTasks);
+    }
+    
+    /// <summary>
+    /// Set a custom downloadDirectory, for tests only.
+    /// Directory should already exist.
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal void SetDownloadDirectory(AbsolutePath path)
+    {
+        _downloadDirectory = path;
     }
 }

--- a/src/Networking/NexusMods.Networking.Downloaders/DownloadSettings.cs
+++ b/src/Networking/NexusMods.Networking.Downloaders/DownloadSettings.cs
@@ -1,0 +1,67 @@
+using JetBrains.Annotations;
+using Microsoft.Extensions.DependencyInjection;
+using NexusMods.Abstractions.Settings;
+using NexusMods.Paths;
+
+namespace NexusMods.Networking.Downloaders;
+
+/// <summary>
+/// Settings for downloads.
+/// </summary>
+[PublicAPI]
+public class DownloadSettings : ISettings
+{
+    
+    /// <summary>
+    /// Base directory where files generated during ongoing download operations are located.
+    /// </summary>
+    /// <remarks>
+    /// Should not be placed in Temp or similar directories,
+    /// as download files may need to persist across application and system restarts.
+    /// </remarks>
+    public ConfigurablePath OngoingDownloadLocation { get; set; }
+    
+    
+    /// <inheritdoc/>
+    public static ISettingsBuilder Configure(ISettingsBuilder settingsBuilder)
+    {
+        return settingsBuilder
+            .ConfigureDefault(CreateDefault)
+            .ConfigureStorageBackend<DownloadSettings>(builder => builder.UseJson());
+    }
+    
+    /// <summary>
+    /// Create default value.
+    /// </summary>
+    public static DownloadSettings CreateDefault(IServiceProvider serviceProvider)
+    {
+        var os = serviceProvider.GetRequiredService<IFileSystem>().OS;
+
+        return new DownloadSettings
+        {
+            OngoingDownloadLocation = GetStandardDownloadPath(os),
+        };
+    }
+    
+    private static ConfigurablePath GetStandardDownloadPath(IOSInformation os)
+    {
+         var basePath = os.MatchPlatform(
+            onWindows: () => KnownPath.LocalApplicationDataDirectory,
+            onLinux: () => KnownPath.XDG_DATA_HOME,
+            onOSX: () => KnownPath.LocalApplicationDataDirectory
+        );
+        // NOTE: OSX ".App" is apparently special, using _ instead of . to prevent weirdness
+        var baseDirectoryName = os.IsOSX ? "NexusMods_App/" : "NexusMods.App/";
+        var downloadsSubPath = baseDirectoryName + "Downloads/Ongoing";
+        
+        return new ConfigurablePath(basePath, downloadsSubPath);
+    }
+
+    /// <summary>
+    /// Absolute path to the standard downloads' folder.
+    /// </summary>
+    public static AbsolutePath GetStandardDownloadsFolder(IFileSystem fs)
+    { 
+        return GetStandardDownloadPath(fs.OS).ToPath(fs);
+    }
+}

--- a/src/Networking/NexusMods.Networking.Downloaders/Interfaces/IDownloadService.cs
+++ b/src/Networking/NexusMods.Networking.Downloaders/Interfaces/IDownloadService.cs
@@ -21,6 +21,11 @@ public interface IDownloadService
     ReadOnlyObservableCollection<IDownloadTask> Downloads { get; }
     
     /// <summary>
+    /// The base directory for ongoing downloads
+    /// </summary>
+    AbsolutePath OngoingDownloadsDirectory { get; }
+    
+    /// <summary>
     /// Adds a task that will download from a NXM link.
     /// </summary>
     /// <param name="url">Url to download from.</param>

--- a/src/Networking/NexusMods.Networking.Downloaders/Interfaces/IDownloadTask.cs
+++ b/src/Networking/NexusMods.Networking.Downloaders/Interfaces/IDownloadTask.cs
@@ -16,9 +16,9 @@ public interface IDownloadTask
     DownloaderState.ReadOnly PersistentState { get; }
     
     /// <summary>
-    /// The download location of the task.
+    /// Path of the ongoing download file
     /// </summary>
-    public AbsolutePath DownloadLocation { get; }
+    public AbsolutePath DownloadPath { get; }
     
     /// <summary>
     /// Calculates the download speed of the current job.
@@ -93,12 +93,7 @@ public enum DownloadTaskStatus : byte
     Downloading,
 
     /// <summary>
-    /// The mod is being archived (and possibly installed) to a loadout.
-    /// </summary>
-    Installing,
-
-    /// <summary>
-    /// The task has ran to completion.
+    /// The task has run to completion.
     /// </summary>
     Completed,
     

--- a/src/Networking/NexusMods.Networking.Downloaders/Services.cs
+++ b/src/Networking/NexusMods.Networking.Downloaders/Services.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using NexusMods.Abstractions.Settings;
 using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.Networking.Downloaders.Interfaces;
 using NexusMods.Networking.Downloaders.Tasks;
@@ -18,6 +19,7 @@ public static class Services
     public static IServiceCollection AddDownloaders(this IServiceCollection services)
     {        
         return services.AddSingleton<DownloadService>()
+            .AddSettings<DownloadSettings>()
             .AddHostedService<DownloadService>(sp=> sp.GetRequiredService<DownloadService>())
             .AddSingleton<IDownloadService>(sp=> sp.GetRequiredService<DownloadService>())
             .AddTransient<NxmDownloadTask>()

--- a/src/Networking/NexusMods.Networking.HttpDownloader/AdvancedHttpDownloader.cs
+++ b/src/Networking/NexusMods.Networking.HttpDownloader/AdvancedHttpDownloader.cs
@@ -163,12 +163,12 @@ namespace NexusMods.Networking.HttpDownloader
 
         private static async Task<Hash> FinalizeDownload(DownloadState state, CancellationToken cancel)
         {
-            var tempPath = state.TempFilePath;
+            var progressPath = state.ProgressFilePath;
 
             if (state.HasIncompleteChunk) return Hash.Zero;
 
             state.StateFilePath.Delete();
-            File.Move(tempPath.ToString(), state.Destination.ToString(), true);
+            File.Move(progressPath.ToString(), state.Destination.ToString(), true);
             return await state.Destination.XxHash64Async(token: cancel);
         }
 
@@ -177,8 +177,8 @@ namespace NexusMods.Networking.HttpDownloader
         private async Task FileWriterTask(DownloadState state, ChannelReader<WriteOrder> writes,
             IActivitySource<Size> job, CancellationToken cancel)
         {
-            var tempPath = state.TempFilePath;
-            await using var file = tempPath.Open(FileMode.OpenOrCreate, FileAccess.Write);
+            var progressPath = state.ProgressFilePath;
+            await using var file = progressPath.Open(FileMode.OpenOrCreate, FileAccess.Write);
             file.SetLength((long)(ulong)state.TotalSize);
 
             while (true)
@@ -471,7 +471,7 @@ namespace NexusMods.Networking.HttpDownloader
         {
             DownloadState? state = null;
             var stateFilePath = DownloadState.GetStateFilePath(destination);
-            if (stateFilePath.FileExists && DownloadState.GetTempFilePath(destination).FileExists)
+            if (stateFilePath.FileExists && DownloadState.GetProgressFilePath(destination).FileExists)
             {
                 _logger.LogInformation("Resuming prior download {FilePath}", destination);
                 state = await DeserializeDownloadState(stateFilePath, cancel);

--- a/src/Networking/NexusMods.Networking.HttpDownloader/DTOs/DownloadState.cs
+++ b/src/Networking/NexusMods.Networking.HttpDownloader/DTOs/DownloadState.cs
@@ -69,7 +69,7 @@ class DownloadState
     /// The file where the download is stored while it is in progress
     /// </summary>
     [JsonIgnore]
-    public AbsolutePath TempFilePath => GetTempFilePath(Destination);
+    public AbsolutePath ProgressFilePath => GetProgressFilePath(Destination);
 
     /// <summary>
     /// Based on the destination, get the path to the state file
@@ -83,7 +83,7 @@ class DownloadState
     /// </summary>
     /// <param name="destination"></param>
     /// <returns></returns>
-    public static AbsolutePath GetTempFilePath(AbsolutePath destination) => destination.ReplaceExtension(new Extension(".downloading"));
+    public static AbsolutePath GetProgressFilePath(AbsolutePath destination) => destination.ReplaceExtension(new Extension(".downloading"));
 
 
     /// <summary>

--- a/src/NexusMods.App.UI/Controls/DownloadGrid/Columns/DownloadStatus/DownloadStatusDesignViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/DownloadGrid/Columns/DownloadStatus/DownloadStatusDesignViewModel.cs
@@ -71,7 +71,6 @@ public class DownloadStatusDesignViewModel : AViewModel<IDownloadStatusViewModel
             DownloadTaskStatus.Idle => Language.DownloadStatusDesignViewModel_FormatStatus_Queued,
             DownloadTaskStatus.Paused => Language.DownloadStatusDesignViewModel_FormatStatus_Paused,
             DownloadTaskStatus.Downloading => Language.DownloadStatusDesignViewModel_FormatStatus_Downloading,
-            DownloadTaskStatus.Installing => Language.DownloadStatusDesignViewModel_FormatStatus_Installing,
             DownloadTaskStatus.Completed => Language.DownloadStatusDesignViewModel_FormatStatus_Complete,
             DownloadTaskStatus.Analyzing => Language.DownloadStatusDesignViewModel_FormatStatus_Analyzing,
             DownloadTaskStatus.Cancelled => Language.DownloadStatusDesignViewModel_FormatStatus_Cancelled,

--- a/tests/Networking/NexusMods.Networking.Downloaders.Tests/DownloadServiceDataStoreTests.cs
+++ b/tests/Networking/NexusMods.Networking.Downloaders.Tests/DownloadServiceDataStoreTests.cs
@@ -7,14 +7,21 @@ using NexusMods.Paths;
 
 namespace NexusMods.Networking.Downloaders.Tests;
 
-public class DownloadServiceDataStoreTests(
-    DownloadService downloadService,
-    IServiceProvider serviceProvider,
-    LocalHttpServer server,
-    TemporaryFileManager temporaryFileManager,
-    IHttpDownloader httpDownloader)
-    : AGameTest<SkyrimSpecialEdition>(serviceProvider)
+public class DownloadServiceDataStoreTests : AGameTest<SkyrimSpecialEdition>
 {
+    private readonly DownloadService _downloadService;
+    private readonly LocalHttpServer _server;
+
+    public DownloadServiceDataStoreTests(DownloadService downloadService,
+        IServiceProvider serviceProvider,
+        LocalHttpServer server,
+        TemporaryFileManager temporaryFileManager,
+        IHttpDownloader httpDownloader) : base(serviceProvider)
+    {
+        _downloadService = downloadService;
+        _server = server;
+        _downloadService.SetDownloadDirectory(temporaryFileManager.CreateFolder(prefix: nameof(DownloadServiceDataStoreTests)));
+    }
 
     // Create a new instance of the DownloadService
 
@@ -22,7 +29,7 @@ public class DownloadServiceDataStoreTests(
     public async Task WhenComplete_StaysPersistedInDataStore()
     {
         var currentCount = GetTaskCountIncludingCompleted();
-        await downloadService.AddTask(new Uri($"{server.Prefix}Resources/RootedAtGameFolder/-Skyrim 202X 9.0 - Architecture-2347-9-0-1664994366.zip"));
+        await _downloadService.AddTask(new Uri($"{_server.Prefix}Resources/RootedAtGameFolder/-Skyrim 202X 9.0 - Architecture-2347-9-0-1664994366.zip"));
         var newCount = GetTaskCountIncludingCompleted();
         newCount.Should().Be(currentCount + 1);
     }
@@ -34,8 +41,8 @@ public class DownloadServiceDataStoreTests(
         // Should be persisted into datastore on start, because
         var currentCount = GetTasks().Count();
 
-        var url = new Uri($"{server.Prefix}Resources/RootedAtGameFolder/-Skyrim 202X 9.0 - Architecture-2347-9-0-1664994366.zip");
-        await downloadService.AddTask(url);
+        var url = new Uri($"{_server.Prefix}Resources/RootedAtGameFolder/-Skyrim 202X 9.0 - Architecture-2347-9-0-1664994366.zip");
+        await _downloadService.AddTask(url);
 
         var newCount = GetTasks().Count();
         newCount.Should().Be(currentCount + 1);
@@ -43,13 +50,13 @@ public class DownloadServiceDataStoreTests(
 
     private IEnumerable<IDownloadTask> GetTasks()
     {
-        return downloadService.Downloads
+        return _downloadService.Downloads
             .ToList();
     }
 
 
     private int GetTaskCountIncludingCompleted()
     {
-        return downloadService.Downloads.Count;
+        return _downloadService.Downloads.Count;
     }
 }

--- a/tests/Networking/NexusMods.Networking.Downloaders.Tests/DownloadServiceTests.cs
+++ b/tests/Networking/NexusMods.Networking.Downloaders.Tests/DownloadServiceTests.cs
@@ -20,6 +20,7 @@ public class DownloadServiceTests
         _httpServer = httpServer;
         _downloadService = downloadService;
         _temporaryFileManager = temporaryFileManager;
+        _downloadService.SetDownloadDirectory(_temporaryFileManager.CreateFolder(prefix:nameof(DownloadServiceTests)));
     }
 
     [Fact]
@@ -52,8 +53,8 @@ public class DownloadServiceTests
             DownloadTaskStatus.Downloading, 
             DownloadTaskStatus.Completed);
         
-        task.DownloadLocation.FileExists.Should().BeTrue();
-        (await task.DownloadLocation.ReadAllTextAsync()).Should().Be("Hello, World!");
+        // File is deleted after Analyzing and repacking
+        task.DownloadPath.FileExists.Should().BeFalse();
         
         task.Downloaded.Value.Should().BeGreaterThan(0);
     }
@@ -107,8 +108,8 @@ public class DownloadServiceTests
             DownloadTaskStatus.Downloading,
             DownloadTaskStatus.Completed);
         
-        task.DownloadLocation.FileExists.Should().BeTrue();
-        (await task.DownloadLocation.ReadAllTextAsync()).Should().Be("Suspended Test");
+        // File is deleted after Analyzing and repacking
+        task.DownloadPath.FileExists.Should().BeFalse();
         
         task.Downloaded.Value.Should().BeGreaterThan(0);
     }

--- a/tests/Networking/NexusMods.Networking.HttpDownloader.Tests/AdvancedHttpDownloaderTests.cs
+++ b/tests/Networking/NexusMods.Networking.HttpDownloader.Tests/AdvancedHttpDownloaderTests.cs
@@ -70,7 +70,7 @@ public class AdvancedHttpDownloaderTests
         var downloadTask = _httpDownloader.DownloadAsync(sources,path, token: tokenSource.Token);
 
         var progressFile = DownloadState.GetStateFilePath(path.Path);
-        var downloadingFile = DownloadState.GetTempFilePath(path.Path);
+        var downloadingFile = DownloadState.GetProgressFilePath(path.Path);
 
         while (!progressFile.FileExists)
             await Task.Delay(10);


### PR DESCRIPTION
- fixes #1663 

Ongoing download files are now stored next to DataModel folder, in Downloads/Ongoing.
Each download task will have a separate folder (guid name), which simplifies cleanup on download cancellation and download completion. 

The base folder for the Downloads is determined by a setting, but it can be overruled through an internal method for testing purposes (so that each test has a different download base folder).