### PR TITLE
Postfix datamodel/config names with the release date of the next beta so we don't get so many complaints about failure to start

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Settings/JsonStorageBackend.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Settings/JsonStorageBackend.cs
@@ -11,6 +11,8 @@ namespace NexusMods.Abstractions.Settings;
 public sealed class JsonStorageBackend : ISettingsStorageBackend
 {
     internal static SettingsStorageBackendId StaticId = SettingsStorageBackendId.From(Guid.Parse("ef1470a8-871a-440a-8352-b8d930b776de"));
+    
+    private const string PathPostfix = "_21082024";
 
     private readonly ILogger _logger;
     private readonly Lazy<JsonSerializerOptions> _jsonOptions;
@@ -45,7 +47,7 @@ public sealed class JsonStorageBackend : ISettingsStorageBackend
         );
         
         // NOTE: OSX ".App" is apparently special, using _ instead of . to prevent weirdness
-        var baseDirectoryName = os.IsOSX ? "NexusMods_App/Configs" : "NexusMods.App/Configs";
+        var baseDirectoryName = os.IsOSX ? $"NexusMods_App/Configs_{PathPostfix}" : $"NexusMods.App/Configs_{PathPostfix}";
         return fileSystem.GetKnownPath(baseKnownPath).Combine(baseDirectoryName);
     }
 

--- a/src/NexusMods.DataModel/DataModelSettings.cs
+++ b/src/NexusMods.DataModel/DataModelSettings.cs
@@ -11,6 +11,8 @@ namespace NexusMods.DataModel;
 [PublicAPI]
 public record DataModelSettings : ISettings
 {
+    public const string PathPostfix = "_21082024";
+    
     /// <summary>
     /// If true, data model will be stored in memory only and the paths will be ignored.
     /// </summary>
@@ -44,9 +46,9 @@ public record DataModelSettings : ISettings
 
         return new DataModelSettings
         {
-            MnemonicDBPath = new ConfigurablePath(baseKnownPath, $"{baseDirectoryName}/MnemonicDB.rocksdb"),
+            MnemonicDBPath = new ConfigurablePath(baseKnownPath, $"{baseDirectoryName}/MnemonicDB{PathPostfix}.rocksdb"),
             ArchiveLocations = [
-                new ConfigurablePath(baseKnownPath, $"{baseDirectoryName}/Archives"),
+                new ConfigurablePath(baseKnownPath, $"{baseDirectoryName}/Archives{PathPostfix}"),
             ],
         };
     }


### PR DESCRIPTION
Adds a constant value postfix to path names so that we don't get so many startup issues after a new release. We can remove this once we stop killing the datamodel every release