### PR TITLE
Convert Stardew Valley installers

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.FileExtractor/ISignatureChecker.cs
+++ b/src/Abstractions/NexusMods.Abstractions.FileExtractor/ISignatureChecker.cs
@@ -5,6 +5,8 @@ namespace NexusMods.Abstractions.FileExtractor;
 /// </summary>
 public interface ISignatureChecker
 {
+    public ValueTask<bool> MatchesAnyAsync(Stream stream, CancellationToken cancellationToken = default);
+
     /// <summary>
     /// Looks at the first few bytes of a stream and returns the file types that match. Note: this will only
     /// consider the filetypes that were passed into the factory.

--- a/src/Abstractions/NexusMods.Abstractions.Jobs/IJob.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Jobs/IJob.cs
@@ -6,7 +6,7 @@ namespace NexusMods.Abstractions.Jobs;
 /// Represents a piece of work.
 /// </summary>
 [PublicAPI]
-public interface IJob
+public interface IJob : IDisposable, IAsyncDisposable
 {
     /// <summary>
     /// Gets the ID of the job.

--- a/src/Abstractions/NexusMods.Abstractions.Library.Installers/Extensions.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Library.Installers/Extensions.cs
@@ -1,0 +1,36 @@
+using DynamicData.Kernel;
+using JetBrains.Annotations;
+using NexusMods.Abstractions.Library.Models;
+using NexusMods.Abstractions.Loadouts;
+using NexusMods.MnemonicDB.Abstractions;
+
+namespace NexusMods.Abstractions.Library.Installers;
+
+[PublicAPI]
+public static class Extensions
+{
+    public static LoadoutItemGroup.New ToGroup(
+        this LibraryArchive.ReadOnly archive,
+        LoadoutId loadout,
+        ITransaction tx,
+        out LoadoutItem.New loadoutItem,
+        string? name = null,
+        Optional<EntityId> entityId = default)
+    {
+        var groupId = entityId.ValueOr(tx.TempId);
+
+        loadoutItem = new LoadoutItem.New(tx, groupId)
+        {
+            LoadoutId = loadout,
+            Name = name ?? archive.AsLibraryFile().FileName,
+        };
+
+        var group = new LoadoutItemGroup.New(tx, groupId)
+        {
+            LoadoutItem = loadoutItem,
+            IsIsLoadoutItemGroupMarker = true,
+        };
+
+        return group;
+    }
+}

--- a/src/Abstractions/NexusMods.Abstractions.Library/ILibraryService.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Library/ILibraryService.cs
@@ -16,12 +16,12 @@ public interface ILibraryService
     /// <summary>
     /// Adds a download to the library.
     /// </summary>
-    IJob AddDownload(IDownloadJob downloadJob);
+    [MustDisposeResource] IJob AddDownload(IDownloadJob downloadJob);
 
     /// <summary>
     /// Adds a local file to the library.
     /// </summary>
-    IJob AddLocalFile(AbsolutePath absolutePath);
+    [MustDisposeResource] IJob AddLocalFile(AbsolutePath absolutePath);
 
     /// <summary>
     /// Installs a library item into a target loadout.

--- a/src/ArchiveManagement/NexusMods.FileExtractor/Extractors/SevenZipExtractor.cs
+++ b/src/ArchiveManagement/NexusMods.FileExtractor/Extractors/SevenZipExtractor.cs
@@ -183,18 +183,20 @@ public class SevenZipExtractor : IExtractor
         }
         finally
         {
-            _logger.LogDebug("Cleaning up after extraction");
             if (spoolFile.HasValue)
+            {
+                _logger.LogDebug("Cleaning up after extraction");
                 await spoolFile.Value.DisposeAsync();
+            }
         }
     }
 
     private static string GetExtractorExecutableFileName()
     {
         return OSInformation.MatchPlatform(
-            onWindows: () => "7z.exe",
-            onLinux: () => "7zz",
-            onOSX: () => "7zz"
+            onWindows: static () => "7z.exe",
+            onLinux: static () => "7zz",
+            onOSX: static () => "7zz"
         );
     }
 
