### PR TITLE
Loadout support for collections

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Library/ILibraryService.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Library/ILibraryService.cs
@@ -1,3 +1,4 @@
+using DynamicData.Kernel;
 using JetBrains.Annotations;
 using NexusMods.Abstractions.Downloads;
 using NexusMods.Abstractions.GC;
@@ -31,13 +32,14 @@ public interface ILibraryService
     /// </summary>
     /// <param name="libraryItem">The item to install.</param>
     /// <param name="targetLoadout">The target loadout.</param>
+    /// <param name="parent">If specified the installed item will be placed in this group, otherwise it will default to the user's local collection</param>
     /// <param name="installer">The Library will use this installer to install the item</param>
-    IJobTask<IInstallLoadoutItemJob, LoadoutItemGroup.ReadOnly> InstallItem(LibraryItem.ReadOnly libraryItem, LoadoutId targetLoadout, ILibraryItemInstaller? installer = null);
+    IJobTask<IInstallLoadoutItemJob, LoadoutItemGroup.ReadOnly> InstallItem(LibraryItem.ReadOnly libraryItem, LoadoutId targetLoadout, Optional<LoadoutItemGroupId> parent = default, ILibraryItemInstaller? installer = null);
 
     /// <summary>
     /// Removes a number of items from the library.
     /// </summary>
     /// <param name="libraryItems">The items to remove from the library.</param>
-    /// <param name="gcRunMode">Defines how the garbage collector should be ran.</param>
+    /// <param name="gcRunMode">Defines how the garbage collector should be run</param>
     Task RemoveItems(IEnumerable<LibraryItem.ReadOnly> libraryItems, GarbageCollectorRunMode gcRunMode = GarbageCollectorRunMode.RunAsyncInBackground);
 }

--- a/src/Abstractions/NexusMods.Abstractions.Library/Jobs/IInstallLoadoutItemJob.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Library/Jobs/IInstallLoadoutItemJob.cs
@@ -21,6 +21,11 @@ public interface IInstallLoadoutItemJob : IJobDefinition<LoadoutItemGroup.ReadOn
     public LoadoutId LoadoutId { get; }
     
     /// <summary>
+    /// The target parent group id
+    /// </summary>
+    public LoadoutItemGroupId ParentGroupId { get; }
+    
+    /// <summary>
     /// The optional installer to use (if null, the library will choose the best installer)
     /// </summary>
     public ILibraryItemInstaller? Installer { get; }

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -1038,14 +1038,13 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
 
                 _ = new CollectionGroup.New(tx, out var userCollectionId)
                 {
-                    LoadoutId = loadout,
-                    IsUserCollection = true,
+                    IsReadOnly = false,
                     LoadoutItemGroup = new LoadoutItemGroup.New(tx, userCollectionId)
                     {
                         IsGroup = true,
                         LoadoutItem = new LoadoutItem.New(tx, userCollectionId)
                         {
-                            Name = "My Mods",
+                            Name = "My Collection",
                             LoadoutId = loadout,
                         },
                     },

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -1036,6 +1036,21 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
 
                 await BackupNewFiles(installation, filesToBackup);
 
+                _ = new CollectionGroup.New(tx, out var userCollectionId)
+                {
+                    LoadoutId = loadout,
+                    IsUserCollection = true,
+                    LoadoutItemGroup = new LoadoutItemGroup.New(tx, userCollectionId)
+                    {
+                        IsGroup = true,
+                        LoadoutItem = new LoadoutItem.New(tx, userCollectionId)
+                        {
+                            Name = "My Mods",
+                            LoadoutId = loadout,
+                        },
+                    },
+                };
+
                 // Commit the transaction as of this point the loadout is live
                 var result = await tx.Commit();
 

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts/CollectionGroup.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts/CollectionGroup.cs
@@ -1,0 +1,42 @@
+using DynamicData.Kernel;
+using NexusMods.MnemonicDB.Abstractions.Attributes;
+using NexusMods.MnemonicDB.Abstractions.Models;
+
+namespace NexusMods.Abstractions.Loadouts;
+
+/// <summary>
+/// A definition of a collection. This could be a user's collection, a Nexus Mods collection or perhaps a collection from some other source.
+/// </summary>
+[Include<LoadoutItemGroup>]
+public partial class CollectionGroup : IModelDefinition
+{
+    private const string Namespace = "NexusMods.Abstractions.Loadouts.CollectionGroup";
+    
+    /// <summary>
+    /// Mostly a marker attribute to find all the collections on a given loadout. Likely faster than searching for all the loadout items
+    /// and filtering them by their attributes
+    /// </summary>
+    public static readonly ReferenceAttribute<Loadout> Loadout = new(Namespace, nameof(Loadout));
+
+    /// <summary>
+    /// In this UI this is reflected as "My Collection", it's a group of all mods that the user has installed outside of any
+    /// other collection.
+    /// </summary>
+    public static readonly MarkerAttribute UserCollection = new(Namespace, nameof(UserCollection));
+}
+
+public static partial class CollectionGroupLoaderExtensions
+{
+    /// <summary>
+    /// Find the user collection for a given loadout
+    /// </summary>
+    /// <param name="loadout"></param>
+    /// <returns></returns>
+    public static Optional<CollectionGroup.ReadOnly> FindUserCollection(this Loadout.ReadOnly loadout)
+    {
+        return loadout.Db
+            .Datoms(CollectionGroup.Loadout, loadout.Id)
+            .Select(d => CollectionGroup.Load(loadout.Db, d.E))
+            .FirstOrOptional(x => x.IsUserCollection);
+    }
+}

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts/CollectionGroup.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts/CollectionGroup.cs
@@ -13,11 +13,11 @@ namespace NexusMods.Abstractions.Loadouts;
 public partial class CollectionGroup : IModelDefinition
 {
     private const string Namespace = "NexusMods.Abstractions.Loadouts.CollectionGroup";
-    
+
     /// <summary>
     /// If the collection is read-only it won't support adding new mods or modifying the existing files. 
     /// </summary>
-    public static readonly BooleanAttribute IsReadOnly = new(Namespace, nameof(IsReadOnly));
+    public static readonly BooleanAttribute IsReadOnly = new(Namespace, nameof(IsReadOnly)) { IsIndexed = true };
 }
 
 public static partial class CollectionGroupLoaderExtensions

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts/Extensions/LoadoutItemExtensions.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts/Extensions/LoadoutItemExtensions.cs
@@ -29,6 +29,21 @@ public static class LoadoutItemExtensions
     }
 
     /// <summary>
