### PR TITLE
Fix CleanDirectories deleting folders still containing other files

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -85,7 +85,7 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
         var seenDirectories = new HashSet<GamePath>();
         var directoriesToDelete = new HashSet<GamePath>();
 
-        var newStatePaths = newState.Select(e => (GamePath)e.Path).ToHashSet();
+        var newStatePaths = newState.SelectMany(e => ((GamePath)e.Path).GetAllParents()).ToHashSet();
 
         foreach (var entry in toDelete)
         {

--- a/tests/Games/NexusMods.Games.TestFramework/ACyberpunkIsolatedGameTest.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/ACyberpunkIsolatedGameTest.cs
@@ -1,0 +1,20 @@
+using Microsoft.Extensions.DependencyInjection;
+using NexusMods.Games.RedEngine;
+using NexusMods.Games.RedEngine.Cyberpunk2077;
+using NexusMods.StandardGameLocators.TestHelpers;
+using Xunit.Abstractions;
+
+namespace NexusMods.Games.TestFramework;
+
+/// <summary>
+/// A override for the <see cref="AIsolatedGameTest{TGame}"/> for the <see cref="Cyberpunk2077Game"/>.
+/// </summary>
+public class ACyberpunkIsolatedGameTest<TTest>(ITestOutputHelper helper) : AIsolatedGameTest<TTest, Cyberpunk2077Game>(helper)
+{
+    protected override IServiceCollection AddServices(IServiceCollection services)
+    {
+        return base.AddServices(services)
+            .AddUniversalGameLocator<Cyberpunk2077Game>(new Version("1.61"))
+            .AddRedEngineGames();
+    }
+}

--- a/tests/Games/NexusMods.Games.TestFramework/AIsolatedGameTest.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/AIsolatedGameTest.cs
@@ -1,0 +1,398 @@
+using System.IO.Compression;
+using System.Text;
+using FluentAssertions;
+using JetBrains.Annotations;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using NexusMods.Abstractions.Diagnostics;
+using NexusMods.Abstractions.FileStore;
+using NexusMods.Abstractions.GameLocators;
+using NexusMods.Abstractions.Games;
+using NexusMods.Abstractions.GC;
+using NexusMods.Abstractions.GuidedInstallers;
+using NexusMods.Abstractions.HttpDownloader;
+using NexusMods.Abstractions.Installers;
+using NexusMods.Abstractions.IO;
+using NexusMods.Abstractions.IO.StreamFactories;
+using NexusMods.Abstractions.Library.Models;
+using NexusMods.Abstractions.Loadouts;
+using NexusMods.Abstractions.Loadouts.Synchronizers;
+using NexusMods.Abstractions.Serialization;
+using NexusMods.App.BuildInfo;
+using NexusMods.DataModel;
+using NexusMods.Games.FOMOD;
+using NexusMods.Hashing.xxHash64;
+using NexusMods.MnemonicDB.Abstractions;
+using NexusMods.MnemonicDB.Abstractions.Models;
+using NexusMods.Networking.NexusWebApi;
+using NexusMods.Paths;
+using NexusMods.StandardGameLocators.TestHelpers;
+using Xunit.Abstractions;
+using Xunit.DependencyInjection;
+
+namespace NexusMods.Games.TestFramework;
+
+[PublicAPI]
+public abstract class AIsolatedGameTest<TTest, TGame> : IAsyncLifetime where TGame : AGame
+{
+    protected readonly ILogger Logger;
+    protected readonly IServiceProvider ServiceProvider;
+    protected TGame Game;
+    protected GameInstallation GameInstallation;
+
+    protected readonly IFileSystem FileSystem;
+    protected readonly TemporaryFileManager TemporaryFileManager;
+    protected readonly IFileStore FileStore;
+    protected readonly IGameRegistry GameRegistry;
+
+    protected readonly IConnection Connection;
+
+    protected readonly NexusApiClient NexusNexusApiClient;
+    protected readonly IHttpDownloader HttpDownloader;
+    
+    protected ILoadoutSynchronizer Synchronizer => GameInstallation.GetGame().Synchronizer;
+    
+    private bool _gameFilesWritten = false;
+    private readonly IHost _host;
+    private readonly ITestOutputHelper _helper;
+
+    public IDiagnosticManager DiagnosticManager { get; set; }
+
+
+    private class Accessor : ITestOutputHelperAccessor
+    {
+        public ITestOutputHelper? Output { get; set; }
+    }
+    
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    protected AIsolatedGameTest(ITestOutputHelper helper)
+    {
+        _helper = helper;
+        _host = new HostBuilder()
+            .ConfigureServices(s => AddServices(s))
+            .Build();
+        
+        ServiceProvider = _host.Services;
+
+        GameRegistry = ServiceProvider.GetRequiredService<IGameRegistry>();
+        
+
+
+        FileSystem = ServiceProvider.GetRequiredService<IFileSystem>();
+        FileStore = ServiceProvider.GetRequiredService<IFileStore>();
+        TemporaryFileManager = ServiceProvider.GetRequiredService<TemporaryFileManager>();
+        Connection = ServiceProvider.GetRequiredService<IConnection>();
+
+        DiagnosticManager = ServiceProvider.GetRequiredService<IDiagnosticManager>();
+
+        NexusNexusApiClient = ServiceProvider.GetRequiredService<NexusApiClient>();
+        HttpDownloader = ServiceProvider.GetRequiredService<IHttpDownloader>();
+
+        Logger = ServiceProvider.GetRequiredService<ILogger<TTest>>();
+    }
+    
+    protected virtual IServiceCollection AddServices(IServiceCollection services)
+    {
+        return services.AddDefaultServicesForTesting()
+            .AddSingleton<IGuidedInstaller, NullGuidedInstaller>()
+            .AddFomod()
+            .AddLogging(builder => builder.AddXUnit())
+            .AddGames()
+            .AddSerializationAbstractions()
+            .AddLoadoutAbstractions()
+            .AddFileStoreAbstractions()
+            .AddInstallerTypes()
+            .AddSingleton<ITestOutputHelperAccessor>(_ => new Accessor { Output = _helper })
+            .Validate();
+    }
+
+    /// <summary>
+    /// Override this method to generate the game files for the tests in this class. 
+    /// </summary>
+    protected virtual Task GenerateGameFiles()
+    {
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Adds an empty mod to the loadout in the given transaction.
+    /// </summary>
+    protected LoadoutItemGroupId AddEmptyGroup(ITransaction tx, LoadoutId loadoutId, string name)
+    {
+        var mod = new LoadoutItemGroup.New(tx, out var id)
+        {
+            IsGroup = true,
+            LoadoutItem = new LoadoutItem.New(tx, id)
+            {
+                LoadoutId = loadoutId,
+                Name = name,
+                
+            },
+        };
+        return mod.Id;
+    }
+    
+    /// <summary>
+    /// Creates a file in the loadout for the given mod.
+    /// The file will be named with the given path, the hash will be the hash
+    /// of the name, and the size will be the length of the name. 
+    /// </summary>
+    public LoadoutFileId AddFile(ITransaction tx, LoadoutId loadoutId, LoadoutItemGroupId groupId, GamePath path, string? content = null)
+    {
+        return AddFile(tx, loadoutId, groupId, path, content, out _, out _);
+    }
+    
+    /// <summary>
+    /// Creates a file in the loadout for the given mod.
+    /// The file will be named with the given path, the hash will be the hash
+    /// of the name, and the size will be the length of the name. 
+    /// </summary>
+    public LoadoutFileId AddFile(ITransaction tx, LoadoutId loadoutId, LoadoutItemGroupId groupId, GamePath path, string? content, out Hash hash, out Size size)
+    {
+        content ??= path.Path.ToString();
+        var contentArray = Encoding.UTF8.GetBytes(content);
+
+        hash = contentArray.XxHash64();
+        size = Size.FromLong(contentArray.Length);
+        return AddFileInternal(tx, loadoutId, groupId, path, hash, size).Id;
+    }
+    private static LoadoutFile.New AddFileInternal(ITransaction tx, LoadoutId loadoutId, LoadoutItemGroupId groupId, GamePath path, Hash hash, Size size) => new(tx, out var id)
+    {
+        LoadoutItemWithTargetPath = new LoadoutItemWithTargetPath.New(tx, id)
+        {
+            LoadoutItem = new LoadoutItem.New(tx, id)
+            {
+                LoadoutId = loadoutId,
+                ParentId = groupId,
+                Name = path.Path,
+            },
+            TargetPath = path.ToGamePathParentTuple(loadoutId),
+        },
+        Hash = hash,
+        Size = size,
+    };
+
+    /// <summary>
+    /// Creates a <see cref="LibraryArchive"/> to simulate an item in the library.
+    /// This item can be used in conjunction with <see cref="AddModAsync"/> to simulate
+    /// adding a mod from the library.
+    /// </summary>
+    /// <param name="conn">The connection with the DataStore</param>
+    /// <param name="fileName">Name of the archive.</param>
+    public async Task<LibraryArchive.ReadOnly> CreateLibraryArchive(IConnection conn, string fileName)
+    {
+        using var tx = conn.BeginTransaction();
+        var libraryFile = CreateLibraryFile(fileName, tx, out var entityId);
+        
+        // Note(sewer): These are the same entity, just an API caveat that 2 objects are needed.
+        var archive = new LibraryArchive.New(tx, entityId)
+        {
+            LibraryFile = libraryFile,
+            IsArchive = true,
+        };
+
+        var result = await tx.Commit();
+        return result.Remap(archive);
+    }
+
+    /// <summary>
+    /// Creates a file in the loadout for the given mod.
+    /// The file will be named with the given path, the hash will be the hash
+    /// of the name, and the size will be the length of the name. 
+    /// </summary>
+    /// <param name="tx">The transaction.</param>
+    /// <param name="paths">The names of the file paths to add. The file contents will be the UTF-8 of these paths.</param>
+    /// <param name="loadoutId">The loadout to add the mod to.</param>
+    /// <param name="modName">Name of the mod in the loadout.</param>
+    /// <param name="libraryArchive">
+    ///     The library item created with <see cref="CreateLibraryArchive"/> to attach the mod files to.
+    ///     Specifying this parameter will add DB entries to simulate this being the original archive which
+    ///     the files have come from.
+    /// </param>
+    public async Task<(AbsolutePath archivePath, List<Hash> hashes)> AddModAsync(ITransaction tx, IEnumerable<RelativePath> paths, LoadoutId loadoutId, string modName, LibraryArchive.ReadOnly? libraryArchive = null)
+    {
+        var records = new List<ArchivedFileEntry>();
+        var hashes = new List<Hash>();
+        var modGroup = AddEmptyGroup(tx, loadoutId, modName);
+        foreach (var path in paths)
+        {
+            var data = Encoding.UTF8.GetBytes(path);
+            var hash = data.XxHash64();
+            var size = Size.FromLong(path.Path.Length);
+            
+            // Create the LoadoutFile in DB
+            AddFileInternal(tx, loadoutId, modGroup, new GamePath(LocationId.Game, path), hash, size);
+            
+            // Create the file to backup.
+            hashes.Add(hash);
+            if (!await FileStore.HaveFile(hash))
+            {
+                records.Add(new ArchivedFileEntry(
+                    new MemoryStreamFactory(path, new MemoryStream(data)),
+                    hash,
+                    size
+                ));
+            }
+
+            if (libraryArchive == null)
+                continue;
+
+            var libraryArchiveFileEntry = CreateLibraryFile(path.Path, tx, out _);
+            _ = new LibraryArchiveFileEntry.New(tx, libraryArchiveFileEntry.Id)
+            {
+                Path = path,
+                ParentId = libraryArchive,
+                LibraryFile = libraryArchiveFileEntry,
+            };
+        }
+
+        if (records.Count > 0)
+            await FileStore.BackupFiles(records);
+
+        return (GetArchivePath(hashes.First()), hashes);
+    }
+
+    private static LibraryFile.New CreateLibraryFile(string fileName, ITransaction tx, out EntityId entityId) => new(tx, out entityId)
+    {
+        FileName = fileName,
+        Hash = fileName.XxHash64AsUtf8(),
+        Size = Size.FromLong(fileName.Length),
+        LibraryItem = new LibraryItem.New(tx, entityId)
+        {
+            Name = fileName,
+        },
+    };
+    
+    /// <summary>
+    /// Resets the game folders to a clean state.
+    /// </summary>
+    private void ResetGameFolders()
+    {
+        var register = GameInstallation.LocationsRegister;
+        var oldLocations = register.GetTopLevelLocations().ToArray();
+        var newLocations = new Dictionary<LocationId, AbsolutePath>();
+        foreach (var (k, _) in oldLocations)
+        {
+            newLocations[k] = TemporaryFileManager.CreateFolder().Path;
+        }
+        register.Reset(newLocations);
+        _gameFilesWritten = false;
+    }
+
+    /// <summary>
+    /// Creates a new loadout and returns the <see cref="Loadout.ReadOnly"/> of it.
+    /// </summary>
+    protected async Task<Loadout.ReadOnly> CreateLoadout(bool indexGameFiles = true)
+    {
+        if (!_gameFilesWritten)
+        {
+            await GenerateGameFiles();
+            _gameFilesWritten = true;
+        }
+        return await GameInstallation.GetGame().Synchronizer.CreateLoadout(GameInstallation, Guid.NewGuid().ToString());
+    }
+    
+    /// <summary>
+    /// Deletes a loadout with a given ID.
+    /// </summary>
+    protected Task DeleteLoadoutAsync(LoadoutId loadoutId, GarbageCollectorRunMode gcRunMode = GarbageCollectorRunMode.DoNotRun) => GameInstallation.GetGame().Synchronizer.DeleteLoadout(loadoutId, gcRunMode);
+
+    /// <summary>
+    /// Reloads the entity from the database.
+    /// </summary>
+    protected T Refresh<T>(T entity) where T : IReadOnlyModel<T>
+        => T.Create(Connection.Db, entity.Id);
+    
+    /// <summary>
+    /// Reloads the entity from the database.
+    /// </summary>
+    protected void Refresh<T>(ref T entity) where T : IReadOnlyModel<T>
+        => entity = T.Create(Connection.Db, entity.Id);
+
+    /// <summary>
+    /// Creates a ZIP archive using <see cref="ZipArchive"/> and returns the
+    /// <see cref="TemporaryPath"/> to it.
+    /// </summary>
+    /// <param name="filesToZip"></param>
+    /// <returns></returns>
+    protected async Task<TemporaryPath> CreateTestArchive(IDictionary<RelativePath, byte[]> filesToZip)
+    {
+        var file = TemporaryFileManager.CreateFile();
+
+        await using var stream = file.Path.Create();
+
+        // Don't put this in Create mode, because for some reason it will create broken Zips that are not prefixed
+        // with the ZIP magic number. Not sure why and I can't reproduce it in a simple test case, but if you open
+        // in create mode all your zip archives will be prefixed with 0x0000FFFF04034B50 instead of 0x04034B50.
+        // See https://github.com/dotnet/runtime/blob/23886f158cf925e13c72e661b9891df704806746/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs#L949-L956
+        // for where this bug occurs
+        using var zipArchive = new ZipArchive(stream, ZipArchiveMode.Update);
+
+        foreach (var kv in filesToZip)
+        {
+            var (path, contents) = kv;
+
+            var entry = zipArchive.CreateEntry(path.Path, CompressionLevel.Fastest);
+            await using var entryStream = entry.Open();
+            await using var ms = new MemoryStream(contents);
+            await ms.CopyToAsync(entryStream);
+            await entryStream.FlushAsync();
+        }
+
+        await stream.FlushAsync();
+        return file;
+    }
+
+    protected async Task<TemporaryPath> CreateTestFile(string fileName, byte[] contents)
+    {
+        var folder = TemporaryFileManager.CreateFolder();
+        var path = folder.Path.Combine(fileName);
+        var file = new TemporaryPath(FileSystem, path);
+
+        await path.WriteAllBytesAsync(contents);
+        return file;
+    }
+
+    protected Task<TemporaryPath> CreateTestFile(string fileName, string contents, Encoding? encoding = null)
+        => CreateTestFile(fileName, (encoding ?? Encoding.UTF8).GetBytes(contents));
+
+    protected async Task<TemporaryPath> CreateTestFile(byte[] contents, Extension? extension)
+    {
+        var file = TemporaryFileManager.CreateFile(extension);
+        await file.Path.WriteAllBytesAsync(contents);
+        return file;
+    }
+
+    protected Task<TemporaryPath> CreateTestFile(string contents, Extension? extension, Encoding? encoding = null)
+        => CreateTestFile((encoding ?? Encoding.UTF8).GetBytes(contents), extension);
+    
+    private AbsolutePath GetArchivePath(Hash hash)
+    {
+        if (FileStore is not NxFileStore store)
+            throw new NotSupportedException("GetArchivePath is not currently supported in stubbed file stores.");
+
+        store.TryGetLocation(Connection.Db, hash, null, out var archivePath, out _).Should().BeTrue("Archive should exist");
+        return archivePath;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _host.StartAsync();
+        GameInstallation = GameRegistry.Installations.Values.First(g => g.Game is TGame);
+        Game = (TGame)GameInstallation.Game;
+        
+        if (GameInstallation.Locator is UniversalStubbedGameLocator<TGame> universal)
+        {
+            Logger.LogInformation("Resetting game files for {Game}", Game.Name);
+            ResetGameFolders();
+        }
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.StopAsync();
+    }
+}

--- a/tests/Games/NexusMods.Games.TestFramework/GithubIssueAttribute.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/GithubIssueAttribute.cs
@@ -1,0 +1,25 @@
+namespace NexusMods.Games.TestFramework;
+
+/// <summary>
+/// A documentation attribute to link to a Github issue to a test method.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method)]
+public class GithubIssueAttribute : Attribute
+{
+    /// <summary>
+    /// The GithubId of the issue
+    /// </summary>
+    public int GithubId { get; } 
+    
+    public Uri GithubUri => new("https://github.com/Nexus-Mods/NexusMods.App/issues/" + GithubId);
+
+    public GithubIssueAttribute(int githubId)
+    {
+        GithubId = githubId;
+    }
+
+    public override string ToString()
+    {
+        return "Github Issue: " + GithubId;
+    }
+}

--- a/tests/Games/NexusMods.Games.TestFramework/NexusMods.Games.TestFramework.csproj
+++ b/tests/Games/NexusMods.Games.TestFramework/NexusMods.Games.TestFramework.csproj
@@ -1,6 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <ItemGroup>
+        <ProjectReference Include="..\..\..\src\Abstractions\NexusMods.Abstractions.GuidedInstallers\NexusMods.Abstractions.GuidedInstallers.csproj" />
         <ProjectReference Include="..\..\..\src\ArchiveManagement\NexusMods.FileExtractor\NexusMods.FileExtractor.csproj" />
+        <ProjectReference Include="..\..\..\src\Games\NexusMods.Games.FOMOD\NexusMods.Games.FOMOD.csproj" />
+        <ProjectReference Include="..\..\..\src\Games\NexusMods.Games.RedEngine\NexusMods.Games.RedEngine.csproj" />
         <ProjectReference Include="..\..\..\src\Networking\NexusMods.Networking.HttpDownloader\NexusMods.Networking.HttpDownloader.csproj" />
         <ProjectReference Include="..\..\..\src\Networking\NexusMods.Networking.NexusWebApi\NexusMods.Networking.NexusWebApi.csproj" />
         <ProjectReference Include="..\..\..\src\NexusMods.Activities\NexusMods.Activities.csproj" />

--- a/tests/NexusMods.DataModel.Synchronizer.Tests/GeneralLoadoutManagementTests.cs
+++ b/tests/NexusMods.DataModel.Synchronizer.Tests/GeneralLoadoutManagementTests.cs
@@ -1,16 +1,12 @@
 using System.Text;
-using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using NexusMods.Abstractions.DiskState;
 using NexusMods.Abstractions.GameLocators;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Games.RedEngine.Cyberpunk2077;
 using NexusMods.Games.TestFramework;
-using NexusMods.Games.TestFramework.FluentAssertionExtensions;
 using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.MnemonicDB.Abstractions.BuiltInEntities;
-using NexusMods.MnemonicDB.Abstractions.IndexSegments;
 
 namespace NexusMods.DataModel.Synchronizer.Tests;
 

--- a/tests/NexusMods.DataModel.Synchronizer.Tests/GeneralLoadoutManagementTests.cs
+++ b/tests/NexusMods.DataModel.Synchronizer.Tests/GeneralLoadoutManagementTests.cs
@@ -1,22 +1,16 @@
 using System.Text;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.GameLocators;
 using NexusMods.Abstractions.Loadouts;
-using NexusMods.Games.RedEngine.Cyberpunk2077;
 using NexusMods.Games.TestFramework;
 using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.MnemonicDB.Abstractions.BuiltInEntities;
+using Xunit.Abstractions;
 
 namespace NexusMods.DataModel.Synchronizer.Tests;
 
-public class GeneralLoadoutManagementTests : AGameTest<Cyberpunk2077Game>
+public class GeneralLoadoutManagementTests(ITestOutputHelper helper) : ACyberpunkIsolatedGameTest<GeneralLoadoutManagementTests>(helper)
 {
-    private ILogger<GeneralLoadoutManagementTests> _logger;
-    public GeneralLoadoutManagementTests(IServiceProvider serviceProvider) : base(serviceProvider)
-    {
-        _logger = serviceProvider.GetRequiredService<ILogger<GeneralLoadoutManagementTests>>();
-    }
 
     [Fact]
     public async Task SynchronizerIntegrationTests()
@@ -131,7 +125,7 @@ public class GeneralLoadoutManagementTests : AGameTest<Cyberpunk2077Game>
     /// </summary>
     private void LogState(StringBuilder sb, string sectionName, string comments = "", Loadout.ReadOnly[]? loadouts = null)
     {
-        _logger.LogInformation("Logging State {SectionName}", sectionName);
+        Logger.LogInformation("Logging State {SectionName}", sectionName);
         
         var metadata = GameInstallation.GetMetadata(Connection);
         sb.AppendLine($"{sectionName}:");
@@ -168,5 +162,4 @@ public class GeneralLoadoutManagementTests : AGameTest<Cyberpunk2077Game>
         }
         
     }
-
 }

--- a/tests/NexusMods.DataModel.Synchronizer.Tests/Startup.cs
+++ b/tests/NexusMods.DataModel.Synchronizer.Tests/Startup.cs
@@ -23,6 +23,7 @@ public class Startup
     /// <param name="container"></param>
     public void ConfigureServices(IServiceCollection container)
     {
+        /*
         container
             .AddSingleton<IGuidedInstaller, NullGuidedInstaller>()
             .AddDefaultServicesForTesting()
@@ -36,6 +37,7 @@ public class Startup
             .AddFileStoreAbstractions()
             .AddInstallerTypes()
             .Validate();
+            */
     }
 }
 