@@ -204,9 +206,9 @@ public class SevenZipExtractor : IExtractor
         if (UseSystemExtractor) return fileName;
 
         var directory = OSInformation.MatchPlatform(
-            onWindows: () => "runtimes/win-x64/native/",
-            onLinux: () => "runtimes/linux-x64/native/",
-            onOSX: () => "runtimes/osx-x64/native/"
+            onWindows: static () => "runtimes/win-x64/native/",
+            onLinux: static () => "runtimes/linux-x64/native/",
+            onOSX: static () => "runtimes/osx-x64/native/"
         );
 
         return fileSystem.GetKnownPath(KnownPath.EntryDirectory).Combine(directory + fileName).ToString();

--- a/src/ArchiveManagement/NexusMods.FileExtractor/FileExtractor.cs
+++ b/src/ArchiveManagement/NexusMods.FileExtractor/FileExtractor.cs
@@ -141,7 +141,7 @@ public class FileExtractor : IFileExtractor
     /// <inheritdoc/>
     public async ValueTask<bool> CanExtract(Stream stream)
     {
-        return (await SignatureChecker.MatchesAsync(stream)).Any();
+        return await SignatureChecker.MatchesAnyAsync(stream);
     }
 
     private async ValueTask<IExtractor[]> FindExtractors(IStreamFactory sFn)

--- a/src/Games/NexusMods.Games.StardewValley/Installers/SMAPIInstaller.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Installers/SMAPIInstaller.cs
@@ -306,7 +306,7 @@ public class SMAPIInstaller : ALibraryArchiveInstaller, IModInstaller
                     }
 
                     var fvi = tempFile.Path.FileInfo.GetFileVersionInfo();
