### PR TITLE
Loadout Item API update

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Library.Installers/ALibraryArchiveInstaller.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Library.Installers/ALibraryArchiveInstaller.cs
@@ -18,17 +18,14 @@ public abstract class ALibraryArchiveInstaller : ALibraryFileInstaller, ILibrary
     protected ALibraryArchiveInstaller(IServiceProvider serviceProvider, ILogger logger) : base(serviceProvider, logger) { }
 
     /// <inheritdoc/>
-    public override ValueTask<bool> IsSupportedAsync(LibraryFile.ReadOnly libraryFile, CancellationToken cancellationToken)
+    public override bool IsSupportedLibraryFile(LibraryFile.ReadOnly libraryFile)
     {
-        if (!libraryFile.TryGetAsLibraryArchive(out var libraryArchive)) return ValueTask.FromResult(false);
-        return IsSupportedAsync(libraryArchive, cancellationToken);
+        if (!libraryFile.TryGetAsLibraryArchive(out var libraryArchive)) return false;
+        return IsSupportedLibraryArchive(libraryArchive);
     }
 
     /// <inheritdoc/>
-    public ValueTask<bool> IsSupportedAsync(LibraryArchive.ReadOnly libraryArchive, CancellationToken cancellationToken)
-    {
-        return ValueTask.FromResult(true);
-    }
+    public virtual bool IsSupportedLibraryArchive(LibraryArchive.ReadOnly libraryArchive) => true;
 
     /// <inheritdoc/>
     public override ValueTask<LoadoutItem.New[]> ExecuteAsync(

--- a/src/Abstractions/NexusMods.Abstractions.Library.Installers/ALibraryFileInstaller.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Library.Installers/ALibraryFileInstaller.cs
@@ -18,17 +18,14 @@ public abstract class ALibraryFileInstaller : ALibraryItemInstaller, ILibraryFil
     protected ALibraryFileInstaller(IServiceProvider serviceProvider, ILogger logger) : base(serviceProvider, logger) { }
 
     /// <inheritdoc/>
-    public override ValueTask<bool> IsSupportedAsync(LibraryItem.ReadOnly libraryItem, CancellationToken cancellationToken)
+    public override bool IsSupportedLibraryItem(LibraryItem.ReadOnly libraryItem)
     {
-        if (!libraryItem.TryGetAsLibraryFile(out var libraryFile)) return ValueTask.FromResult(false);
-        return IsSupportedAsync(libraryFile, cancellationToken);
+        if (!libraryItem.TryGetAsLibraryFile(out var libraryFile)) return false;
+        return IsSupportedLibraryFile(libraryFile);
     }
 
     /// <inheritdoc/>
-    public virtual ValueTask<bool> IsSupportedAsync(LibraryFile.ReadOnly libraryFile, CancellationToken cancellationToken)
-    {
-        return ValueTask.FromResult(true);
-    }
+    public virtual bool IsSupportedLibraryFile(LibraryFile.ReadOnly libraryFile) => true;
 
     /// <inheritdoc/>
     public override ValueTask<LoadoutItem.New[]> ExecuteAsync(

--- a/src/Abstractions/NexusMods.Abstractions.Library.Installers/ALibraryItemInstaller.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Library.Installers/ALibraryItemInstaller.cs
@@ -34,10 +34,7 @@ public abstract class ALibraryItemInstaller : ILibraryItemInstaller
     }
 
     /// <inheritdoc/>
-    public virtual ValueTask<bool> IsSupportedAsync(LibraryItem.ReadOnly libraryItem, CancellationToken cancellationToken)
-    {
-        return ValueTask.FromResult(true);
-    }
+    public virtual bool IsSupportedLibraryItem(LibraryItem.ReadOnly libraryItem) => true;
 
     /// <inheritdoc/>
     public abstract ValueTask<LoadoutItem.New[]> ExecuteAsync(

--- a/src/Abstractions/NexusMods.Abstractions.Library.Installers/ILibraryArchiveInstaller.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Library.Installers/ILibraryArchiveInstaller.cs
@@ -14,7 +14,10 @@ public interface ILibraryArchiveInstaller : ILibraryFileInstaller
     /// <summary>
     /// Checks whether the provided library archive is supported by this installer.
     /// </summary>
-    ValueTask<bool> IsSupportedAsync(LibraryArchive.ReadOnly libraryArchive, CancellationToken cancellationToken);
+    /// <remarks>
+    /// This method should only do surface checks on the entity itself.
+    /// </remarks>
+    bool IsSupportedLibraryArchive(LibraryArchive.ReadOnly libraryArchive);
 
     /// <summary>
     /// Executes the installer.

--- a/src/Abstractions/NexusMods.Abstractions.Library.Installers/ILibraryFileInstaller.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Library.Installers/ILibraryFileInstaller.cs
@@ -14,7 +14,10 @@ public interface ILibraryFileInstaller : ILibraryItemInstaller
     /// <summary>
     /// Checks whether the provided library file is supported by this installer.
     /// </summary>
-    ValueTask<bool> IsSupportedAsync(LibraryFile.ReadOnly libraryFile, CancellationToken cancellationToken);
+    /// <remarks>
+    /// This method should only do surface checks on the entity itself.
+    /// </remarks>
+    bool IsSupportedLibraryFile(LibraryFile.ReadOnly libraryFile);
 
     /// <summary>
     /// Executes the installer.

--- a/src/Abstractions/NexusMods.Abstractions.Library.Installers/ILibraryItemInstaller.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Library.Installers/ILibraryItemInstaller.cs
@@ -14,7 +14,10 @@ public interface ILibraryItemInstaller
     /// <summary>
     /// Checks whether the provided library item is supported by this installer.
     /// </summary>
-    ValueTask<bool> IsSupportedAsync(LibraryItem.ReadOnly libraryItem, CancellationToken cancellationToken);
+    /// <remarks>
+    /// This method should only do surface checks on the entity itself.
+    /// </remarks>
+    bool IsSupportedLibraryItem(LibraryItem.ReadOnly libraryItem);
 
     /// <summary>
     /// Executes the installer.

--- a/src/Abstractions/NexusMods.Abstractions.Library.Models/LibraryArchive.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Library.Models/LibraryArchive.cs
@@ -16,7 +16,7 @@ public partial class LibraryArchive : IModelDefinition
     /// <summary>
     /// Marker.
     /// </summary>
-    public static readonly MarkerAttribute LibraryArchiveMarker = new(Namespace, nameof(LibraryArchiveMarker));
+    public static readonly MarkerAttribute IsLibraryArchiveMarker = new(Namespace, nameof(IsLibraryArchiveMarker));
 
     /// <summary>
     /// Back-reference to all files inside the archive.

--- a/src/Abstractions/NexusMods.Abstractions.Library.Models/LibraryArchiveFileEntry.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Library.Models/LibraryArchiveFileEntry.cs
@@ -1,4 +1,5 @@
 using JetBrains.Annotations;
+using NexusMods.Abstractions.MnemonicDB.Attributes;
 using NexusMods.MnemonicDB.Abstractions.Attributes;
 using NexusMods.MnemonicDB.Abstractions.Models;
 
@@ -12,6 +13,11 @@ namespace NexusMods.Abstractions.Library.Models;
 public partial class LibraryArchiveFileEntry : IModelDefinition
 {
     private const string Namespace = "NexusMods.Library.LibraryArchiveFileEntry";
+
+    /// <summary>
+    /// Path to the file inside the archive.
+    /// </summary>
+    public static readonly RelativePathAttribute Path = new(Namespace, nameof(Path));
 
     /// <summary>
     /// Reference to the parent archive that contains this file.

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts/LoadoutItem.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts/LoadoutItem.cs
@@ -20,13 +20,13 @@ public partial class LoadoutItem : IModelDefinition
     public static readonly StringAttribute Name = new(Namespace, nameof(Name));
 
     /// <summary>
-    /// Whether the item is disabled. A disabled loadout item will not participate
-    /// in actions.
+    /// Marker to signal that the item is disabled. A disabled loadout item will
+    /// not participate in actions.
     /// </summary>
     /// <remarks>
     /// The exact meaning of a "disabled" loadout item is up to the implementations.
     /// </remarks>
-    public static readonly BooleanAttribute IsDisabled = new(Namespace, nameof(IsDisabled));
+    public static readonly MarkerAttribute IsDisabledMarker = new(Namespace, nameof(IsDisabledMarker));
 
     /// <summary>
     /// Loadout that contains the item.

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts/LoadoutItemGroup.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts/LoadoutItemGroup.cs
@@ -16,7 +16,7 @@ public partial class LoadoutItemGroup : IModelDefinition
     /// <summary>
     /// Marker.
     /// </summary>
-    public static readonly MarkerAttribute GroupMarker = new(Namespace, nameof(GroupMarker));
+    public static readonly MarkerAttribute IsLoadoutItemGroupMarker = new(Namespace, nameof(IsLoadoutItemGroupMarker));
 
     /// <summary>
     /// Children of the group.

--- a/src/NexusMods.Library/AddLibraryFileJobWorker.cs
+++ b/src/NexusMods.Library/AddLibraryFileJobWorker.cs
@@ -155,10 +155,13 @@ internal class AddLibraryFileJobWorker : AJobWorker<AddLibraryFileJob>
             cancellationToken.ThrowIfCancellationRequested();
             foreach (var tuple in job.AddExtractedFileJobResults.Value)
             {
-                var (jobResult, _) = tuple;
+                var (jobResult, fileEntry) = tuple;
                 var libraryFile = jobResult.RequireData<LibraryFile.New>();
+                var path = fileEntry.Path.RelativeTo(job.ExtractionDirectory.Value.Path);
+
                 var archiveFileEntry = new LibraryArchiveFileEntry.New(job.Transaction, libraryFile.Id)
                 {
+                    Path = path,
                     LibraryFile = libraryFile,
                     ParentId = job.LibraryArchive.Value,
                 };

--- a/src/NexusMods.Library/AddLibraryFileJobWorker.cs
+++ b/src/NexusMods.Library/AddLibraryFileJobWorker.cs
@@ -82,6 +82,7 @@ internal class AddLibraryFileJobWorker : AJobWorker<AddLibraryFileJob>
                 job.LibraryArchive = new LibraryArchive.New(job.Transaction, job.EntityId.Value)
                 {
                     LibraryFile = job.LibraryFile.Value,
+                    IsIsLibraryArchiveMarker = true,
                 };
             }
 

--- a/src/NexusMods.Library/InstallLoadoutItemJob.cs
+++ b/src/NexusMods.Library/InstallLoadoutItemJob.cs
@@ -1,6 +1,4 @@
-using DynamicData.Kernel;
 using NexusMods.Abstractions.Jobs;
-using NexusMods.Abstractions.Library.Installers;
 using NexusMods.Abstractions.Library.Models;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.MnemonicDB.Abstractions;
@@ -14,17 +12,7 @@ public class InstallLoadoutItemJob : AJob
         IJobWorker? worker = default,
         IJobMonitor? monitor = default) : base(new MutableProgress(new IndeterminateProgress()), group, worker, monitor) { }
 
-    public required ITransaction Transaction { get; init; }
+    public required IConnection Connection { get; init; }
     public required LibraryItem.ReadOnly LibraryItem { get; init; }
     public required Loadout.ReadOnly Loadout { get; init; }
-
-    protected override void Dispose(bool disposing)
-    {
-        if (disposing)
-        {
-            Transaction.Dispose();
-        }
-
-        base.Dispose(disposing);
-    }
 }

--- a/src/NexusMods.Library/InstallLoadoutItemJob.cs
+++ b/src/NexusMods.Library/InstallLoadoutItemJob.cs
@@ -18,8 +18,6 @@ public class InstallLoadoutItemJob : AJob
     public required LibraryItem.ReadOnly LibraryItem { get; init; }
     public required Loadout.ReadOnly Loadout { get; init; }
 
-    public Optional<ILibraryItemInstaller> Installer { get; set; }
-
     protected override void Dispose(bool disposing)
     {
         if (disposing)

--- a/src/NexusMods.Library/InstallLoadoutItemJobWorker.cs
+++ b/src/NexusMods.Library/InstallLoadoutItemJobWorker.cs
@@ -29,7 +29,7 @@ internal class InstallLoadoutItemJobWorker : AJobWorker<InstallLoadoutItemJob>
             var installers = job.Loadout.InstallationInstance.GetGame().LibraryItemInstallers;
             foreach (var installer in installers)
             {
-                var isSupported = await installer.IsSupportedAsync(job.LibraryItem, cancellationToken);
+                var isSupported = installer.IsSupportedLibraryItem(job.LibraryItem);
                 if (!isSupported) continue;
 
                 foundInstaller = installer;

--- a/src/NexusMods.Library/LibraryService.cs
+++ b/src/NexusMods.Library/LibraryService.cs
@@ -49,7 +49,7 @@ public sealed class LibraryService : ILibraryService
     {
         var job = new InstallLoadoutItemJob(worker: _serviceProvider.GetRequiredService<InstallLoadoutItemJobWorker>())
         {
-            Transaction = _connection.BeginTransaction(),
+            Connection = _connection,
             LibraryItem = libraryItem,
             Loadout = targetLoadout,
         };


### PR DESCRIPTION
Part of #1763, will conflict with #1799.

Changes:
- adds `Path` to `LibraryArchiveFileEntry`
- uses `MarkerAttribute` for `LoadoutItem.IsDisabled`
- renamed existing markers and updated usage to set them
- updated the installer API with a simpler `IsSupported`
- updated the job worker to skip unsupported installers

There is one issue here:

The job worker for installing a loadout item passes a transaction to each of the installer. If the installer doesn't support the item, we need to retract all entities it has added to the transaction before continuing. Not sure what's the best approach here @halgari.