### PR TITLE
Fixes for virtualization with our use of the TreeDataGrid

### DIFF
--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/CustomElementFactory.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/CustomElementFactory.cs
@@ -41,9 +41,11 @@ public class CustomElementFactory : TreeDataGridElementFactory
         
         switch (data)
         {
-            case IIndentedRow:
+            case IIndentedRow { Indent: 0 }:
+            {
                 var rowKey = $"{base.GetDataRecycleKey(data)}|{RootRowClass}";
                 return string.Intern(rowKey);
+            }
             case ICustomCell customCell:
             {
                 // NOTE(Al12rs): the keys generated here should match the ones in GetElementRecycleKey, ensure order and format is the same
@@ -63,7 +65,7 @@ public class CustomElementFactory : TreeDataGridElementFactory
         
         var sb = new StringBuilder(value: base.GetElementRecycleKey(element));
         
-        if (element is not TreeDataGridCell or TreeDataGridRow)
+        if (element is not TreeDataGridCell and not TreeDataGridRow)
             return string.Intern(sb.ToString());
         
         // NOTE(Al12rs): Order here should match the insertion order in CreateElement, first the id, then the RootRowClass


### PR DESCRIPTION
We weren't generating keys properly in our factory class, causing rows to be created but never reused. The massive performance issues in the Library were due to building up hundreds (or thousands) of rows. Each of these rows was listening to Avalonia Styling classes and causing a ton of issues throughout the app as they left their bindings and styling active. 

Big thanks to @erri120 and @Al12rs for helping me walk through this code. 