### PR TITLE
Fix changes to existing files not persisting after synchronize

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -18,7 +18,6 @@ using NexusMods.Extensions.Hashing;
 using NexusMods.Hashing.xxHash64;
 using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.MnemonicDB.Abstractions.DatomIterators;
-using NexusMods.MnemonicDB.Abstractions.ElementComparers;
 using NexusMods.MnemonicDB.Abstractions.IndexSegments;
 using NexusMods.MnemonicDB.Abstractions.Internals;
 using NexusMods.MnemonicDB.Abstractions.TxFunctions;

--- a/src/Games/NexusMods.Games.StardewValley/StardewValleyLoadoutSynchronizer.cs
+++ b/src/Games/NexusMods.Games.StardewValley/StardewValleyLoadoutSynchronizer.cs
@@ -8,6 +8,7 @@ using NexusMods.Abstractions.Settings;
 using NexusMods.Extensions.BCL;
 using NexusMods.Games.StardewValley.Models;
 using NexusMods.MnemonicDB.Abstractions;
+using NexusMods.MnemonicDB.Abstractions.TxFunctions;
 using NexusMods.Paths;
 using NexusMods.Paths.Extensions;
 using File = NexusMods.Abstractions.Loadouts.Files.File;
@@ -59,6 +60,15 @@ public class StardewValleyLoadoutSynchronizer : ALoadoutSynchronizer
                 smapiModDirectoryNameToModel[modDirectoryName] = smapiMod;
             }
 
+            // Replace the existing entry if it exists
+            if (newFile.SyncTreeNode.LoadoutFileId.HasValue)
+            {
+                var existingFile = LoadoutItemWithTargetPath.Load(loadout.Db, newFile.SyncTreeNode.LoadoutFileId.Value);
+                if (existingFile.IsValid() && existingFile.AsLoadoutItem().ParentId.Value == smapiMod.Id)
+                {
+                    tx.Delete(existingFile.Id, false);
+                }
+            }
             newFile.LoadoutItem.ParentId = smapiMod.Id;
         }
         return ValueTask.CompletedTask;

--- a/src/Games/NexusMods.Games.StardewValley/StardewValleyLoadoutSynchronizer.cs
+++ b/src/Games/NexusMods.Games.StardewValley/StardewValleyLoadoutSynchronizer.cs
@@ -59,16 +59,7 @@ public class StardewValleyLoadoutSynchronizer : ALoadoutSynchronizer
 
                 smapiModDirectoryNameToModel[modDirectoryName] = smapiMod;
             }
-
-            // Replace the existing entry if it exists
-            if (newFile.SyncTreeNode.LoadoutFileId.HasValue)
-            {
-                var existingFile = LoadoutItemWithTargetPath.Load(loadout.Db, newFile.SyncTreeNode.LoadoutFileId.Value);
-                if (existingFile.IsValid() && existingFile.AsLoadoutItem().ParentId.Value == smapiMod.Id)
-                {
-                    tx.Delete(existingFile.Id, false);
-                }
-            }
+            
             newFile.LoadoutItem.ParentId = smapiMod.Id;
         }
         return ValueTask.CompletedTask;

--- a/src/Games/NexusMods.Games.StardewValley/StardewValleyLoadoutSynchronizer.cs
+++ b/src/Games/NexusMods.Games.StardewValley/StardewValleyLoadoutSynchronizer.cs
@@ -1,17 +1,13 @@
 using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.GameLocators;
 using NexusMods.Abstractions.Loadouts;
-using NexusMods.Abstractions.Loadouts.Files;
-using NexusMods.Abstractions.Loadouts.Mods;
 using NexusMods.Abstractions.Loadouts.Synchronizers;
 using NexusMods.Abstractions.Settings;
 using NexusMods.Extensions.BCL;
 using NexusMods.Games.StardewValley.Models;
 using NexusMods.MnemonicDB.Abstractions;
-using NexusMods.MnemonicDB.Abstractions.TxFunctions;
 using NexusMods.Paths;
 using NexusMods.Paths.Extensions;
-using File = NexusMods.Abstractions.Loadouts.Files.File;
 
 namespace NexusMods.Games.StardewValley;
 


### PR DESCRIPTION
- Fixes #1924 
The issue was caused by the generation of duplicated file entries in the loadout when the new version was ingested, as the previous version was never removed.

This changes the Synchronizer logic to _update_ the LoadoutFile entries in place instead of adding new entries in Override.

This not only fixes the issue of duplicated entries (since we were not removing previous entries) but also ensures that any metadata or references that was attached to the previous LoadoutFile entry are not lost.
Replacing the entries would lose us data.

This is a change in behavior but  we don't actually have a spec for how Synchronizer should behave so and this was the best solution available. 

In the future, if we did want to instead create copies of the entries in Override or in sidecar mods, then I think we will need better generic db entity cloning support from the DB side, but some questions would still remain on how to handle references to previous file.

I would like to write a test for this, but need #1932 to be merged first, so it can go in a future PR as well. 