### PR TITLE
Rework downloader

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,10 +3,10 @@
     <PackageVersion Include="Avalonia.AvaloniaEdit" Version="11.1.0" />
     <PackageVersion Include="Avalonia.Labs.Panels" Version="11.1.0" />
     <PackageVersion Include="AvaloniaEdit.TextMate" Version="11.1.0" />
-    <PackageVersion Include="Downloader" Version="3.1.2" />
     <PackageVersion Include="FlatSharp.Compiler" Version="7.6.0" />
     <PackageVersion Include="FlatSharp.Runtime" Version="7.6.0" />
     <PackageVersion Include="LinqGen" Version="0.3.1" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="8.8.0" />
     <PackageVersion Include="Nerdbank.FullDuplexStream" Version="1.1.12" />
     <PackageVersion Include="Nerdbank.Streams" Version="2.11.74" />
     <PackageVersion Include="NexusMods.Paths" Version="0.10.0" />
@@ -25,6 +25,7 @@
     <PackageVersion Include="Noggog.CSharpExt" Version="2.64.0" />
     <PackageVersion Include="ObservableCollections" Version="2.2.0" />
     <PackageVersion Include="ObservableCollections.R3" Version="2.2.0" />
+    <PackageVersion Include="Polly" Version="8.4.1" />
     <PackageVersion Include="R3" Version="1.2.8" />
     <PackageVersion Include="R3Extensions.Avalonia" Version="1.2.8" />
     <PackageVersion Include="ReactiveUI" Version="20.1.1" />

--- a/src/Abstractions/NexusMods.Abstractions.Jobs/AJobWorker.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Jobs/AJobWorker.cs
@@ -177,27 +177,28 @@ public abstract class AJobWorker<TJob> : AJobWorker
 
     /// <inheritdoc cref="AJobWorker.ExecuteAsync"/>
     protected abstract Task<JobResult> ExecuteAsync(TJob job, CancellationToken cancellationToken);
-    
-    
+
+    protected DeterminateProgress GetDeterminateProgress(TJob job)
+    {
+        if (!job.Progress.TryGetDeterminateProgress(out var determinateProgress))
+            throw new InvalidOperationException("Job does not have determinate progress");
+
+        return determinateProgress;
+    }
+
     /// <summary>
     /// Sets the absolute progress percentage of the job.
     /// </summary>
     protected void SetProgress(TJob job, Percent progress)
     {
-        if (!job.Progress.TryGetDeterminateProgress(out var determinateProgress))
-            throw new InvalidOperationException("Job does not have determinate progress");
-        
-        determinateProgress.SetPercent(progress);
+        GetDeterminateProgress(job).SetPercent(progress);
     }
-    
+
     /// <summary>
     /// Sets the relative progress rate of the job.
     /// </summary>
     protected void SetProgressRate(TJob job, double rate)
     {
-        if (!job.Progress.TryGetDeterminateProgress(out var determinateProgress))
-            throw new InvalidOperationException("Job does not have determinate progress");
-        
-        determinateProgress.SetProgressRate(new ProgressRate(rate, ProgressRateFormatter.Value));
+        GetDeterminateProgress(job).SetProgressRate(new ProgressRate(rate, ProgressRateFormatter.Value));
     }
 }

--- a/src/Abstractions/NexusMods.Abstractions.Jobs/DeterminateProgress.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Jobs/DeterminateProgress.cs
@@ -25,21 +25,21 @@ public class DeterminateProgress : AProgress, IDeterminateProgress
         ProgressRate = new ProgressRate(value: 0.0, formatter);
     }
 
-    internal void SetPercent(Percent value)
+    public void SetPercent(Percent value)
     {
         // TODO: sanity checks
         Percent = value;
         _subjectPercent.OnNext(value);
     }
 
-    internal void SetProgressRate(ProgressRate value)
+    public void SetProgressRate(ProgressRate value)
     {
         // TODO: sanity checks
         ProgressRate = value;
         _subjectProgressRate.OnNext(value);
     }
 
