### PR TITLE
Fixed: Adding Library Files no longer Adds Duplicates

### DIFF
--- a/benchmarks/NexusMods.Benchmarks/Benchmarks/Loadouts/Harness/DummyFileStore.cs
+++ b/benchmarks/NexusMods.Benchmarks/Benchmarks/Loadouts/Harness/DummyFileStore.cs
@@ -11,7 +11,7 @@ public class DummyFileStore : IFileStore
         return ValueTask.FromResult(false);
     }
 
-    public Task BackupFiles(IEnumerable<ArchivedFileEntry> backups, CancellationToken token = default)
+    public Task BackupFiles(IEnumerable<ArchivedFileEntry> backups, bool deduplicate = true, CancellationToken token = default)
     {
         return Task.CompletedTask;
     }

--- a/src/Abstractions/NexusMods.Abstractions.IO/IFileStore.cs
+++ b/src/Abstractions/NexusMods.Abstractions.IO/IFileStore.cs
@@ -17,12 +17,23 @@ public interface IFileStore
     public ValueTask<bool> HaveFile(Hash hash);
 
     /// <summary>
-    /// Backup the given files. If the size or hash do not match during the
-    /// backup process a exception may be thrown.
+    /// Backup the given set of NEW files.
+    ///
+    /// If the size or hash do not match during the
+    /// backup process an exception may be thrown.
     /// </summary>
-    /// <param name="backups"></param>
+    /// <param name="backups">
+    ///     The files to back up.
+    ///     These should not contain any already stored files unless <paramref name="deduplicate"/>
+    ///     is set to true.
+    /// </param>
+    /// <param name="deduplicate">
+    ///     Ensures no duplicate files are stored.
+    ///     Only set this to false if you are certain there are no duplicates
+    ///     with existing files in the input.
+    /// </param>
     /// <param name="token"></param>
-    Task BackupFiles(IEnumerable<ArchivedFileEntry> backups, CancellationToken token = default);
+    Task BackupFiles(IEnumerable<ArchivedFileEntry> backups, bool deduplicate = true, CancellationToken token = default);
 
     /// <summary>
     /// Extract the given files to the given disk locations, provide as a less-abstract interface incase

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -808,7 +808,8 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
             }
         );
 
-        await _fileStore.BackupFiles(archivedFiles);
+        // SAFETY: We deduplicate above with the HaveFile call.
+        await _fileStore.BackupFiles(archivedFiles, deduplicate: false);
     }
 
     private async Task<DiskState> GetOrCreateInitialDiskState(GameInstallation installation)

--- a/src/NexusMods.App.UI/Pages/TextEdit/TextEditorPageViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/TextEdit/TextEditorPageViewModel.cs
@@ -95,7 +95,7 @@ public class TextEditorPageViewModel : APageViewModel<ITextEditorPageViewModel>,
             using (var streamFactory = new MemoryStreamFactory(filePath.Path, new MemoryStream(bytes, writable: false)))
             {
                 if (!await fileStore.HaveFile(hash))
-                    await fileStore.BackupFiles([new ArchivedFileEntry(streamFactory, hash, size)]);
+                    await fileStore.BackupFiles([new ArchivedFileEntry(streamFactory, hash, size)], deduplicate: false);
             }
 
             // update the file

--- a/src/NexusMods.App.UI/Pages/TextEdit/TextEditorPageViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/TextEdit/TextEditorPageViewModel.cs
@@ -94,7 +94,8 @@ public class TextEditorPageViewModel : APageViewModel<ITextEditorPageViewModel>,
 
             using (var streamFactory = new MemoryStreamFactory(filePath.Path, new MemoryStream(bytes, writable: false)))
             {
-                await fileStore.BackupFiles([new ArchivedFileEntry(streamFactory, hash, size)]);
+                if (!await fileStore.HaveFile(hash))
+                    await fileStore.BackupFiles([new ArchivedFileEntry(streamFactory, hash, size)]);
             }
 
             // update the file

--- a/src/NexusMods.DataModel/NxFileStore.cs
+++ b/src/NexusMods.DataModel/NxFileStore.cs
@@ -76,7 +76,6 @@ public class NxFileStore : IFileStore
         var builder = new NxPackerBuilder();
         var distinct = backups.DistinctBy(d => d.Hash).ToArray();
         var streams = new List<Stream>();
-        _logger.LogDebug("Backing up {Count} files of {Size} in size", distinct.Length, distinct.Sum(s => s.Size));
         foreach (var backup in distinct)
         {
             if (await IsDuplicate(deduplicate, backup))
@@ -90,6 +89,7 @@ public class NxFileStore : IFileStore
             });
         }
 