--- a/tests/NexusMods.DataModel.Synchronizer.Tests/SynchronizerUnitTests.cs
+++ b/tests/NexusMods.DataModel.Synchronizer.Tests/SynchronizerUnitTests.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using NexusMods.Abstractions.GameLocators;
+using NexusMods.Games.RedEngine.Cyberpunk2077;
+using NexusMods.Games.TestFramework;
+using NexusMods.MnemonicDB.Abstractions.TxFunctions;
+
+namespace NexusMods.DataModel.Synchronizer.Tests;
+
+/// <summary>
+/// Tests for specific issues or regressions in the Synchronizer.
+/// </summary>
+public class SynchronizerUnitTests : AGameTest<Cyberpunk2077Game>
+{
+    public SynchronizerUnitTests(IServiceProvider serviceProvider) : base(serviceProvider)
+    {
+    }
+
+    [Fact]
+    [GithubIssue(1925)]
+    public async Task EmptyChildFoldersDontDeleteNonEmptyParents()
+    {
+        var loadout = await CreateLoadout(false);
+        
+        var parentFile = new GamePath(LocationId.Game, "a/parent.txt");
+        var grandChildFile = new GamePath(LocationId.Game, "a/b/c/grandchild.txt");
+        
+        var parentFileFullPath = GameInstallation.LocationsRegister.GetResolvedPath(parentFile);
+        var grandChildFileFullPath = GameInstallation.LocationsRegister.GetResolvedPath(grandChildFile);
+        
+        parentFileFullPath.Parent.CreateDirectory();
+        await parentFileFullPath.WriteAllTextAsync("Parent File");
+        
+        grandChildFileFullPath.Parent.CreateDirectory();
+        await grandChildFileFullPath.WriteAllTextAsync("Grand Child File");
+        
+        loadout = await Synchronizer.Synchronize(loadout);
+        
+        loadout.Items.Should().ContainSingle(f => f.Name == "parent.txt");
+        loadout.Items.Should().ContainSingle(f => f.Name == "grandchild.txt");
+        
+
+
+        using (var tx = Connection.BeginTransaction())
+        {
+            var toDelete = loadout.Items.First(f => f.Name == "grandchild.txt").Id;
+            tx.Delete(toDelete, false);
+            await tx.Commit();
+        }
+
+        loadout = loadout.Rebase();
+        loadout = await Synchronizer.Synchronize(loadout);
+        
+        grandChildFileFullPath.FileExists.Should().BeFalse();
+        parentFileFullPath.FileExists.Should().BeTrue();
+        
+        
+    }
+}