-    internal void SetEstimatedFinishTime(DateTime value)
+    public void SetEstimatedFinishTime(DateTime value)
     {
         // TODO: sanity checks
         EstimatedFinishTime = value;

--- a/src/Abstractions/NexusMods.Abstractions.Jobs/Percent.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Jobs/Percent.cs
@@ -42,9 +42,8 @@ public readonly struct Percent : IEquatable<Percent>, IComparable<Percent>
     public static Percent Create<TNumber>(TNumber current, TNumber maximum)
     where TNumber : INumber<TNumber>, IConvertible
     {
-        var value = current / maximum;
-        var result = value.ToDouble(NumberFormatInfo.InvariantInfo);
-        return CreateClamped(result);
+        var value = current.ToDouble(NumberFormatInfo.InvariantInfo) / maximum.ToDouble(NumberFormatInfo.InvariantInfo);
+        return CreateClamped(value);
     }
 
     /// <inheritdoc/>

--- a/src/Abstractions/NexusMods.Abstractions.Jobs/StreamProgressWrapper.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Jobs/StreamProgressWrapper.cs
@@ -27,7 +27,7 @@ public sealed class StreamProgressWrapper<TState> : Stream
         _state = state;
         _notifyWritten = notifyWritten;
 
-        _period = period == default(TimeSpan) ? TimeSpan.FromMilliseconds(250) : period;
+        _period = period == default(TimeSpan) ? TimeSpan.FromSeconds(1) : period;
         timeProvider ??= TimeProvider.System;
 
         _timer = timeProvider.CreateTimer(NotifyLoop, state: this, dueTime: TimeSpan.Zero, period: _period);

--- a/src/Abstractions/NexusMods.Abstractions.Jobs/StreamProgressWrapper.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Jobs/StreamProgressWrapper.cs
@@ -1,0 +1,140 @@
+using NexusMods.Paths;
+
+namespace NexusMods.Abstractions.Jobs;
+
+/// <summary>
+/// Stream wrapper for progress reporting.
+/// </summary>
+public sealed class StreamProgressWrapper<TState> : Stream
+{
+    private readonly Stream _innerStream;
+
+    private readonly TState _state;
+    private readonly Action<TState, (Size, double)> _notifyWritten;
+    private readonly ITimer _timer;
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    public StreamProgressWrapper(
+        Stream innerStream,
+        TState state,
+        Action<TState, (Size, double)> notifyWritten,
+        TimeSpan period = default,
+        TimeProvider? timeProvider = null)
+    {
+        _innerStream = innerStream;
+        _state = state;
+        _notifyWritten = notifyWritten;
+
+        _period = period == default(TimeSpan) ? TimeSpan.FromMilliseconds(250) : period;
+        timeProvider ??= TimeProvider.System;
+
+        _timer = timeProvider.CreateTimer(NotifyLoop, state: this, dueTime: TimeSpan.Zero, period: _period);
+    }
+
+    private readonly TimeSpan _period;
+    private Size _lastBytesWritten;
+    private Size _currentBytesWritten;
+
+    private static void NotifyLoop(object? state)
+    {
+        if (state is not StreamProgressWrapper<TState> self) return;
+
+        var current = self._currentBytesWritten;
+
+        var diff = current - self._lastBytesWritten;
+        var speed = diff.Value / self._period.TotalSeconds;
+
+        self._lastBytesWritten = self._currentBytesWritten;
+        self._notifyWritten.Invoke(self._state, (current, speed));
+    }
+
+    private void SetBytesWritten(long count)
+    {
+        _currentBytesWritten = Size.FromLong(count);
+    }
+
+    /// <inheritdoc/>
+    public override void Flush()
+    {
+        _innerStream.Flush();
+    }
+
+    /// <inheritdoc/>
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        return _innerStream.Read(buffer, offset, count);
+    }
+
+    /// <inheritdoc/>
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        return _innerStream.Seek(offset, origin);
+    }
+
+    /// <inheritdoc/>
+    public override void SetLength(long value)
+    {
+        _innerStream.SetLength(value);
+    }
+
+    /// <inheritdoc/>
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        _innerStream.Write(buffer, offset, count);
+        SetBytesWritten(_innerStream.Position);
+    }
+
+    /// <inheritdoc/>
+    public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        await _innerStream.WriteAsync(buffer, cancellationToken);
+        SetBytesWritten(_innerStream.Position);
+    }
+
+    /// <inheritdoc/>
+    public override void Write(ReadOnlySpan<byte> buffer)
+    {
+        _innerStream.Write(buffer);
+        SetBytesWritten(_innerStream.Position);
+    }
+
+    /// <inheritdoc/>
+    public override bool CanRead => _innerStream.CanRead;
+
+    /// <inheritdoc/>
+    public override bool CanSeek => _innerStream.CanSeek;
+
+    /// <inheritdoc/>
+    public override bool CanWrite => _innerStream.CanWrite;
+
+    /// <inheritdoc/>
+    public override long Length => _innerStream.Length;
+
+    /// <inheritdoc/>
+    public override long Position
+    {
+        get => _innerStream.Position;
+        set => _innerStream.Position = value;
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _innerStream.Dispose();
+            _timer.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    /// <inheritdoc/>
+    public override async ValueTask DisposeAsync()
+    {
+        await _innerStream.DisposeAsync();
+        await _timer.DisposeAsync();
+    }
+}