+        _logger.LogDebug("Backing up {Count} files of {Size} in size", distinct.Length, distinct.Sum(s => s.Size));
         var guid = Guid.NewGuid();
         var id = guid.ToString();
         var outputPath = _archiveLocations.First().Combine(id).AppendExtension(KnownExtensions.Tmp);

--- a/src/NexusMods.Library/AddLibraryFileJob.cs
+++ b/src/NexusMods.Library/AddLibraryFileJob.cs
@@ -44,10 +44,7 @@ internal class AddLibraryFileJob : IJobDefinitionWithStart<AddLibraryFileJob, Li
         if (!FilePath.FileExists)
             throw new Exception($"File '{FilePath}' does not exist.");
         
-        var topFile = await AnalyzeOne(context, FilePath);
-        
-        await FileStore.BackupFiles(ToArchive, context.CancellationToken);
-        return topFile;
+        return await AnalyzeOne(context, FilePath);
     }
 
     private async Task<LibraryFile.New> AnalyzeOne(IJobContext<AddLibraryFileJob> context, AbsolutePath filePath)
@@ -87,10 +84,11 @@ internal class AddLibraryFileJob : IJobDefinitionWithStart<AddLibraryFileJob, Li
         else
         {
             var size = filePath.FileInfo.Size;
-            if (!(await FileStore.HaveFile(hash)))
+            if (!await FileStore.HaveFile(hash))
                 ToArchive.Add(new ArchivedFileEntry(new NativeFileStreamFactory(filePath), hash, size)); 
         }
 
+        await FileStore.BackupFiles(ToArchive, deduplicate: false, context.CancellationToken);
         return libraryFile;
     }
 

--- a/src/NexusMods.Library/AddLibraryFileJob.cs
+++ b/src/NexusMods.Library/AddLibraryFileJob.cs
@@ -87,7 +87,8 @@ internal class AddLibraryFileJob : IJobDefinitionWithStart<AddLibraryFileJob, Li
         else
         {
             var size = filePath.FileInfo.Size;
-            ToArchive.Add(new ArchivedFileEntry(new NativeFileStreamFactory(filePath), hash, size)); 
+            if (!(await FileStore.HaveFile(hash)))
+                ToArchive.Add(new ArchivedFileEntry(new NativeFileStreamFactory(filePath), hash, size)); 
         }
 
         return libraryFile;

--- a/tests/NexusMods.Collections.Tests/CollectionInstallTests.CanInstallBasicCollection.verified.txt
+++ b/tests/NexusMods.Collections.Tests/CollectionInstallTests.CanInstallBasicCollection.verified.txt
@@ -2,7 +2,7 @@
   mods: [
     Game Files,
     Halgari's Helper,
-    My Collection
+    My Mods
   ],
   files: [
     {Game}/archive/pc/mod/_1_Ves_HanakoFixedBodyNaked.archive,


### PR DESCRIPTION

## Summary

This is a fix for
- #1994

This fixes a bug where we unnecessarily back up items which may already be in the FileStore.

## Explanation

[Explanation Copied from Discord]

When the code for adding library items was rewritten to the new job system, someone forgot to add a check to make sure we're not packing duplicates.

[Which is a bug]

When adding an item we're only supposed to back up new files. Much of our previous code, including the GC was written under this assumption. We've broken this behaviour for adding library items; and now we've got a situation where adding mods with duplicates causes us to store compressed duplicates in separate archives on disk.

The general repro on this is:

- Install an archive for ModA
- Install an archive for ModB where some files in ModB existed in ModA
- Delete ModB

It's around 90% consistent, part of it depends on operation order.
[This was very not trivial to find/reproduce, given the amount of variables and bit of RNG required to even repro this]

So the exact reason this happens (I believe) is that there are multiple of the same file in different archives.

i.e. A file with a given hash can be in more than 1 container (Archive) due to this.

But when we query for files throughout the App (and in the GC included), we query them by *hash*. i.e. There should only be a single entry and single container for a hash. We have multiple.
 
So when an `ArchivedFile` is swooped up by the GC, it's retracted. Retract works on first element of the `Entity`. That first element happens to be container reference which is how #1994 shows up.

When the GC reassigns the container of ***the duplicate*** of that item that's been repacked, it errors because there is no container. It was retracted by accident due to the failed assertion above. Because the query by hash returned the wrong entity (there should be 1 entity for a given hash, but we have multiple).

Tags
-----
fixes #1994