### PR TITLE
Update to the new Include model structure in MnemonicDB

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,9 +7,9 @@
     <PackageVersion Include="LinqGen" Version="0.3.1" />
     <PackageVersion Include="Nerdbank.FullDuplexStream" Version="1.1.12" />
     <PackageVersion Include="Nerdbank.Streams" Version="2.11.74" />
-    <PackageVersion Include="NexusMods.MnemonicDB" Version="0.9.53" />
-    <PackageVersion Include="NexusMods.MnemonicDB.Abstractions" Version="0.9.53" />
-    <PackageVersion Include="NexusMods.MnemonicDB.Storage" Version="0.9.53" />
+    <PackageVersion Include="NexusMods.MnemonicDB" Version="0.9.60" />
+    <PackageVersion Include="NexusMods.MnemonicDB.Abstractions" Version="0.9.60" />
+    <PackageVersion Include="NexusMods.MnemonicDB.Storage" Version="0.9.60" />
     <PackageVersion Include="NexusMods.Paths" Version="0.9.5" />
     <PackageVersion Include="NexusMods.Hashing.xxHash64" Version="2.0.1" />
     <PackageVersion Include="NexusMods.Paths.TestingHelpers" Version="0.9.5" />
@@ -64,7 +64,7 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="8.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="8.0.6" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
@@ -113,7 +113,7 @@
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="ini-parser-netstandard" Version="2.5.2" />
     <PackageVersion Include="Mutagen.Bethesda.Skyrim" Version="0.44.0" />
-    <PackageVersion Include="NexusMods.MnemonicDB.SourceGenerator" Version="0.9.53" />
+    <PackageVersion Include="NexusMods.MnemonicDB.SourceGenerator" Version="0.9.60" />
     <PackageVersion Include="NLog.Extensions.Logging" Version="5.3.11" />
     <PackageVersion Include="OneOf" Version="3.0.271" />
     <PackageVersion Include="ReactiveUI.Fody" Version="19.5.41" />

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -357,9 +357,9 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
 
         foreach (var item in toAddDelete)
         {
-            var delete = new DeletedFile.New(tx)
+            var delete = new DeletedFile.New(tx, out var id)
             {
-                File = new File.New(tx)
+                File = new File.New(tx, id)
                 {
                     To = item.Path,
                     ModId = overridesMod,
@@ -461,9 +461,9 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
 
         foreach (var file in toIngest)
         {
-            var storedFile = new StoredFile.New(tx)
+            var storedFile = new StoredFile.New(tx, out var id)
             {
-                File = new File.New(tx)
+                File = new File.New(tx, id)
                 {
                     To = file.Path,
                     ModId = overridesMod,
@@ -692,9 +692,9 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
             if (!IsIgnoredBackupPath(path)) 
                 filesToBackup.Add((path, file.Item.Value.Hash, file.Item.Value.Size));
             
-            allStoredFileModels.Add(new StoredFile.New(tx)
+            allStoredFileModels.Add(new StoredFile.New(tx, out var id)
             {
-                File = new File.New(tx)
+                File = new File.New(tx, id)
                 {
                     To = path,
                     LoadoutId = loadout,
@@ -861,9 +861,9 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
             if (!IsIgnoredBackupPath(path)) 
                 filesToBackup.Add((path, file.Item.Value.Hash, file.Item.Value.Size));
             
-            _ = new StoredFile.New(tx)
+            _ = new StoredFile.New(tx, out var id)
             {
-                File = new File.New(tx)
+                File = new File.New(tx, id)
                 {
                     LoadoutId = loadout,
                     ModId = gameFiles,

--- a/src/Networking/NexusMods.Networking.Downloaders/DownloadService.cs
+++ b/src/Networking/NexusMods.Networking.Downloaders/DownloadService.cs
@@ -61,8 +61,8 @@ public class DownloadService : IDownloadService, IDisposable, IHostedService
     {
         var db = _conn.Db;
 
-        var tasks = db.Find(DownloaderState.Status)
-            .Select(x => DownloaderState.Load(db, x))
+        var tasks = db.Datoms(DownloaderState.Status)
+            .AsModels<DownloaderState.ReadOnly>(db)
             .Where(x => x.Status != DownloadTaskStatus.Completed && 
                              x.Status != DownloadTaskStatus.Cancelled)
             .Select(GetTaskFromState)

--- a/src/Networking/NexusMods.Networking.NexusWebApi/Auth/JWTToken.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/Auth/JWTToken.cs
@@ -57,7 +57,7 @@ public partial class JWTToken : IModelDefinition
         if (reply.AccessToken is null || reply.RefreshToken is null) 
             return null;
             
-        var existingId = db.Find(JWTToken.AccessToken).FirstOrDefault();
+        var existingId = db.Datoms(JWTToken.AccessToken).FirstOrDefault().E;
         if (existingId == EntityId.From(0))
             existingId = tx.TempId();
         

--- a/src/NexusMods.DataModel/NxFileStore.cs
+++ b/src/NexusMods.DataModel/NxFileStore.cs
@@ -4,6 +4,7 @@ using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.IO;
+using NexusMods.Abstractions.MnemonicDB.Attributes;
 using NexusMods.Abstractions.Settings;
 using NexusMods.Archives.Nx.FileProviders;
 using NexusMods.Archives.Nx.Headers;
@@ -284,7 +285,7 @@ public class NxFileStore : IFileStore
         var fileHashes = new HashSet<ulong>();
         
         // Replace this once we redo the IFileStore. Instead that can likely query MneumonicDB directly.
-        fileHashes.AddRange(_conn.Db.Find(ArchivedFile.Hash).Select(f => f.Value));
+        fileHashes.AddRange(_conn.Db.Datoms(ArchivedFile.Hash).Resolved().OfType<HashAttribute.ReadDatom>().Select(d => d.V.Value));
         
         return fileHashes;
     }

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/StardewValleySynchronizerTests.cs
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/StardewValleySynchronizerTests.cs
@@ -38,9 +38,9 @@ public class StardewValleySynchronizerTests(IServiceProvider serviceProvider) : 
         var manifestData = "{}";
         var manifestHash = manifestData.XxHash64AsUtf8();
         
-        var manfiestFile = new StoredFile.New(tx)
+        var manfiestFile = new StoredFile.New(tx, out var id)
         {
-            File = new File.New(tx)
+            File = new File.New(tx, id)
             {
                 To = new GamePath(LocationId.Game, "Mods/test_mod_42/manifest.json".ToRelativePath()),
                 ModId = mod,


### PR DESCRIPTION
Updates to the latest version of MnemonicDB which introduces some small *code only* breaking changes to the API. Firstly, all the query methods on `IDb` now return `IndexSegment` instead of `IEnumerable<Datom>`, they were already `IndexSegment` internally, so this exposes some optimization options. 

Secondly we now support multiple `Include<T>` attributes on models, in order maintain consistent ids in construction, the including model must either create a id (and return it via `out`) or use a pre-defined Id. Further examples can be seen here (https://github.com/Nexus-Mods/NexusMods.MnemonicDB/blob/main/tests/NexusMods.MnemonicDB.Tests/DbTests.cs#L627-L689). The model construction code will throw if any included entity does not have the same Id when it is assigned. This change makes the existing behavior explicit. 

So either use `out var id` once on the top-most model, and feed `id` to each child model, or use some pre-existing id and pass it through to all the `included` models during construction. Either way is fine, but all models in the single entity must share the same `id`.