### PR TITLE
Added: Scrolling for Library Delete Confirmation Dialog

### DIFF
--- a/src/NexusMods.App.UI/Overlays/LibraryDeleteConfirmation/LibraryItemDeleteConfirmationView.axaml
+++ b/src/NexusMods.App.UI/Overlays/LibraryDeleteConfirmation/LibraryItemDeleteConfirmationView.axaml
@@ -108,19 +108,20 @@
                         VerticalAlignment="Center"/>
                 </DockPanel>
 
-                <StackPanel x:Name="ModalContentsPanel" Classes="CommonPanel">
-                    <!-- 'Deleting these mods removes them from the App' -->
-                    <TextBlock Classes="BodyMDBold" x:Name="QuestionTitle" Text="{x:Static rsrc:Language.LibraryItemDeleteConfirmation_HeaderQuestion}"/>
+                <ScrollViewer MaxHeight="300">
+                    <StackPanel x:Name="ModalContentsPanel" Classes="CommonPanel">
+                        <!-- 'Deleting these mods removes them from the App' -->
+                        <TextBlock Classes="BodyMDBold" x:Name="QuestionTitle" Text="{x:Static rsrc:Language.LibraryItemDeleteConfirmation_HeaderQuestion}"/>
                 
-                    <!-- Items -->
-                    <ItemsControl x:Name="RemovedItemsList" Classes="ModsList"/>
+                        <!-- Items -->
+                        <ItemsControl x:Name="RemovedItemsList" Classes="ModsList"/>
                 
-                    <!-- Loadout List (when added to a number of loadouts -->
-                    <StackPanel x:Name="LoadoutsPanel">
-                        <ItemsControl x:Name="SourceLoadoutsList" Classes="LoadoutsList"/>
+                        <!-- Loadout List (when added to a number of loadouts -->
+                        <StackPanel x:Name="LoadoutsPanel">
+                            <ItemsControl x:Name="SourceLoadoutsList" Classes="LoadoutsList"/>
+                        </StackPanel>
                     </StackPanel>
-                </StackPanel>
-
+                </ScrollViewer>
             </StackPanel>
         </base:MessageBoxBackground.TopContent>
 


### PR DESCRIPTION
This adds a missing scrollbar to the library delete confirmation dialog.

Max Dialog Size Allowed @ Steam Deck Size
![image](https://github.com/user-attachments/assets/8fae2960-7ed8-44a6-a636-b649e8ef39bd)

(Ignore the content, just let me know if you want the max size of window smaller/bigger)

And the window of course shrinks if the content doesn't match this max size:
![image](https://github.com/user-attachments/assets/ff069311-7418-43e3-a28d-d9b9d7ed15ac)

Tags
-----
fixes #1990