### PR TITLE
Upgrade to MenmonicDB sync startup

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,9 +7,9 @@
     <PackageVersion Include="LinqGen" Version="0.3.1" />
     <PackageVersion Include="Nerdbank.FullDuplexStream" Version="1.1.12" />
     <PackageVersion Include="Nerdbank.Streams" Version="2.11.74" />
-    <PackageVersion Include="NexusMods.MnemonicDB" Version="0.9.52" />
-    <PackageVersion Include="NexusMods.MnemonicDB.Abstractions" Version="0.9.52" />
-    <PackageVersion Include="NexusMods.MnemonicDB.Storage" Version="0.9.52" />
+    <PackageVersion Include="NexusMods.MnemonicDB" Version="0.9.53" />
+    <PackageVersion Include="NexusMods.MnemonicDB.Abstractions" Version="0.9.53" />
+    <PackageVersion Include="NexusMods.MnemonicDB.Storage" Version="0.9.53" />
     <PackageVersion Include="NexusMods.Paths" Version="0.9.5" />
     <PackageVersion Include="NexusMods.Hashing.xxHash64" Version="2.0.1" />
     <PackageVersion Include="NexusMods.Paths.TestingHelpers" Version="0.9.5" />
@@ -113,7 +113,7 @@
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="ini-parser-netstandard" Version="2.5.2" />
     <PackageVersion Include="Mutagen.Bethesda.Skyrim" Version="0.44.0" />
-    <PackageVersion Include="NexusMods.MnemonicDB.SourceGenerator" Version="0.9.52" />
+    <PackageVersion Include="NexusMods.MnemonicDB.SourceGenerator" Version="0.9.53" />
     <PackageVersion Include="NLog.Extensions.Logging" Version="5.3.11" />
     <PackageVersion Include="OneOf" Version="3.0.271" />
     <PackageVersion Include="ReactiveUI.Fody" Version="19.5.41" />

--- a/src/NexusMods.App/Services.cs
+++ b/src/NexusMods.App/Services.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using NexusMods.Abstractions.FileStore;
 using NexusMods.Abstractions.Games;
 using NexusMods.Abstractions.Installers;
@@ -41,6 +42,15 @@ public static class Services
         ExperimentalSettings? experimentalSettings = null,
         GameLocatorSettings? gameLocatorSettings = null)
     {
+        services.Configure<HostOptions>(options =>
+        {
+            // Sequential execution can lead to long startup times depending on number of hostedServices.
+            options.ServicesStartConcurrently = true;
+            // If executed sequentially, one service taking a long time can trigger the timeout,
+            // preventing StopAsync of other services from being called. 
+            options.ServicesStopConcurrently = true;
+        });
+        
         startupMode ??= new StartupMode();
         if (startupMode.RunAsMain)
         {

--- a/src/NexusMods.DataModel/GameRegistry/GameRegistry.cs
+++ b/src/NexusMods.DataModel/GameRegistry/GameRegistry.cs
@@ -3,22 +3,14 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
-using System.Threading;
-using System.Threading.Tasks;
 using DynamicData;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.GameLocators;
 using NexusMods.Abstractions.Games;
-using NexusMods.Abstractions.Games.DTO;
 using NexusMods.Extensions.BCL;
-using NexusMods.MnemonicDB;
 using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.MnemonicDB.Abstractions.TxFunctions;
-using NexusMods.Paths;
 using GameMetadata = NexusMods.Abstractions.Loadouts.GameMetadata;
 
 namespace NexusMods.DataModel;
@@ -26,7 +18,7 @@ namespace NexusMods.DataModel;
 /// <summary>
 /// Game registry for all installed games.
 /// </summary>
-public class Registry : IGameRegistry, IHostedService
+public class GameRegistry : IGameRegistry, IHostedService
 {
     private readonly IConnection _conn;
 
@@ -34,7 +26,7 @@ public class Registry : IGameRegistry, IHostedService
     private readonly SourceCache<GameInstallation, EntityId> _cache = new(x => x.GameMetadataId); 
     
     private readonly ReadOnlyObservableCollection<GameInstallation> _installedGames;
-    private readonly ILogger<Registry> _logger;
+    private readonly ILogger<GameRegistry> _logger;
     private readonly IEnumerable<IGame> _games;
     private readonly IEnumerable<IGameLocator> _locators;
     private readonly ConcurrentDictionary<EntityId, GameInstallation> _byId = new();
@@ -49,7 +41,7 @@ public class Registry : IGameRegistry, IHostedService
     /// <summary>
     /// Game registry for all installed games.
     /// </summary>
-    public Registry(ILogger<Registry> logger, IEnumerable<ILocatableGame> games, IEnumerable<IGameLocator> locators, IConnection conn)
+    public GameRegistry(ILogger<GameRegistry> logger, IEnumerable<ILocatableGame> games, IEnumerable<IGameLocator> locators, IConnection conn)
     {
         _games = games.OfType<IGame>().ToArray();
         _locators = locators;
@@ -76,8 +68,6 @@ public class Registry : IGameRegistry, IHostedService
     
     private async Task Startup(CancellationToken token)
     {
-        await ((IHostedService)_conn).StartAsync(token);
-
         var results = await FindInstallations()
             .Distinct().ToArrayAsync(token);
         

--- a/src/NexusMods.DataModel/GameRegistry/GameRegistry.cs
+++ b/src/NexusMods.DataModel/GameRegistry/GameRegistry.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using DynamicData;

--- a/src/NexusMods.DataModel/Services.cs
+++ b/src/NexusMods.DataModel/Services.cs
@@ -94,8 +94,8 @@ public static class Services
         coll.AddSingleton<JsonConverter, SizeConverter>();
         
         // Game Registry
-        coll.AddSingleton<IGameRegistry, Registry>();
-        coll.AddHostedService(s => (Registry)s.GetRequiredService<IGameRegistry>());
+        coll.AddSingleton<IGameRegistry, GameRegistry>();
+        coll.AddHostedService(s => (GameRegistry)s.GetRequiredService<IGameRegistry>());
         coll.AddAttributeCollection(typeof(GameMetadata));
         
         // File Store


### PR DESCRIPTION
Summary:
- Removed game registry waiting on Db initialization since it should already be ready.
- Renamed the game `Registry` to `GameRegistry` for clarity
- Made the execution of different `HostedServices` `StartAsync` and `StopAsync` calls concurrent
- `StartAsync` for performance reasons
- `StopAsync` to avoid one call stalling and preventing the others from executing before the timeout. 

I tried moving the `StartAsync` of `DownloadService` into the constructor since it wasn't actually async, but I got infinite loading on startup due to DI getting stuck when trying to resolve new `DownloadTasks` from loaded download states.
Didn't really manage to figure out the cause for that. 