-                    version = fvi.FileVersionString;
+                    version = fvi.FileVersion.ToString(fieldCount: 3);
                 }
                 catch (Exception e)
                 {
@@ -358,7 +358,7 @@ public class SMAPIInstaller : ALibraryArchiveInstaller, IModInstaller
         // TODO: copy the game file "Stardew Valley.deps.json" to "StardewModdingAPI.deps.json"
         // https://github.com/Pathoschild/SMAPI/blob/9763bc7484e29cbc9e7f37c61121d794e6720e75/src/SMAPI.Installer/InteractiveInstaller.cs#L419-L425
 
-        var smapi = new SMAPILoadoutItem.New(transaction, group.Id)
+        _ = new SMAPILoadoutItem.New(transaction, group.Id)
         {
             LoadoutItemGroup = group,
             Version = version.ValueOrDefault(),

--- a/src/Games/NexusMods.Games.StardewValley/Installers/SMAPIInstaller.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Installers/SMAPIInstaller.cs
@@ -1,4 +1,3 @@
-using System.Runtime.InteropServices.Marshalling;
 using DynamicData.Kernel;
 using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.DiskState;
@@ -30,10 +29,6 @@ using File = NexusMods.Abstractions.Loadouts.Files.File;
 
 namespace NexusMods.Games.StardewValley.Installers;
 
-/// <summary>
-/// <see cref="IModInstaller"/> for SMAPI itself. This is different from <see cref="SMAPIModInstaller"/>,
-/// which is an implementation of <see cref="IModInstaller"/> for mods that use SMAPI.
-/// </summary>
 public class SMAPIInstaller : ALibraryArchiveInstaller, IModInstaller
 {
     private static readonly RelativePath InstallDatFile = "install.dat".ToRelativePath();
@@ -41,7 +36,6 @@ public class SMAPIInstaller : ALibraryArchiveInstaller, IModInstaller
     private static readonly RelativePath WindowsFolder = "windows".ToRelativePath();
     private static readonly RelativePath MacOSFolder = "macOS".ToRelativePath();
 
-    private readonly ILogger<SMAPIInstaller> _logger;
     private readonly IOSInformation _osInformation;
     private readonly IFileHashCache _fileHashCache;
     private readonly IFileOriginRegistry _fileOriginRegistry;
@@ -58,7 +52,6 @@ public class SMAPIInstaller : ALibraryArchiveInstaller, IModInstaller
         IFileStore fileStore)
         : base(serviceProvider, logger)
     {
-        _logger = logger;
         _osInformation = osInformation;
         _fileHashCache = fileHashCache;
         _fileOriginRegistry = fileOriginRegistry;
@@ -105,7 +98,7 @@ public class SMAPIInstaller : ALibraryArchiveInstaller, IModInstaller
         {
             if (isSMAPI)
             {
-                _logger.LogError("SMAPI doesn't contain three install.dat files, unable to install SMAPI. This might be a bug with the installer");
+                Logger.LogError("SMAPI doesn't contain three install.dat files, unable to install SMAPI. This might be a bug with the installer");
             }
 
             return [];
@@ -175,7 +168,7 @@ public class SMAPIInstaller : ALibraryArchiveInstaller, IModInstaller
                 }
                 catch (Exception e)
                 {
-                    _logger.LogError(e, "Exception while getting version of {Path}", item.Path);
+                    Logger.LogError(e, "Exception while getting version of {Path}", item.Path);
                 }
             }
 
@@ -226,7 +219,7 @@ public class SMAPIInstaller : ALibraryArchiveInstaller, IModInstaller
         }
         else
         {
-            _logger.LogError("Unable to find {Path} in the game folder. Your installation might be broken!", gameDepsFilePath);
+            Logger.LogError("Unable to find {Path} in the game folder. Your installation might be broken!", gameDepsFilePath);
         }
 
         version ??= "0.0.0";
@@ -271,7 +264,7 @@ public class SMAPIInstaller : ALibraryArchiveInstaller, IModInstaller
         if (!foundInstallDataFile) return [];
         if (!installDataFile.AsLibraryFile().TryGetAsLibraryArchive(out var installDataArchive))
         {
-            _logger.LogError("Expected Library Item `{LibraryItem}` (`{Id}`) to be an archive", installDataFile.AsLibraryFile().AsLibraryItem().Name, installDataFile.Id);
+            Logger.LogError("Expected Library Item `{LibraryItem}` (`{Id}`) to be an archive", installDataFile.AsLibraryFile().AsLibraryItem().Name, installDataFile.Id);
             return [];
         }
 
@@ -317,7 +310,7 @@ public class SMAPIInstaller : ALibraryArchiveInstaller, IModInstaller
                 }
                 catch (Exception e)
                 {
-                    _logger.LogError(e, "Exception while getting version of SMAPI from DLL");
+                    Logger.LogError(e, "Exception while getting version of SMAPI from DLL");
                 }
             }
 

--- a/src/Games/NexusMods.Games.StardewValley/Models/SMAPILoadoutItem.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Models/SMAPILoadoutItem.cs
@@ -14,10 +14,10 @@ public partial class SMAPILoadoutItem : IModelDefinition
     /// <summary>
     /// The version of SMAPI.
     /// </summary>
-    public static readonly StringAttribute Version = new(Namespace, nameof(Version));
+    public static readonly StringAttribute Version = new(Namespace, nameof(Version)) { IsOptional = true };
 
     /// <summary>
     /// Reference to the mod database loadout file.
     /// </summary>
-    public static readonly ReferenceAttribute<SMAPIModDatabaseLoadoutFile> ModDatabase = new(Namespace, nameof(ModDatabase));
+    public static readonly ReferenceAttribute<SMAPIModDatabaseLoadoutFile> ModDatabase = new(Namespace, nameof(ModDatabase)) { IsOptional = true};
 }