--- a/src/Networking/NexusMods.Networking.HttpDownloader/HttpDownloadJob.cs
+++ b/src/Networking/NexusMods.Networking.HttpDownloader/HttpDownloadJob.cs
@@ -1,4 +1,4 @@
-using Downloader;
+using System.Net.Http.Headers;
 using DynamicData.Kernel;
 using JetBrains.Annotations;
 using NexusMods.Abstractions.HttpDownloads;
@@ -32,9 +32,12 @@ public class HttpDownloadJob : APersistedJob, IHttpDownloadJob
     /// <inheritdoc/>
     public Uri DownloadPageUri => Get(HttpDownloadJobPersistedState.DownloadPageUri);
 
-    public Optional<DownloadPackage> DownloadPackage { get; set; }
+    public Size TotalBytesDownloaded { get; set; }
+    public Optional<bool> AcceptRanges { get; set; }
+    public Optional<Size> ContentLength { get; set; }
+    public Optional<EntityTagHeaderValue> ETag { get; set; }
 
-    public Optional<DownloadConfiguration> DownloadConfiguration { get; set; }
+    public bool IsFirstRequest => TotalBytesDownloaded == default(Size);
 
     /// <inheritdoc/>
     public ValueTask AddMetadata(ITransaction transaction, LibraryFile.New libraryFile)

--- a/src/Networking/NexusMods.Networking.HttpDownloader/HttpDownloadJobWorker.cs
+++ b/src/Networking/NexusMods.Networking.HttpDownloader/HttpDownloadJobWorker.cs
@@ -1,13 +1,22 @@
-using Downloader;
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.Http.Headers;
+using DynamicData.Kernel;
+using Microsoft.Extensions.Http.Resilience;
 using NexusMods.Abstractions.Jobs;
 using NexusMods.Abstractions.Settings;
 using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.Paths;
