### PR TITLE
Fixed: Adding Mods to Library no longer Adds Duplicate Files

### DIFF
--- a/benchmarks/NexusMods.Benchmarks/Benchmarks/Loadouts/Harness/DummyFileStore.cs
+++ b/benchmarks/NexusMods.Benchmarks/Benchmarks/Loadouts/Harness/DummyFileStore.cs
@@ -11,7 +11,7 @@ public class DummyFileStore : IFileStore
         return ValueTask.FromResult(false);
     }
 
-    public Task BackupFiles(IEnumerable<ArchivedFileEntry> backups, CancellationToken token = default)
+    public Task BackupFiles(IEnumerable<ArchivedFileEntry> backups, bool deduplicate = true, CancellationToken token = default)
     {
         return Task.CompletedTask;
     }

--- a/src/Abstractions/NexusMods.Abstractions.IO/IFileStore.cs
+++ b/src/Abstractions/NexusMods.Abstractions.IO/IFileStore.cs
@@ -17,22 +17,31 @@ public interface IFileStore
     public ValueTask<bool> HaveFile(Hash hash);
 
     /// <summary>
-    /// Backup the given set of NEW files.
+    /// Backup the given set of files.
     ///
     /// If the size or hash do not match during the
     /// backup process an exception may be thrown.
     /// </summary>
-    /// <param name="backups">
-    ///     The files to back up.
-    ///     These should not contain any already stored files unless <paramref name="deduplicate"/>
-    ///     is set to true.
-    /// </param>
-    /// <param name="deduplicate">
-    ///     Ensures no duplicate files are stored.
-    ///     Only set this to false if you are certain there are no duplicates
-    ///     with existing files in the input.
-    /// </param>
+    /// <param name="backups">The files to back up.</param>
+    /// <param name="deduplicate">Ensures no duplicate files are stored.</param>
     /// <param name="token"></param>
+    /// <remarks>
+    /// Backing up duplicates should generally be avoided, as it encurs a performance and
+    /// disk space penalty. However accidentally creating a duplicate is not
+    /// considered a failure case; the Garbage Collector is equipped to deal
+    /// with duplicates.
+    ///
+    /// As a default <paramref name="deduplicate"/> is set to 'true' to avoid duplicates,
+    /// however it is slightly more efficient to set <paramref name="deduplicate"/> to 'false'
+    /// and manually check for duplicates with <see cref="HaveFile"/> API when constructing
+    /// the <paramref name="backups"/> collection.
+    ///
+    /// The <see cref="BackupFiles"/> itself is thread safe, but duplicates may be made
+    /// if called from duplicate threads at once. This can prevent with taking a lock
+    /// via <see cref="Lock"/> (and `using` statement). That said, the probability of duplicates
+    /// being made without a lock is so low that it is generally recommended not to lock
+    /// to instead maximize performance. The Garbage Collector will remove any duplicates down the road.
+    /// </remarks>
     Task BackupFiles(IEnumerable<ArchivedFileEntry> backups, bool deduplicate = true, CancellationToken token = default);
 
     /// <summary>

--- a/src/Abstractions/NexusMods.Abstractions.IO/IFileStore.cs
+++ b/src/Abstractions/NexusMods.Abstractions.IO/IFileStore.cs
@@ -17,12 +17,23 @@ public interface IFileStore
     public ValueTask<bool> HaveFile(Hash hash);
 
     /// <summary>
-    /// Backup the given files. If the size or hash do not match during the
-    /// backup process a exception may be thrown.
+    /// Backup the given set of NEW files.
+    ///
+    /// If the size or hash do not match during the
+    /// backup process an exception may be thrown.
     /// </summary>
-    /// <param name="backups"></param>
+    /// <param name="backups">
+    ///     The files to back up.
+    ///     These should not contain any already stored files unless <paramref name="deduplicate"/>
+    ///     is set to true.
+    /// </param>
+    /// <param name="deduplicate">
+    ///     Ensures no duplicate files are stored.
+    ///     Only set this to false if you are certain there are no duplicates
+    ///     with existing files in the input.
+    /// </param>
     /// <param name="token"></param>
