### PR TITLE
Changed: Explicitly Set Working Directory for nxm handler on Linux

### DIFF
--- a/src/NexusMods.App/com.nexusmods.app.desktop
+++ b/src/NexusMods.App/com.nexusmods.app.desktop
@@ -10,6 +10,7 @@ MimeType=x-scheme-handler/nxm
 Icon=com.nexusmods.app
 Exec=${INSTALL_EXEC} %u
 TryExec=${INSTALL_EXEC}
+Path=${WORKING_DIRECTORY}
 X-AppImage-Integrate=true
 X-AppImage-Name=NexusMods.App
 X-AppImage-Arch=x86_64

--- a/src/NexusMods.CrossPlatform/ProtocolRegistration/ProtocolRegistrationLinux.cs
+++ b/src/NexusMods.CrossPlatform/ProtocolRegistration/ProtocolRegistrationLinux.cs
@@ -17,6 +17,7 @@ internal class ProtocolRegistrationLinux : IProtocolRegistration
     private const string DesktopFile = $"{ApplicationId}.desktop";
     private const string DesktopFileResourceName = $"NexusMods.CrossPlatform.{DesktopFile}";
     private const string ExecutablePathPlaceholder = "${INSTALL_EXEC}";
+    private const string ExecutableWorkingDirPlaceholder = "${WORKING_DIRECTORY}";
 
     private readonly ILogger _logger;
     private readonly IProcessFactory _processFactory;
@@ -108,7 +109,9 @@ internal class ProtocolRegistrationLinux : IProtocolRegistration
         using var sr = new StreamReader(stream, encoding: Encoding.UTF8);
 
         var text = await sr.ReadToEndAsync(cancellationToken);
-        text = text.Replace(ExecutablePathPlaceholder, EscapeWhitespaceForCli(_osInterop.GetOwnExe()));
+        var elfPath = _osInterop.GetOwnExe();
+        text = text.Replace(ExecutablePathPlaceholder, EscapeWhitespaceForCli(elfPath));
+        text = text.Replace(ExecutableWorkingDirPlaceholder, EscapeWhitespaceForCli(elfPath.Parent));
 
         await filePath.WriteAllTextAsync(text, cancellationToken);
     }


### PR DESCRIPTION
For the details, please see:
- https://github.com/Nexus-Mods/NexusMods.App/issues/2056

Putting this PR up so I can get a build; want to know if this fixes the end user issue.

---------------

Because this may be brought up. Yes, ideally our App shouldn't break if executed from the wrong working directory, but that's a topic for another day.