+using Polly;
 
 namespace NexusMods.Networking.HttpDownloader;
 
 public class HttpDownloadJobWorker : APersistedJobWorker<HttpDownloadJob>
 {
+#pragma warning disable EXTEXP0001
+    private static readonly HttpClient Client = BuildClient();
+#pragma warning restore EXTEXP0001
+
     private readonly IConnection _connection;
     private readonly IJobMonitor _jobMonitor;
     private readonly ISettingsManager _settingsManager;
@@ -30,31 +39,143 @@ public class HttpDownloadJobWorker : APersistedJobWorker<HttpDownloadJob>
     protected override async Task<JobResult> ExecuteAsync(HttpDownloadJob job, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        if (!job.DownloadPackage.HasValue)
+        if (!job.AcceptRanges.HasValue)
         {
-            job.DownloadPackage = new DownloadPackage
-            {
-                FileName = job.Destination.ToNativeSeparators(OSInformation.Shared),
-                Urls = [job.Uri.ToString()],
-            };
+            await FetchMetadata(job, cancellationToken);
         }
 
-        var settings = _settingsManager.Get<HttpDownloaderSettings>();
-        var downloadService = new DownloadService(settings.ToConfiguration());
-        
-        downloadService.DownloadProgressChanged += (sender, args) =>
+        await using var outputStream = job.Destination.Open(FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read);
+        if (job.ContentLength.HasValue)
         {
-            // Divide by 100 because the library gives us a value between 0 and 100.
-            SetProgress(job, Percent.CreateClamped(args.ProgressPercentage / 100));
-            SetProgressRate(job, args.BytesPerSecondSpeed);
-        };
+            var contentLength = (long)job.ContentLength.Value.Value;
+            if (outputStream.Length != contentLength) outputStream.SetLength(contentLength);
+        }
 
-        await downloadService.DownloadFileTaskAsync(
-            package: job.DownloadPackage.Value,
+        outputStream.Position = (long)job.TotalBytesDownloaded.Value;
+
+        cancellationToken.ThrowIfCancellationRequested();
+        using var request = PrepareRequest(job, out var isRangeRequest);
+        using var response = await Client.SendAsync(
+            request: request,
+            completionOption: HttpCompletionOption.ResponseContentRead,
             cancellationToken: cancellationToken
         );
 
+        response.EnsureSuccessStatusCode();
+
+        // NOTE(erri120): We might've not gotten the content length in the initial HEAD request.
+        if (!isRangeRequest && !job.ContentLength.HasValue)
+        {
+            // For full requests only, the response should contain the content length at this point.
+            // For range requests, the content length equals the length of the range, so we can't use that here.
+            var newContentLength = response.Content.Headers.ContentLength;
+            if (newContentLength is not null)
+            {
+                job.ContentLength = Size.FromLong(newContentLength.Value);
+                outputStream.SetLength(newContentLength.Value);
+            }
+        } else if (isRangeRequest && !job.ContentLength.HasValue)
+        {
+            // Responses to range requests should have this header
+            // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Range
+            var contentRange = response.Content.Headers.ContentRange;
+            var length = contentRange?.Length;
+            if (length is not null)
+            {
+                job.ContentLength = Size.FromLong(length.Value);
+                outputStream.SetLength(length.Value);
+            }
+        }
+
+        if (isRangeRequest && response.StatusCode == HttpStatusCode.OK)
+        {
+            // TODO: The server accepts ranges but didn't return partial content
+            // NOTE(erri120): we need to reset and download the entire thing again...
+            // This scenario should be rare, and would indicate some serious server bullshit
+            throw new NotSupportedException();
+        }
+
+        try
+        {
+            await response.Content.CopyToAsync(outputStream, cancellationToken);
+        } catch (Exception)
+        {
+            job.TotalBytesDownloaded = Size.FromLong(outputStream.Position);
+            throw;
+        }
+
         return JobResult.CreateCompleted(job.Destination);
+    }
+
+    private static HttpRequestMessage PrepareRequest(HttpDownloadJob job, out bool isRangeRequest)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, job.Uri);
+
+        // NOTE(erri120): Our first request is a normal GET request that downloads the entire file for.
+        // Follow-up requests are range requests, if the server allows it. A range response uses 206 Partial Content
+
+        if (job.IsFirstRequest || !job.AcceptRanges.Value)
+        {
+            // NOTE(erri120): Using If-Match to ensure that what we're downloading didn't suddenly change
+            if (job.ETag.HasValue)
+            {
+                // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Match
+                request.Headers.IfMatch.Add(job.ETag.Value);
+            }
+
+            isRangeRequest = false;
+        }
+        else
+        {
+            // NOTE(erri120): Using If-Range for range requests instead of If-Match
+            if (job.ETag.HasValue)
+            {
+                // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Range
+                request.Headers.IfRange = new RangeConditionHeaderValue(job.ETag.Value);
+            }
+
+            // A server MAY send a Content-Length header field in a response to a HEAD request
+            // https://httpwg.org/specs/rfc9110.html#rfc.section.8.6
+
+            // NOTE(erri120): As such, we might not know the content length, but since we download
+            // in serial, we can omit the end position to request all remaining bytes
+            var range = job.ContentLength.HasValue
+                ? new RangeHeaderValue(
+                    from: (long)job.TotalBytesDownloaded.Value,
+                    to: (long)job.ContentLength.Value.Value
+                )
+                : new RangeHeaderValue(
+                    from: (long)job.TotalBytesDownloaded.Value,
+                    to: null
+                );
+
+            // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Range
+            request.Headers.Range = range;
+            isRangeRequest = true;
+        }
+
+        return request;
+    }
+
+    private static async ValueTask FetchMetadata(HttpDownloadJob job, CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Head, job.Uri);
+        using var response = await Client.SendAsync(
+            request: request,
+            completionOption: HttpCompletionOption.ResponseHeadersRead,
+            cancellationToken: cancellationToken
+        ).ConfigureAwait(false);
+
+        response.EnsureSuccessStatusCode();
+
+        // https://datatracker.ietf.org/doc/html/rfc7233#section-5.1.2
+        // "bytes" and "none" are the only range units we care about,
+        // "none" meaning the server doesn't support ranges
+        job.AcceptRanges = response.Headers.AcceptRanges.Contains("bytes");
+        job.ETag = response.Headers.ETag;
+
+        var contentLength = response.Content.Headers.ContentLength;
+        job.ContentLength = contentLength is not null ? Size.FromLong(contentLength.Value) : Optional<Size>.None;
     }
 
     /// <inheritdoc/>