+    /// Returns true if the LoadoutItem is a child of the LoadoutItemGroup.
+    /// </summary>
+    public static bool IsChildOf(this LoadoutItem.ReadOnly item, LoadoutItemGroupId groupId)
+    {
+        while (item.Contains(LoadoutItem.Parent))
+        {
+            var group = item.Parent;
+            if (group.LoadoutItemGroupId == groupId)
+                return true;
+            item = group.AsLoadoutItem();
+        }
+        return false;
+    }
+
+    /// <summary>
     /// Returns all the LoadoutFiles in the collection that are enabled.
     /// </summary>
     /// <param name="items"></param>

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts/Services.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts/Services.cs
@@ -23,6 +23,7 @@ public static class Services
             .AddLoadoutItemWithTargetPathModel()
             .AddLoadoutFileModel()
             .AddDeletedFileModel()
+            .AddCollectionGroupModel()
             
             // deprecated:
             .AddFileModel()

--- a/src/NexusMods.App.UI/Pages/ILoadoutDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/ILoadoutDataProvider.cs
@@ -1,6 +1,8 @@
 using System.Reactive.Linq;
 using DynamicData;
+using DynamicData.Kernel;
 using NexusMods.Abstractions.Loadouts;
+using NexusMods.Abstractions.Loadouts.Extensions;
 using NexusMods.Abstractions.MnemonicDB.Attributes.Extensions;
 using NexusMods.App.UI.Pages.LoadoutPage;
 using NexusMods.MnemonicDB.Abstractions;
@@ -16,6 +18,7 @@ public interface ILoadoutDataProvider
 public class LoadoutFilter
 {
     public required LoadoutId LoadoutId { get; init; }
+    public required Optional<LoadoutItemGroupId> CollectionGroupId { get; init; }
 }
 
 public static class LoadoutDataProviderHelper
@@ -25,6 +28,15 @@ public static class LoadoutDataProviderHelper
         IConnection connection,
         LoadoutFilter loadoutFilter)
     {
+        if (loadoutFilter.CollectionGroupId.HasValue)
+        {
+            return source.Filter(datom =>
+                {
+                    var item = LoadoutItem.Load(connection.Db, datom.E);
+                    return item.LoadoutId == loadoutFilter.LoadoutId && item.IsChildOf(loadoutFilter.CollectionGroupId.Value);
+                }
+            );
+        }
         return source.Filter(datom => LoadoutItem.Load(connection.Db, datom.E).LoadoutId.Equals(loadoutFilter.LoadoutId));
     }
 