--- a/src/Games/NexusMods.Games.StardewValley/Models/SMAPILoadoutItem.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Models/SMAPILoadoutItem.cs
@@ -1,0 +1,23 @@
+using JetBrains.Annotations;
+using NexusMods.Abstractions.Loadouts;
+using NexusMods.MnemonicDB.Abstractions.Attributes;
+using NexusMods.MnemonicDB.Abstractions.Models;
+
+namespace NexusMods.Games.StardewValley.Models;
+
+[PublicAPI]
+[Include<LoadoutItemGroup>]
+public partial class SMAPILoadoutItem : IModelDefinition
+{
+    private const string Namespace = "NexusMods.StardewValley.SMAPILoadoutItem";
+
+    /// <summary>
+    /// The version of SMAPI.
+    /// </summary>
+    public static readonly StringAttribute Version = new(Namespace, nameof(Version));
+
+    /// <summary>
+    /// Reference to the mod database loadout file.
+    /// </summary>
+    public static readonly ReferenceAttribute<SMAPIModDatabaseLoadoutFile> ModDatabase = new(Namespace, nameof(ModDatabase));
+}

--- a/src/Games/NexusMods.Games.StardewValley/Models/SMAPIManifestLoadoutFile.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Models/SMAPIManifestLoadoutFile.cs
@@ -1,0 +1,13 @@
+using NexusMods.Abstractions.Loadouts;
+using NexusMods.MnemonicDB.Abstractions.Attributes;
+using NexusMods.MnemonicDB.Abstractions.Models;
+
+namespace NexusMods.Games.StardewValley.Models;
+
+[Include<LoadoutFile>]
+public partial class SMAPIManifestLoadoutFile : IModelDefinition
+{
+    private const string Namespace = "NexusMods.StardewValley.SMAPIManifestLoadoutFile";
+
+    public static readonly MarkerAttribute IsManifestMarker = new(Namespace, nameof(IsManifestMarker));
+}

--- a/src/Games/NexusMods.Games.StardewValley/Models/SMAPIManifestMetadata.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Models/SMAPIManifestMetadata.cs
@@ -11,6 +11,7 @@ namespace NexusMods.Games.StardewValley.Models;
 /// Marker for manifest files.
 /// </summary>
 [Include<StoredFile>]