@@ -69,5 +190,35 @@ public class HttpDownloadJobWorker : APersistedJobWorker<HttpDownloadJob>
             worker: this,
             monitor: _jobMonitor
         );
+    }
+
+    [Experimental("EXTEXP0001")]
+    private static HttpClient BuildClient()
+    {
+        // TODO: get values from settings, probably make this a singleton
+
+        var pipeline = new ResiliencePipelineBuilder<HttpResponseMessage>()
+            .AddRetry(new HttpRetryStrategyOptions())
+            .Build();
+
+        HttpMessageHandler handler = new ResilienceHandler(pipeline)
+        {
+            InnerHandler = new SocketsHttpHandler
+            {
+                ConnectTimeout = TimeSpan.FromSeconds(10),
+                KeepAlivePingPolicy = HttpKeepAlivePingPolicy.WithActiveRequests,
+                KeepAlivePingDelay = TimeSpan.FromSeconds(5),
+                KeepAlivePingTimeout = TimeSpan.FromSeconds(20),
+            },
+        };
+
+        var client = new HttpClient(handler)
+        {
+            Timeout = TimeSpan.FromSeconds(5),
+            DefaultRequestVersion = HttpVersion.Version11,
+            DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher,
+        };
+
+        return client;
     }
 }

--- a/src/Networking/NexusMods.Networking.HttpDownloader/HttpDownloadJobWorker.cs
+++ b/src/Networking/NexusMods.Networking.HttpDownloader/HttpDownloadJobWorker.cs
@@ -58,7 +58,7 @@ public class HttpDownloadJobWorker : APersistedJobWorker<HttpDownloadJob>
         using var request = PrepareRequest(job, out var isRangeRequest);
         using var response = await Client.SendAsync(
             request: request,
-            completionOption: HttpCompletionOption.ResponseContentRead,
+            completionOption: HttpCompletionOption.ResponseHeadersRead,
             cancellationToken: cancellationToken
         );
 

--- a/src/Networking/NexusMods.Networking.HttpDownloader/HttpDownloaderSettings.cs
+++ b/src/Networking/NexusMods.Networking.HttpDownloader/HttpDownloaderSettings.cs
@@ -1,8 +1,5 @@
-using Downloader;
 using JetBrains.Annotations;
 using NexusMods.Abstractions.Settings;
-using NexusMods.App.BuildInfo;
-using NexusMods.Paths;
 
 namespace NexusMods.Networking.HttpDownloader;
 