-    Task BackupFiles(IEnumerable<ArchivedFileEntry> backups, CancellationToken token = default);
+    Task BackupFiles(IEnumerable<ArchivedFileEntry> backups, bool deduplicate = true, CancellationToken token = default);
 
     /// <summary>
     /// Extract the given files to the given disk locations, provide as a less-abstract interface incase

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -808,7 +808,7 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
             }
         );
 
-        // SAFETY: We deduplicate above with the HaveFile call.
+        // PERFORMANCE: We deduplicate above with the HaveFile call.
         await _fileStore.BackupFiles(archivedFiles, deduplicate: false);
     }
 

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -808,7 +808,8 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
             }
         );
 
-        await _fileStore.BackupFiles(archivedFiles);
+        // SAFETY: We deduplicate above with the HaveFile call.
+        await _fileStore.BackupFiles(archivedFiles, deduplicate: false);
     }
 
     private async Task<DiskState> GetOrCreateInitialDiskState(GameInstallation installation)

--- a/src/NexusMods.App.UI/Pages/TextEdit/TextEditorPageViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/TextEdit/TextEditorPageViewModel.cs
@@ -95,7 +95,7 @@ public class TextEditorPageViewModel : APageViewModel<ITextEditorPageViewModel>,
             using (var streamFactory = new MemoryStreamFactory(filePath.Path, new MemoryStream(bytes, writable: false)))
             {
                 if (!await fileStore.HaveFile(hash))
-                    await fileStore.BackupFiles([new ArchivedFileEntry(streamFactory, hash, size)]);
+                    await fileStore.BackupFiles([new ArchivedFileEntry(streamFactory, hash, size)], deduplicate: false);
             }
 
             // update the file

--- a/src/NexusMods.App.UI/Pages/TextEdit/TextEditorPageViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/TextEdit/TextEditorPageViewModel.cs
@@ -94,7 +94,8 @@ public class TextEditorPageViewModel : APageViewModel<ITextEditorPageViewModel>,
 
             using (var streamFactory = new MemoryStreamFactory(filePath.Path, new MemoryStream(bytes, writable: false)))
             {
-                await fileStore.BackupFiles([new ArchivedFileEntry(streamFactory, hash, size)]);
+                if (!await fileStore.HaveFile(hash))
+                    await fileStore.BackupFiles([new ArchivedFileEntry(streamFactory, hash, size)]);
             }
 
             // update the file

--- a/src/NexusMods.DataModel/NxFileStore.cs
+++ b/src/NexusMods.DataModel/NxFileStore.cs
@@ -76,7 +76,6 @@ public class NxFileStore : IFileStore
         var builder = new NxPackerBuilder();
         var distinct = backups.DistinctBy(d => d.Hash).ToArray();
         var streams = new List<Stream>();
-        _logger.LogDebug("Backing up {Count} files of {Size} in size", distinct.Length, distinct.Sum(s => s.Size));
         foreach (var backup in distinct)
         {
             if (await IsDuplicate(deduplicate, backup))
@@ -90,6 +89,7 @@ public class NxFileStore : IFileStore
             });
         }
 
+        _logger.LogDebug("Backing up {Count} files of {Size} in size", distinct.Length, distinct.Sum(s => s.Size));
         var guid = Guid.NewGuid();
         var id = guid.ToString();
         var outputPath = _archiveLocations.First().Combine(id).AppendExtension(KnownExtensions.Tmp);

--- a/src/NexusMods.Library/AddLibraryFileJob.cs
+++ b/src/NexusMods.Library/AddLibraryFileJob.cs
@@ -44,10 +44,7 @@ internal class AddLibraryFileJob : IJobDefinitionWithStart<AddLibraryFileJob, Li
         if (!FilePath.FileExists)
             throw new Exception($"File '{FilePath}' does not exist.");
         
