### PR TITLE
Improve `LoadoutUserFilters` performance

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Loadouts/Loadout.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts/Loadout.cs
@@ -135,12 +135,12 @@ public partial class Loadout : IModelDefinition
             
             // Start with a backref. This assumes that the number of loadouts with a given library item will be fairly small.
             // This could be false, but it's a good starting point.
-            return LibraryLinkedLoadoutItem.FindByLibraryItem(Db, libraryItem)
+            return LibraryLinkedLoadoutItem
+                .FindByLibraryItem(Db, libraryItem)
                 .Where(linked => linked.AsLoadoutItem().LoadoutId == thisId);
         }
     }
 }
-
 
 public partial struct LoadoutId
 {

--- a/src/NexusMods.App.UI/Controls/LoadoutCard/Standard/LoadoutCardViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/LoadoutCard/Standard/LoadoutCardViewModel.cs
@@ -72,7 +72,7 @@ public class LoadoutCardViewModel : AViewModel<ILoadoutCardViewModel>, ILoadoutC
             //     .BindToVM(this, x => x.HumanizedLoadoutLastApplyTime);
 
             Loadout.Observe(conn, loadout.Id)
-                .Select(l => FormatNumMods(l.Items.Count(LoadoutUserFilters.ShouldShow)))
+                .Select(l => FormatNumMods(LoadoutUserFilters.GetItems(l).Count()))
                 .OnUI()
                 .BindToVM(this, x => x.LoadoutModCount)
                 .DisposeWith(d);

--- a/src/NexusMods.App.UI/Filters/LoadoutUserFilters.cs
+++ b/src/NexusMods.App.UI/Filters/LoadoutUserFilters.cs
@@ -10,13 +10,21 @@ namespace NexusMods.App.UI;
 public static class LoadoutUserFilters
 {
     /// <summary>
-    /// Returns whether the given loadout item should be shown to the user.
+    /// Returns an enumerable containing all items to be shown to the user.
     /// </summary>
-    public static bool ShouldShow(LoadoutItem.ReadOnly loadoutItem)
+    public static IEnumerable<LoadoutItem.ReadOnly> GetItems(Loadout.ReadOnly loadout)
     {
-        if (!loadoutItem.IsLoadoutItemGroup()) return false;
+        var db = loadout.Db;
+        var loadoutId = loadout.LoadoutId;
 
-        if (!loadoutItem.TryGetAsLibraryLinkedLoadoutItem(out var linked)) return false;
-        return LibraryUserFilters.ShouldShow(linked.LibraryItem);
+        var libraryLinkedLoadoutItems = db.Datoms(LibraryLinkedLoadoutItem.LibraryItem).AsModels<LoadoutItem.ReadOnly>(db);
+        foreach (var entity in libraryLinkedLoadoutItems)
+        {
+            if (entity.LoadoutId != loadoutId) continue;
+            if (!entity.IsLoadoutItemGroup()) continue;
+            if (!LibraryUserFilters.ShouldShow(entity.ToLibraryLinkedLoadoutItem().LibraryItem)) continue;
+
+            yield return entity;
+        }
     }
 }

--- a/src/NexusMods.App.UI/Pages/LoadoutGrid/LoadoutGridViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutGrid/LoadoutGridViewModel.cs
@@ -126,9 +126,7 @@ public class LoadoutGridViewModel : APageViewModel<ILoadoutGridViewModel>, ILoad
             this.WhenAnyValue(vm => vm.LoadoutId)
                 .Select(loadoutId => Loadout.Observe(_connection, loadoutId))
                 .Switch()
-                .Select(loadout => loadout
-                    .Items
-                    .Where(LoadoutUserFilters.ShouldShow)
+                .Select(loadout => LoadoutUserFilters.GetItems(loadout)
                     .OfTypeLoadoutItemGroup()
                     .Select(group => group.LoadoutItemGroupId)
                 )


### PR DESCRIPTION
Instead of filtering per-item, this filters on all items.