### PR TITLE
Fix FlexPanel crashes by updating Avalonia Labs version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <ItemGroup>
     <PackageVersion Include="Avalonia.AvaloniaEdit" Version="11.0.6" />
-    <PackageVersion Include="Avalonia.Labs.Panels" Version="11.0.10.1" />
+    <PackageVersion Include="Avalonia.Labs.Panels" Version="11.1.0" />
     <PackageVersion Include="AvaloniaEdit.TextMate" Version="11.0.6" />
     <PackageVersion Include="Downloader" Version="3.1.2" />
     <PackageVersion Include="FlatSharp.Compiler" Version="7.6.0" />

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/FlexPanel/FlexPanelStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/FlexPanel/FlexPanelStyles.axaml
@@ -21,15 +21,6 @@
     <!-- FlexPanel Styles -->
     <Style Selector="panels|FlexPanel">
         
-        <!-- NOTE(Al12rs): `FlexPanel` has initial values that don't match the `FlexBox` specification. -->
-        <!-- Specification: https://www.w3.org/TR/css-flexbox-1/#property-index -->
-        <!-- This workaround can be removed once this PR on Avalonia.Labs repo is merged: -->
-        <!-- https://github.com/Nexus-Mods/NexusMods.App/pull/1725 -->
-        <Setter Property="AlignItems" Value="Stretch" />
-        <Setter Property="AlignContent" Value="Stretch" />
-        <Setter Property="Wrap" Value="NoWrap" />
-        
-        
         <!-- NOTE(Al12rs): FlexPanel layout doesn't work correctly if its children don't have the default alignment (Stretch). -->
         <!-- As a notable example, Buttons have Left alignment by default set in Avalonia.Fluent theme. -->
         <Style Selector="^ > :is(Control)">


### PR DESCRIPTION
- fix #1816 
and other resizing related crashes caused by old FlexPanel version.

I tested the app with the labs version with the fixes and am no longer able to reproduce the crashes.
