### PR TITLE
[Loadouts.Synchronizers][Actions] change action order

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/Rules/Actions.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/Rules/Actions.cs
@@ -6,40 +6,40 @@ public enum Actions : ushort
     /// <summary>
     /// Do nothing, should not be combined with any other action
     /// </summary>
-    DoNothing = 1,
-    
-    /// <summary>
-    /// Extracts the file specified in the loadout to disk, file should be previously deleted
-    /// </summary>
-    ExtractToDisk = 2,
-    
+    DoNothing = 1 << 0,
+
     /// <summary>
     /// Create a backup of the file
     /// </summary>
-    BackupFile = 4,
-    
-    /// <summary>
-    /// Deletes the file from the loadout via adding a reified delete
-    /// </summary>
-    AddReifiedDelete = 8,
-    
+    BackupFile = 1 << 1,
+
     /// <summary>
     /// Updates the loadout to reference the new hash from the disk
     /// </summary>
-    IngestFromDisk = 16,
-    
+    IngestFromDisk = 1 << 2,
+
     /// <summary>
-    /// A file would be extracted, but it's not archived, warn the user.
+    /// Deletes the file from the loadout via adding a reified delete
     /// </summary>
-    WarnOfUnableToExtract = 32,
-    
+    AddReifiedDelete = 1 << 3,
+
     /// <summary>
     /// Deletes the file from disk
     /// </summary>
-    DeleteFromDisk = 64,
-    
+    DeleteFromDisk = 1 << 4,
+
+    /// <summary>
+    /// Extracts the file specified in the loadout to disk, file should be previously deleted
+    /// </summary>
+    ExtractToDisk = 1 << 5,
+
+    /// <summary>
+    /// A file would be extracted, but it's not archived, warn the user.
+    /// </summary>
+    WarnOfUnableToExtract = 1 << 6,
+
     /// <summary>
     /// Warn the user that the merge has failed and we don't know what to do with the file
     /// </summary>
-    WarnOfConflict = 128,
+    WarnOfConflict = 1 << 7,
 }


### PR DESCRIPTION
currently `DeleteFromDisk` action was ordered after `ExtractToDisk` action which in combination of the 2 resulted in a deleted file instead of a replaced one, it looks like actions need reordering but I am not too sure about the side effects so a draft. Also, bitshift, in C# should be endianness independent.