@@ -12,39 +9,9 @@ namespace NexusMods.Networking.HttpDownloader;
 [PublicAPI]
 public record HttpDownloaderSettings : ISettings
 {
-    public int ChunkCount { get; set; } = 4;
-
-    public Size BufferBlockSize { get; set; } = Size.KB * 8;
-
-    public bool ParallelDownload { get; set; } = true;
-
-    public TimeSpan Timeout { get; set; } = TimeSpan.FromMinutes(1);
-
     /// <inheritdoc/>
     public static ISettingsBuilder Configure(ISettingsBuilder settingsBuilder)
     {
         return settingsBuilder;
-    }
-
-    internal DownloadConfiguration ToConfiguration()
-    {
-        return new DownloadConfiguration
-        {
-            ChunkCount = ChunkCount,
-            BufferBlockSize = (int)BufferBlockSize.Value,
-            ParallelDownload = ParallelDownload,
-            Timeout = (int)Timeout.TotalMilliseconds,
-
-            ReserveStorageSpaceBeforeStartingDownload = true,
-            CheckDiskSizeBeforeDownload = true,
-
-            RequestConfiguration = new RequestConfiguration
-            {
-                AllowAutoRedirect = true,
-                MaximumAutomaticRedirections = 3,
-
-                UserAgent = ApplicationConstants.UserAgent,
-            },
-        };
     }
 }

--- a/src/Networking/NexusMods.Networking.HttpDownloader/NexusMods.Networking.HttpDownloader.csproj
+++ b/src/Networking/NexusMods.Networking.HttpDownloader/NexusMods.Networking.HttpDownloader.csproj
@@ -3,6 +3,7 @@
     <Import Project="$([MSBuild]::GetPathOfFileAbove('NuGet.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
     <ItemGroup>
+        <PackageReference Include="Polly" />
         <ProjectReference Include="..\..\Abstractions\NexusMods.Abstractions.Activities\NexusMods.Abstractions.Activities.csproj" />
         <ProjectReference Include="..\..\Abstractions\NexusMods.Abstractions.Cli\NexusMods.Abstractions.Cli.csproj" />
         <ProjectReference Include="..\..\Abstractions\NexusMods.Abstractions.HttpDownloader\NexusMods.Abstractions.HttpDownloader.csproj" />
@@ -11,11 +12,11 @@
         <ProjectReference Include="..\..\Extensions\NexusMods.Extensions.Hashing\NexusMods.Extensions.Hashing.csproj" />
         <ProjectReference Include="..\..\NexusMods.App.BuildInfo\NexusMods.App.BuildInfo.csproj" />
         <ProjectReference Include="..\..\NexusMods.ProxyConsole.Abstractions\NexusMods.ProxyConsole.Abstractions.csproj" />
+        <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
         <PackageReference Include="NexusMods.MnemonicDB.SourceGenerator" PrivateAssets="all" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Downloader" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     </ItemGroup>

--- a/src/Networking/NexusMods.Networking.HttpDownloader/SimpleHttpDownloader.cs
+++ b/src/Networking/NexusMods.Networking.HttpDownloader/SimpleHttpDownloader.cs
@@ -9,7 +9,7 @@ namespace NexusMods.Networking.HttpDownloader;
 /// A simple implementation of <see cref="IHttpDownloader"/> used for diagnostic
 /// purposes, or as a fallback.
 /// </summary>
-[Obsolete(message: "To be replaced with Jobs and an easier implementation using the Downloader package")]
+[Obsolete(message: "To be replaced with Jobs")]
 public class SimpleHttpDownloader : IHttpDownloader
 {
     private static readonly HttpClient HttpClient = new();
@@ -24,10 +24,11 @@ public class SimpleHttpDownloader : IHttpDownloader
     {
         var url = sources[0].RequestUri!.ToString();
 
-        await using var inStream = await HttpClient.GetStreamAsync(url, cancellationToken: cancellationToken);
-        await using var outStream = destination.Open(FileMode.Create, FileAccess.ReadWrite, FileShare.Read);
-
-        await inStream.CopyToAsync(outStream, cancellationToken: cancellationToken);
+        await using (var inStream = await HttpClient.GetStreamAsync(url, cancellationToken: cancellationToken))
+        await using (var outStream = destination.Open(FileMode.Create, FileAccess.ReadWrite, FileShare.Read))
+        {
+            await inStream.CopyToAsync(outStream, cancellationToken: cancellationToken);
+        }
 
         return await destination.XxHash64Async(token: cancellationToken);
     }

--- a/src/NexusMods.App.UI/Controls/Spine/Buttons/Download/SpineDownloadButtonViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/Spine/Buttons/Download/SpineDownloadButtonViewModel.cs
@@ -31,7 +31,8 @@ public class SpineDownloadButtonViewModel : AViewModel<ISpineDownloadButtonViewM
                 .SumProgressRate()
                 .OnUI()
                 // Convert from bytes to MB/s
-                .Subscribe(rate => Number = rate / 1024 / 1024 / 8)
+                // TODO: use Humanizer
+                .Subscribe(rate => Number = rate / 1024 / 1024)
                 .DisposeWith(disposables);
         });
     }