-        var topFile = await AnalyzeOne(context, FilePath);
-        
-        await FileStore.BackupFiles(ToArchive, context.CancellationToken);
-        return topFile;
+        return await AnalyzeOne(context, FilePath);
     }
 
     private async Task<LibraryFile.New> AnalyzeOne(IJobContext<AddLibraryFileJob> context, AbsolutePath filePath)
@@ -87,10 +84,11 @@ internal class AddLibraryFileJob : IJobDefinitionWithStart<AddLibraryFileJob, Li
         else
         {
             var size = filePath.FileInfo.Size;
-            if (!(await FileStore.HaveFile(hash)))
+            if (!await FileStore.HaveFile(hash))
                 ToArchive.Add(new ArchivedFileEntry(new NativeFileStreamFactory(filePath), hash, size)); 
         }
 
+        await FileStore.BackupFiles(ToArchive, deduplicate: false, context.CancellationToken);
         return libraryFile;
     }
 

--- a/src/NexusMods.Library/AddLibraryFileJob.cs
+++ b/src/NexusMods.Library/AddLibraryFileJob.cs
@@ -44,7 +44,9 @@ internal class AddLibraryFileJob : IJobDefinitionWithStart<AddLibraryFileJob, Li
         if (!FilePath.FileExists)
             throw new Exception($"File '{FilePath}' does not exist.");
         
-        return await AnalyzeOne(context, FilePath);
+        var topFile = await AnalyzeOne(context, FilePath);
+        await FileStore.BackupFiles(ToArchive, deduplicate: false, context.CancellationToken);
+        return topFile;
     }
 
     private async Task<LibraryFile.New> AnalyzeOne(IJobContext<AddLibraryFileJob> context, AbsolutePath filePath)
@@ -88,7 +90,6 @@ internal class AddLibraryFileJob : IJobDefinitionWithStart<AddLibraryFileJob, Li
                 ToArchive.Add(new ArchivedFileEntry(new NativeFileStreamFactory(filePath), hash, size)); 
         }
 
-        await FileStore.BackupFiles(ToArchive, deduplicate: false, context.CancellationToken);
         return libraryFile;
     }
 

--- a/src/NexusMods.Library/AddLibraryFileJob.cs
+++ b/src/NexusMods.Library/AddLibraryFileJob.cs
@@ -87,7 +87,8 @@ internal class AddLibraryFileJob : IJobDefinitionWithStart<AddLibraryFileJob, Li
         else
         {
             var size = filePath.FileInfo.Size;
-            ToArchive.Add(new ArchivedFileEntry(new NativeFileStreamFactory(filePath), hash, size)); 
+            if (!(await FileStore.HaveFile(hash)))
+                ToArchive.Add(new ArchivedFileEntry(new NativeFileStreamFactory(filePath), hash, size)); 
         }
 
         return libraryFile;

--- a/tests/NexusMods.Collections.Tests/CollectionInstallTests.CanInstallBasicCollection.verified.txt
+++ b/tests/NexusMods.Collections.Tests/CollectionInstallTests.CanInstallBasicCollection.verified.txt
@@ -2,7 +2,7 @@
   mods: [
     Game Files,
     Halgari's Helper,
-    My Collection
+    My Mods
   ],
   files: [
     {Game}/archive/pc/mod/_1_Ves_HanakoFixedBodyNaked.archive,


### PR DESCRIPTION
This is a revised version of #2015 , with the following changes:

- `AddLibraryFileJob` is left unchanged, sans adding the duplicate check.
- `IFileStore.BackupFiles` has a `remarks` section with recommended usage.

And fixed any comments related to the code changes.

Quick Notes.

## Deduplication

It's enabled by default and opt-out.

Manually checking for duplicates and opting out has small minimal performance improvement;
so it is recommended that you do so by the remarks section. However it is not mandatory.

## Race Condition(s)

No change here.
Calling `BackupFiles` or `ExtractFiles` from multiple threads is safe, but may lead to duplicates.
This is a-ok as noted in the remarks section, GC will clean up duplicates after #2053

If a GC is happening, you can't update the FileStore info in DataStore or query the FileStore due to RwLock, same as before.