### PR TITLE
Fix some of the CLI commands and fix logic with the mod installer fallback to advanced installer

### DIFF
--- a/src/NexusMods.DataModel/CommandLine/Verbs/LoadoutManagementVerbs.cs
+++ b/src/NexusMods.DataModel/CommandLine/Verbs/LoadoutManagementVerbs.cs
@@ -135,11 +135,16 @@ public static class LoadoutManagementVerbs
         [Injected] CancellationToken token)
     {
         var rows = new List<object[]>();
-        var mod = loadout.Mods.First(m => m.Name == modName);
-        foreach (var file in mod.Files)
+        var mod = loadout.Items
+            .OfTypeLoadoutItemGroup()
+            .First(m => m.AsLoadoutItem().Name == modName);
+        foreach (var file in mod.Children)
         {
-            if (file.TryGetAsStoredFile(out var stored))
-                rows.Add([file.To, stored.Hash]);
+            if (!file.TryGetAsLoadoutItemWithTargetPath(out var withPath))
+                continue;
+            
+            if (withPath.TryGetAsLoadoutFile(out var stored))
+                rows.Add([withPath.TargetPath, stored.Hash]);
             else
                 rows.Add([file.GetType().ToString(), "<none>"]);
         }

--- a/src/NexusMods.Library/InstallLoadoutItemJobWorker.cs
+++ b/src/NexusMods.Library/InstallLoadoutItemJobWorker.cs
@@ -34,8 +34,11 @@ internal class InstallLoadoutItemJobWorker : AJobWorker<InstallLoadoutItemJob>
 
         var result = await ExecuteInstallersAsync(job, installers, cancellationToken);
 
-        if (!result.HasValue && job.Installer is not AdvancedManualInstaller)
+        if (!result.HasValue)
         {
+            if (job.Installer is not AdvancedManualInstaller)
+                return JobResult.CreateFailed($"Advanced installer did not succeed for `{job.LibraryItem.Name}` (`{job.LibraryItem.Id}`)");
+            
             var manualInstaller = AdvancedManualInstaller.Create(_serviceProvider);
             result = await ExecuteInstallersAsync(job, [manualInstaller], cancellationToken);
 
@@ -43,10 +46,6 @@ internal class InstallLoadoutItemJobWorker : AJobWorker<InstallLoadoutItemJob>
             {
                 return JobResult.CreateFailed($"Found no installer that supports `{job.LibraryItem.Name}` (`{job.LibraryItem.Id}`), including the advanced installer!");
             }
-        }
-        else
-        {
-            return JobResult.CreateFailed($"Advanced installer did not succeed for `{job.LibraryItem.Name}` (`{job.LibraryItem.Id}`)");
         }
 
         var (loadoutGroup, transaction) = result.Value;

--- a/src/NexusMods.Library/InstallLoadoutItemJobWorker.cs
+++ b/src/NexusMods.Library/InstallLoadoutItemJobWorker.cs
@@ -36,7 +36,7 @@ internal class InstallLoadoutItemJobWorker : AJobWorker<InstallLoadoutItemJob>
 
         if (!result.HasValue)
         {
-            if (job.Installer is not AdvancedManualInstaller)
+            if (job.Installer is AdvancedManualInstaller)
                 return JobResult.CreateFailed($"Advanced installer did not succeed for `{job.LibraryItem.Name}` (`{job.LibraryItem.Id}`)");
             
             var manualInstaller = AdvancedManualInstaller.Create(_serviceProvider);

--- a/tests/NexusMods.CLI.Tests/VerbTests/ModManagementVerbs.cs
+++ b/tests/NexusMods.CLI.Tests/VerbTests/ModManagementVerbs.cs
@@ -8,7 +8,6 @@ public class ModManagementVerbs(StubbedGame stubbedGame, IServiceProvider provid
 {
     
     [Fact]
-    [Trait("FlakeyTest", "True")]
     public async Task CanCreateAndManageLists()
     {
         var listName = Guid.NewGuid().ToString();
@@ -31,7 +30,7 @@ public class ModManagementVerbs(StubbedGame stubbedGame, IServiceProvider provid
         log = await Run("list-mods", "-l", listName);
         log.LastTable.Rows.Length.Should().Be(2);
 
-        log = await Run("list-mod-contents", "-l", listName, "-m", Data7ZipLZMA2.GetFileNameWithoutExtension());
+        log = await Run("list-mod-contents", "-l", listName, "-m", Data7ZipLZMA2.FileName);
         log.LastTable.Rows.Length.Should().Be(3);
         
         log = await Run("synchronize", "-l", listName);


### PR DESCRIPTION
Fixes a regression caused by incorrect boolean logic around how we fallback to advanced installers. It's a 3-state situation, not a 2 state