### PR TITLE
Copy Loadouts

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,8 +9,8 @@
     <PackageVersion Include="LinqGen" Version="0.3.1" />
     <PackageVersion Include="Nerdbank.FullDuplexStream" Version="1.1.12" />
     <PackageVersion Include="Nerdbank.Streams" Version="2.11.74" />
-    <PackageVersion Include="NexusMods.MnemonicDB" Version="0.9.76" />
-    <PackageVersion Include="NexusMods.MnemonicDB.Abstractions" Version="0.9.76" />
+    <PackageVersion Include="NexusMods.MnemonicDB" Version="0.9.79" />
+    <PackageVersion Include="NexusMods.MnemonicDB.Abstractions" Version="0.9.79" />
     <PackageVersion Include="NexusMods.Paths" Version="0.9.5" />
     <PackageVersion Include="NexusMods.Hashing.xxHash64" Version="2.0.1" />
     <PackageVersion Include="NexusMods.Paths.TestingHelpers" Version="0.9.5" />
@@ -119,7 +119,7 @@
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="ini-parser-netstandard" Version="2.5.2" />
     <PackageVersion Include="Mutagen.Bethesda.Skyrim" Version="0.44.0" />
-    <PackageVersion Include="NexusMods.MnemonicDB.SourceGenerator" Version="0.9.76" />
+    <PackageVersion Include="NexusMods.MnemonicDB.SourceGenerator" Version="0.9.79" />
     <PackageVersion Include="NLog.Extensions.Logging" Version="5.3.11" />
     <PackageVersion Include="OneOf" Version="3.0.271" />
     <PackageVersion Include="ReactiveUI.Fody" Version="19.5.41" />

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -1100,9 +1100,10 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
     /// <inheritdoc />
     public async Task<Loadout.ReadOnly> CopyLoadout(Loadout.ReadOnly loadout)
     {
+        loadout = loadout.Rebase();
         Memory<byte> buffer = GC.AllocateUninitializedArray<byte>(1024);
         
-        var baseDb = loadout.Rebase().Db;
+        var baseDb = loadout.Db;
 
         var registry = baseDb.Registry;
         var nameId = Loadout.Name.GetDbId(registry.Id);

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -1098,7 +1098,7 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
     }
 
     /// <inheritdoc />
-    public async Task CopyLoadout(Loadout.ReadOnly loadout)
+    public async Task<Loadout.ReadOnly> CopyLoadout(Loadout.ReadOnly loadout)
     {
         Memory<byte> buffer = GC.AllocateUninitializedArray<byte>(1024);
         
@@ -1154,9 +1154,9 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
             }
         }
 
-        await tx.Commit();
+        var result = await tx.Commit();
 
-        return;
+        return Loadout.Load(Connection.Db, result[entityIdList[loadout.Id]]);
         
         EntityId RemapFn(EntityId entityId)
         {

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ILoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ILoadoutSynchronizer.cs
@@ -122,4 +122,8 @@ public interface ILoadoutSynchronizer
 
 #endregion
 
+    /// <summary>
+    /// Create a clone of the current loadout
+    /// </summary>
+    Task CopyLoadout(Loadout.ReadOnly loadout);
 }

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ILoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ILoadoutSynchronizer.cs
@@ -125,5 +125,5 @@ public interface ILoadoutSynchronizer
     /// <summary>
     /// Create a clone of the current loadout
     /// </summary>
-    Task<Loadout.ReadOnly> CopyLoadout(Loadout.ReadOnly loadout);
+    Task<Loadout.ReadOnly> CopyLoadout(LoadoutId loadout);
 }

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ILoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ILoadoutSynchronizer.cs
@@ -125,5 +125,5 @@ public interface ILoadoutSynchronizer
     /// <summary>
     /// Create a clone of the current loadout
     /// </summary>
-    Task CopyLoadout(Loadout.ReadOnly loadout);
+    Task<Loadout.ReadOnly> CopyLoadout(Loadout.ReadOnly loadout);
 }

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts/LoadoutObservables.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts/LoadoutObservables.cs
@@ -16,7 +16,8 @@ public partial class Loadout
         var analyzerDatas = connection.Revisions.Select(db => db.AnalyzerData<TreeAnalyzer, FrozenSet<EntityId>>());
         
         return Loadout.ObserveAll(connection)
-            .AutoRefreshOnObservable(itm => analyzerDatas.Where(set => set.Contains(itm.Id)));
+            .AutoRefreshOnObservable(itm => analyzerDatas.Where(set => set.Contains(itm.Id)))
+            .RemoveKey();
     }
     
     /// <summary>

