### PR TITLE
Disable download page & Wire up the download spine button

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Jobs/IJobMonitorExtensions.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Jobs/IJobMonitorExtensions.cs
@@ -1,0 +1,58 @@
+using System.Reactive.Linq;
+using DynamicData;
+
+namespace NexusMods.Abstractions.Jobs;
+
+/// <summary>
+/// Extensions for <see cref="IJobMonitor"/>.
+/// </summary>
+public static class IJobMonitorExtensions
+{
+    /// <summary>
+    /// Returns an observable collection containing every job of the given type the monitor knows about, filtered to only include active (Paused or Running) jobs.
+    ///
+    /// Note: as job status changes, the changeset will be updated to reflect the new status.
+    /// </summary>
+    /// <param name="jobMonitor"></param>
+    /// <typeparam name="TJobType"></typeparam>
+    /// <returns></returns>
+    public static IObservable<IChangeSet<TJobType, JobId>> ObserveActiveJobs<TJobType>(this IJobMonitor jobMonitor) 
+        where TJobType : IJob
+    {
+        return jobMonitor.GetObservableChangeSet<TJobType>()
+            .FilterOnObservable(job => job.ObservableStatus.Select(status => status is JobStatus.Running or JobStatus.Paused));
+    } 
+    
+    
+    /// <summary>
+    /// Gets an observable of the average progress percent of all given jobs.
+    /// </summary>
+    public static IObservable<Percent> AverageProgressPercent<TJobType>(this IObservable<IChangeSet<TJobType, JobId>> jobs) 
+        where TJobType : IJob
+    {
+        return jobs.TransformOnObservable(job =>
+                {
+                    if (!job.Progress.TryGetDeterminateProgress(out var determinateProgress))
+                        return Observable.Empty<Percent>();
+                    return determinateProgress.ObservablePercent;
+                }
+            )
+            .QueryWhenChanged(coll => Percent.CreateClamped(coll.Items.Aggregate(0.0d, (acc, source) => acc + source.Value) / coll.Count));
+    }
+    
+    /// <summary>
+    /// Gets an observable of the sum of the progress rate of all given jobs.
+    /// </summary>
+    public static IObservable<double> SumProgressRate<TJobType>(this IObservable<IChangeSet<TJobType, JobId>> jobs) 
+        where TJobType : IJob
+    {
+        return jobs.TransformOnObservable(job =>
+                {
+                    if (!job.Progress.TryGetDeterminateProgress(out var determinateProgress))
+                        return Observable.Empty<ProgressRate>();
+                    return determinateProgress.ObservableProgressRate;
+                }
+            )
+            .QueryWhenChanged(coll => coll.Items.Select(r => r.Value).Sum());
+    }
+}

--- a/src/Abstractions/NexusMods.Abstractions.Jobs/IJobMonitorExtensions.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Jobs/IJobMonitorExtensions.cs
@@ -20,7 +20,8 @@ public static class IJobMonitorExtensions
         where TJobType : IJob
     {
         return jobMonitor.GetObservableChangeSet<TJobType>()
-            .FilterOnObservable(job => job.ObservableStatus.Select(status => status is JobStatus.Running or JobStatus.Paused));
+            .FilterOnObservable(job => job.ObservableStatus
+                .Select(status => status is JobStatus.Running or JobStatus.Paused));
     } 
     
     
@@ -37,7 +38,13 @@ public static class IJobMonitorExtensions
                     return determinateProgress.ObservablePercent;
                 }
             )
-            .QueryWhenChanged(coll => Percent.CreateClamped(coll.Items.Aggregate(0.0d, (acc, source) => acc + source.Value) / coll.Count));
+            .QueryWhenChanged(coll =>
+                {
+                    if (coll.Count == 0)
+                        return Percent.Zero;
+                    return Percent.CreateClamped(coll.Items.Aggregate(0.0d, (acc, source) => acc + source.Value) / coll.Count);
+                }
+            );
     }
     
     /// <summary>
@@ -53,6 +60,12 @@ public static class IJobMonitorExtensions
                     return determinateProgress.ObservableProgressRate;
                 }
             )
-            .QueryWhenChanged(coll => coll.Items.Select(r => r.Value).Sum());
+            .QueryWhenChanged(coll =>
+                {
+                    if (coll.Count == 0)
+                        return 0.0d;
+                    return coll.Items.Select(r => r.Value).Sum();
+                }
+            );
     }
 }

--- a/src/Abstractions/NexusMods.Abstractions.Jobs/Percent.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Jobs/Percent.cs
@@ -10,7 +10,7 @@ public readonly struct Percent : IEquatable<Percent>, IComparable<Percent>
     public readonly double Value;
 
     public static readonly Percent One = new(1.0);