--- a/tests/NexusMods.DataModel.Synchronizer.Tests/SynchronizerUnitTests.cs
+++ b/tests/NexusMods.DataModel.Synchronizer.Tests/SynchronizerUnitTests.cs
@@ -1,20 +1,21 @@
 using FluentAssertions;
+using MartinCostello.Logging.XUnit;
+using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.GameLocators;
+using NexusMods.Games.RedEngine;
 using NexusMods.Games.RedEngine.Cyberpunk2077;
 using NexusMods.Games.TestFramework;
 using NexusMods.MnemonicDB.Abstractions.TxFunctions;
+using NexusMods.StandardGameLocators.TestHelpers;
+using Xunit.Abstractions;
 
 namespace NexusMods.DataModel.Synchronizer.Tests;
 
 /// <summary>
 /// Tests for specific issues or regressions in the Synchronizer.
 /// </summary>
-public class SynchronizerUnitTests : AGameTest<Cyberpunk2077Game>
+public class SynchronizerUnitTests(ITestOutputHelper testOutputHelper) : ACyberpunkIsolatedGameTest<SynchronizerUnitTests>(testOutputHelper)
 {
-    public SynchronizerUnitTests(IServiceProvider serviceProvider) : base(serviceProvider)
-    {
-    }
-
     [Fact]
     [GithubIssue(1925)]
     public async Task EmptyChildFoldersDontDeleteNonEmptyParents()


### PR DESCRIPTION
- fixes #1925
- Could maybe fix #1907  

To explain the fix, the function created a hashset of existing file paths and was using `hashSet.Contains(parentPath)` to check whether a parent folder had any children, this always returned false, since the hashset contained the file paths, not parent paths. This change builds a hashset of all the parent paths, so the check works correctly.

Probably not the most efficient way to do the entire directory check but this is the simplest fix.