--- a/src/NexusMods.App.UI/Controls/LoadoutCard/Standard/LoadoutCardView.axaml
+++ b/src/NexusMods.App.UI/Controls/LoadoutCard/Standard/LoadoutCardView.axaml
@@ -65,16 +65,12 @@
                                 <Border x:Name="ActionsBorder">
                                     <panels:FlexPanel x:Name="ActionsFlexPanel">
 
-                                        <!-- TODO: Make button visible after LoadoutCloning is implemented and remove border -->
-                                        <!-- CreateCopyBorder is used to maintain the layout of the buttons in the meantime  -->
-                                        <Border x:Name="CreateCopyBorder">
-                                            <Button x:Name="CreateCopyButton" IsVisible="False"
-                                                    Classes="Rounded Primary">
-                                                <StackPanel HorizontalAlignment="Center">
-                                                    <TextBlock Classes="BodySMBold" Text="{x:Static resources:Language.LoadoutCardViewCreateCopyButton}" />
-                                                </StackPanel>
-                                            </Button>
-                                        </Border>
+                                        <Button x:Name="CreateCopyButton"
+                                                Classes="Rounded Primary">
+                                            <StackPanel HorizontalAlignment="Center">
+                                                <TextBlock Classes="BodySMBold" Text="{x:Static resources:Language.LoadoutCardViewCreateCopyButton}" />
+                                            </StackPanel>
+                                        </Button>
 
                                         <Button x:Name="DeleteButton"
                                                 Classes="Rounded Primary">

--- a/src/NexusMods.App.UI/Controls/LoadoutCard/Standard/LoadoutCardViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/LoadoutCard/Standard/LoadoutCardViewModel.cs
@@ -41,6 +41,12 @@ public class LoadoutCardViewModel : AViewModel<ILoadoutCardViewModel>, ILoadoutC
             }
         );
         
+        CloneLoadoutCommand = ReactiveCommand.CreateFromTask(() =>
+            {
+                return CopyLoadout(loadout);
+            }
+        );
+        
         this.WhenActivated(d =>
         {
             Observable.FromAsync(() => LoadImage(loadout.InstallationInstance))
@@ -102,7 +108,7 @@ public class LoadoutCardViewModel : AViewModel<ILoadoutCardViewModel>, ILoadoutC
     [Reactive] public bool IsDeleting { get;  private set; } = false;
     public bool IsSkeleton => false;
     public required ReactiveCommand<Unit, Unit> VisitLoadoutCommand { get; init; }
-    public required ReactiveCommand<Unit, Unit> CloneLoadoutCommand { get; init; } 
+    public ReactiveCommand<Unit, Unit> CloneLoadoutCommand { get; } 
     public ReactiveCommand<Unit, Unit> DeleteLoadoutCommand { get; }
     
     [Reactive] public bool IsLastLoadout { get; set; } = true;
@@ -143,6 +149,11 @@ public class LoadoutCardViewModel : AViewModel<ILoadoutCardViewModel>, ILoadoutC
     private static Task DeleteLoadout(Loadout.ReadOnly loadout)
     {
         return Task.Run(() => loadout.InstallationInstance.GetGame().Synchronizer.DeleteLoadout(loadout));
+    }
+    
+    private static Task CopyLoadout(Loadout.ReadOnly loadout)
+    {
+        return Task.Run(() => loadout.InstallationInstance.GetGame().Synchronizer.CopyLoadout(loadout));
     }
     
 }

--- a/src/NexusMods.App.UI/Filters/LibraryUserFilters.cs
+++ b/src/NexusMods.App.UI/Filters/LibraryUserFilters.cs
@@ -29,6 +29,6 @@ public static class LibraryUserFilters
     /// </summary>
     public static IObservable<IChangeSet<LibraryItem.ReadOnly>> ObserveFilteredLibraryItems(IConnection connection)
     {
-        return LibraryItem.ObserveAll(connection).Where(ShouldShow);
+        return LibraryItem.ObserveAll(connection).Where(ShouldShow).RemoveKey();
     }
 }