--- a/src/NexusMods.App.UI/Pages/ILoadoutDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/ILoadoutDataProvider.cs
@@ -28,16 +28,15 @@ public static class LoadoutDataProviderHelper
         IConnection connection,
         LoadoutFilter loadoutFilter)
     {
-        if (loadoutFilter.CollectionGroupId.HasValue)
+        var filterByCollection = loadoutFilter.CollectionGroupId.HasValue;
+        return source.Filter(datom =>
         {
-            return source.Filter(datom =>
-                {
-                    var item = LoadoutItem.Load(connection.Db, datom.E);
-                    return item.LoadoutId == loadoutFilter.LoadoutId && item.IsChildOf(loadoutFilter.CollectionGroupId.Value);
-                }
-            );
-        }
-        return source.Filter(datom => LoadoutItem.Load(connection.Db, datom.E).LoadoutId.Equals(loadoutFilter.LoadoutId));
+            var item = LoadoutItem.Load(connection.Db, datom.E);
+            if (!item.LoadoutId.Equals(loadoutFilter.LoadoutId)) return false;
+            if (filterByCollection) 
+                return item.IsChildOf(loadoutFilter.CollectionGroupId.Value);
+            return true;
+        });
     }
 
     public static LoadoutItemModel ToLoadoutItemModel(IConnection connection, LibraryLinkedLoadoutItem.ReadOnly libraryLinkedLoadoutItem)

--- a/src/NexusMods.App.UI/Pages/LibraryPage/LibraryViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LibraryPage/LibraryViewModel.cs
@@ -215,7 +215,7 @@ public class LibraryViewModel : APageViewModel<ILibraryViewModel>, ILibraryViewM
         CancellationToken cancellationToken,
         bool useAdvancedInstaller = false)
     {
-        await _libraryService.InstallItem(libraryItem, loadout, useAdvancedInstaller ? _advancedInstaller : null);
+        await _libraryService.InstallItem(libraryItem, loadout, installer: useAdvancedInstaller ? _advancedInstaller : null);
     }
 
     private async ValueTask RemoveSelectedItems(CancellationToken cancellationToken)

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutPage.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutPage.cs
@@ -36,7 +36,7 @@ public class LoadoutPageFactory : APageFactory<ILoadoutViewModel, LoadoutPageCon
     public override ILoadoutViewModel CreateViewModel(LoadoutPageContext context)
     {
         // Default to the user group for now
-        var userGroup = Loadout.Load(_connection.Db, context.LoadoutId).FindUserCollection().Value.AsLoadoutItemGroup();
+        var userGroup = Loadout.Load(_connection.Db, context.LoadoutId).MutableCollections().First().AsLoadoutItemGroup();
         var vm = new LoadoutViewModel(ServiceProvider.GetRequiredService<IWindowManager>(), ServiceProvider, context.LoadoutId, userGroup.LoadoutItemGroupId);
         return vm;
     }

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutPage.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutPage.cs
@@ -8,6 +8,7 @@ using NexusMods.App.UI.Settings;
 using NexusMods.App.UI.Windows;
 using NexusMods.App.UI.WorkspaceSystem;
 using NexusMods.Icons;
+using NexusMods.MnemonicDB.Abstractions;
 
 namespace NexusMods.App.UI.Pages.LoadoutPage;
 
