### PR TITLE
FileOriginViewModel to Library

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Library/ILibraryService.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Library/ILibraryService.cs
@@ -28,5 +28,6 @@ public interface ILibraryService
     /// </summary>
     /// <param name="libraryItem">The item to install.</param>
     /// <param name="targetLoadout">The target loadout.</param>
-    IJob InstallItem(LibraryItem.ReadOnly libraryItem, Loadout.ReadOnly targetLoadout);
+    /// <param name="installer">If set, must be set to a ILibraryItemInstaller (untyped here as to not require a library reference). The Library will use this installer to install the item</param>
+    IJob InstallItem(LibraryItem.ReadOnly libraryItem, Loadout.ReadOnly targetLoadout, object? installer = null);
 }

--- a/src/Games/NexusMods.Games.RedEngine/ModInstallers/RedModInstaller.cs
+++ b/src/Games/NexusMods.Games.RedEngine/ModInstallers/RedModInstaller.cs
@@ -96,6 +96,7 @@ public class RedModInstaller : ALibraryArchiveInstaller, IModInstaller
     {
         var tree = libraryArchive.GetTree();
         var infosList = new List<(KeyedBox<RelativePath, LibraryArchiveTree>  File, RedModInfo InfoJson)>();
+        
         foreach (var f in tree.GetFiles())
         {
             if (f.Key().FileName != InfoJson)
@@ -105,6 +106,10 @@ public class RedModInstaller : ALibraryArchiveInstaller, IModInstaller
             if (infoJson != null)
                 infosList.Add((f, infoJson));
         }
+        
+        if (infosList.Count == 0)
+            return new NotSupported();
+        
         
         foreach (var (file, infoJson) in infosList.OrderBy(x => x.InfoJson.Name))
         {

--- a/src/NexusMods.App.UI/LeftMenu/Loadout/LoadoutLeftMenuViewModel.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Loadout/LoadoutLeftMenuViewModel.cs
@@ -6,6 +6,7 @@ using DynamicData.Binding;
 using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.Diagnostics;
 using NexusMods.Abstractions.FileStore.Downloads;
+using NexusMods.Abstractions.Library.Models;
 using NexusMods.Abstractions.MnemonicDB.Attributes;
 using NexusMods.App.UI.Controls.Navigation;
 using NexusMods.App.UI.LeftMenu.Items;
@@ -135,8 +136,7 @@ public class LoadoutLeftMenuViewModel : AViewModel<ILoadoutLeftMenuViewModel>, I
                 .BindToVM(diagnosticItem, vm => vm.Badges)
                 .DisposeWith(disposable);
             
-            conn.ObserveDatoms(DownloadAnalysis.Hash)
-                .Transform(d => DownloadAnalysis.Load(conn.Db, d.E))
+            LibraryArchive.ObserveAll(conn)
                 .OnUI()
                 .WhereReasonsAre(ListChangeReason.Add, ListChangeReason.AddRange)
                 .Filter(model => FileOriginsPageViewModel.FilterDownloadAnalysisModel(model, game.Domain))

--- a/src/NexusMods.App.UI/Pages/LoadoutGrid/LoadoutGridViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutGrid/LoadoutGridViewModel.cs
@@ -100,7 +100,8 @@ public class LoadoutGridViewModel : APageViewModel<ILoadoutGridViewModel>, ILoad
             workspaceController.OpenPage(WorkspaceId, pageData, behavior);
         });
         
-        var settings = settingsManager.GetChanges<LoadoutGridSettings>();
+        var settings = settingsManager.GetChanges<LoadoutGridSettings>()
+            .StartWith(settingsManager.Get<LoadoutGridSettings>());
 
         var hasSelection = SelectedGroupIds.CountChanged.Select(count => count > 0);
 

--- a/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginEntry/FileOriginEntryViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginEntry/FileOriginEntryViewModel.cs
@@ -3,6 +3,7 @@ using System.Reactive.Linq;
 using DynamicData.Alias;
 using Humanizer;
 using NexusMods.Abstractions.FileStore.Downloads;
+using NexusMods.Abstractions.Library.Models;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Loadouts.Ids;
 using NexusMods.Abstractions.Loadouts.Mods;
@@ -34,7 +35,7 @@ public class FileOriginEntryViewModel : AViewModel<IFileOriginEntryViewModel>, I
 
     private readonly ObservableAsPropertyHelper<string> _displayLastInstalledDate;
     public string DisplayLastInstalledDate => _displayLastInstalledDate.Value;