--- a/src/NexusMods.App.UI/Pages/LocalFileDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/LocalFileDataProvider.cs
@@ -30,14 +30,16 @@ internal class LocalFileDataProvider : ILibraryDataProvider
             {
                 var libraryFile = LibraryFile.Load(_connection.Db, datom.E);
                 return ToLibraryItemModel(libraryFile);
-            });
+            })
+            .RemoveKey();
     }
 
     private LibraryItemModel ToLibraryItemModel(LibraryFile.ReadOnly libraryFile)
     {
         var linkedLoadoutItemsObservable = _connection
             .ObserveDatoms(LibraryLinkedLoadoutItem.LibraryItemId, libraryFile.Id)
-            .Transform(datom => LibraryLinkedLoadoutItem.Load(_connection.Db, datom.E));
+            .Transform(datom => LibraryLinkedLoadoutItem.Load(_connection.Db, datom.E))
+            .RemoveKey();
 
         return new LibraryItemModel
         {
@@ -62,7 +64,8 @@ internal class LocalFileDataProvider : ILibraryDataProvider
 
                 var linkedLoadoutItemsObservable = _connection
                     .ObserveDatoms(LibraryLinkedLoadoutItem.LibraryItemId, libraryFile.Id)
-                    .Transform(d => LibraryLinkedLoadoutItem.Load(_connection.Db, d.E));
+                    .Transform(d => LibraryLinkedLoadoutItem.Load(_connection.Db, d.E))
+                    .RemoveKey();
 
                 return new LibraryItemModel
                 {
@@ -72,8 +75,9 @@ internal class LocalFileDataProvider : ILibraryDataProvider
                     Size = libraryFile.Size,
                     HasChildrenObservable = hasChildrenObservable,
                     ChildrenObservable = childrenObservable,
-                    LinkedLoadoutItemsObservable =linkedLoadoutItemsObservable,
+                    LinkedLoadoutItemsObservable = linkedLoadoutItemsObservable,
                 };
-            });
+            })
+            .RemoveKey();
     }
 }

--- a/src/NexusMods.App.UI/Pages/MyGames/MyGamesViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/MyGames/MyGamesViewModel.cs
@@ -52,6 +52,7 @@ public class MyGamesViewModel : APageViewModel<IMyGamesViewModel>, IMyGamesViewM
                 // Managed games widgets
                 Loadout.ObserveAll(conn)
                     .Filter(l => l.IsVisible())
+                    .RemoveKey()
                     .GroupOn(loadout => loadout.InstallationInstance.LocationsRegister[LocationId.Game])
                     .Transform(group=> group.List.Items.First())
                     .OnUI()

--- a/src/NexusMods.App.UI/Pages/MyLoadouts/GameLoadoutsSectionEntry/GameLoadoutsSectionEntryViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/MyLoadouts/GameLoadoutsSectionEntry/GameLoadoutsSectionEntryViewModel.cs
@@ -45,11 +45,6 @@ public class GameLoadoutsSectionEntryViewModel : AViewModel<IGameLoadoutsSection
                     return (IViewModelInterface)new LoadoutCardViewModel(loadout, conn, serviceProvider)
                     {
                         VisitLoadoutCommand = ReactiveCommand.Create(() => NavigateToLoadout(loadout)),
-                        CloneLoadoutCommand = ReactiveCommand.Create(() =>
-                            {
-                                // TODO: Implement Loadout cloning
-                            }
-                        ),
                     };
                 }
             )

