### PR TITLE
Add support for ignoring game assets

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ILoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ILoadoutSynchronizer.cs
@@ -98,5 +98,13 @@ public interface ILoadoutSynchronizer
     /// </summary>
     /// <param name="installation">Game installation which should be unmanaged.</param>
     Task UnManage(GameInstallation installation);
-    #endregion
+
+    /// <summary>
+    /// Returns true if the path should be ignored by the synchronizer when backing up or restoring files. This does not mean
+    /// that files on the given path will not be managed or moddable, just that the default files on that path are not backed
+    /// up. This method is ignored when the global configuration is set to always back up all game files.
+    /// </summary>
+    bool IsIgnoredBackupPath(GamePath path);
+
+#endregion
 }

--- a/src/Abstractions/NexusMods.Abstractions.Settings/Sections.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Settings/Sections.cs
@@ -17,4 +17,6 @@ public static class Sections
     public static readonly SectionId DeveloperTools = SectionId.From(Guid.Parse("c33fb41c-7dc5-4911-b48c-3a8c822083d9"));
 
     public static readonly SectionId Experimental = SectionId.From(Guid.Parse("864495d4-aa30-48a7-b292-d23adce391f1"));
+
+    public static readonly SectionId GameSpecific = SectionId.From(Guid.Parse("16eb49ba-e1c2-4319-8219-005806759203"));
 }

--- a/src/Games/NexusMods.Games.StardewValley/Services.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Services.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.Games;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Serialization.ExpressionGenerator;
+using NexusMods.Abstractions.Settings;
 using NexusMods.Games.StardewValley.Emitters;
 using NexusMods.Games.StardewValley.Installers;
 using NexusMods.Games.StardewValley.Models;
@@ -38,7 +39,8 @@ public static class Services
             .AddAttributeCollection(typeof(SMAPIModDatabaseMarker))
 
             // Misc
-            .AddSingleton<ISMAPIWebApi, SMAPIWebApi>();
+            .AddSingleton<ISMAPIWebApi, SMAPIWebApi>()
+            .AddSettings<StardewValleySettings>();
 
         return services;
     }

--- a/src/Games/NexusMods.Games.StardewValley/StardewValleyLoadoutSynchronizer.cs
+++ b/src/Games/NexusMods.Games.StardewValley/StardewValleyLoadoutSynchronizer.cs
@@ -1,18 +1,39 @@
+using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.GameLocators;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Loadouts.Files;
 using NexusMods.Abstractions.Loadouts.Mods;
 using NexusMods.Abstractions.Loadouts.Synchronizers;
+using NexusMods.Abstractions.Settings;
 using NexusMods.Extensions.BCL;
 using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.Paths;
+using NexusMods.Paths.Extensions;
 using File = NexusMods.Abstractions.Loadouts.Files.File;
 
 namespace NexusMods.Games.StardewValley;
 
 public class StardewValleyLoadoutSynchronizer : ALoadoutSynchronizer
 {
-    public StardewValleyLoadoutSynchronizer(IServiceProvider provider) : base(provider) { }
+    public StardewValleyLoadoutSynchronizer(IServiceProvider provider) : base(provider)
+    {
+        var settingsManager = provider.GetRequiredService<ISettingsManager>();
+        _settings = settingsManager.Get<StardewValleySettings>();
+    }
+
+    /// <summary>
+    /// The content folder of the game, we ignore files in this folder
+    /// </summary>
+    private static readonly GamePath ContentFolder = new(LocationId.Game, "Content".ToRelativePath());
+
+    private readonly StardewValleySettings _settings;
+
+    public override bool IsIgnoredBackupPath(GamePath path)
+    {
+        if (!_settings.IgnoreContentFolder) return false;
+        if (path.LocationId != LocationId.Game) return false;
+        return path.Path.InFolder(ContentFolder.Path);
+    }
 
 
     protected override async Task<Loadout.ReadOnly> MoveNewFilesToMods(Loadout.ReadOnly loadout, StoredFile.ReadOnly[] newFiles)

--- a/src/Games/NexusMods.Games.StardewValley/StardewValleySettings.cs
+++ b/src/Games/NexusMods.Games.StardewValley/StardewValleySettings.cs
@@ -1,0 +1,27 @@
+using NexusMods.Abstractions.Settings;
+
+namespace NexusMods.Games.StardewValley;
+
+public class StardewValleySettings : ISettings
+{
+    /// <summary>
+    /// If true, the contents of the Content folder will not be backed up. If the game updates
+    /// the loadout may become invalid. If mods are installed into this folder via the app they
+    /// will still be backed up as needed
+    /// </summary>
+    public bool IgnoreContentFolder { get; set; } = true;
+
+
+    public static ISettingsBuilder Configure(ISettingsBuilder settingsBuilder)
+    {
+        return settingsBuilder.AddToUI<StardewValleySettings>(builder => builder
+            .AddPropertyToUI(x => x.IgnoreContentFolder, propertyBuilder => propertyBuilder
+                .AddToSection(Sections.GameSpecific)
+                .WithDisplayName("Stardew Valley: Ignore Content Folder")
+                .WithDescription("Don't back up the Content folder. If the game updates this may render the loadout invalid.")
+                .UseBooleanContainer()
+            )
+        );
+        
+    }
+}

--- a/src/NexusMods.Settings/Services.cs
+++ b/src/NexusMods.Settings/Services.cs
@@ -43,6 +43,13 @@ public static class Services
                 IconFunc = static () => IconValues.WarningAmber,
                 Name = "Experimental - Not currently supported",
                 Priority = ushort.MinValue,
+            })
+            .AddSettingsSection(new SettingsSectionSetup
+            {
+                Id = Sections.GameSpecific,
+                IconFunc = static () => IconValues.Game,
+                Name = "Game specific",
+                Priority = ushort.MinValue + 3,
             });
     }
 }

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/StardewValleySynchronizerTests.cs
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/StardewValleySynchronizerTests.cs
@@ -1,9 +1,12 @@
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.GameLocators;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Loadouts.Files;
 using NexusMods.Abstractions.Loadouts.Mods;
