### PR TITLE
Update MnemonicDB

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,9 +9,8 @@
     <PackageVersion Include="LinqGen" Version="0.3.1" />
     <PackageVersion Include="Nerdbank.FullDuplexStream" Version="1.1.12" />
     <PackageVersion Include="Nerdbank.Streams" Version="2.11.74" />
-    <PackageVersion Include="NexusMods.MnemonicDB" Version="0.9.61" />
-    <PackageVersion Include="NexusMods.MnemonicDB.Abstractions" Version="0.9.61" />
-    <PackageVersion Include="NexusMods.MnemonicDB.Storage" Version="0.9.61" />
+    <PackageVersion Include="NexusMods.MnemonicDB" Version="0.9.65" />
+    <PackageVersion Include="NexusMods.MnemonicDB.Abstractions" Version="0.9.65" />
     <PackageVersion Include="NexusMods.Paths" Version="0.9.5" />
     <PackageVersion Include="NexusMods.Hashing.xxHash64" Version="2.0.1" />
     <PackageVersion Include="NexusMods.Paths.TestingHelpers" Version="0.9.5" />
@@ -116,7 +115,7 @@
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="ini-parser-netstandard" Version="2.5.2" />
     <PackageVersion Include="Mutagen.Bethesda.Skyrim" Version="0.44.0" />
-    <PackageVersion Include="NexusMods.MnemonicDB.SourceGenerator" Version="0.9.61" />
+    <PackageVersion Include="NexusMods.MnemonicDB.SourceGenerator" Version="0.9.65" />
     <PackageVersion Include="NLog.Extensions.Logging" Version="5.3.11" />
     <PackageVersion Include="OneOf" Version="3.0.271" />
     <PackageVersion Include="ReactiveUI.Fody" Version="19.5.41" />

--- a/src/Abstractions/NexusMods.Abstractions.Downloads/NexusMods.Abstractions.Downloads.csproj
+++ b/src/Abstractions/NexusMods.Abstractions.Downloads/NexusMods.Abstractions.Downloads.csproj
@@ -6,7 +6,6 @@
         <ProjectReference Include="..\NexusMods.Abstractions.Jobs\NexusMods.Abstractions.Jobs.csproj" />
         <ProjectReference Include="..\NexusMods.Abstractions.MnemonicDB.Attributes\NexusMods.Abstractions.MnemonicDB.Attributes.csproj" />
         <PackageReference Include="NexusMods.MnemonicDB.Abstractions" />
-        <PackageReference Include="NexusMods.MnemonicDB.Storage" />
         <PackageReference Include="ReactiveUI" />
         <PackageReference Include="ReactiveUI.Fody" />
         <PackageReference Include="TransparentValueObjects" PrivateAssets="all" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />

--- a/src/Abstractions/NexusMods.Abstractions.FileStore/NexusMods.Abstractions.FileStore.csproj
+++ b/src/Abstractions/NexusMods.Abstractions.FileStore/NexusMods.Abstractions.FileStore.csproj
@@ -6,7 +6,6 @@
       <ProjectReference Include="..\NexusMods.Abstractions.IO\NexusMods.Abstractions.IO.csproj" />
       <ProjectReference Include="..\NexusMods.Abstractions.MnemonicDB.Attributes\NexusMods.Abstractions.MnemonicDB.Attributes.csproj" />
       <ProjectReference Include="..\NexusMods.Abstractions.Serialization\NexusMods.Abstractions.Serialization.csproj" />
-      <PackageReference Include="NexusMods.MnemonicDB.Storage" />
       <PackageReference Include="TransparentValueObjects" PrivateAssets="all" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
         <PackageReference Include="NexusMods.MnemonicDB.SourceGenerator" PrivateAssets="all" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>

--- a/src/Abstractions/NexusMods.Abstractions.Jobs/NexusMods.Abstractions.Jobs.csproj
+++ b/src/Abstractions/NexusMods.Abstractions.Jobs/NexusMods.Abstractions.Jobs.csproj
@@ -8,7 +8,6 @@
         <PackageReference Include="TransparentValueObjects" PrivateAssets="all" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
         <PackageReference Include="NexusMods.MnemonicDB.SourceGenerator" PrivateAssets="all" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
         <PackageReference Include="NexusMods.MnemonicDB.Abstractions" />
-        <PackageReference Include="NexusMods.MnemonicDB.Storage" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Abstractions/NexusMods.Abstractions.Library.Models/NexusMods.Abstractions.Library.Models.csproj
+++ b/src/Abstractions/NexusMods.Abstractions.Library.Models/NexusMods.Abstractions.Library.Models.csproj
@@ -5,7 +5,6 @@
     <ItemGroup>
         <ProjectReference Include="..\NexusMods.Abstractions.MnemonicDB.Attributes\NexusMods.Abstractions.MnemonicDB.Attributes.csproj" />
         <PackageReference Include="NexusMods.MnemonicDB.Abstractions" />
-        <PackageReference Include="NexusMods.MnemonicDB.Storage" />
         <PackageReference Include="TransparentValueObjects" PrivateAssets="all" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
         <PackageReference Include="NexusMods.MnemonicDB.SourceGenerator" PrivateAssets="all" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts/NexusMods.Abstractions.Loadouts.csproj
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts/NexusMods.Abstractions.Loadouts.csproj
@@ -15,7 +15,6 @@
       </PackageReference>
       <PackageReference Include="FlatSharp.Runtime" />
       <PackageReference Include="NexusMods.MnemonicDB.Abstractions" />
-      <PackageReference Include="NexusMods.MnemonicDB.Storage" />
       <PackageReference Include="TransparentValueObjects" PrivateAssets="all" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
       <PackageReference Include="NexusMods.MnemonicDB.SourceGenerator" PrivateAssets="all" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>

--- a/src/Networking/NexusMods.Networking.Downloaders/DownloadService.cs
+++ b/src/Networking/NexusMods.Networking.Downloaders/DownloadService.cs
@@ -166,10 +166,10 @@ public class DownloadService : IDownloadService, IDisposable, IHostedService
             // We should be using ObserveDatoms here
             .SelectMany(revision =>
             {
-                return revision.AddedDatoms
+                return revision.RecentlyAdded
                     .Select(r => r.Resolved)
                     .Where(d => d.A == DownloaderState.Status)
-                    .Select(d => (revision.Database, d.E));
+                    .Select(d => (revision, d.E));
             })
             .StartWith(DownloaderState.All(_conn.Db).Select(state => (state.Db, state.Id)))
             .Subscribe(x =>

--- a/src/NexusMods.DataModel/Services.cs
+++ b/src/NexusMods.DataModel/Services.cs
@@ -39,7 +39,6 @@ public static class Services
     public static IServiceCollection AddDataModel(this IServiceCollection coll)
     {
         coll.AddMnemonicDB();
-        coll.AddMnemonicDBStorage();
 
         // Settings
         coll.AddSettings<DataModelSettings>();


### PR DESCRIPTION
Updates to the latest version of MnemonicDB. Mostly small changes resulting of MnemonicDB merging .Storage into .MnemonicDB and deprecating the former library. 