+[Obsolete($"To be replaced with {nameof(SMAPIManifestLoadoutFile)}")]
 public partial class SMAPIManifestMetadata : IModelDefinition
 {
     private const string Namespace = "NexusMods.Games.StardewValley.Models.SMAPIManifestMetadata";

--- a/src/Games/NexusMods.Games.StardewValley/Models/SMAPIMarker.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Models/SMAPIMarker.cs
@@ -5,9 +5,10 @@ namespace NexusMods.Games.StardewValley.Models;
 /// <summary>
 /// Marker attribute for SMAPI
 /// </summary>
+[Obsolete($"To be replaced by {nameof(SMAPILoadoutItem)}")]
 public static class SMAPIMarker
 {
     private const string Namespace = "NexusMods.Games.StardewValley.Models.SMAPIMarker";
-    
+
     public static readonly StringAttribute Version = new(Namespace, nameof(Version));
 }

--- a/src/Games/NexusMods.Games.StardewValley/Models/SMAPIModDatabaseLoadoutFile.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Models/SMAPIModDatabaseLoadoutFile.cs
@@ -1,0 +1,13 @@
+using NexusMods.Abstractions.Loadouts;
+using NexusMods.MnemonicDB.Abstractions.Attributes;
+using NexusMods.MnemonicDB.Abstractions.Models;
+
+namespace NexusMods.Games.StardewValley.Models;
+
+[Include<LoadoutFile>]
+public partial class SMAPIModDatabaseLoadoutFile : IModelDefinition
+{
+    private const string Namespace = "NexusMods.StardewValley.SMAPIModDatabaseLoadoutFile";
+
+    public static readonly MarkerAttribute IsModDatabaseFileMarker = new(Namespace, nameof(IsModDatabaseFileMarker));
+}

--- a/src/Games/NexusMods.Games.StardewValley/Models/SMAPIModDatabaseMarker.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Models/SMAPIModDatabaseMarker.cs
@@ -8,6 +8,7 @@ using NexusMods.MnemonicDB.Abstractions.Models;
 namespace NexusMods.Games.StardewValley.Models;
 
 [Include<StoredFile>]
+[Obsolete($"To be replaced with {nameof(SMAPIModDatabaseLoadoutFile)}")]
 public partial class SMAPIModDatabaseMarker : IModelDefinition
 {
     private const string Namespace = "NexusMods.Games.StardewValley.Models.SMAPIModDatabaseMarker";

--- a/src/Games/NexusMods.Games.StardewValley/Models/SMAPIModLoadoutItem.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Models/SMAPIModLoadoutItem.cs
@@ -1,0 +1,13 @@
+using NexusMods.Abstractions.Loadouts;
+using NexusMods.MnemonicDB.Abstractions.Attributes;
+using NexusMods.MnemonicDB.Abstractions.Models;
+
+namespace NexusMods.Games.StardewValley.Models;
+
+[Include<LoadoutItemGroup>]
+public partial class SMAPIModLoadoutItem : IModelDefinition
+{
+    private const string Namespace = "NexusMods.StardewValley.SMAPIModLoadoutItem";
+
+    public static readonly ReferenceAttribute<SMAPIManifestLoadoutFile> Manifest = new(Namespace, nameof(Manifest));
+}

--- a/src/Games/NexusMods.Games.StardewValley/Models/SMAPIModMarker.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Models/SMAPIModMarker.cs
@@ -2,6 +2,7 @@ using NexusMods.MnemonicDB.Abstractions.Attributes;
 
 namespace NexusMods.Games.StardewValley.Models;
 
+[Obsolete($"To be replaced with {nameof(SMAPIModLoadoutItem)}")]
 public static class SMAPIModMarker
 {
     private const string Namespace = "NexusMods.Games.StardewValley.Models.SMAPIModMarker";

--- a/src/Games/NexusMods.Games.StardewValley/Services.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Services.cs
@@ -41,7 +41,7 @@ public static class Services
             // Attributes
             .AddSMAPILoadoutItemModel()
             .AddSMAPIModDatabaseLoadoutFileModel()
-            .AddSMAPILoadoutItemModel()
+            .AddSMAPIModLoadoutItemModel()
             .AddSMAPIManifestLoadoutFileModel()
 
             // Misc

--- a/src/Games/NexusMods.Games.StardewValley/Services.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Services.cs
@@ -32,11 +32,17 @@ public static class Services
             .AddSingleton<VersionDiagnosticEmitter>()
             .AddSingleton<ModOverwritesGameFilesEmitter>()
 
-            // Attributes
+            // Attributes (old)
             .AddAttributeCollection(typeof(SMAPIMarker))
             .AddAttributeCollection(typeof(SMAPIModMarker))
             .AddAttributeCollection(typeof(SMAPIManifestMetadata))
             .AddAttributeCollection(typeof(SMAPIModDatabaseMarker))
+
+            // Attributes
+            .AddSMAPILoadoutItemModel()
+            .AddSMAPIModDatabaseLoadoutFileModel()
+            .AddSMAPILoadoutItemModel()
+            .AddSMAPIManifestLoadoutFileModel()
 
             // Misc
             .AddSingleton<ISMAPIWebApi, SMAPIWebApi>()

--- a/src/Games/NexusMods.Games.StardewValley/StardewValley.cs
+++ b/src/Games/NexusMods.Games.StardewValley/StardewValley.cs
@@ -11,6 +11,7 @@ using NexusMods.Abstractions.Games.DTO;
 using NexusMods.Abstractions.Installers;
 using NexusMods.Abstractions.IO;
 using NexusMods.Abstractions.IO.StreamFactories;
+using NexusMods.Abstractions.Library.Installers;
 using NexusMods.Abstractions.Loadouts.Synchronizers;
 using NexusMods.Games.StardewValley.Emitters;
 using NexusMods.Games.StardewValley.Installers;
@@ -88,6 +89,11 @@ public class StardewValley : AGame, ISteamGame, IGogGame, IXboxGame
         _serviceProvider.GetRequiredService<SMAPIInstaller>(),
         _serviceProvider.GetRequiredService<SMAPIModInstaller>(),
     };
+
+    public override ILibraryItemInstaller[] LibraryItemInstallers =>
+    [
+        _serviceProvider.GetRequiredService<SMAPIInstaller>(),
+    ];
 
     public override IDiagnosticEmitter[] DiagnosticEmitters =>
     [

--- a/src/NexusMods.DataModel/ArchiveInstaller.cs
+++ b/src/NexusMods.DataModel/ArchiveInstaller.cs
@@ -64,7 +64,7 @@ public class ArchiveInstaller : IArchiveInstaller
                 return;
             }
 
-            var job = _libraryService.InstallItem(libraryFile.AsLibraryItem(), loadout);
+            await using var job = _libraryService.InstallItem(libraryFile.AsLibraryItem(), loadout);
             await job.StartAsync(cancellationToken: cancellationToken);
             var result = await job.WaitToFinishAsync(cancellationToken: cancellationToken);
             _logger.LogInformation("InstallItem result: `{Result}`", result.ToString());

--- a/src/NexusMods.DataModel/FileOriginRegistry.cs
+++ b/src/NexusMods.DataModel/FileOriginRegistry.cs
@@ -84,7 +84,7 @@ public class FileOriginRegistry : IFileOriginRegistry
         if (!CompileConstants.IsDebug) return;
         try
         {
-            var job = _libraryService.AddLocalFile(path);
+            await using var job = _libraryService.AddLocalFile(path);
             await job.StartAsync(cancellationToken: cancellationToken);
             var result = await job.WaitToFinishAsync(cancellationToken: cancellationToken);
             _logger.LogInformation("AddLocalFile result: `{Result}`", result.ToString());

--- a/src/NexusMods.Library/AddLibraryFileJob.cs
+++ b/src/NexusMods.Library/AddLibraryFileJob.cs
@@ -30,8 +30,6 @@ internal class AddLibraryFileJob : AJob
     {
         if (disposing)
         {
-            Transaction.Dispose();
-
             if (ExtractionDirectory.HasValue)
             {
                 ExtractionDirectory.Value.Dispose();

--- a/src/NexusMods.Library/AddLocalFileJob.cs
+++ b/src/NexusMods.Library/AddLocalFileJob.cs
@@ -20,4 +20,11 @@ internal class AddLocalFileJob : AJob
 
         base.Dispose(disposing);
     }
+
+    protected override ValueTask DisposeAsyncCore()
+    {
+        Transaction.Dispose();
+
+        return base.DisposeAsyncCore();
+    }
 }

--- a/src/NexusMods.Library/AddLocalFileJobWorker.cs
+++ b/src/NexusMods.Library/AddLocalFileJobWorker.cs
@@ -20,7 +20,7 @@ internal class AddLocalFileJobWorker : AJobWorker<AddLocalFileJob>
         var absolutePath = job.FilePath;
 
         var worker = _serviceProvider.GetRequiredService<AddLibraryFileJobWorker>();
-        var addLibraryFileJob = new AddLibraryFileJob(job, worker)
+        await using var addLibraryFileJob = new AddLibraryFileJob(job, worker)
         {
             Transaction = job.Transaction,
             FilePath = job.FilePath,


### PR DESCRIPTION
Part of #1763, requires #1801, conflicts with #1799.

This also contains many miscellaneous fixes to the library and job system, as well as making the `SignatureChecker` thread-safe.

This is missing tests, I'll add those after #1799 gets merged. The SMAPI installer is not complete yet, it's missing access to the game files.