@@ -21,9 +22,12 @@ public record LoadoutPageContext : IPageFactoryContext
 public class LoadoutPageFactory : APageFactory<ILoadoutViewModel, LoadoutPageContext>
 {
     private readonly ISettingsManager _settingsManager;
+    private readonly IConnection _connection;
+
     public LoadoutPageFactory(IServiceProvider serviceProvider) : base(serviceProvider)
     {
         _settingsManager = serviceProvider.GetRequiredService<ISettingsManager>();
+        _connection = serviceProvider.GetRequiredService<IConnection>();
     }
 
     public static readonly PageFactoryId StaticId = PageFactoryId.From(Guid.Parse("62fda6ce-e6b7-45d6-936f-a8f325bfc644"));
@@ -31,7 +35,9 @@ public class LoadoutPageFactory : APageFactory<ILoadoutViewModel, LoadoutPageCon
 
     public override ILoadoutViewModel CreateViewModel(LoadoutPageContext context)
     {
-        var vm = new LoadoutViewModel(ServiceProvider.GetRequiredService<IWindowManager>(), ServiceProvider, context.LoadoutId);
+        // Default to the user group for now
+        var userGroup = Loadout.Load(_connection.Db, context.LoadoutId).FindUserCollection().Value.AsLoadoutItemGroup();
+        var vm = new LoadoutViewModel(ServiceProvider.GetRequiredService<IWindowManager>(), ServiceProvider, context.LoadoutId, userGroup.LoadoutItemGroupId);
         return vm;
     }
 

--- a/src/NexusMods.Library/InstallLoadoutItemJob.cs
+++ b/src/NexusMods.Library/InstallLoadoutItemJob.cs
@@ -15,17 +15,20 @@ internal class InstallLoadoutItemJob : IJobDefinitionWithStart<InstallLoadoutIte
 {
     public ILibraryItemInstaller? Installer { get; init; }
     public LibraryItem.ReadOnly LibraryItem { get; init; }
+    public LoadoutItemGroupId ParentGroupId { get; init; }
     public LoadoutId LoadoutId { get; init; }
     internal required IConnection Connection { get; init; }
     internal required IServiceProvider ServiceProvider { get; init; }
     
-    public static IJobTask<InstallLoadoutItemJob, LoadoutItemGroup.ReadOnly> Create(IServiceProvider serviceProvider, LibraryItem.ReadOnly libraryItem, LoadoutId loadout, ILibraryItemInstaller? installer = null)
+    public static IJobTask<InstallLoadoutItemJob, LoadoutItemGroup.ReadOnly> Create(IServiceProvider serviceProvider, LibraryItem.ReadOnly libraryItem, LoadoutItemGroupId groupId, ILibraryItemInstaller? installer = null)
     {
+        var group = LoadoutItemGroup.Load(libraryItem.Db, groupId);
         var job = new InstallLoadoutItemJob
         {
             Installer = installer,
             LibraryItem = libraryItem,
-            LoadoutId = loadout,
+            ParentGroupId = groupId,
+            LoadoutId = group.AsLoadoutItem().LoadoutId,
             Connection = serviceProvider.GetRequiredService<IConnection>(),
             ServiceProvider = serviceProvider,
         };
@@ -92,6 +95,7 @@ internal class InstallLoadoutItemJob : IJobDefinitionWithStart<InstallLoadoutIte
                 {
                     Name = LibraryItem.Name,
                     LoadoutId = LoadoutId,
+                    ParentId = ParentGroupId,
                 },
             };
 

--- a/src/NexusMods.Library/LibraryService.cs
+++ b/src/NexusMods.Library/LibraryService.cs
@@ -9,6 +9,7 @@ using NexusMods.Abstractions.Library.Installers;
 using NexusMods.Abstractions.Library.Jobs;
 using NexusMods.Abstractions.Library.Models;
 using NexusMods.Abstractions.Loadouts;
+using NexusMods.Extensions.BCL;
 using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.MnemonicDB.Abstractions.TxFunctions;
 using NexusMods.Paths;
@@ -50,10 +51,9 @@ public sealed class LibraryService : ILibraryService
     {
         if (!parent.HasValue)
         {
-            var userCollection = Loadout.Load(libraryItem.Db, targetLoadout).FindUserCollection();
-            if (!userCollection.HasValue)
+            if (!Loadout.Load(libraryItem.Db, targetLoadout).MutableCollections().TryGetFirst(out var userCollection))
                 throw new InvalidOperationException("Could not find the user collection for the target loadout");
-            parent = userCollection.Value.AsLoadoutItemGroup().LoadoutItemGroupId;
+            parent = userCollection.AsLoadoutItemGroup().LoadoutItemGroupId;
         }
 
         return InstallLoadoutItemJob.Create(_serviceProvider, libraryItem, parent.Value, itemInstaller);

--- a/tests/NexusMods.CLI.Tests/VerbTests/ModManagementVerbs.cs
+++ b/tests/NexusMods.CLI.Tests/VerbTests/ModManagementVerbs.cs
@@ -23,7 +23,7 @@ public class ModManagementVerbs(StubbedGame stubbedGame, IServiceProvider provid
         log.TableCellsWith(0, listName).Should().NotBeEmpty();
 
         log = await Run("list-mods", "-l", listName);
-        log.LastTable.Rows.Length.Should().Be(1);
+        log.LastTable.Rows.Length.Should().Be(2);
 
         log = await Run("install-mod", "-l", listName, "-f", Data7ZipLZMA2.ToString(), "-n", Data7ZipLZMA2.GetFileNameWithoutExtension());
 

--- a/tests/NexusMods.DataModel.Synchronizer.Tests/GeneralLoadoutManagementTests.SynchronizerIntegrationTests.verified.md
+++ b/tests/NexusMods.DataModel.Synchronizer.Tests/GeneralLoadoutManagementTests.SynchronizerIntegrationTests.verified.md
@@ -114,7 +114,7 @@ A new loadout is created, but it has not been synchronized yet. So again the 'La
 ### Loadout B - (1)
 | Path | Hash | Size | TxId |
 | --- | --- | --- | --- |
-| (EId:20000000000000C, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:10000000000000E |
+| (EId:20000000000000D, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:10000000000000E |
 
 
 
@@ -141,7 +141,7 @@ loadout are different from the previous loadout due to the new file only being i
 ### Loadout B - (1)
 | Path | Hash | Size | TxId |
 | --- | --- | --- | --- |
-| (EId:20000000000000C, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:10000000000000E |
+| (EId:20000000000000D, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:10000000000000E |
 
 
 
@@ -169,8 +169,8 @@ A new file has been added to the game folder and B loadout has been synchronized
 ### Loadout B - (2)
 | Path | Hash | Size | TxId |
 | --- | --- | --- | --- |
-| (EId:20000000000000C, Game, bin/newFileInGameFolderB.txt) | 0x3E6AD5D9F57F8D4E | 28 B | Tx:100000000000012 |
-| (EId:20000000000000C, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:10000000000000E |
+| (EId:20000000000000D, Game, bin/newFileInGameFolderB.txt) | 0x3E6AD5D9F57F8D4E | 28 B | Tx:100000000000012 |
+| (EId:20000000000000D, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:10000000000000E |
 
 
 
@@ -198,8 +198,8 @@ Now we switch back to the A loadout, and the new file should be removed from the
 ### Loadout B - (2)
 | Path | Hash | Size | TxId |
 | --- | --- | --- | --- |
-| (EId:20000000000000C, Game, bin/newFileInGameFolderB.txt) | 0x3E6AD5D9F57F8D4E | 28 B | Tx:100000000000012 |
-| (EId:20000000000000C, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:10000000000000E |
+| (EId:20000000000000D, Game, bin/newFileInGameFolderB.txt) | 0x3E6AD5D9F57F8D4E | 28 B | Tx:100000000000012 |
+| (EId:20000000000000D, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:10000000000000E |
 
 
 
@@ -227,13 +227,13 @@ Loadout A has been copied to Loadout C, and the contents should match.
 ### Loadout B - (2)
 | Path | Hash | Size | TxId |
 | --- | --- | --- | --- |
-| (EId:20000000000000C, Game, bin/newFileInGameFolderB.txt) | 0x3E6AD5D9F57F8D4E | 28 B | Tx:100000000000012 |
-| (EId:20000000000000C, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:10000000000000E |
+| (EId:20000000000000D, Game, bin/newFileInGameFolderB.txt) | 0x3E6AD5D9F57F8D4E | 28 B | Tx:100000000000012 |
+| (EId:20000000000000D, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:10000000000000E |
 ### Loadout C - (2)
 | Path | Hash | Size | TxId |
 | --- | --- | --- | --- |
-| (EId:200000000000013, Game, bin/newFileInGameFolderA.txt) | 0x2D489D43D46C8849 | 25 B | Tx:100000000000016 |
-| (EId:200000000000013, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:100000000000016 |
+| (EId:200000000000015, Game, bin/newFileInGameFolderA.txt) | 0x2D489D43D46C8849 | 25 B | Tx:100000000000016 |
+| (EId:200000000000015, Game, bin/originalGameFile.txt) | 0xA52B286A3E7F4D91 | 12 B | Tx:100000000000016 |
 
 
 


### PR DESCRIPTION
This probably needs to wait until #1705, but the structure here is helpful for what comes after that code

* Adds the concept of collections in the loadouts
* Makes a default "My Mods" collection when a loadout is created
* All mods that are not assigned to another group will be put into the "My Mods" collection
* Adds a "group" filter to the Loadout tree view that scopes it to "My Mods" by default

This should be a unoticable change to users, but internally all mods are now in a collection and the loadout should filter out any mods that are not part of the currently selected collection. There is no way to select a collection or add a new one, but the code is there. We can merge this or #1705 first, or merge them both. Once the code is in, we can update the modesl in #1705 to include the models in this PR and things should "just work". 