+using NexusMods.Abstractions.Settings;
 using NexusMods.Extensions.BCL;
+using NexusMods.Extensions.Hashing;
 using NexusMods.Games.TestFramework;
 using NexusMods.Hashing.xxHash64;
 using NexusMods.Paths;
@@ -69,6 +72,47 @@ public class StardewValleySynchronizerTests(IServiceProvider serviceProvider) : 
 
         found.Mod.Name.Should().Be("Test Mod", "The file was ingested into the parent mod folder");
         found.Mod.Id.Should().Be(newModId, "The file was ingested into the parent mod folder");
+    }
+
+    [Fact]
+    public async Task ContentIsIgnoredWhenSettingIsSet()
+    {
+        // Get the settings
+        var settings = ServiceProvider.GetRequiredService<ISettingsManager>().Get<StardewValleySettings>();
+        settings.IgnoreContentFolder = true;
+        
+        // Setup the paths we want to edit, one will be in the `Content` folder, thus not backed up
+        var ignoredGamePath = new GamePath(LocationId.Game, "Content/foo.dat".ToRelativePath());
+        var notIgnoredGamePath = new GamePath(LocationId.Game, "foo.dat".ToRelativePath());
+        
+        var ignoredPath = GameInstallation.LocationsRegister.GetResolvedPath(ignoredGamePath);
+        ignoredPath.Parent.CreateDirectory();
+        var notIgnoredPath = GameInstallation.LocationsRegister.GetResolvedPath(notIgnoredGamePath);
+        
+        // Write the files
+        await ignoredPath.WriteAllTextAsync("Ignore me");
+        var ignoredHash = await ignoredPath.XxHash64Async();
+        await notIgnoredPath.WriteAllTextAsync("Don't you dare ignore me!");
+        var notIgnoredHash = await notIgnoredPath.XxHash64Async();
+        
+        // Create the loadout
+        var loadout = await CreateLoadout();
+        
+        loadout.Files.Should().Contain(f => f.To == ignoredGamePath, "The file exists, but is ignored");
+        (await FileStore.HaveFile(ignoredHash)).Should().BeFalse("The file is ignored");
+        
+        loadout.Files.Should().Contain(f => f.To == notIgnoredGamePath, "The file was not ignored");
+        (await FileStore.HaveFile(notIgnoredHash)).Should().BeTrue("The file was not ignored"); 
+        
+        // Not disable the ignore setting
+        settings.IgnoreContentFolder = false;
+
+        var loadout2 = await CreateLoadout();
+        
+        loadout2.Files.Should().Contain(f => f.To == ignoredGamePath, "The file exists, but is ignored");
+        (await FileStore.HaveFile(ignoredHash)).Should().BeTrue("The file is not ignored");
+        loadout2.Files.Should().Contain(f => f.To == notIgnoredGamePath, "The file was not ignored");
+        (await FileStore.HaveFile(notIgnoredHash)).Should().BeTrue("The file was not ignored");
     }
 
 }


### PR DESCRIPTION
This implements #1578. The selection of files is game specific, and there should be a game specific setting for each game we support. So far this only includes SDV and the files ignored are in the `Contents` folder. We could extend this to also ignore `.dll` files in the game folder, but it is assumed that those files are more likely to be overwritten by users and the files are not large. *The setting defaults to on in the current implementation, meaning new loadouts will not have the contents of the `/Content` folder backed up on SDV.

This hooks into the existing Synchronizer logic and properly sets the `PathIgnored` flag in the Synchronizer, which was previously hardcoded as `false`.

Initial Game management size:
Before this PR: ~450MB
After this PR: 48MB

10% reduction in backup sizes isn't bad!

Also implements an integration test for making sure the files truely are not backed up when the setting is enabled, and are when it is disabled. 

Implemented as a predicate on `ALoadoutSynchronizer` so any game need only override this method to take advantage of these features. 