### PR TITLE
Fixed: Edge Case Where Power Loss During GC within a (200-600 microsecond window) could break App

### DIFF
--- a/src/NexusMods.App.GarbageCollection.DataModel/RunGarbageCollector.cs
+++ b/src/NexusMods.App.GarbageCollection.DataModel/RunGarbageCollector.cs
@@ -23,8 +23,12 @@ public static class RunGarbageCollector
         DataStoreReferenceMarker.MarkUsedFiles(connection, gc);
         gc.CollectGarbage(new Progress<double>(), (progress, toArchive, toRemove, archive) =>
         {
-            NxRepacker.RepackArchive(progress, toArchive, toRemove, archive, true, out var newArchivePath);
+            NxRepacker.RepackArchive(progress, toArchive, toRemove, archive, false, out var newArchivePath);
             updater.UpdateNxFileStore(toRemove, archive.FilePath, newArchivePath);
+            // Delete original archive. We do this in a delayed fashion such that
+            // a power loss during the UpdateNxFileStore operation does not lead
+            // to an inconsistent state
+            archive.FilePath.Delete();
         });
     }
 }

--- a/src/NexusMods.App.GarbageCollection.Nx/NxRepacker.cs
+++ b/src/NexusMods.App.GarbageCollection.Nx/NxRepacker.cs
@@ -18,16 +18,6 @@ public static class NxRepacker
     ///     can be used to repack Nx archives. See <see cref="ArchiveGarbageCollector{TParsedHeaderState,TFileEntryWrapper}.RepackDelegate"/>
     ///     type for more info.
     /// </summary>
-    public static void RepackArchive(IProgress<double> progress, List<Hash> toArchive, List<Hash> toRemove, ArchiveReference<NxParsedHeaderState> archive)
-    {
-        RepackArchive(progress, toArchive, toRemove, archive, true, out _);
-    }
-    
-    /// <summary>
-    ///     The method to pass to the 'CollectGarbage' method that
-    ///     can be used to repack Nx archives. See <see cref="ArchiveGarbageCollector{TParsedHeaderState,TFileEntryWrapper}.RepackDelegate"/>
-    ///     type for more info.
-    /// </summary>
     // ReSharper disable once UnusedParameter.Global
     public static void RepackArchive(IProgress<double> progress, List<Hash> toArchive, List<Hash> toRemove, ArchiveReference<NxParsedHeaderState> archive, bool deleteOriginal, out AbsolutePath newArchivePath)
     {


### PR DESCRIPTION
This PR follows #2053 (to avoid merge conflict), please merge after #2053.

There is a minor flaw I caught in the GC code I noticed 1-2 weeks back.
Now's the right time to fix it.

## Description (Short)

Before this PR, there was technically a small amount of time,
(around 200-600 microseconds) where a power loss (or process death)
could mean leaving the App in an inconsistent state; namely:

- Archive was repacked
- Original archive was deleted
- DataStore entries were not adjusted to point at new repacked archive.

That would break the App.

Before this PR, deleting original archive was done before the DataStore entries were adjusted. Now it happens after.
Therefore, if there is power loss in that 200-600us time span, the App will not end up broken.

> [!NOTE]  
> Should that power loss occur, the old archive that was left over will be cleaned/removed up in a subsequent GC.