### PR TITLE
[VS2022] fix build

### DIFF
--- a/src/NexusMods.App.Generators.Diagnostics/NexusMods.App.Generators.Diagnostics/NexusMods.App.Generators.Diagnostics.csproj
+++ b/src/NexusMods.App.Generators.Diagnostics/NexusMods.App.Generators.Diagnostics/NexusMods.App.Generators.Diagnostics.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <LangVersion>latest</LangVersion>
 


### PR DESCRIPTION
For reasons yet unknown `NexusMods.App.Generators.Diagnostics` targeting `netstandard2.1` results in the compiler not being able to load the emitted DLL. Switching to `netstandard2.0` resolves this issue. Most of the dependencies don't even have `2.1` targeting versions, only 2 do.

Unless you specifically need `2.1` this seems to be a valid solution for now. As a bonus while `2.1` and `2.0` are supposed to be compatible having all the deps and the project on a single version is better - reduces the risk of unintended shenanigans.