-    public static readonly Percent Zero = new(1.0);
+    public static readonly Percent Zero = new(0.0);
 
     public Percent(double value)
     {

--- a/src/Networking/NexusMods.Networking.HttpDownloader/BytesPerSecondFormatter.cs
+++ b/src/Networking/NexusMods.Networking.HttpDownloader/BytesPerSecondFormatter.cs
@@ -1,0 +1,33 @@
+using NexusMods.Abstractions.Jobs;
+
+namespace NexusMods.Networking.HttpDownloader;
+
+/// <summary>
+/// Super simple formatter for progress rates.
+/// </summary>
+public class BytesPerSecondFormatter : IProgressRateFormatter
+{
+    /// <inheritdoc/>
+    public string Format(double value)
+    {
+        if (value < 1024)
+        {
+            return $"{value:F2} B/s";
+        }
+
+        value /= 1024;
+        if (value < 1024)
+        {
+            return $"{value:F2} KB/s";
+        }
+
+        value /= 1024;
+        if (value < 1024)
+        {
+            return $"{value:F2} MB/s";
+        }
+
+        value /= 1024;
+        return $"{value:F2} GB/s";
+    }
+}

--- a/src/Networking/NexusMods.Networking.HttpDownloader/HttpDownloadJob.cs
+++ b/src/Networking/NexusMods.Networking.HttpDownloader/HttpDownloadJob.cs
@@ -20,7 +20,7 @@ public class HttpDownloadJob : APersistedJob, IHttpDownloadJob
         HttpDownloadJobPersistedState.ReadOnly state,
         IJobGroup? group = default,
         IJobWorker? worker = default,
-        IJobMonitor? monitor = default) : base(connection, state.AsPersistedJobState(), null!, group, worker, monitor
+        IJobMonitor? monitor = default) : base(connection, state.AsPersistedJobState(), new MutableProgress(new DeterminateProgress(new BytesPerSecondFormatter())), group, worker, monitor
     ) { }
 
     /// <inheritdoc/>

--- a/src/Networking/NexusMods.Networking.HttpDownloader/HttpDownloadJobWorker.cs
+++ b/src/Networking/NexusMods.Networking.HttpDownloader/HttpDownloadJobWorker.cs
@@ -49,7 +49,6 @@ public class HttpDownloadJobWorker : APersistedJobWorker<HttpDownloadJob>
             SetProgressRate(job, args.BytesPerSecondSpeed);
         };
 
-        // TODO: progress reporting
         await downloadService.DownloadFileTaskAsync(
             package: job.DownloadPackage.Value,
             cancellationToken: cancellationToken

--- a/src/Networking/NexusMods.Networking.HttpDownloader/HttpDownloadJobWorker.cs
+++ b/src/Networking/NexusMods.Networking.HttpDownloader/HttpDownloadJobWorker.cs
@@ -20,6 +20,7 @@ public class HttpDownloadJobWorker : APersistedJobWorker<HttpDownloadJob>
         _connection = connection;
         _jobMonitor = jobMonitor;
         _settingsManager = settingsManager;
+        ProgressRateFormatter = new BytesPerSecondFormatter();
     }
 
     /// <inheritdoc/>
@@ -40,9 +41,15 @@ public class HttpDownloadJobWorker : APersistedJobWorker<HttpDownloadJob>
 
         var settings = _settingsManager.Get<HttpDownloaderSettings>();
         var downloadService = new DownloadService(settings.ToConfiguration());
+        
+        downloadService.DownloadProgressChanged += (sender, args) =>
+        {
+            // Divide by 100 because the library gives us a value between 0 and 100.
+            SetProgress(job, Percent.CreateClamped(args.ProgressPercentage / 100));
+            SetProgressRate(job, args.BytesPerSecondSpeed);
+        };
 
         // TODO: progress reporting
