### PR TITLE
Add `LoadoutGameFilesGroup`

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -15,7 +15,6 @@ using NexusMods.Abstractions.MnemonicDB.Attributes.Extensions;
 using NexusMods.Extensions.BCL;
 using NexusMods.Hashing.xxHash64;
 using NexusMods.MnemonicDB.Abstractions;
-using NexusMods.MnemonicDB.Abstractions.BuiltInEntities;
 using NexusMods.MnemonicDB.Abstractions.TxFunctions;
 using NexusMods.Paths;
 using File = NexusMods.Abstractions.Loadouts.Files.File;
@@ -357,7 +356,7 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
 
         foreach (var item in toAddDelete)
         {
-            var delete = new DeletedFile.New(tx, out var id)
+            var delete = new Files.DeletedFile.New(tx, out var id)
             {
                 File = new File.New(tx, eid: id)
                 {

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts/DeletedFile.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts/DeletedFile.cs
@@ -4,19 +4,17 @@ using NexusMods.MnemonicDB.Abstractions.Models;
 
 namespace NexusMods.Abstractions.Loadouts;
 
-// TODO: replace old DeletedFile with this new one
+/// <summary>
+/// Represents a deleted file.
+/// </summary>
+[PublicAPI]
+[Include<LoadoutItemWithTargetPath>]
+public partial class DeletedFile : IModelDefinition
+{
+    private const string Namespace = "NexusMods.Loadouts.DeletedFile";
 
-// <summary>
-// Represents a deleted file.
-// </summary>
-// [PublicAPI]
-// [Include<LoadoutItemWithTargetPath>]
-// public partial class DeletedFile : IModelDefinition
-// {
-//     private const string Namespace = "NexusMods.Loadouts.DeletedFile";
-//
-//     /// <summary>
-//     /// Marker.
-//     /// </summary>
-//     public static readonly MarkerAttribute DeletedFileMarker = new(Namespace, nameof(DeletedFileMarker));
-// }
+    /// <summary>
+    /// Marker.
+    /// </summary>
+    public static readonly MarkerAttribute IsDeletedFileMarker = new(Namespace, nameof(IsDeletedFileMarker));
+}

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts/LoadoutGameFilesGroup.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts/LoadoutGameFilesGroup.cs
@@ -1,0 +1,38 @@
+using JetBrains.Annotations;
+using NexusMods.Abstractions.GameLocators;
+using NexusMods.MnemonicDB.Abstractions.Attributes;
+using NexusMods.MnemonicDB.Abstractions.Models;
+
+namespace NexusMods.Abstractions.Loadouts;
+
+/// <summary>
+/// Represents a group of game file loadout items.
+/// </summary>
+[PublicAPI]
+[Include<LoadoutItemGroup>]
+public partial class LoadoutGameFilesGroup : IModelDefinition
+{
+    private const string Namespace = "NexusMods.Loadouts.LoadoutGameFilesGroup";
+
+    /// <summary>
+    /// Raw location id.
+    /// </summary>
+    public static readonly StringAttribute RawLocationId = new(Namespace, nameof(LocationId));
+
+    /// <summary/>
+    [PublicAPI]
+    public partial struct ReadOnly
+    {
+        /// <summary>
+        /// Gets the location ID.
+        /// </summary>
+        public LocationId LocationId => LocationId.From(RawLocationId);
+
+        /// <summary>
+        /// Gets the children as <see cref="LoadoutFile.ReadOnly"/>.
+        /// </summary>
+        public IEnumerable<LoadoutFile.ReadOnly> GameFiles => AsLoadoutItemGroup().Children.OfTypeLoadoutItemWithTargetPath().OfTypeLoadoutFile();
+    }
+}
+
+

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts/LoadoutGameFilesGroup.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts/LoadoutGameFilesGroup.cs
@@ -17,7 +17,7 @@ public partial class LoadoutGameFilesGroup : IModelDefinition
     /// <summary>
     /// Raw location id.
     /// </summary>
-    public static readonly StringAttribute RawLocationId = new(Namespace, nameof(LocationId));
+    public static readonly StringAttribute RawLocationId = new(Namespace, nameof(LocationId)) { IsIndexed = true };
 
     /// <summary/>
     [PublicAPI]

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts/NexusMods.Abstractions.Loadouts.csproj
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts/NexusMods.Abstractions.Loadouts.csproj
@@ -35,6 +35,9 @@
       <Compile Update="LibraryLinkedLoadoutItem.cs">
         <DependentUpon>LoadoutItem.cs</DependentUpon>
       </Compile>
+      <Compile Update="LoadoutGameFilesGroup.cs">
+        <DependentUpon>LoadoutItemGroup.cs</DependentUpon>
+      </Compile>
     </ItemGroup>
 
 </Project>

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts/Services.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts/Services.cs
@@ -1,8 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.Loadouts.Files;
 using NexusMods.Abstractions.Loadouts.Mods;
-using NexusMods.MnemonicDB.Abstractions;
-using File = NexusMods.Abstractions.Loadouts.Files.File;
 
 namespace NexusMods.Abstractions.Loadouts;
 
@@ -16,19 +14,20 @@ public static class Services
     /// </summary>
     public static IServiceCollection AddLoadoutAbstractions(this IServiceCollection services)
     {
-        return services
+        services = services
             .AddLoadoutItemModel()
             .AddLoadoutItemGroupModel()
             .AddLibraryLinkedLoadoutItemModel()
             .AddLoadoutItemWithTargetPathModel()
             .AddLoadoutFileModel()
-            // .AddDeletedFileModel()
+            .AddDeletedFileModel()
 
             // deprecated:
             .AddFileModel()
             .AddStoredFileModel()
             .AddModModel()
-            .AddLoadoutModel()
-            .AddDeletedFileModel();
+            .AddLoadoutModel();
+
+        return Files.DeletedFileExtensions.AddDeletedFileModel(services);
     }
 }

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts/Services.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts/Services.cs
@@ -17,6 +17,7 @@ public static class Services
         services = services
             .AddLoadoutItemModel()
             .AddLoadoutItemGroupModel()
+            .AddLoadoutGameFilesGroupModel()
             .AddLibraryLinkedLoadoutItemModel()
             .AddLoadoutItemWithTargetPathModel()
             .AddLoadoutFileModel()

--- a/tests/NexusMods.DataModel.Tests/ApplyServiceTests.cs
+++ b/tests/NexusMods.DataModel.Tests/ApplyServiceTests.cs
@@ -1,15 +1,8 @@
-﻿using System.Runtime.InteropServices;
-using FluentAssertions;
-using Microsoft.Extensions.DependencyInjection;
+﻿using FluentAssertions;
 using NexusMods.Abstractions.GameLocators;
-using NexusMods.Abstractions.Loadouts;
-using NexusMods.Abstractions.Loadouts.Files;
 using NexusMods.Abstractions.Loadouts.Mods;
-using NexusMods.Abstractions.MnemonicDB.Attributes;
-using NexusMods.DataModel.Serializers.DiskStateTreeSchema;
 using NexusMods.DataModel.Tests.Harness;
-using Xunit.Sdk;
-using File = NexusMods.Abstractions.Loadouts.Files.File;
+using DeletedFile = NexusMods.Abstractions.Loadouts.Files.DeletedFile;
 
 namespace NexusMods.DataModel.Tests;
 


### PR DESCRIPTION
Part of #1763.

- enables `DeletedFile` model and fixes imports
- adds `LoadoutGameFilesGroup`
- updates the synchronizer to create groups per location

Planned for #1763 is putting game files in some capacity into the library as well. This would also remove the need for a "vanilla state loadout".