### PR TITLE
Fix deletions not updating UI 

### DIFF
--- a/src/NexusMods.App.UI/Filters/LibraryUserFilters.cs
+++ b/src/NexusMods.App.UI/Filters/LibraryUserFilters.cs
@@ -27,8 +27,8 @@ public static class LibraryUserFilters
     /// Returns an observable stream of all library items that should be shown
     /// to the user.
     /// </summary>
-    public static IObservable<IChangeSet<LibraryItem.ReadOnly>> ObserveFilteredLibraryItems(IConnection connection)
+    public static IObservable<IChangeSet<LibraryItem.ReadOnly, EntityId>> ObserveFilteredLibraryItems(IConnection connection)
     {
-        return LibraryItem.ObserveAll(connection).Where(ShouldShow).RemoveKey();
+        return LibraryItem.ObserveAll(connection).Where(ShouldShow);
     }
 }

--- a/src/NexusMods.App.UI/LeftMenu/Loadout/LoadoutLeftMenuViewModel.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Loadout/LoadoutLeftMenuViewModel.cs
@@ -205,6 +205,7 @@ public class LoadoutLeftMenuViewModel : AViewModel<ILoadoutLeftMenuViewModel>, I
                 .DisposeWith(disposable);
 
             LibraryUserFilters.ObserveFilteredLibraryItems(connection: conn)
+                .RemoveKey()
                 .OnUI()
                 .WhereReasonsAre(ListChangeReason.Add, ListChangeReason.AddRange)
                 .SubscribeWithErrorLogging(changeSet => NewDownloadModelCount += changeSet.Adds)

--- a/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginsPageViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/ModLibrary/FileOrigins/FileOriginsPageViewModel.cs
@@ -135,7 +135,7 @@ public class FileOriginsPageViewModel : APageViewModel<IFileOriginsPageViewModel
                 }
             );
 
-            LibraryUserFilters.ObserveFilteredLibraryItems(connection: _conn)
+            LibraryItem.ObserveAll(_conn).Where(LibraryUserFilters.ShouldShow)
                 .Select(item => item.ToLibraryFile())
                 .Where(file => file.IsValid())
                 .OnUI()

--- a/src/NexusMods.App.UI/Pages/MyGames/MyGamesViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/MyGames/MyGamesViewModel.cs
@@ -3,6 +3,7 @@ using System.Reactive.Disposables;
 using Avalonia.Threading;
 using DynamicData;
 using DynamicData.Binding;
+using DynamicData.Kernel;
 using JetBrains.Annotations;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.DependencyInjection;
@@ -16,7 +17,6 @@ using NexusMods.App.UI.Pages.LoadoutGrid;
 using NexusMods.App.UI.Resources;
 using NexusMods.App.UI.Windows;
 using NexusMods.App.UI.WorkspaceSystem;
-using NexusMods.Extensions.BCL;
 using NexusMods.Icons;
 using NexusMods.MnemonicDB.Abstractions;
 using OneOf;
@@ -58,27 +58,26 @@ public class MyGamesViewModel : APageViewModel<IMyGamesViewModel>, IMyGamesViewM
             // Managed games widgets
             Loadout.ObserveAll(conn)
                 .Filter(l => l.IsVisible())
+                .DistinctValues(loadout => loadout.InstallationInstance)
                 .RemoveKey()
-                .GroupOn(loadout => loadout.InstallationInstance.LocationsRegister[LocationId.Game])
-                .Transform(group=> group.List.Items.First())
                 .OnUI()