-
         await downloadService.DownloadFileTaskAsync(
             package: job.DownloadPackage.Value,
             cancellationToken: cancellationToken

--- a/src/Networking/NexusMods.Networking.HttpDownloader/HttpDownloaderSettings.cs
+++ b/src/Networking/NexusMods.Networking.HttpDownloader/HttpDownloaderSettings.cs
@@ -28,6 +28,7 @@ public record HttpDownloaderSettings : ISettings
         return new DownloadConfiguration
         {
             ChunkCount = ChunkCount,
+            BufferBlockSize = 1024 * 8,
             ParallelDownload = ParallelDownload,
             Timeout = (int)Timeout.TotalMilliseconds,
 

--- a/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsLibrary.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsLibrary.cs
@@ -152,10 +152,14 @@ public class NexusModsLibrary
 
         var txResult = await tx.Commit();
         var state = txResult.Remap(newState);
+        
+        var monitor = _serviceProvider.GetRequiredService<IJobMonitor>();
 
-        var job = new NexusModsDownloadJob(_connection, state, worker: worker)
+        var job = new NexusModsDownloadJob(_connection, state, worker: worker, monitor: monitor)
         {
-            HttpDownloadJob = new HttpDownloadJob(_connection, state.AsHttpDownloadJobPersistedState(), worker: _serviceProvider.GetRequiredService<HttpDownloadJobWorker>()),
+            HttpDownloadJob = new HttpDownloadJob(_connection, state.AsHttpDownloadJobPersistedState(), 
+                worker: _serviceProvider.GetRequiredService<HttpDownloadJobWorker>(),
+                monitor: monitor),
         };
 
         return job;

--- a/src/NexusMods.App.UI/Controls/Spine/Buttons/Download/ISpineDownloadButtonViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/Spine/Buttons/Download/ISpineDownloadButtonViewModel.cs
@@ -1,6 +1,5 @@
-using System.Windows.Input;
 using DynamicData.Kernel;
-using NexusMods.Abstractions.Activities;
+using NexusMods.Abstractions.Jobs;
 
 namespace NexusMods.App.UI.Controls.Spine.Buttons.Download;
 

--- a/src/NexusMods.App.UI/Controls/Spine/Buttons/Download/SpineDownloadButtonDesignerViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/Spine/Buttons/Download/SpineDownloadButtonDesignerViewModel.cs
@@ -1,6 +1,6 @@
 using System.Reactive;
 using DynamicData.Kernel;
-using NexusMods.Abstractions.Activities;
+using NexusMods.Abstractions.Jobs;
 using NexusMods.App.UI.Resources;
 using NexusMods.App.UI.WorkspaceSystem;
 using ReactiveUI;

--- a/src/NexusMods.App.UI/Controls/Spine/Buttons/Download/SpineDownloadButtonViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/Spine/Buttons/Download/SpineDownloadButtonViewModel.cs
@@ -1,13 +1,13 @@
 ﻿using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
+using DynamicData;
 using DynamicData.Kernel;
 using JetBrains.Annotations;
-using NexusMods.Abstractions.Activities;
+using NexusMods.Abstractions.HttpDownloads;
+using NexusMods.Abstractions.Jobs;
 using NexusMods.App.UI.Resources;
 using NexusMods.App.UI.WorkspaceSystem;
-using NexusMods.Networking.Downloaders.Interfaces;
-using NexusMods.Paths;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
 
@@ -16,22 +16,22 @@ namespace NexusMods.App.UI.Controls.Spine.Buttons.Download;
 [UsedImplicitly]
 public class SpineDownloadButtonViewModel : AViewModel<ISpineDownloadButtonViewModel>, ISpineDownloadButtonViewModel
 {
-    private const int PollTimeMilliseconds = 1000;
-
-    private IObservable<Unit> Tick { get; } = Observable.Defer(() =>
-        Observable.Interval(TimeSpan.FromMilliseconds(PollTimeMilliseconds))
-            .Select(_ => Unit.Default));
-
-    public SpineDownloadButtonViewModel(IDownloadService downloadService)
+    public SpineDownloadButtonViewModel(IJobMonitor jobMonitor)
     {
         this.WhenActivated(disposables =>
         {
-            Tick.OnUI().Subscribe(_ =>
-            {
-                Number = downloadService.GetThroughput() / Size.MB;
-                Units = "MB/s";
-                Progress = downloadService.GetTotalProgress();
-            }).DisposeWith(disposables);
+            jobMonitor.ObserveActiveJobs<IHttpDownloadJob>()
+                .AverageProgressPercent()
+                .OnUI()
+                .Subscribe(rate => Progress = rate)
+                .DisposeWith(disposables);
+            
+            jobMonitor.ObserveActiveJobs<IHttpDownloadJob>()
+                .SumProgressRate()
+                .OnUI()
+                // Convert from bytes to MB/s
+                .Subscribe(rate => Number = rate / 1024 / 1024 / 8)
+                .DisposeWith(disposables);
         });
     }
 

--- a/src/NexusMods.App.UI/Controls/Spine/Buttons/Download/SpineDownloadButtonViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/Spine/Buttons/Download/SpineDownloadButtonViewModel.cs
@@ -4,6 +4,7 @@ using System.Reactive.Linq;
 using DynamicData;
 using DynamicData.Kernel;
 using JetBrains.Annotations;
+using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.HttpDownloads;
 using NexusMods.Abstractions.Jobs;
 using NexusMods.App.UI.Resources;
@@ -16,14 +17,14 @@ namespace NexusMods.App.UI.Controls.Spine.Buttons.Download;
 [UsedImplicitly]
 public class SpineDownloadButtonViewModel : AViewModel<ISpineDownloadButtonViewModel>, ISpineDownloadButtonViewModel
 {
-    public SpineDownloadButtonViewModel(IJobMonitor jobMonitor)
+    public SpineDownloadButtonViewModel(IJobMonitor jobMonitor, ILogger<SpineDownloadButtonViewModel> logger)
     {
         this.WhenActivated(disposables =>
         {
             jobMonitor.ObserveActiveJobs<IHttpDownloadJob>()
                 .AverageProgressPercent()
                 .OnUI()
-                .Subscribe(rate => Progress = rate)
+                .Subscribe(rate => { Progress = rate.Value > 0 ? rate : Optional<Percent>.None; })
                 .DisposeWith(disposables);
             
             jobMonitor.ObserveActiveJobs<IHttpDownloadJob>()

--- a/src/NexusMods.App.UI/Pages/Downloads/IInProgressViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/Downloads/IInProgressViewModel.cs
@@ -3,6 +3,7 @@ using System.Reactive;
 using DynamicData;
 using LiveChartsCore;
 using LiveChartsCore.SkiaSharpView;
+using NexusMods.Abstractions.Jobs;
 using NexusMods.App.UI.Controls.DataGrid;
 using NexusMods.App.UI.Controls.DownloadGrid;
 using NexusMods.App.UI.Pages.Downloads.ViewModels;
@@ -13,6 +14,12 @@ namespace NexusMods.App.UI.Pages.Downloads;
 
 public interface IInProgressViewModel : IPageViewModelInterface
 {
+    
+    /// <summary>
+    /// Temporary progress value until we redo the downloads page
+    /// </summary>
+    public Percent NewProgress { get; }
+    
     /// <summary>
     /// Collection of in progress download tasks (downloading, paused, etc.)
     /// </summary>

--- a/src/NexusMods.App.UI/Pages/Downloads/InProgressView.axaml
+++ b/src/NexusMods.App.UI/Pages/Downloads/InProgressView.axaml
@@ -11,6 +11,7 @@
     xmlns:lvc="clr-namespace:LiveChartsCore.SkiaSharpView.Avalonia;assembly=LiveChartsCore.SkiaSharpView.Avalonia"
     xmlns:viewModels="clr-namespace:NexusMods.App.UI.Pages.Downloads.ViewModels"
     xmlns:navigation="clr-namespace:NexusMods.App.UI.Controls.Navigation"
+    xmlns:controls="clr-namespace:NexusMods.App.UI.Controls"
     mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="664"
     x:Class="NexusMods.App.UI.Pages.Downloads.InProgressView">
     <Design.DataContext>
@@ -18,7 +19,7 @@
     </Design.DataContext>
     <Grid RowDefinitions="Auto, *">
         <!-- ToolBar -->
-        <Border Classes="Toolbar" Grid.Row="0">
+        <Border Classes="Toolbar" Grid.Row="0" IsVisible="False">
            <StackPanel>
                 <Button x:Name="CancelButton">
                     <StackPanel>
@@ -67,8 +68,22 @@
             </StackPanel>
         </Border>
 
+        <controls:EmptyState Grid.Row="1" x:Name="EmptyState" IsActive="True">
+            <controls:EmptyState.Subtitle>
+                <StackPanel>
+                    <TextBlock Text="{x:Static resources:Language.DownloadsView_UnderDevelopment}" />
+                </StackPanel>
+            </controls:EmptyState.Subtitle>
+
+            <DataGrid Classes="NoTopBorder"
+                      CanUserResizeColumns="True"
+                      CanUserSortColumns="True"
+                      x:Name="DataGrid" />
+
+        </controls:EmptyState>
+        
         <!-- Page Content -->
-        <ScrollViewer Grid.Row="1">
+        <ScrollViewer Grid.Row="1" IsVisible="False">
             <Grid RowDefinitions="Auto, *, 24, *, *" Margin="0, 16">
 
                 <!-- Title & Status -->

--- a/src/NexusMods.App.UI/Pages/Downloads/InProgressView.axaml
+++ b/src/NexusMods.App.UI/Pages/Downloads/InProgressView.axaml
@@ -70,15 +70,18 @@
 
         <controls:EmptyState Grid.Row="1" x:Name="EmptyState" IsActive="True">
             <controls:EmptyState.Subtitle>
-                <StackPanel>
+                <StackPanel Orientation="Vertical">
                     <TextBlock Text="{x:Static resources:Language.DownloadsView_UnderDevelopment}" />
+                    <ProgressBar Classes="DownloadBar"
+                                 Height="24"
+                                 x:Name="DownloadProgressBarNew"
+                                 Margin="24, 16"
+                                 Minimum="0" 
+                                 Maximum="1"
+                                 ProgressTextFormat="{x:Static resources:Language.ProgressBar_ProgressTextFormat__Total_1_0}"/>
                 </StackPanel>
             </controls:EmptyState.Subtitle>
 
-            <DataGrid Classes="NoTopBorder"
-                      CanUserResizeColumns="True"
-                      CanUserSortColumns="True"
-                      x:Name="DataGrid" />
 
         </controls:EmptyState>
         

--- a/src/NexusMods.App.UI/Pages/Downloads/InProgressView.axaml.cs
+++ b/src/NexusMods.App.UI/Pages/Downloads/InProgressView.axaml.cs
@@ -2,6 +2,7 @@ using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using Avalonia.Controls;
 using Avalonia.ReactiveUI;
+using NexusMods.Abstractions.Jobs;
 using NexusMods.App.UI.Controls.DataGrid;
 using NexusMods.App.UI.Extensions;
 using NexusMods.App.UI.Helpers;
@@ -20,6 +21,17 @@ public partial class InProgressView : ReactiveUserControl<IInProgressViewModel>
         this.WhenActivated(d =>
         {
             CompletedDataGrid.Width = double.NaN;
+            
+            ViewModel.WhenAnyValue(vm => vm.NewProgress)
+                .Select(p => p.Value)
+                .BindTo(this, view => view.DownloadProgressBarNew.Value)
+                .DisposeWith(d);
+            
+            ViewModel.WhenAnyValue(vm => vm.NewProgress)
+                .Select(p => p.Value > 0)
+                .StartWith(false)
+                .BindTo(this, view => view.DownloadProgressBarNew.IsVisible)
+                .DisposeWith(d);
             
             this.OneWayBind(ViewModel, vm => vm.Series, view => view.Chart.Series)
                 .DisposeWith(d);

--- a/src/NexusMods.App.UI/Resources/Language.Designer.cs
+++ b/src/NexusMods.App.UI/Resources/Language.Designer.cs
@@ -645,6 +645,15 @@ namespace NexusMods.App.UI.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The Downloads page is currently being reworked and will be replaced in a future update. We apologize for the inconvenience..
+        /// </summary>
+        public static string DownloadsView_UnderDevelopment {
+            get {
+                return ResourceManager.GetString("DownloadsView_UnderDevelopment", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unknown.
         /// </summary>
         public static string DownloadTaskViewModel_Field_Unknown {

--- a/src/NexusMods.App.UI/Resources/Language.resx
+++ b/src/NexusMods.App.UI/Resources/Language.resx
@@ -156,6 +156,9 @@
     <data name="DownloadsView__Download_history" xml:space="preserve">
         <value>Download history</value>
     </data>
+    <data name="DownloadsView_UnderDevelopment" xml:space="preserve">
+        <value>The Downloads page is currently being reworked and will be replaced in a future update. We apologize for the inconvenience.</value>
+    </data>
     <data name="NexusLoginOverlayView__Please_Click_Authorize" xml:space="preserve">
         <value>Please click "Authorize" on the website</value>
     </data>

--- a/tests/NexusMods.UI.Tests/Controls/Spine/DownloadButtonViewTests.cs
+++ b/tests/NexusMods.UI.Tests/Controls/Spine/DownloadButtonViewTests.cs
@@ -2,7 +2,7 @@
 using Avalonia.Controls.Shapes;
 using DynamicData.Kernel;
 using FluentAssertions;
-using NexusMods.Abstractions.Activities;
+using NexusMods.Abstractions.Jobs;
 using NexusMods.App.UI.Controls.Spine.Buttons.Download;
 
 namespace NexusMods.UI.Tests.Controls.Spine;


### PR DESCRIPTION
As discussed, wires up the download spine button to the new job manager, also disables the contents of the Downloads panel and replaces them with a message and a progress bar. It's super simple, but gets the message across

![NexusMods App_GJoh9O91KY](https://github.com/user-attachments/assets/aaf37301-132d-46ec-ab2d-9e039593f27d)

The download happened to fast to see it in that image, but we do get a download speed update in the button still:

![NexusMods App_6Or5BE3Fs3](https://github.com/user-attachments/assets/0f144e2e-e608-4726-93a1-04f59ea22635)

