### PR TITLE
Fix for loadout->library item links

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Loadouts/Loadout.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts/Loadout.cs
@@ -131,11 +131,12 @@ public partial class Loadout : IModelDefinition
         /// </summary>
         public IEnumerable<LibraryLinkedLoadoutItem.ReadOnly> GetLoadoutItemsByLibraryItem(LibraryItem.ReadOnly libraryItem)
         {
-            return Items.Where(item =>
-            {
-                if (!item.TryGetAsLibraryLinkedLoadoutItem(out var linked)) return false;
-                return linked.LibraryItemId == libraryItem.LibraryItemId;
-            }).Select(item => item.ToLibraryLinkedLoadoutItem());
+            var thisId = LoadoutId; // Compiler complains about using `this` in a lambda otherwise
+            
+            // Start with a backref. This assumes that the number of loadouts with a given library item will be fairly small.
+            // This could be false, but it's a good starting point.
+            return LibraryLinkedLoadoutItem.FindByLibraryItem(Db, libraryItem)
+                .Where(linked => linked.AsLoadoutItem().LoadoutId == thisId);
         }
     }
 }


### PR DESCRIPTION
Improves the performance of finding loadout items that link to a given library item. 

Before:

* For each item in the loadout (there could be thousands)
* Try to convert it to a Library linked item: O(n) filter
* See if the item points to the library item we're looking for

Complexity: O(loadoutItems * libraryItems)

After:

* Find all the loadout items that link to a given library item
* Filter out those that are from the wrong loadout O(n)

Complexity: O(libraryItems * loadouts with those libary items)

Since we will likely have only a few loadouts for a given library item, this should always be a performance win.