### PR TITLE
[CrossPlatform][ProcessFactory] fix log file creation

### DIFF
--- a/src/NexusMods.CrossPlatform/Process/ProcessFactory.cs
+++ b/src/NexusMods.CrossPlatform/Process/ProcessFactory.cs
@@ -70,7 +70,7 @@ public class ProcessFactory : IProcessFactory
 
         var fileName = GetFileName(command);
 
-        var logFileName = $"{fileName}-{DateTime.Now:s}";
+        var logFileName = $"{fileName}-{DateTime.Now:yyyy-MM-dd_HH-mm-ss}";
         var stdOutFilePath = _processLogsFolder.Combine(logFileName + ".stdout.log");
         var stdErrFilePath = _processLogsFolder.Combine(logFileName + ".stderr.log");
         _logger.LogInformation("Using process logs {StdOutLogPath} and {StdErrLogPath}", stdOutFilePath, stdErrFilePath);


### PR DESCRIPTION
Current formatting results in file name containing `:` symbol and so file creation fails. Basically it results in something like
```
PenDriverPro.exe-2024-07-08T02:05:41.stdout.log
```
And since the path isn't validated in any way it fails with 
```
00:00:21.847 [ERROR] (NexusMods.App.Program) Encountered an exception published to an object with an unobserved ThrownExceptions property|System.IO.IOException: The filename, directory name, or volume label syntax is incorrect. : 'C:\Users\██████\AppData\Local\NexusMods.App\Logs\ProcessLogs\PenDriverPro.exe-2024-07-08T02:05:41.stdout.log'
   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)
   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)
   at NexusMods.Paths.BaseFileSystem.OpenFile(AbsolutePath path, FileMode mode, FileAccess access, FileShare share)
   at NexusMods.Paths.AbsolutePath.Open(FileMode mode, FileAccess access, FileShare share)
   at NexusMods.CrossPlatform.Process.ProcessFactory.ExecuteAsync(Command command, Boolean logProcessOutput, CancellationToken cancellationToken) in E:\Projects\NexusMods.App_fork\src\NexusMods.CrossPlatform\Process\ProcessFactory.cs:line 78
   at NexusMods.Abstractions.Games.RunGameTool`1.RunCommand(CancellationToken cancellationToken, AbsolutePath program) in E:\Projects\NexusMods.App_fork\src\Abstractions\NexusMods.Abstractions.Games\RunGameTool.cs:line 123
   at NexusMods.Abstractions.Games.RunGameTool`1.Execute(ReadOnly loadout, CancellationToken cancellationToken) in E:\Projects\NexusMods.App_fork\src\Abstractions\NexusMods.Abstractions.Games\RunGameTool.cs:line 94
   at NexusMods.DataModel.ToolManager.RunTool(ITool tool, ReadOnly loadout, CancellationToken token) in E:\Projects\NexusMods.App_fork\src\NexusMods.DataModel\ToolManager.cs:line 57
   at NexusMods.App.UI.LeftMenu.Items.LaunchButtonViewModel.<>c__DisplayClass19_0.<<LaunchGame>b__0>d.MoveNext() in E:\Projects\NexusMods.App_fork\src\NexusMods.App.UI\LeftMenu\Items\LaunchButtonViewModel.cs:line 44
--- End of stack trace from previous location ---
   at NexusMods.App.UI.LeftMenu.Items.LaunchButtonViewModel.LaunchGame(CancellationToken token) in E:\Projects\NexusMods.App_fork\src\NexusMods.App.UI\LeftMenu\Items\LaunchButtonViewModel.cs:line 42
```