--- a/tests/Games/NexusMods.Games.TestFramework/DependencyInjectionHelper.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/DependencyInjectionHelper.cs
@@ -43,13 +43,13 @@ public static class DependencyInjectionHelper
     /// </summary>
     /// <param name="serviceCollection"></param>
     /// <returns></returns>
-    public static IServiceCollection AddDefaultServicesForTesting(this IServiceCollection serviceCollection)
+    public static IServiceCollection AddDefaultServicesForTesting(this IServiceCollection serviceCollection, AbsolutePath prefix = default(AbsolutePath))
     {
         const KnownPath baseKnownPath = KnownPath.EntryDirectory;
         var baseDirectory = $"DataModel.{Guid.NewGuid()}";
-        var prefix = FileSystem.Shared
+        prefix = prefix == default(AbsolutePath) ? FileSystem.Shared
             .GetKnownPath(KnownPath.EntryDirectory)
-            .Combine($"NexusMods.Games.TestFramework-{Guid.NewGuid()}");
+            .Combine($"NexusMods.Games.TestFramework-{Guid.NewGuid()}") : prefix;
 
         return serviceCollection
             .AddLogging(builder => builder.AddXunitOutput().SetMinimumLevel(LogLevel.Debug))

--- a/tests/Networking/NexusMods.Networking.HttpDownloader.Tests/HttpDownloadJobWorkerTests.cs
+++ b/tests/Networking/NexusMods.Networking.HttpDownloader.Tests/HttpDownloadJobWorkerTests.cs
@@ -1,0 +1,64 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using NexusMods.Abstractions.Jobs;
+using NexusMods.Extensions.Hashing;
+using NexusMods.Hashing.xxHash64;
+using NexusMods.MnemonicDB.Abstractions;
+using NexusMods.Paths;
+
+namespace NexusMods.Networking.HttpDownloader.Tests;
+
+public class HttpDownloadJobWorkerTests
+{
+    private readonly TemporaryFileManager _temporaryFileManager;
+    private readonly HttpDownloadJobWorker _worker;
+    private readonly IConnection _connection;
+
+    public HttpDownloadJobWorkerTests(IServiceProvider serviceProvider)
+    {
+        _temporaryFileManager = serviceProvider.GetRequiredService<TemporaryFileManager>();
+        _worker = serviceProvider.GetRequiredService<HttpDownloadJobWorker>();
+        _connection = serviceProvider.GetRequiredService<IConnection>();
+    }
+
+    [Fact]
+    [Trait("RequiresNetworking", "True")]
+    public async Task Test_NexusModsCDN100MFile()
+    {
+        const string url = "https://paris.nexus-cdn.com/100M";
+
+        await using var outputPath = _temporaryFileManager.CreateFile();
+        await using var job = await CreateJob(new Uri(url), outputPath);
+
+        await job.StartAsync();
+        var result = await job.WaitToFinishAsync();
+        result.ResultType.Should().Be(JobResultType.Completed);
+
+        outputPath.Path.FileExists.Should().BeTrue();
+        outputPath.Path.FileInfo.Size.Should().Be(Size.MB * 100);
+
+        var hash = await outputPath.Path.XxHash64Async();
+        hash.Should().Be(Hash.From(0xBEEADB5B05BED390));
+    }
+
+    private async ValueTask<HttpDownloadJob> CreateJob(Uri uri, AbsolutePath destination)
+    {
+        using var tx = _connection.BeginTransaction();
+
+        var state = new HttpDownloadJobPersistedState.New(tx, out var id)
+        {
+            Destination = destination,
+            Uri = uri,
+            DownloadPageUri = uri,
+            PersistedJobState = new PersistedJobState.New(tx, id)
+            {
+                Status = JobStatus.None,
+                Worker = _worker,
+            },
+        };
+
+        var result = await tx.Commit();
+        var job = new HttpDownloadJob(_connection, result.Remap(state), worker: _worker);
+        return job;
+    }
+}

--- a/tests/Networking/NexusMods.Networking.HttpDownloader.Tests/HttpDownloaderTests.cs
+++ b/tests/Networking/NexusMods.Networking.HttpDownloader.Tests/HttpDownloaderTests.cs
@@ -27,12 +27,11 @@ public class HttpDownloaderTests
 
         var resultHash = await _httpDownloader.DownloadAsync(new[]
         {
-            "http://miami.nexus-cdn.com/100M",
-            "http://la.nexus-cdn.com/100M",
-            "http://paris.nexus-cdn.com/100M",
-            "http://chicago.nexus-cdn.com/100M"
-        }.Select(x => new HttpRequestMessage(HttpMethod.Get, new Uri(x)))
-        .ToArray(), path);
+            "https://paris.nexus-cdn.com/100M",
+            "https://miami.nexus-cdn.com/100M",
+            "https://la.nexus-cdn.com/100M",
+            "https://chicago.nexus-cdn.com/100M"
+        }.Select(x => new HttpRequestMessage(HttpMethod.Get, new Uri(x))).ToArray(), path);
 
         resultHash.Should().Be(Hash.From(0xBEEADB5B05BED390));
     }

