### PR TITLE
Update loadout naming

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -967,7 +967,7 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
 
         var loadout = new Loadout.New(tx)
         {
-            Name = suggestedName ?? installation.Game.Name + " " + shortName,
+            Name = suggestedName ?? "Loadout " + shortName,
             ShortName = shortName,
             InstallationId = installation.GameMetadataId,
             Revision = 0,
@@ -1102,6 +1102,7 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
     {
         var baseDb = Connection.Db;
         var loadout = Loadout.Load(baseDb, loadoutId);
+        var installation = loadout.InstallationInstance;
         
         // Temp space for datom values
         Memory<byte> buffer = GC.AllocateUninitializedArray<byte>(32);
@@ -1112,8 +1113,12 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
         var shortNameId = Loadout.ShortName.GetDbId(registry.Id);
         
         // Generate a new name and short name
-        var newShortName = LoadoutNameProvider.GetNewShortName(Loadout.All(baseDb).Select(l => l.ShortName).ToArray());
-        var newName = loadout.Name + " Copy";
+        var newShortName = LoadoutNameProvider.GetNewShortName(Loadout.All(baseDb)
+            .Where(l => l.IsVisible() && l.InstallationId == loadout.InstallationId)
+            .Select(l => l.ShortName)
+            .ToArray()
+        );
+        var newName = "Loadout " + newShortName;
         
         // Create a mapping of old entity ids to new (temp) entity ids
         Dictionary<EntityId, EntityId> entityIdList = new();

--- a/src/NexusMods.App.UI/Controls/Spine/SpineViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/Spine/SpineViewModel.cs
@@ -100,7 +100,7 @@ public class SpineViewModel : AViewModel<ISpineViewModel>, ISpineViewModel
                             await using var iconStream = await ((IGame)loadout.InstallationInstance.Game).Icon.GetStreamAsync();
 
                             var vm = serviceProvider.GetRequiredService<IImageButtonViewModel>();
-                            vm.Name = loadout.Name;
+                            vm.Name = loadout.InstallationInstance.Game.Name + " - " + loadout.Name;
                             vm.Image = LoadImageFromStream(iconStream);
                             vm.LoadoutBadgeViewModel = new LoadoutBadgeViewModel(_conn, _syncService, hideOnSingleLoadout: true);
                             vm.LoadoutBadgeViewModel.LoadoutValue = loadout;


### PR DESCRIPTION
Checked in with design to update the following:
- Changed loadout naming scheme to `"Loadout " + ShortName` from `GameName  + " " + ShortName`
- Fixed CopyLoadout from considering short names of other game installs when generating new `ShortName`
- Updated Spine Loadout ToolTips to show `GameName + " - " + LoadoutName` 