### PR TITLE
Fixes deleting of mods

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,8 +10,8 @@
     <PackageVersion Include="Nerdbank.FullDuplexStream" Version="1.1.12" />
     <PackageVersion Include="Nerdbank.Streams" Version="2.11.74" />
     <PackageVersion Include="NexusMods.Paths" Version="0.10.0" />
-    <PackageVersion Include="NexusMods.MnemonicDB.Abstractions" Version="0.9.79" />
-    <PackageVersion Include="NexusMods.MnemonicDB" Version="0.9.79" />
+    <PackageVersion Include="NexusMods.MnemonicDB.Abstractions" Version="0.9.80" />
+    <PackageVersion Include="NexusMods.MnemonicDB" Version="0.9.80" />
     <PackageVersion Include="NexusMods.Hashing.xxHash64" Version="2.0.1" />
     <PackageVersion Include="NexusMods.Paths.Extensions.Nx" Version="0.10.0" />
     <PackageVersion Include="NexusMods.Paths.TestingHelpers" Version="0.9.5" />
@@ -120,7 +120,7 @@
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="ini-parser-netstandard" Version="2.5.2" />
     <PackageVersion Include="Mutagen.Bethesda.Skyrim" Version="0.44.0" />
-    <PackageVersion Include="NexusMods.MnemonicDB.SourceGenerator" Version="0.9.79" />
+    <PackageVersion Include="NexusMods.MnemonicDB.SourceGenerator" Version="0.9.80" />
     <PackageVersion Include="NLog.Extensions.Logging" Version="5.3.11" />
     <PackageVersion Include="OneOf" Version="3.0.271" />
     <PackageVersion Include="ReactiveUI.Fody" Version="19.5.41" />

--- a/tests/NexusMods.DataModel.Tests/LoadoutObservableTests.cs
+++ b/tests/NexusMods.DataModel.Tests/LoadoutObservableTests.cs
@@ -1,0 +1,75 @@
+using System.Collections.Frozen;
+using System.Reactive.Linq;
+using DynamicData;
+using DynamicData.Alias;
+using FluentAssertions;
+using NexusMods.Abstractions.GameLocators;
+using NexusMods.Abstractions.Loadouts;
+using NexusMods.Abstractions.MnemonicDB.Analyzers;
+using NexusMods.Games.RedEngine.Cyberpunk2077;
+using NexusMods.Games.TestFramework;
+using NexusMods.MnemonicDB.Abstractions;
+using NexusMods.MnemonicDB.Abstractions.TxFunctions;
+using NexusMods.StandardGameLocators.TestHelpers.StubbedGames;
+
+namespace NexusMods.DataModel.Tests;
+
+public class LoadoutObservableTests(IServiceProvider provider) : AGameTest<Cyberpunk2077Game>(provider)
+{
+    [Fact]
+    public async Task DeletingAModShouldUpdateTheLoadout()
+    {
+        using var tx = Connection.BeginTransaction();
+        var loadoutId = tx.TempId();
+
+        var loadout = new Loadout.New(tx, loadoutId)
+        {
+            Name = "Test Loadout",
+            ShortName = "B",
+            InstallationId = GameInstallation.GameMetadataId,
+            LoadoutKind = LoadoutKind.Default,
+            Revision = 0
+        };
+        
+        
+        var group = new LoadoutItemGroup.New(tx, out var groupId)
+        {
+            IsGroup = true,
+            LoadoutItem = new LoadoutItem.New(tx, groupId)
+            {
+                LoadoutId = loadoutId,
+                Name = "Test Group",
+            }
+        };
+        
+        var fileId = tx.TempId();
+        var file = new LoadoutItem.New(tx, fileId)
+        {
+            LoadoutId = loadoutId,
+            Name = "Test Mod",
+            ParentId = groupId,
+        };
+
+
+        var result = await tx.Commit();
+        loadoutId = result[loadoutId];
+        fileId = result[fileId];
+        groupId = result[groupId];
+
+        var changedItems = new List<EntityId>();
+
+        using var updates = Connection.Revisions.Select(r => r.AnalyzerData<TreeAnalyzer, FrozenSet<EntityId>>())
+                .Subscribe(itm => changedItems.Add(itm));
+        
+        changedItems.Clear();
+        
+        using var tx2 = Connection.BeginTransaction();
+        tx2.Delete(fileId, false);
+        await tx2.Commit();
+        
+        changedItems.Should().Contain(loadoutId);
+        changedItems.Should().Contain(groupId);
+        changedItems.Should().Contain(fileId);
+
+    }
+}