--- a/tests/Networking/NexusMods.Networking.HttpDownloader.Tests/NexusMods.Networking.HttpDownloader.Tests.csproj
+++ b/tests/Networking/NexusMods.Networking.HttpDownloader.Tests/NexusMods.Networking.HttpDownloader.Tests.csproj
@@ -7,6 +7,9 @@
         <ProjectReference Include="..\..\..\src\Networking\NexusMods.Networking.HttpDownloader\NexusMods.Networking.HttpDownloader.csproj" />
         <ProjectReference Include="..\..\..\src\NexusMods.Activities\NexusMods.Activities.csproj" />
         <ProjectReference Include="..\..\..\src\NexusMods.App.BuildInfo\NexusMods.App.BuildInfo.csproj" />
+        <ProjectReference Include="..\..\..\src\NexusMods.DataModel\NexusMods.DataModel.csproj" />
+        <ProjectReference Include="..\..\..\src\NexusMods.Jobs\NexusMods.Jobs.csproj" />
         <ProjectReference Include="..\..\..\src\NexusMods.Settings\NexusMods.Settings.csproj" />
+        <ProjectReference Include="..\..\Games\NexusMods.Games.TestFramework\NexusMods.Games.TestFramework.csproj" />
     </ItemGroup>
 </Project>

--- a/tests/Networking/NexusMods.Networking.HttpDownloader.Tests/Startup.cs
+++ b/tests/Networking/NexusMods.Networking.HttpDownloader.Tests/Startup.cs
@@ -1,7 +1,11 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using NexusMods.Abstractions.Jobs;
 using NexusMods.Activities;
 using NexusMods.App.BuildInfo;
+using NexusMods.DataModel;
+using NexusMods.Games.TestFramework;
+using NexusMods.Jobs;
 using NexusMods.Paths;
 using NexusMods.Settings;
 
@@ -16,13 +20,9 @@ public class Startup
             .Combine($"NexusMods.Networking.HttpDownloader.Tests-{Guid.NewGuid()}");
 
         container
-            .AddSettingsManager()
+            .AddDefaultServicesForTesting(prefix)
             .AddSingleton<SimpleHttpDownloader>()
-            .AddFileSystem()
-            .AddSingleton(new TemporaryFileManager(FileSystem.Shared, prefix))
-            .AddSingleton<HttpClient>()
             .AddSingleton<LocalHttpServer>()
-            .AddActivityMonitor()
             .AddLogging(builder => builder.AddXUnit())
             .Validate();
     }


### PR DESCRIPTION
Resolves #1927.

Replaces the downloader with a resilient `HttpClient` that supports resuming using ranges.