--- a/src/NexusMods.App.UI/Pages/MyLoadouts/MyLoadoutsViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/MyLoadouts/MyLoadoutsViewModel.cs
@@ -30,6 +30,7 @@ public class MyLoadoutsViewModel : APageViewModel<IMyLoadoutsViewModel>, IMyLoad
         {
             Loadout.ObserveAll(conn)
                 .Filter(l => l.IsVisible())
+                .RemoveKey()
                 .GroupOn(loadout => loadout.Installation.Path)
                 .Transform(group => group.List.Items.First().InstallationInstance)
                 .Transform(managedGameInstall =>

--- a/src/NexusMods.App/TelemetryProvider.cs
+++ b/src/NexusMods.App/TelemetryProvider.cs
@@ -35,6 +35,7 @@ internal sealed class TelemetryProvider : ITelemetryProvider, IDisposable
         // download size
         _connection.ObserveDatoms(DownloadAnalysis.Size)
             .Transform(d => (SizeAttribute.ReadDatom)d.Resolved)
+            .RemoveKey()
             .QueryWhenChanged(datoms => datoms.Sum(d => d.V))
             .SubscribeWithErrorLogging(totalDownloadSize => _downloadSize = Size.From((ulong)totalDownloadSize))
             .DisposeWith(_disposable);

--- a/tests/NexusMods.DataModel.Synchronizer.Tests/GeneralLoadoutManagementTests.SynchronizerIntegrationTests.verified.md
+++ b/tests/NexusMods.DataModel.Synchronizer.Tests/GeneralLoadoutManagementTests.SynchronizerIntegrationTests.verified.md
@@ -28,7 +28,7 @@ A new loadout has been created and has been synchronized, so the 'Last Synced St
 ### Loadout A - (1)
 | Path | Hash | Size | TxId |
 | --- | --- | --- | --- |
-| (EId:300020000000002, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:100000000000007 |
+| (EId:200000000000005, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:100000000000007 |
 
 
 
@@ -50,7 +50,7 @@ New files have been added to the game folder by the user or the game, but the lo
 ### Loadout A - (1)
 | Path | Hash | Size | TxId |
 | --- | --- | --- | --- |
-| (EId:300020000000002, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:100000000000007 |
+| (EId:200000000000005, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:100000000000007 |
 
 
 
@@ -73,7 +73,7 @@ After the loadout has been synchronized, the new file should be added to the loa
 ### Loadout A - (2)
 | Path | Hash | Size | TxId |
 | --- | --- | --- | --- |
-| (EId:300020000000002, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:100000000000007 |
+| (EId:200000000000005, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:100000000000007 |
 | (EId:200000000000005, Game, bin/newFileInGameFolderA.txt) | 0x2D489D43D46C8849 | 25 B | Tx:10000000000000B |
 
 
@@ -91,7 +91,7 @@ At this point the loadout is deactivated, and all the files in the current state
 ### Loadout A - (2)
 | Path | Hash | Size | TxId |
 | --- | --- | --- | --- |
-| (EId:300020000000002, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:100000000000007 |
+| (EId:200000000000005, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:100000000000007 |
 | (EId:200000000000005, Game, bin/newFileInGameFolderA.txt) | 0x2D489D43D46C8849 | 25 B | Tx:10000000000000B |
 
 
@@ -109,12 +109,12 @@ A new loadout is created, but it has not been synchronized yet. So again the 'La
 ### Loadout A - (2)
 | Path | Hash | Size | TxId |
 | --- | --- | --- | --- |
-| (EId:300020000000002, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:100000000000007 |
+| (EId:200000000000005, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:100000000000007 |
 | (EId:200000000000005, Game, bin/newFileInGameFolderA.txt) | 0x2D489D43D46C8849 | 25 B | Tx:10000000000000B |
 ### Loadout B - (1)
 | Path | Hash | Size | TxId |
 | --- | --- | --- | --- |
-| (EId:300020000000002, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:10000000000000F |
+| (EId:20000000000000D, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:10000000000000F |
 
 
 
@@ -136,12 +136,12 @@ loadout are different from the previous loadout due to the new file only being i
 ### Loadout A - (2)
 | Path | Hash | Size | TxId |
 | --- | --- | --- | --- |
-| (EId:300020000000002, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:100000000000007 |
+| (EId:200000000000005, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:100000000000007 |
 | (EId:200000000000005, Game, bin/newFileInGameFolderA.txt) | 0x2D489D43D46C8849 | 25 B | Tx:10000000000000B |
 ### Loadout B - (1)
 | Path | Hash | Size | TxId |
 | --- | --- | --- | --- |
-| (EId:300020000000002, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:10000000000000F |
+| (EId:20000000000000D, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:10000000000000F |
 
 
 
@@ -164,12 +164,12 @@ A new file has been added to the game folder and B loadout has been synchronized
 ### Loadout A - (2)
 | Path | Hash | Size | TxId |
 | --- | --- | --- | --- |
-| (EId:300020000000002, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:100000000000007 |
+| (EId:200000000000005, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:100000000000007 |
 | (EId:200000000000005, Game, bin/newFileInGameFolderA.txt) | 0x2D489D43D46C8849 | 25 B | Tx:10000000000000B |
 ### Loadout B - (2)
 | Path | Hash | Size | TxId |
 | --- | --- | --- | --- |
-| (EId:300020000000002, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:10000000000000F |
+| (EId:20000000000000D, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:10000000000000F |
 | (EId:20000000000000D, Game, bin/newFileInGameFolderB.txt) | 0x3E6AD5D9F57F8D4E | 28 B | Tx:100000000000013 |
 
 
@@ -193,23 +193,57 @@ Now we switch back to the A loadout, and the new file should be removed from the
 ### Loadout A - (2)
 | Path | Hash | Size | TxId |
 | --- | --- | --- | --- |
-| (EId:300020000000002, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:100000000000007 |
+| (EId:200000000000005, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:100000000000007 |
 | (EId:200000000000005, Game, bin/newFileInGameFolderA.txt) | 0x2D489D43D46C8849 | 25 B | Tx:10000000000000B |
 ### Loadout B - (2)
 | Path | Hash | Size | TxId |
 | --- | --- | --- | --- |
-| (EId:300020000000002, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:10000000000000F |
+| (EId:20000000000000D, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:10000000000000F |
 | (EId:20000000000000D, Game, bin/newFileInGameFolderB.txt) | 0x3E6AD5D9F57F8D4E | 28 B | Tx:100000000000013 |
 
 
 
-## 11 - Game Unmanaged:
+## 11 - Loadout A Copied to Loadout C:
+Loadout A has been copied to Loadout C, and the contents should match.
+### Initial State - (1) - Tx:100000000000005
+| Path | Hash | Size | TxId |
+| --- | --- | --- | --- |
+| (EId:200000000000001, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:100000000000005 |
+### Last Synced State - (2) - Tx:100000000000016
+| Path | Hash | Size | TxId |
+| --- | --- | --- | --- |
+| (EId:200000000000001, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:100000000000005 |
+| (EId:200000000000001, Game, bin/newFileInGameFolderA.txt) | 0x2D489D43D46C8849 | 25 B | Tx:100000000000016 |
+### Current State - (2) - Tx:100000000000016
+| Path | Hash | Size | TxId |
+| --- | --- | --- | --- |
+| (EId:200000000000001, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:100000000000005 |
+| (EId:200000000000001, Game, bin/newFileInGameFolderA.txt) | 0x2D489D43D46C8849 | 25 B | Tx:100000000000016 |
+### Loadout A - (2)
+| Path | Hash | Size | TxId |
+| --- | --- | --- | --- |
+| (EId:200000000000005, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:100000000000007 |
+| (EId:200000000000005, Game, bin/newFileInGameFolderA.txt) | 0x2D489D43D46C8849 | 25 B | Tx:10000000000000B |
+### Loadout B - (2)
+| Path | Hash | Size | TxId |
+| --- | --- | --- | --- |
+| (EId:20000000000000D, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:10000000000000F |
+| (EId:20000000000000D, Game, bin/newFileInGameFolderB.txt) | 0x3E6AD5D9F57F8D4E | 28 B | Tx:100000000000013 |
+### Loadout C - (2)
+| Path | Hash | Size | TxId |
+| --- | --- | --- | --- |
+| (EId:200000000000014, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:100000000000017 |
+| (EId:200000000000014, Game, bin/newFileInGameFolderA.txt) | 0x2D489D43D46C8849 | 25 B | Tx:100000000000017 |
+
+
+
+## 12 - Game Unmanaged:
 The loadouts have been deleted and the game folder should be back to its initial state.
 ### Initial State - (1) - Tx:100000000000005
 | Path | Hash | Size | TxId |
 | --- | --- | --- | --- |
 | (EId:200000000000001, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:100000000000005 |
-### Current State - (1) - Tx:100000000000018
+### Current State - (1) - Tx:100000000000019
 | Path | Hash | Size | TxId |
 | --- | --- | --- | --- |
 | (EId:200000000000001, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:100000000000005 |

--- a/tests/NexusMods.DataModel.Synchronizer.Tests/GeneralLoadoutManagementTests.cs
+++ b/tests/NexusMods.DataModel.Synchronizer.Tests/GeneralLoadoutManagementTests.cs
@@ -111,9 +111,17 @@ public class GeneralLoadoutManagementTests : AGameTest<Cyberpunk2077Game>
             """, [loadoutA, loadoutB]
         );
         
+        var loadoutC = await Synchronizer.CopyLoadout(loadoutA);
+        
+        LogState(sb, "## 11 - Loadout A Copied to Loadout C",
+            """
+            Loadout A has been copied to Loadout C, and the contents should match.
+            """, [loadoutA, loadoutB, loadoutC]
+        );
+        
         await Synchronizer.UnManage(GameInstallation);
         
-        LogState(sb, "## 11 - Game Unmanaged",
+        LogState(sb, "## 12 - Game Unmanaged",
             """
             The loadouts have been deleted and the game folder should be back to its initial state.
             """,


### PR DESCRIPTION
Allows users to clone loadouts. This is a shockingly fast operation. Even with 50k files the clone time is less than a second. 

*Note:* this PR also updates to the latest MnemonicDB which while it's faster also changes `ObserveDatoms` to return a `IChangeSet<Datom, DatomKey>` I fixed most of the code by using `.RemoveKey()` but we likely will want to go back later and remove these method calls and update the Observable chains to also use keyed changesets.

Example usage:


![NexusMods App_9Umw9XfDmP](https://github.com/user-attachments/assets/ffb6aba4-0474-47af-9df3-d0f1f63396b3)


fixes #406 