### PR TITLE
Fix Stardew Valley disabled diagnostic

### DIFF
--- a/src/Games/NexusMods.Games.StardewValley/Emitters/DependencyDiagnosticEmitter.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/DependencyDiagnosticEmitter.cs
@@ -7,6 +7,7 @@ using NexusMods.Abstractions.Diagnostics.Emitters;
 using NexusMods.Abstractions.Diagnostics.References;
 using NexusMods.Abstractions.IO;
 using NexusMods.Abstractions.Loadouts;
+using NexusMods.Abstractions.Loadouts.Extensions;
 using NexusMods.Games.StardewValley.Models;
 using NexusMods.Games.StardewValley.WebAPI;
 using NexusMods.Paths;
@@ -77,7 +78,8 @@ public class DependencyDiagnosticEmitter : ILoadoutDiagnosticEmitter
             .Where(kv =>
             {
                 var (loadoutItemId, _) = kv;
-                return !SMAPIModLoadoutItem.Load(loadout.Db, loadoutItemId).AsLoadoutItemGroup().AsLoadoutItem().IsDisabled;
+                var smapiLoadoutItem = SMAPILoadoutItem.Load(loadout.Db, loadoutItemId);
+                return smapiLoadoutItem.AsLoadoutItemGroup().AsLoadoutItem().IsEnabled();
             })
             .Select(kv =>
             {
@@ -87,7 +89,7 @@ public class DependencyDiagnosticEmitter : ILoadoutDiagnosticEmitter
                 var disabledDependencies = requiredDependencies
                     .Select(uniqueIdToLoadoutItemId.GetValueOrDefault)
                     .Where(id => id != default(SMAPIModLoadoutItemId))
-                    .Where(id => !SMAPIModLoadoutItem.Load(loadout.Db, id).AsLoadoutItemGroup().AsLoadoutItem().IsDisabled)
+                    .Where(id => !SMAPIModLoadoutItem.Load(loadout.Db, id).AsLoadoutItemGroup().AsLoadoutItem().IsEnabled())
                     .ToArray();
 
                 return (Id: loadoutItemId, DisabledDependencies: disabledDependencies);
@@ -118,7 +120,7 @@ public class DependencyDiagnosticEmitter : ILoadoutDiagnosticEmitter
             .Where(kv =>
             {
                 var (loadoutItemId, _) = kv;
-                return !SMAPIModLoadoutItem.Load(loadout.Db, loadoutItemId).AsLoadoutItemGroup().AsLoadoutItem().IsDisabled;
+                return SMAPIModLoadoutItem.Load(loadout.Db, loadoutItemId).AsLoadoutItemGroup().AsLoadoutItem().IsEnabled();
             })
             .Select(kv =>
             {

--- a/src/Networking/NexusMods.Networking.HttpDownloader/HttpDownloaderSettings.cs
+++ b/src/Networking/NexusMods.Networking.HttpDownloader/HttpDownloaderSettings.cs
@@ -2,6 +2,7 @@ using Downloader;
 using JetBrains.Annotations;
 using NexusMods.Abstractions.Settings;
 using NexusMods.App.BuildInfo;
+using NexusMods.Paths;
 
 namespace NexusMods.Networking.HttpDownloader;
 
@@ -12,6 +13,8 @@ namespace NexusMods.Networking.HttpDownloader;
 public record HttpDownloaderSettings : ISettings
 {
     public int ChunkCount { get; set; } = 4;
+
+    public Size BufferBlockSize { get; set; } = Size.KB * 8;
 
     public bool ParallelDownload { get; set; } = true;
 
@@ -28,7 +31,7 @@ public record HttpDownloaderSettings : ISettings
         return new DownloadConfiguration
         {
             ChunkCount = ChunkCount,
-            BufferBlockSize = 1024 * 8,
+            BufferBlockSize = (int)BufferBlockSize.Value,
             ParallelDownload = ParallelDownload,
             Timeout = (int)Timeout.TotalMilliseconds,
 


### PR DESCRIPTION
Enabled mods showed up as disabled.