-    public DownloadAnalysis.ReadOnly FileOrigin { get; }
+    public LibraryArchive.ReadOnly FileOrigin { get; }
     public ReactiveCommand<NavigationInformation, Unit> ViewModCommand { get; }
     public ReactiveCommand<Unit, Unit> AddToLoadoutCommand { get; }
     public ReactiveCommand<Unit, Unit> AddAdvancedToLoadoutCommand { get; }
@@ -42,7 +43,7 @@ public class FileOriginEntryViewModel : AViewModel<IFileOriginEntryViewModel>, I
     public FileOriginEntryViewModel(
         IConnection conn,
         LoadoutId loadoutId,
-        DownloadAnalysis.ReadOnly fileOrigin,
+        LibraryArchive.ReadOnly fileOrigin,
         ReactiveCommand<NavigationInformation, Unit> viewModCommand,
         ReactiveCommand<Unit, Unit> addModToLoadoutCommand,
         ReactiveCommand<Unit, Unit> addAdvancedToLoadoutCommand)
@@ -52,10 +53,9 @@ public class FileOriginEntryViewModel : AViewModel<IFileOriginEntryViewModel>, I
         AddToLoadoutCommand = addModToLoadoutCommand;
         AddAdvancedToLoadoutCommand = addAdvancedToLoadoutCommand;
 
-        Name = DownloaderState.FriendlyName.TryGet(fileOrigin, out var foundName) && foundName != "Unknown" ? foundName : fileOrigin.SuggestedName;
-        
-        Size = DownloadAnalysis.Size.TryGet(fileOrigin, out var analysisSize) ? analysisSize : 
-            DownloaderState.Size.TryGet(fileOrigin, out var dlStateSize) ? dlStateSize : Size.From(0);
+        Name = fileOrigin.AsLibraryFile().AsLibraryItem().Name;
+
+        Size = fileOrigin.AsLibraryFile().Size;
 
         Version = DownloaderState.Version.TryGet(fileOrigin, out var version) && version != "Unknown" ? version : "-";
         

--- a/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginEntry/IFileOriginEntryViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginEntry/IFileOriginEntryViewModel.cs
@@ -1,5 +1,6 @@
 using System.Reactive;
 using NexusMods.Abstractions.FileStore.Downloads;
+using NexusMods.Abstractions.Library.Models;
 using NexusMods.App.UI.Controls.Navigation;
 using NexusMods.Paths;
 using ReactiveUI;
@@ -14,7 +15,7 @@ public interface IFileOriginEntryViewModel : IViewModelInterface
     string DisplayArchiveDate { get; }
     string DisplayLastInstalledDate { get; }
     bool IsModAddedToLoadout { get; }
-    DownloadAnalysis.ReadOnly FileOrigin { get; }
+    LibraryArchive.ReadOnly FileOrigin { get; }
     ReactiveCommand<Unit, Unit> AddToLoadoutCommand { get; }
     ReactiveCommand<Unit, Unit> AddAdvancedToLoadoutCommand { get; }
     ReactiveCommand<NavigationInformation, Unit> ViewModCommand { get; }

--- a/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginsPageViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginsPageViewModel.cs
@@ -13,6 +13,7 @@ using NexusMods.Abstractions.FileStore.Downloads;
 using NexusMods.Abstractions.Games.DTO;
 using NexusMods.Abstractions.Installers;
 using NexusMods.Abstractions.Library;
+using NexusMods.Abstractions.Library.Installers;
 using NexusMods.Abstractions.Library.Models;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Telemetry;
@@ -100,7 +101,7 @@ public class FileOriginsPageViewModel : APageViewModel<IFileOriginsPageViewModel
         _fileOrigins = new ReadOnlyObservableCollection<IFileOriginEntryViewModel>([]);
 
         var canAddMod = new Subject<bool>();
