### PR TITLE
Revert "Fixed: Adding Library Files no longer Adds Duplicates"

### DIFF
--- a/benchmarks/NexusMods.Benchmarks/Benchmarks/Loadouts/Harness/DummyFileStore.cs
+++ b/benchmarks/NexusMods.Benchmarks/Benchmarks/Loadouts/Harness/DummyFileStore.cs
@@ -11,7 +11,7 @@ public class DummyFileStore : IFileStore
         return ValueTask.FromResult(false);
     }
 
-    public Task BackupFiles(IEnumerable<ArchivedFileEntry> backups, bool deduplicate = true, CancellationToken token = default)
+    public Task BackupFiles(IEnumerable<ArchivedFileEntry> backups, CancellationToken token = default)
     {
         return Task.CompletedTask;
     }

--- a/src/Abstractions/NexusMods.Abstractions.IO/IFileStore.cs
+++ b/src/Abstractions/NexusMods.Abstractions.IO/IFileStore.cs
@@ -17,23 +17,12 @@ public interface IFileStore
     public ValueTask<bool> HaveFile(Hash hash);
 
     /// <summary>
-    /// Backup the given set of NEW files.
-    ///
-    /// If the size or hash do not match during the
-    /// backup process an exception may be thrown.
+    /// Backup the given files. If the size or hash do not match during the
+    /// backup process a exception may be thrown.
     /// </summary>
-    /// <param name="backups">
-    ///     The files to back up.
-    ///     These should not contain any already stored files unless <paramref name="deduplicate"/>
-    ///     is set to true.
-    /// </param>
-    /// <param name="deduplicate">
-    ///     Ensures no duplicate files are stored.
-    ///     Only set this to false if you are certain there are no duplicates
-    ///     with existing files in the input.
-    /// </param>
+    /// <param name="backups"></param>
     /// <param name="token"></param>
-    Task BackupFiles(IEnumerable<ArchivedFileEntry> backups, bool deduplicate = true, CancellationToken token = default);
+    Task BackupFiles(IEnumerable<ArchivedFileEntry> backups, CancellationToken token = default);
 
     /// <summary>
     /// Extract the given files to the given disk locations, provide as a less-abstract interface incase

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -808,8 +808,7 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
             }
         );
 
-        // SAFETY: We deduplicate above with the HaveFile call.
-        await _fileStore.BackupFiles(archivedFiles, deduplicate: false);
+        await _fileStore.BackupFiles(archivedFiles);
     }
 
     private async Task<DiskState> GetOrCreateInitialDiskState(GameInstallation installation)

--- a/src/NexusMods.App.UI/Pages/TextEdit/TextEditorPageViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/TextEdit/TextEditorPageViewModel.cs
@@ -94,8 +94,7 @@ public class TextEditorPageViewModel : APageViewModel<ITextEditorPageViewModel>,
 
             using (var streamFactory = new MemoryStreamFactory(filePath.Path, new MemoryStream(bytes, writable: false)))
             {
-                if (!await fileStore.HaveFile(hash))
-                    await fileStore.BackupFiles([new ArchivedFileEntry(streamFactory, hash, size)], deduplicate: false);
+                await fileStore.BackupFiles([new ArchivedFileEntry(streamFactory, hash, size)]);
             }
 
             // update the file

--- a/src/NexusMods.DataModel/NxFileStore.cs
+++ b/src/NexusMods.DataModel/NxFileStore.cs
@@ -67,7 +67,7 @@ public class NxFileStore : IFileStore
     }
 
     /// <inheritdoc />
-    public async Task BackupFiles(IEnumerable<ArchivedFileEntry> backups, bool deduplicate = true, CancellationToken token = default)
+    public async Task BackupFiles(IEnumerable<ArchivedFileEntry> backups, CancellationToken token = default)
     {
         var hasAnyFiles = backups.Any();
         if (hasAnyFiles == false)
@@ -76,11 +76,9 @@ public class NxFileStore : IFileStore
         var builder = new NxPackerBuilder();
         var distinct = backups.DistinctBy(d => d.Hash).ToArray();
         var streams = new List<Stream>();
+        _logger.LogDebug("Backing up {Count} files of {Size} in size", distinct.Length, distinct.Sum(s => s.Size));
         foreach (var backup in distinct)
         {
-            if (await IsDuplicate(deduplicate, backup))
-                continue;
-            
             var stream = await backup.StreamFactory.GetStreamAsync();
             streams.Add(stream);
             builder.AddFile(stream, new AddFileParams
@@ -89,7 +87,6 @@ public class NxFileStore : IFileStore
             });
         }
 
-        _logger.LogDebug("Backing up {Count} files of {Size} in size", distinct.Length, distinct.Sum(s => s.Size));
         var guid = Guid.NewGuid();
         var id = guid.ToString();
         var outputPath = _archiveLocations.First().Combine(id).AppendExtension(KnownExtensions.Tmp);
@@ -109,24 +106,6 @@ public class NxFileStore : IFileStore
         await using var os = finalPath.Read();
         var unpacker = new NxUnpacker(new FromStreamProvider(os));
         await UpdateIndexes(unpacker, finalPath);
-    }
-
-    private async Task<bool> IsDuplicate(bool deduplicate, ArchivedFileEntry backup)
-    {
-        // Extra sanity test for debug builds, else take hot path since
-        // this is supposed to be a speedy-ish API.
-        #if DEBUG
-        var haveFile = await HaveFile(backup.Hash);
-        if (!haveFile) 
-            return false;
-
-        if (!deduplicate)
-            throw new Exception("Writing duplicate but deduplicate is disabled. This is a bug.");
-        
-        return true;
-        #else
-        return deduplicate && await HaveFile(backup.Hash);
-        #endif
     }
 
     private async Task UpdateIndexes(NxUnpacker unpacker, AbsolutePath finalPath)

--- a/tests/NexusMods.Collections.Tests/CollectionInstallTests.CanInstallBasicCollection.verified.txt
+++ b/tests/NexusMods.Collections.Tests/CollectionInstallTests.CanInstallBasicCollection.verified.txt
@@ -2,7 +2,7 @@
   mods: [
     Game Files,
     Halgari's Helper,
-    My Mods
+    My Collection
   ],
   files: [
     {Game}/archive/pc/mod/_1_Ves_HanakoFixedBodyNaked.archive,


### PR DESCRIPTION
Reverts Nexus-Mods/NexusMods.App#2015

I find several parts of this to be a hack, I'll detail them below:

`bool deduplicate = true` - something that would stop the app from working if configured wrong shouldn't be a boolean flag. Components should work correctly and maintain consistency internally. If stuff breaks if there are duplicates the component should *always* deduplicate.

```
if (!await fileStore.HaveFile(hash))
                    await fileStore.BackupFiles([new ArchivedFileEntry(streamFactory, hash, size)], deduplicate: false);
```
Users of this component shouldn't have to constantly watch out for foot guns like this. The component should work correctly without out-of-band logic. This is also a race condition.

`ToArchive` being global to the job was intentional. That way we do all our analysis then do a single build at the end. This code was also intended to be parallel (looks like I forgot to do that part), which was why it was global to the job and a `ConcurrentBag`