--- a/tests/NexusMods.DataModel.Tests/NexusMods.DataModel.Tests.csproj
+++ b/tests/NexusMods.DataModel.Tests/NexusMods.DataModel.Tests.csproj
@@ -6,6 +6,7 @@
     <ItemGroup>
       <ProjectReference Include="..\..\src\Abstractions\NexusMods.Abstractions.GuidedInstallers\NexusMods.Abstractions.GuidedInstallers.csproj" />
       <ProjectReference Include="..\..\src\ArchiveManagement\NexusMods.FileExtractor\NexusMods.FileExtractor.csproj" />
+      <ProjectReference Include="..\..\src\Games\NexusMods.Games.RedEngine\NexusMods.Games.RedEngine.csproj" />
       <ProjectReference Include="..\..\src\NexusMods.Activities\NexusMods.Activities.csproj" />
       <ProjectReference Include="..\..\src\NexusMods.DataModel\NexusMods.DataModel.csproj" />
       <ProjectReference Include="..\..\src\NexusMods.App.BuildInfo\NexusMods.App.BuildInfo.csproj" />
@@ -14,6 +15,7 @@
       <ProjectReference Include="..\..\src\NexusMods.Library\NexusMods.Library.csproj" />
       <ProjectReference Include="..\..\src\NexusMods.Settings\NexusMods.Settings.csproj" />
       <ProjectReference Include="..\..\src\NexusMods.StandardGameLocators\NexusMods.StandardGameLocators.csproj" />
+      <ProjectReference Include="..\Games\NexusMods.Games.TestFramework\NexusMods.Games.TestFramework.csproj" />
       <ProjectReference Include="..\NexusMods.StandardGameLocators.TestHelpers\NexusMods.StandardGameLocators.TestHelpers.csproj" />
     </ItemGroup>
 

--- a/tests/NexusMods.DataModel.Tests/Startup.cs
+++ b/tests/NexusMods.DataModel.Tests/Startup.cs
@@ -13,8 +13,12 @@ using NexusMods.Activities;
 using NexusMods.App.BuildInfo;
 using NexusMods.CrossPlatform;
 using NexusMods.FileExtractor;
+using NexusMods.Games.RedEngine;
+using NexusMods.Games.RedEngine.Cyberpunk2077;
+using NexusMods.Games.TestFramework;
 using NexusMods.Jobs;
 using NexusMods.Library;
+using NexusMods.Networking.NexusWebApi;
 using NexusMods.Paths;
 using NexusMods.Settings;
 using NexusMods.StandardGameLocators;
@@ -46,34 +50,10 @@ public static class Startup
             .Combine(baseDirectory);
 
         return container
-            .AddSingleton<IGuidedInstaller, NullGuidedInstaller>()
-            .AddLogging(builder => builder.AddXunitOutput().SetMinimumLevel(LogLevel.Trace))
-            .AddFileSystem()
-            .AddSingleton(new TemporaryFileManager(FileSystem.Shared, prefix))
-            .AddSettingsManager()
-            .AddDataModel()
-            .AddLibrary()
-            .AddLibraryModels()
-            .AddJobMonitor()
-            .OverrideSettingsForTests<DataModelSettings>(settings => settings with
-            {
-                UseInMemoryDataModel = true,
-                MnemonicDBPath = new ConfigurablePath(baseKnownPath, $"{baseDirectory}/MnemonicDB.rocksdb"),
-                ArchiveLocations = [
-                    new ConfigurablePath(baseKnownPath, $"{baseDirectory}/Archives"),
-                ],
-            })
-            .AddGames()
-            .AddStandardGameLocators(false)
-            .AddFileExtractors()
-            .AddStubbedGameLocators()
-            .AddFileStoreAbstractions()
+            .AddDefaultServicesForTesting()
+            .AddUniversalGameLocator<Cyberpunk2077Game>(new Version("1.61"))
+            .AddRedEngineGames()
             .AddLoadoutAbstractions()
-            .AddSerializationAbstractions()
-            .AddActivityMonitor()
-            .AddInstallerTypes()
-            .AddCrossPlatform()
-            .AddSingleton<ITypeFinder>(_ => new AssemblyTypeFinder(typeof(Startup).Assembly))
             .Validate();
     }
 }


### PR DESCRIPTION
Previously the TreeAnalyzer would try to find parent entities in the database handed to it from MnemonicDB. However, if the entity was deleted as part of the transaction, the entity would be null, so the parents of the entity wouldn't be notified. This change uses the previous DB value for retracts and the current for asserts. 

Fixes #1904.