-        var advancedInstaller = _provider.GetKeyedService<IModInstaller>("AdvancedManualInstaller");
+        var advancedInstaller = _provider.GetKeyedService<ILibraryItemInstaller>("AdvancedManualInstaller");
         AddMod = ReactiveCommand.CreateFromTask(async cancellationToken => await DoAddModImpl(null, cancellationToken), canAddMod);
         AddModAdvanced = ReactiveCommand.CreateFromTask(async cancellationToken =>
         {
@@ -203,19 +204,16 @@ public class FileOriginsPageViewModel : APageViewModel<IFileOriginsPageViewModel
         await _osInterop.OpenUrl(uri, true);
     }
 
-    private async Task DoAddModImpl(IModInstaller? installer, CancellationToken token)
+    private async Task DoAddModImpl(ILibraryItemInstaller? installer, CancellationToken token)
     {
-        throw new NotImplementedException();
-        /*
         foreach (var mod in SelectedModsCollection)
             await AddUsingInstallerToLoadout(mod.FileOrigin, installer, token);
-            */
     }
 
-    private async Task AddUsingInstallerToLoadout(LibraryArchive.ReadOnly fileOrigin, IModInstaller? installer, CancellationToken token)
+    private async Task AddUsingInstallerToLoadout(LibraryArchive.ReadOnly fileOrigin, ILibraryItemInstaller? installer, CancellationToken token)
     {
         var loadout = Loadout.Load(_conn.Db, LoadoutId);
-        await using var job = _libraryService.InstallItem(fileOrigin.AsLibraryFile().AsLibraryItem(), loadout);
+        await using var job = _libraryService.InstallItem(fileOrigin.AsLibraryFile().AsLibraryItem(), loadout, installer);
         await job.StartAsync(token);
         await job.WaitToFinishAsync(token);
     }

--- a/src/NexusMods.Library/InstallLoadoutItemJob.cs
+++ b/src/NexusMods.Library/InstallLoadoutItemJob.cs
@@ -1,4 +1,5 @@
 using NexusMods.Abstractions.Jobs;
+using NexusMods.Abstractions.Library.Installers;
 using NexusMods.Abstractions.Library.Models;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.MnemonicDB.Abstractions;
@@ -10,9 +11,11 @@ public class InstallLoadoutItemJob : AJob
     public InstallLoadoutItemJob(
         IJobGroup? group = default,
         IJobWorker? worker = default,
-        IJobMonitor? monitor = default) : base(new MutableProgress(new IndeterminateProgress()), group, worker, monitor) { }
+        IJobMonitor? monitor = default) 
+        : base(new MutableProgress(new IndeterminateProgress()), group, worker, monitor) { }
 
     public required IConnection Connection { get; init; }
     public required LibraryItem.ReadOnly LibraryItem { get; init; }
     public required Loadout.ReadOnly Loadout { get; init; }
+    public ILibraryItemInstaller? Installer { get; init; }
 }

--- a/src/NexusMods.Library/InstallLoadoutItemJobWorker.cs
+++ b/src/NexusMods.Library/InstallLoadoutItemJobWorker.cs
@@ -28,6 +28,10 @@ internal class InstallLoadoutItemJobWorker : AJobWorker<InstallLoadoutItemJob>
         cancellationToken.ThrowIfCancellationRequested();
 
         var installers = job.Loadout.InstallationInstance.GetGame().LibraryItemInstallers;
+        
+        if (job.Installer != null)
+            installers = [job.Installer];
+        
         var result = await ExecuteInstallersAsync(job, installers, cancellationToken);
 
         if (!result.HasValue)

--- a/src/NexusMods.Library/LibraryService.cs
+++ b/src/NexusMods.Library/LibraryService.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.Downloads;
 using NexusMods.Abstractions.Jobs;
 using NexusMods.Abstractions.Library;
+using NexusMods.Abstractions.Library.Installers;
 using NexusMods.Abstractions.Library.Models;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.MnemonicDB.Abstractions;
@@ -45,13 +46,14 @@ public sealed class LibraryService : ILibraryService
         return group;
     }
 
-    public IJob InstallItem(LibraryItem.ReadOnly libraryItem, Loadout.ReadOnly targetLoadout)
+    public IJob InstallItem(LibraryItem.ReadOnly libraryItem, Loadout.ReadOnly targetLoadout, object? itemInstaller = null)
     {
         var job = new InstallLoadoutItemJob(worker: _serviceProvider.GetRequiredService<InstallLoadoutItemJobWorker>())
         {
             Connection = _connection,
             LibraryItem = libraryItem,
             Loadout = targetLoadout,
+            Installer = itemInstaller as ILibraryItemInstaller,
         };
 
         return job;


### PR DESCRIPTION
Converts the internals of the FileOrigin Page/ViewModel over to `ILibraryService`. 

The loop of Download->Install->Sync->Disable->Sync has been hand verified by me. NXM links also work, but the name in the library is all whack. We'll handle that in a separate PR.