### PR TITLE
Fix exception on cached value

### DIFF
--- a/src/Networking/NexusMods.Networking.NexusWebApi/Auth/JWTToken.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/Auth/JWTToken.cs
@@ -1,10 +1,8 @@
-using System.Diagnostics.CodeAnalysis;
+using DynamicData.Kernel;
 using NexusMods.Abstractions.NexusWebApi.DTOs.OAuth;
 using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.MnemonicDB.Abstractions.Attributes;
 using NexusMods.MnemonicDB.Abstractions.Models;
-using NexusMods.MnemonicDB.Abstractions.TxFunctions;
-using File = NexusMods.Abstractions.Loadouts.Files.File;
 
 namespace NexusMods.Networking.NexusWebApi.Auth;
 
@@ -29,49 +27,50 @@ public partial class JWTToken : IModelDefinition
     /// The date at which the token expires
     /// </summary>
     public static readonly TimestampAttribute ExpiresAt = new(Namespace, nameof(ExpiresAt));
-    
-    
+
+    private static Optional<EntityId> GetEntityId(IDb db)
+    {
+        var datoms = db.Datoms(PrimaryAttribute);
+        return datoms.Count == 0 ? Optional<EntityId>.None : datoms[0].E;
+    }
+
     /// <summary>
     /// Try to find the JWT Token in the database.
     /// </summary>
     public static bool TryFind(IDb db, out ReadOnly token)
     {
-        var found = All(db).FirstOrDefault();
-        if (found.IsValid())
+        var entityId = GetEntityId(db);
+        if (!entityId.HasValue)
         {
-            token = found;
-            return true;
+            token = default(ReadOnly);
+            return false;
         }
-        
-        token = default(ReadOnly);
-        return false;
+
+        token = Load(db, entityId.Value);
+        return token.IsValid();
     }
-    
-    
+
     /// <summary>
     /// Creates a new JWT Token model from a <see cref="JwtTokenReply"/>. And reuses the existing
     /// database id if it exists, as this data is a singleton.
     /// </summary>
-    public static EntityId? Create(IDb db, ITransaction tx, JwtTokenReply reply)
+    public static Optional<EntityId> Create(IDb db, ITransaction tx, JwtTokenReply reply)
     {
-        if (reply.AccessToken is null || reply.RefreshToken is null) 
-            return null;
-            
-        var existingId = db.Datoms(JWTToken.AccessToken).FirstOrDefault().E;
-        if (existingId == EntityId.From(0))
-            existingId = tx.TempId();
-        
-        tx.Add(existingId, JWTToken.AccessToken, reply.AccessToken);
-        tx.Add(existingId, JWTToken.RefreshToken, reply.RefreshToken);
-        tx.Add(existingId, JWTToken.ExpiresAt, DateTimeOffset.FromUnixTimeSeconds(reply.CreatedAt).DateTime + TimeSpan.FromSeconds(reply.ExpiresIn));
+        if (reply.AccessToken is null || reply.RefreshToken is null) return Optional<EntityId>.None;
 
-        return existingId;
+        var existingId = GetEntityId(db);
+        var entityId = existingId.HasValue ? existingId.Value : tx.TempId();
+
+        tx.Add(entityId, AccessToken, reply.AccessToken);
+        tx.Add(entityId, RefreshToken, reply.RefreshToken);
+        tx.Add(entityId, ExpiresAt, DateTimeOffset.FromUnixTimeSeconds(reply.CreatedAt).DateTime + TimeSpan.FromSeconds(reply.ExpiresIn));
+
+        return entityId;
     }
     
     /// <summary>
     /// Model for the JWT Token
     /// </summary>
-    /// <param name="tx"></param>
     public partial struct ReadOnly
     {
         /// <summary>

--- a/src/Networking/NexusMods.Networking.NexusWebApi/LoginManager.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/LoginManager.cs
@@ -135,7 +135,7 @@ public sealed class LoginManager : IDisposable, ILoginManager
         using var tx = _conn.BeginTransaction();
 
         var newTokenEntity = JWTToken.Create(_conn.Db, tx, jwtToken);
-        if (newTokenEntity is null)
+        if (!newTokenEntity.HasValue)
         {
             _logger.LogError("Invalid new token data");
             return;


### PR DESCRIPTION
Fixes #2031.

I'm guessing there was a concurrency issue where we set a field to a valid non-null value, and before we could access the value, something else changed the value back to a null value.

I decided to remove the cached value entirely and always get the latest from the DB, that's what our code did anyway.