### PR TITLE
Fix the file deletion error by removing the deadlock

### DIFF
--- a/src/NexusMods.DataModel/NxFileStore.cs
+++ b/src/NexusMods.DataModel/NxFileStore.cs
@@ -60,7 +60,6 @@ public class NxFileStore : IFileStore
     /// <inheritdoc />
     public ValueTask<bool> HaveFile(Hash hash)
     {
-        using var lck = _lock.ReadLock();
         var db = _conn.Db;
         var archivedFiles = ArchivedFile.FindByHash(db, hash).Any(x => x.IsValid());
         return ValueTask.FromResult(archivedFiles);


### PR DESCRIPTION
This fixes the file deletion deadlock, by removing the lock inside `HaveFile` this is a one line change

But won't this cause issues? Perhaps, but the lock was mostly worthless anyways. Look at the code, we lock and say "do we have this file" because someone may want to make sure a file exists before they open it. Okay, so what if they call `HaveFile` and then before they can call `GetFileStream` the GC deletes the file? 

A good rule of thumb here is no predicate can protect against race conditions unless the predicate is itself inside a lock. All the locking code in the GC needs to be re-considered and reworked to either be lock-free or fault tollerant. 

At any rate, this solves the issue at hand and won't introduce any new bugs. 