-                .Transform(loadout =>
+                .Transform(installation =>
                 {
                     var vm = provider.GetRequiredService<IGameWidgetViewModel>();
-                    vm.Installation = loadout.InstallationInstance;
+                    vm.Installation = installation;
 
                     vm.RemoveAllLoadoutsCommand = ReactiveCommand.CreateFromTask(async () =>
                     {
-                        if (GetJobRunningForGameInstallation(loadout.InstallationInstance).IsT2) return;
+                        if (GetJobRunningForGameInstallation(installation).IsT2) return;
 
                         vm.State = GameWidgetState.RemovingGame;
-                        await Task.Run(async () => await RemoveAllLoadouts(loadout.InstallationInstance));
+                        await Task.Run(async () => await RemoveAllLoadouts(installation));
                         vm.State = GameWidgetState.ManagedGame;
                     });
 
-                    vm.ViewGameCommand = ReactiveCommand.Create(() => { NavigateToLoadout(conn, loadout); });
+                    vm.ViewGameCommand = ReactiveCommand.Create(() => { NavigateToFirstLoadout(conn, installation); });
 
-                    var job = GetJobRunningForGameInstallation(loadout.InstallationInstance);
+                    var job = GetJobRunningForGameInstallation(installation);
                     vm.State = job.IsT2 ? GameWidgetState.RemovingGame : GameWidgetState.ManagedGame;
 
                     return vm;
@@ -141,17 +140,18 @@ public class MyGamesViewModel : APageViewModel<IMyGamesViewModel>, IMyGamesViewM
         await installation.GetGame().Synchronizer.CreateLoadout(installation);
     }
 
-    private void NavigateToLoadout(IConnection conn, Loadout.ReadOnly loadout)
+    private void NavigateToFirstLoadout(IConnection conn, GameInstallation installation)
     {
-        // We can't navigate to an invisible loadout, make sure we pick a visible one.
         var db = conn.Db;
-        if (!loadout.IsVisible())
+        
+        var loadout = Loadout.All(db).FirstOrOptional(loadout => loadout.IsVisible() 
+                                                                 && loadout.InstallationInstance.Equals(installation));
+        if (!loadout.HasValue)
         {
-            // Note(sewer) | If we're here, last loadout was most likely a LoadoutKind.VanillaState
-            loadout = Loadout.All(db).First(x => x.IsVisible());
+            return;
         }
 
-        var loadoutId = loadout.LoadoutId;
+        var loadoutId = loadout.Value.LoadoutId;
         Dispatcher.UIThread.Invoke(() =>
             {
                 var workspaceController = _windowManager.ActiveWorkspaceController;

--- a/src/NexusMods.App.UI/Pages/MyGames/MyGamesViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/MyGames/MyGamesViewModel.cs
@@ -59,7 +59,6 @@ public class MyGamesViewModel : APageViewModel<IMyGamesViewModel>, IMyGamesViewM
             Loadout.ObserveAll(conn)
                 .Filter(l => l.IsVisible())
                 .DistinctValues(loadout => loadout.InstallationInstance)
-                .RemoveKey()
                 .OnUI()
                 .Transform(installation =>
                 {

--- a/src/NexusMods.App.UI/Pages/MyLoadouts/MyLoadoutsViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/MyLoadouts/MyLoadoutsViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using System.Reactive.Disposables;
+using System.Reactive.Linq;
 using DynamicData;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.App.UI.Pages.MyLoadouts.GameLoadoutsSectionEntry;
@@ -30,9 +31,7 @@ public class MyLoadoutsViewModel : APageViewModel<IMyLoadoutsViewModel>, IMyLoad
         {
             Loadout.ObserveAll(conn)
                 .Filter(l => l.IsVisible())
-                .RemoveKey()
-                .GroupOn(loadout => loadout.Installation.Path)
-                .Transform(group => group.List.Items.First().InstallationInstance)
+                .DistinctValues(loadout => loadout.InstallationInstance)
                 .Transform(managedGameInstall =>
                     {
                         return (IGameLoadoutsSectionEntryViewModel)new GameLoadoutsSectionEntryViewModel(


### PR DESCRIPTION
This fixes a number of UI related to DynamicData not propagating Removals for Value types unless passing a Keyed changeset.
The `RemoveKey` was used too early in these cases and breaking it.

- fixes #1921 
- fixes game not moving from "Added Games" to "Detected Games" section in My Games page after Unmanaging it
- fixes My Loadouts Page not removing Games sections after unmanaging games