### PR TITLE
Styling bug fixes for TreeDataGrid

### DIFF
--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/AdvancedManualInstallerUI.cs
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/AdvancedManualInstallerUI.cs
@@ -50,7 +50,7 @@ public class AdvancedManualInstallerUI : ALibraryArchiveInstaller, IAdvancedInst
         if (Headless) return new NotSupported();
 
         var tree = LibraryArchiveTree.Create(libraryArchive);
-        var (shouldInstall, deploymentData) = await GetDeploymentDataAsync(Language.AdvancedInstaller_Manual_Mod, tree, loadout);
+        var (shouldInstall, deploymentData) = await GetDeploymentDataAsync(loadoutGroup.GetLoadoutItem(transaction).Name, tree, loadout);
 
         if (!shouldInstall) return new NotSupported();
 

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/BodyView.axaml
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/BodyView.axaml
@@ -45,11 +45,12 @@
         <Border Grid.Row="0" x:Name="TitleContainerBorder">
             <StackPanel x:Name="HeadingAndSubHeadingStackPanel" Orientation="Vertical">
                 <!-- Mod Name -->
-                <TextBlock Classes="TitleMDSemi" x:Name="ModNameTextBlock" Text="TEMP MOD NAME" />
+                <TextBlock Classes="HeadingSMSemi" x:Name="ModNameTextBlock" Text="TEMP MOD NAME" />
 
                 <!-- Installer Name -->
                 <TextBlock Classes="HeadingMDSemi" x:Name="InstallerNameTextBlock"
-                           Text="{x:Static resources:Language.InstallerNameText}" />
+                           Text="{x:Static resources:Language.InstallerNameText}" 
+                           IsVisible="False"/>
 
                 <!-- 'Please Select Files' -->
                 <TextBlock Classes="BodyLGNormal" x:Name="SubHeadingTextBlock"

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/BodyView.axaml
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/BodyView.axaml
@@ -45,15 +45,18 @@
         <Border Grid.Row="0" x:Name="TitleContainerBorder">
             <StackPanel x:Name="HeadingAndSubHeadingStackPanel" Orientation="Vertical">
                 <!-- Mod Name -->
-                <TextBlock Classes="HeadingSMSemi" x:Name="ModNameTextBlock" Text="TEMP MOD NAME" />
+                <TextBlock Theme="{StaticResource HeadingSMSemiTheme}" 
+                           x:Name="ModNameTextBlock" Text="TEMP MOD NAME" />
 
                 <!-- Installer Name -->
-                <TextBlock Classes="HeadingMDSemi" x:Name="InstallerNameTextBlock"
+                <TextBlock Theme="{StaticResource HeadingMDSemiTheme}" 
+                           x:Name="InstallerNameTextBlock"
                            Text="{x:Static resources:Language.InstallerNameText}" 
                            IsVisible="False"/>
 
                 <!-- 'Please Select Files' -->
-                <TextBlock Classes="BodyLGNormal" x:Name="SubHeadingTextBlock"
+                <TextBlock Theme="{StaticResource BodyLGNormalTheme}" 
+                           x:Name="SubHeadingTextBlock"
                            Text="{x:Static resources:Language.SubHeadingText_Please_select_files}" />
             </StackPanel>
         </Border>

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/BodyView.axaml.cs
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/BodyView.axaml.cs
@@ -18,7 +18,7 @@ public partial class BodyView : ReactiveUserControl<IBodyViewModel>
             // Set the mod name if VM is not null.
             this.WhenAnyValue(view => view.ViewModel)
                 .WhereNotNull()
-                .Do(vm => ModNameTextBlock.Text = vm.ModName.ToUpper())
+                .Do(vm => ModNameTextBlock.Text = vm.ModName)
                 .Subscribe()
                 .DisposeWith(disposables);
 

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Left/ModContent/ModContentView.axaml
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Left/ModContent/ModContentView.axaml
@@ -12,12 +12,13 @@
         <modContent:ModContentDesignViewModel />
     </Design.DataContext>
 
+    
     <UserControl.Styles>
         <Style Selector="Border.HeaderAreaBorder">
             <Setter Property="BorderThickness" Value="0, 0, 0, 1" />
             <Setter Property="Margin" Value="0, 0, 0, 16" />
         </Style>
-
+    
         <Style Selector="TextBlock.ContentSubHeading">
             <Setter Property="Margin" Value="0, 4, 0, 16" />
         </Style>
@@ -27,11 +28,12 @@
         <!-- "Mod Content" Header and "Description" -->
         <Border Grid.Row="0" Classes="HeaderAreaBorder OutlineWeak" x:Name="HeaderAreaBorder">
             <StackPanel Orientation="Vertical">
-                <TextBlock Classes="TitleSMSemi"
+                <TextBlock Theme="{StaticResource TitleSMSemiTheme}"
                            Text="{x:Static resources:Language.ModContentTitle_MOD_CONTENT}"
                            x:Name="ModContentTitle" />
 
-                <TextBlock Classes="BodySMNormal ForegroundSubdued ContentSubHeading"
+                <TextBlock Theme="{StaticResource BodySMNormalTheme}"
+                           Classes="ForegroundSubdued ContentSubHeading"
                            Text="{x:Static resources:Language.ModContentSubHeading_Files_with_no}"
                            x:Name="ModContentSubHeading" />
             </StackPanel>
@@ -39,7 +41,7 @@
 
         <!-- "Mod Content" Tree -->
         <!-- Don't remove the width, it's a hack around https://github.com/AvaloniaUI/Avalonia.Controls.TreeDataGrid/issues/221 -->
-        <TreeDataGrid Grid.Row="1" Classes="TreeWhiteCaret" x:Name="ModContentTreeDataGrid" 
+        <TreeDataGrid Grid.Row="1" Classes="Compact" x:Name="ModContentTreeDataGrid" 
                       ShowColumnHeaders="False" Width="1"/>
     </Grid>
 </reactiveUi:ReactiveUserControl>

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Left/ModContent/TreeEntry/ModContentTreeEntryView.axaml
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Left/ModContent/TreeEntry/ModContentTreeEntryView.axaml
@@ -34,10 +34,11 @@
             <icons:UnifiedIcon Classes="FileTypeIcon" x:Name="EntryIcon" />
 
             <!-- File Name -->
-            <TextBlock Classes="BodyMDNormal" VerticalAlignment="Center"
-                       TextTrimming="CharacterEllipsis"
-                       Text="Example-file.bsa"
-                       x:Name="FileNameTextBlock" />
+            <TextBlock   Theme="{StaticResource BodyMDNormalTheme}"
+                         VerticalAlignment="Center"
+                         TextTrimming="CharacterEllipsis"
+                         Text="Example-file.bsa"
+                         x:Name="FileNameTextBlock" />
         </StackPanel>
 
         <!-- Right Elements -->

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Left/ModContent/TreeEntry/ModContentTreeEntryView.axaml
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Left/ModContent/TreeEntry/ModContentTreeEntryView.axaml
@@ -45,14 +45,14 @@
                     x:Name="EntryRightElementsStackPanel">
 
             <!-- Install Button (Install / Install all / Install folder) -->
-            <Button Classes="Rounded Primary RightElements" HorizontalAlignment="Right" IsVisible="False"
-                    x:Name="InstallRoundedButton">
+            <Button Classes="Standard Tertiary Weak RightElements" HorizontalAlignment="Right" IsVisible="False"
+                    x:Name="InstallRoundedButton" Height="24">
                 <TextBlock Text="Install temp text" x:Name="InstallRoundedButtonTextBlock" />
             </Button>
 
             <!-- X Select location ['Selecting' State] -->
-            <Button Classes="Rounded Primary Active RightElements" HorizontalAlignment="Right" IsVisible="False"
-                    x:Name="SelectLocationRoundedButton">
+            <Button Classes="Standard Secondary RightElements" HorizontalAlignment="Right" IsVisible="False"
+                    x:Name="SelectLocationRoundedButton" Height="24">
                 <StackPanel Orientation="Horizontal">
                     <icons:UnifiedIcon Classes="Close" x:Name="SelectLocationCloseIcon" />
                     <TextBlock Text="{x:Static resources:Language.SelectLocationButton_Select_location}"
@@ -61,8 +61,8 @@
             </Button>
 
             <!-- Remove from Location Button ['IncludedExplicit' State] -->
-            <Button Classes="Rounded Accent RightElements" HorizontalAlignment="Right" IsVisible="False"
-                    x:Name="RemoveFromLocationButton">
+            <Button Classes="Standard Secondary RightElements" HorizontalAlignment="Right" IsVisible="False"
+                    x:Name="RemoveFromLocationButton" Height="24">
                 <StackPanel Orientation="Horizontal">
                     <icons:UnifiedIcon Classes="Close" x:Name="RemoveFromLocationCloseIcon" />
                     <TextBlock Text="temp Loc" x:Name="RemoveFromLocationButtonTextBlock" />
@@ -70,8 +70,8 @@
             </Button>
 
             <!-- Include Transition Button (Include / Include folder / Include with folder) [`Selecting`,`SelectingViaParent`]-->
-            <Button Classes="Rounded Primary SemiActive RightElements" HorizontalAlignment="Right" IsVisible="False"
-                    x:Name="IncludeTransitionButton">
+            <Button Classes="Standard Tertiary Weak SemiActive RightElements" HorizontalAlignment="Right" IsVisible="False"
+                    x:Name="IncludeTransitionButton" Height="24">
                 <StackPanel Orientation="Horizontal">
                     <icons:UnifiedIcon Classes="Close" x:Name="IncludeTransitionCloseIcon" />
                     <TextBlock Text="Include temp text" x:Name="IncludeTransitionButtonTextBlock" />
@@ -79,8 +79,8 @@
             </Button>
 
             <!-- Included Remove Button (Included / Included folder / Included with folder) -->
-            <Button Classes="Rounded Accent SemiActive RightElements" HorizontalAlignment="Right" IsVisible="False"
-                    x:Name="IncludedRemoveButton">
+            <Button Classes="Standard Tertiary Weak SemiActive RightElements" HorizontalAlignment="Right" IsVisible="False"
+                    x:Name="IncludedRemoveButton" Height="24">
                 <StackPanel Orientation="Horizontal">
                     <icons:UnifiedIcon Classes="Close" x:Name="IncludedRemoveButtonCloseIcon" />
                     <TextBlock Text="Included temp text" x:Name="IncludedRemoveButtonTextBlock" />

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/EmptyPreview/EmptyPreviewView.axaml
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/EmptyPreview/EmptyPreviewView.axaml
@@ -22,9 +22,10 @@
         </Border.Styles>
 
         <ScrollViewer>
-            <TextBlock Classes="BodyMDNormal ForegroundSubdued"
-                       Text="{x:Static resources:Language.EmptyPreviewText_Select_files_to_install}"
-                       x:Name="EmptyPreviewTextBlock" />
+            <TextBlock Theme="{StaticResource BodyMDNormalTheme}"
+                Classes="ForegroundSubdued"
+                Text="{x:Static resources:Language.EmptyPreviewText_Select_files_to_install}"
+                x:Name="EmptyPreviewTextBlock" />
         </ScrollViewer>
     </Border>
 

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/EmptyPreview/EmptyPreviewView.axaml
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/EmptyPreview/EmptyPreviewView.axaml
@@ -12,7 +12,8 @@
         <emptyPreview:EmptyPreviewViewModel />
     </Design.DataContext>
 
-    <Border Classes="Rounded-lg OutlineModerate">
+    <Border Classes="Rounded-lg OutlineModerate" BorderThickness="2">
+        
         <Border.Styles>
             <Style Selector="TextBlock#EmptyPreviewTextBlock">
                 <Setter Property="VerticalAlignment" Value="Center" />

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/Preview/PreviewView.axaml
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/Preview/PreviewView.axaml
@@ -18,7 +18,7 @@
                 <Setter Property="BorderThickness" Value="0, 0, 0, 1" />
                 <Setter Property="Margin" Value="0, 0, 0, 16" />
             </Style>
-
+        
             <Style Selector="TextBlock#InstallLocationPreviewSubHeading">
                 <Setter Property="Margin" Value="0, 4, 0, 16" />
             </Style>
@@ -27,17 +27,18 @@
         <Grid RowDefinitions="Auto *">
             <Border Grid.Row="0" Classes="OutlineWeak HeaderAreaBorder" x:Name="HeaderAreaBorder">
                 <StackPanel Orientation="Vertical">
-                    <TextBlock Classes="TitleSMSemi"
+                    <TextBlock Theme="{StaticResource TitleSMSemiTheme}"
                                Text="{x:Static resources:Language.PreviewHeader_INSTALL_LOCATION_PREVIEW}" />
 
-                    <TextBlock Classes="BodySMNormal ForegroundSubdued SubHeading"
+                    <TextBlock Theme="{StaticResource BodySMNormalTheme}"
+                               Classes="ForegroundSubdued SubHeading"
                                Text="{x:Static resources:Language.PreviewSubHeading_Files_labelled_as_new}"
                                x:Name="InstallLocationPreviewSubHeading" />
                 </StackPanel>
             </Border>
 
             <!-- Don't remove this width, it's a hack around https://github.com/AvaloniaUI/Avalonia.Controls.TreeDataGrid/issues/221 -->
-            <TreeDataGrid Grid.Row="1" Classes="TreeWhiteCaret" x:Name="LocationPreviewTreeDataGrid" 
+            <TreeDataGrid Grid.Row="1" Classes="Compact" x:Name="LocationPreviewTreeDataGrid" 
                           ShowColumnHeaders="False" Width="1" />
         </Grid>
     </Border>

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/Preview/PreviewView.axaml
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/Preview/PreviewView.axaml
@@ -12,11 +12,11 @@
         <preview:PreviewViewModel />
     </Design.DataContext>
 
-    <Border Classes="Rounded-lg Mid" Padding="16">
+    <Border Classes="Rounded-lg Mid" Padding="16" BorderThickness="2">
         <Border.Styles>
             <Style Selector="Border.HeaderAreaBorder">
-                <Setter Property="BorderThickness" Value="0, 0, 0, 1" />
                 <Setter Property="Margin" Value="0, 0, 0, 16" />
+                <Setter Property="BorderThickness" Value="0, 0, 0, 1" />
             </Style>
         
             <Style Selector="TextBlock#InstallLocationPreviewSubHeading">

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/Preview/TreeEntry/PreviewTreeEntryView.axaml
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/Preview/TreeEntry/PreviewTreeEntryView.axaml
@@ -24,7 +24,7 @@
             </Style>
 
             <Style Selector="Button.RightElements">
-                <Setter Property="Margin" Value="0,0,8,0" />
+                <Setter Property="Margin" Value="0" />
             </Style>
 
             <Style Selector="Button.PillElement">
@@ -43,23 +43,24 @@
             <icons:UnifiedIcon Classes="FileTypeIcon" x:Name="EntryIcon" />
 
             <!-- File Name -->
-            <TextBlock Classes="BodyMDNormal" VerticalAlignment="Center"
-                       TextTrimming="CharacterEllipsis"
-                       Text="Example-file.bsa"
-                       x:Name="FileNameTextBlock" />
+            <TextBlock  Theme="{StaticResource BodyMDNormalTheme}"
+                        VerticalAlignment="Center"
+                        TextTrimming="CharacterEllipsis"
+                        Text="Example-file.bsa"
+                        x:Name="FileNameTextBlock" />
 
             <!-- Pills -->
             <StackPanel Orientation="Horizontal" Classes="Spacing-2">
 
                 <!-- NEW Pill Label -->
-                <Button Classes="Pill Accent Label Hug PillElement" IsVisible="False" x:Name="NewPill">
+                <Button Classes="Pill Accent Label Hug PillElement" IsVisible="False" x:Name="NewPill" Height="18">
                     <StackPanel>
                         <TextBlock Text="{x:Static resources:Language.NewFilePill_NEW}" />
                     </StackPanel>
                 </Button>
 
                 <!-- Dupe Folder Pill Label -->
-                <Button Classes="Pill Light Label Hug PillElement" IsVisible="False" x:Name="DupeFolderPill">
+                <Button Classes="Pill Light Label Hug PillElement" IsVisible="False" x:Name="DupeFolderPill" Height="18">
                     <StackPanel>
                         <icons:UnifiedIcon Classes="Alert" />
                         <TextBlock Text="{x:Static resources:Language.Pill_DUPE_FOLDER}" />
@@ -67,7 +68,7 @@
                 </Button>
 
                 <!-- Folder Merged Pill Label -->
-                <Button Classes="Pill Light Label Hug PillElement" IsVisible="False" x:Name="FolderMergedPill">
+                <Button Classes="Pill Light Label Hug PillElement" IsVisible="False" x:Name="FolderMergedPill" Height="18">
                     <StackPanel>
                         <icons:UnifiedIcon Classes="Check" />
                         <TextBlock Text="{x:Static resources:Language.Pill_FOLDER_MERGED}" />
@@ -80,8 +81,8 @@
 
         <!-- Right Elements // Add StackPanel here if adding additional ones -->
         <!-- X Button -->
-        <Button Grid.Column="1" Classes="Rounded Primary RightElements" HorizontalAlignment="Right"
-                x:Name="XRoundedButton">
+        <Button Grid.Column="1" Classes="Standard Tertiary Weak RightElements" HorizontalAlignment="Right"
+                x:Name="XRoundedButton" Height="24" Width="24">
             <icons:UnifiedIcon Classes="Close" x:Name="StandaloneCloseIcon" />
         </Button>
     </Grid>

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/Preview/TreeEntry/PreviewTreeEntryView.axaml.cs
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/Preview/TreeEntry/PreviewTreeEntryView.axaml.cs
@@ -47,9 +47,6 @@ public partial class PreviewTreeEntryView : ReactiveUserControl<IPreviewTreeEntr
         {
             EntryIcon.Classes.Add("FolderOutline");
 
-            // Make directory name bold.
-            FileNameTextBlock.Classes.Remove("BodyMDNormal");
-            FileNameTextBlock.Classes.Add("BodyMDBold");
         }
         else
         {

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/SelectLocation/SelectLocationView.axaml
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/SelectLocation/SelectLocationView.axaml
@@ -89,7 +89,6 @@
                         <StackPanel Classes="SuggestedHeaderStackPanel" Orientation="Vertical">
                             <!-- Header: 'ALL FOLDERS' -->
                             <TextBlock Theme="{StaticResource TitleXSSemiTheme}"
-                                       Classes="TitleXSSemi"
                                        Text="{x:Static resources:Language.AllFoldersAreaHeaderText_ALL_FOLDERS}" />
                             <!-- Description: 'Select from full folder structure' -->
                             <TextBlock Theme="{StaticResource BodySMNormalTheme}"

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/SelectLocation/SelectLocationView.axaml
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/SelectLocation/SelectLocationView.axaml
@@ -12,45 +12,46 @@
         <selectLocation:SelectLocationDesignViewModel />
     </Design.DataContext>
 
-    <Border Classes="Rounded-lg Mid OutlineStrong" Padding="16">
+    <Border Classes="Rounded-lg Mid OutlineModerate" Padding="16" BorderThickness="2">
         <Border.Styles>
             <Style Selector="Border#HeaderAreaBorder">
                 <Setter Property="Margin" Value="0, 0, 0, 16" />
             </Style>
-
+        
             <Style Selector="TextBlock#SelectLocationSubHeading">
                 <Setter Property="Margin" Value="0, 4, 0, 16" />
             </Style>
-
+        
             <Style Selector="TextBlock#AllFoldersAreaSubHeaderText">
                 <Setter Property="Margin" Value="0, 0, 0, 8" />
             </Style>
-
+        
             <Style Selector="StackPanel.SuggestedHeaderStackPanel">
                 <Setter Property="Margin" Value="0, 0, 0, 8" />
             </Style>
-
+        
             <Style Selector="Border.SuggestedAreaBorder">
                 <Setter Property="Margin" Value="0, 0, 0, 16" />
             </Style>
-
+        
             <Style Selector="Border.Padding16">
                 <Setter Property="Padding" Value="16" />
             </Style>
         </Border.Styles>
 
         <ScrollViewer>
-            <StackPanel Orientation="Vertical">
+            <StackPanel Orientation="Vertical" Margin="0,0,16,0">
 
                 <!-- 'Select Install Location' -->
                 <Border x:Name="HeaderAreaBorder" Classes="OutlineWeak" BorderThickness="0, 0, 0, 1">
                     <StackPanel Orientation="Vertical">
                         <!-- 'Select Install Location' -->
-                        <TextBlock Classes="TitleSMSemi"
+                        <TextBlock Theme="{StaticResource TitleSMSemiTheme}"
                                    Text="{x:Static resources:Language.SelectLocationHeaderText_SELECT_INSTALL_LOCATION}" />
 
                         <!-- 'Select where to install the mod file/folder' -->
-                        <TextBlock Classes="BodySMNormal ForegroundSubdued"
+                        <TextBlock Theme="{StaticResource BodySMNormalTheme}"
+                                   Classes="ForegroundSubdued"
                                    Text="{x:Static resources:Language.SelectLocationSubHeadingText_Select_where_to}"
                                    x:Name="SelectLocationSubHeading" />
                     </StackPanel>
@@ -61,10 +62,11 @@
                     <StackPanel Orientation="Vertical">
                         <StackPanel Classes="SuggestedHeaderStackPanel" Orientation="Vertical">
                             <!-- Header: 'SUGGESTED' -->
-                            <TextBlock Classes="TitleXSSemi"
+                            <TextBlock Theme="{StaticResource TitleXSSemiTheme}"
                                        Text="{x:Static resources:Language.SuggestedHeaderText_SUGGESTED}" />
 
-                            <TextBlock Classes="BodySMNormal ForegroundSubdued"
+                            <TextBlock Theme="{StaticResource BodySMNormalTheme}"
+                                       Classes="ForegroundSubdued"
                                        TextWrapping="Wrap"
                                        Text="TEMP SUBTITLE"
                                        x:Name="SuggestedSubHeaderText" />
@@ -86,14 +88,16 @@
                     <StackPanel Orientation="Vertical">
                         <StackPanel Classes="SuggestedHeaderStackPanel" Orientation="Vertical">
                             <!-- Header: 'ALL FOLDERS' -->
-                            <TextBlock Classes="TitleXSSemi"
+                            <TextBlock Theme="{StaticResource TitleXSSemiTheme}"
+                                       Classes="TitleXSSemi"
                                        Text="{x:Static resources:Language.AllFoldersAreaHeaderText_ALL_FOLDERS}" />
                             <!-- Description: 'Select from full folder structure' -->
-                            <TextBlock Classes="BodySMNormal ForegroundSubdued"
+                            <TextBlock Theme="{StaticResource BodySMNormalTheme}"
+                                       Classes="ForegroundSubdued"
                                        Text="{x:Static resources:Language.AllFoldersAreaSubHeaderText_Select_from_full}" />
                         </StackPanel>
 
-                        <TreeDataGrid Classes="TreeWhiteCaret"
+                        <TreeDataGrid Classes="Compact"
                                       ShowColumnHeaders="False"
                                       x:Name="SelectTreeDataGrid" />
                     </StackPanel>

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/SelectLocation/SuggestedEntry/SuggestedEntryView.axaml
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/SelectLocation/SuggestedEntry/SuggestedEntryView.axaml
@@ -49,7 +49,7 @@
         </StackPanel>
 
         <!-- Select Button -->
-        <Button Grid.Column="2" Classes="Rounded Primary RightElements" HorizontalAlignment="Right"
+        <Button Grid.Column="2" Classes="Standard Tertiary Weak RightElements" HorizontalAlignment="Right"
                 x:Name="SelectRoundedButton">
             <StackPanel Orientation="Horizontal">
                 <TextBlock Text="{x:Static resources:Language.SelectButton_Select}" />

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/SelectLocation/TreeEntry/SelectableTreeEntryView.axaml
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/SelectLocation/TreeEntry/SelectableTreeEntryView.axaml
@@ -31,6 +31,12 @@
             <Style Selector="TextBlock#FileNameTextBlock">
                 <Setter Property="Margin" Value="0,4,8,0" />
             </Style>
+            
+            <Style Selector="TextBox#CreateFolderNameTextBox">
+                <Setter Property="Margin" Value="0" />
+                <Setter Property="Padding" Value="4,2" />
+            </Style>
+            
         </Grid.Styles>
 
         <!-- Left Elements -->
@@ -59,12 +65,12 @@
                            x:Name="FileNameTextBlock" />
 
                 <!-- Create Folder Name Input Field -->
-                <TextBox Theme="{StaticResource BodyMDNormalTheme}"
+                <TextBox 
                          VerticalAlignment="Center"
                          Text="" 
                          IsVisible="False"
                          x:Name="CreateFolderNameTextBox"
-                         Height="24"/>
+                         MinHeight="24"/>
             </StackPanel>
         </Grid>
 

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/SelectLocation/TreeEntry/SelectableTreeEntryView.axaml
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/SelectLocation/TreeEntry/SelectableTreeEntryView.axaml
@@ -37,7 +37,7 @@
         <Grid Grid.Column="0" ColumnDefinitions="*">
 
             <!-- Create Folder Button -->
-            <Button Classes="Rounded Primary" HorizontalAlignment="Left" IsVisible="False" x:Name="CreateFolderButton">
+            <Button Classes="Standard Tertiary Weak" HorizontalAlignment="Left" IsVisible="False" x:Name="CreateFolderButton" Height="24">
                 <StackPanel Orientation="Horizontal">
                     <icons:UnifiedIcon Classes="Plus" x:Name="CreateFolderPlusIcon" />
                     <TextBlock Text="{x:Static resources:Language.CreateFolderButton_Create_new_folder}" />
@@ -51,17 +51,20 @@
                 <icons:UnifiedIcon Classes="FolderOutline FileTypeIcon" IsVisible="False" x:Name="FolderEntryIcon" />
 
                 <!-- File Name -->
-                <TextBlock Classes="BodyMDNormal"
+                <TextBlock Theme="{StaticResource BodyMDNormalTheme}"
                            VerticalAlignment="Center"
                            TextTrimming="CharacterEllipsis"
-                           Text="Example-file.bsa" IsVisible="False"
+                           Text="Example-file.bsa" 
+                           IsVisible="False"
                            x:Name="FileNameTextBlock" />
 
                 <!-- Create Folder Name Input Field -->
-                <TextBox Classes="BodyMDNormal"
+                <TextBox Theme="{StaticResource BodyMDNormalTheme}"
                          VerticalAlignment="Center"
-                         Text="" IsVisible="False"
-                         x:Name="CreateFolderNameTextBox" />
+                         Text="" 
+                         IsVisible="False"
+                         x:Name="CreateFolderNameTextBox"
+                         Height="24"/>
             </StackPanel>
         </Grid>
 
@@ -69,8 +72,8 @@
         <StackPanel Grid.Column="1" HorizontalAlignment="Right" Orientation="Horizontal">
 
             <!-- Delete Created Folder Button -->
-            <Button Classes="Rounded Primary RightElements" HorizontalAlignment="Right" IsVisible="False"
-                    x:Name="DeleteCreatedFolderButton">
+            <Button Classes="Standard Tertiary Weak RightElements" HorizontalAlignment="Right" IsVisible="False"
+                    x:Name="DeleteCreatedFolderButton" Height="24">
                 <StackPanel Orientation="Horizontal">
                     <icons:UnifiedIcon Classes="DeleteOutline" x:Name="DeleteCreatedFolderDeleteIcon" />
                     <TextBlock Text="{x:Static resources:Language.DeleteCreatedFolderButton_Delete}" />
@@ -78,24 +81,24 @@
             </Button>
 
             <!-- Select Button -->
-            <Button Classes="Rounded Primary RightElements" HorizontalAlignment="Right" IsVisible="False"
-                    x:Name="SelectRoundedButton">
+            <Button Classes="Standard Secondary RightElements" HorizontalAlignment="Right" IsVisible="False"
+                    x:Name="SelectRoundedButton" Height="24">
                 <StackPanel Orientation="Horizontal">
                     <TextBlock Text="{x:Static resources:Language.SelectButton_Select}" />
                 </StackPanel>
             </Button>
 
             <!-- Cancel Create Folder Button -->
-            <Button Classes="Rounded Primary RightElements" HorizontalAlignment="Right" IsVisible="False"
-                    x:Name="CancelCreateFolderButton">
+            <Button Classes="Standard Tertiary Weak RightElements" HorizontalAlignment="Right" IsVisible="False"
+                    x:Name="CancelCreateFolderButton" Height="24">
                 <StackPanel Orientation="Horizontal">
                     <TextBlock Text="{x:Static resources:Language.CancelCreateFolderButton_Cancel}" />
                 </StackPanel>
             </Button>
 
             <!-- Save Created Folder Button -->
-            <Button Classes="Rounded Primary RightElements" HorizontalAlignment="Right" IsVisible="False"
-                    x:Name="SaveCreatedFolderButton">
+            <Button Classes="Standard Tertiary Weak RightElements" HorizontalAlignment="Right" IsVisible="False"
+                    x:Name="SaveCreatedFolderButton" Height="24">
                 <StackPanel Orientation="Horizontal">
                     <TextBlock Text="{x:Static resources:Language.SaveCreatedFolderButton_Save}" />
                 </StackPanel>

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Pages/AdvancedInstallerPages/AdvancedInstallerPageView.axaml
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Pages/AdvancedInstallerPages/AdvancedInstallerPageView.axaml
@@ -9,9 +9,6 @@
                                 xmlns:resources="clr-namespace:NexusMods.Games.AdvancedInstaller.UI.Resources"
                                 mc:Ignorable="d" d:DesignWidth="1232" d:DesignHeight="672"
                                 x:Class="NexusMods.Games.AdvancedInstaller.UI.AdvancedInstallerPageView">
-    <Design.DataContext>
-        <ui:AdvancedInstallerPageDesignViewModel />
-    </Design.DataContext>
 
     <Grid RowDefinitions="*, Auto">
         <Grid.Styles>

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Pages/AdvancedInstallerPages/AdvancedInstallerPageView.axaml
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Pages/AdvancedInstallerPages/AdvancedInstallerPageView.axaml
@@ -9,7 +9,10 @@
                                 xmlns:resources="clr-namespace:NexusMods.Games.AdvancedInstaller.UI.Resources"
                                 mc:Ignorable="d" d:DesignWidth="1232" d:DesignHeight="672"
                                 x:Class="NexusMods.Games.AdvancedInstaller.UI.AdvancedInstallerPageView">
-
+    <Design.DataContext>
+        <ui:AdvancedInstallerPageDesignViewModel />
+    </Design.DataContext>
+    
     <Grid RowDefinitions="*, Auto">
         <Grid.Styles>
 

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Pages/ModUnsupportedPage/UnsupportedModPageView.axaml
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Pages/ModUnsupportedPage/UnsupportedModPageView.axaml
@@ -72,12 +72,13 @@
                     <Border Grid.Row="1">
                         <StackPanel Orientation="Vertical">
 
-                            <TextBlock Classes="TitleMDSemi ModNameTitle" Text="TEMP MOD NAME"
+                            <TextBlock Classes="HeadingMDSemi ModNameTitle" Text="TEMP MOD NAME"
                                        x:Name="ModNameTextBlock" />
 
                             <TextBlock Classes="HeadingMDSemi MessageTitle"
                                        Text="{x:Static resources:Language.UnsupportedTitleTextBlock_This_mod_is_not_supported}"
-                                       x:Name="UnsupportedTitleTextBlock" />
+                                       x:Name="UnsupportedTitleTextBlock" 
+                                       IsVisible="False"/>
 
                             <TextBlock Classes="BodyLGNormal DescriptionText" TextWrapping="Wrap"
                                        Text="{x:Static resources:Language.UnsupportedDescriptionTextBlock_This_mod_is_structured}"

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Pages/ModUnsupportedPage/UnsupportedModPageView.axaml
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Pages/ModUnsupportedPage/UnsupportedModPageView.axaml
@@ -64,7 +64,7 @@
 
                             <icons:UnifiedIcon Grid.Column="0" Classes="AlertOutline" x:Name="WarningIcon" />
 
-                            <TextBlock Grid.Column="1" Classes="BodyLGBold"
+                            <TextBlock Grid.Column="1" Theme="{StaticResource BodyLGBoldTheme}"
                                        Text="{x:Static resources:Language.UnsupportedModHeader_Unsupported_mod}"
                                        x:Name="OverlayHeaderTextBlock" />
                         </Grid>
@@ -72,19 +72,23 @@
                     <Border Grid.Row="1">
                         <StackPanel Orientation="Vertical">
 
-                            <TextBlock Classes="HeadingMDSemi ModNameTitle" Text="TEMP MOD NAME"
+                            <TextBlock Theme="{StaticResource HeadingMDSemiTheme}"
+                                       Classes="ModNameTitle" Text="TEMP MOD NAME"
                                        x:Name="ModNameTextBlock" />
 
-                            <TextBlock Classes="HeadingMDSemi MessageTitle"
+                            <TextBlock Theme="{StaticResource HeadingMDSemiTheme}"
+                                       Classes="MessageTitle"
                                        Text="{x:Static resources:Language.UnsupportedTitleTextBlock_This_mod_is_not_supported}"
                                        x:Name="UnsupportedTitleTextBlock" 
                                        IsVisible="False"/>
 
-                            <TextBlock Classes="BodyLGNormal DescriptionText" TextWrapping="Wrap"
+                            <TextBlock Theme="{StaticResource BodyLGNormalTheme}"
+                                       Classes="DescriptionText" TextWrapping="Wrap"
                                        Text="{x:Static resources:Language.UnsupportedDescriptionTextBlock_This_mod_is_structured}"
                                        x:Name="UnsupportedDescriptionTextBlock" />
 
-                            <TextBlock Classes="BodyLGNormal DescriptionText" TextWrapping="Wrap"
+                            <TextBlock Theme="{StaticResource BodyLGNormalTheme}"
+                                       Classes="DescriptionText" TextWrapping="Wrap"
                                        Text="{x:Static resources:Language.ExtraDescriptionTextBlock_If_you_are_confident}"
                                        x:Name="ExtraDescriptionTextBlock" />
                         </StackPanel>

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Pages/ModUnsupportedPage/UnsupportedModPageView.axaml.cs
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Pages/ModUnsupportedPage/UnsupportedModPageView.axaml.cs
@@ -15,7 +15,7 @@ public partial class UnsupportedModPageView : ReactiveUserControl<IUnsupportedMo
         {
             this.WhenAnyValue(view => view.ViewModel)
                 .WhereNotNull()
-                .Do(vm => ModNameTextBlock.Text = vm.ModName.ToUpper())
+                .Do(vm => ModNameTextBlock.Text = vm.ModName)
                 .Subscribe()
                 .DisposeWith(d);
 

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Resources/Language.Designer.cs
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Resources/Language.Designer.cs
@@ -69,7 +69,7 @@ namespace NexusMods.Games.AdvancedInstaller.UI.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to All folders.
+        ///   Looks up a localized string similar to ALL FOLDERS.
         /// </summary>
         public static string AllFoldersAreaHeaderText_ALL_FOLDERS {
             get {
@@ -186,7 +186,7 @@ namespace NexusMods.Games.AdvancedInstaller.UI.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to New.
+        ///   Looks up a localized string similar to NEW.
         /// </summary>
         public static string NewFilePill_NEW {
             get {
@@ -204,7 +204,7 @@ namespace NexusMods.Games.AdvancedInstaller.UI.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Dupe folder.
+        ///   Looks up a localized string similar to DUPE FOLDER.
         /// </summary>
         public static string Pill_DUPE_FOLDER {
             get {
@@ -213,7 +213,7 @@ namespace NexusMods.Games.AdvancedInstaller.UI.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Folder merged.
+        ///   Looks up a localized string similar to FOLDER MERGED.
         /// </summary>
         public static string Pill_FOLDER_MERGED {
             get {
@@ -222,7 +222,7 @@ namespace NexusMods.Games.AdvancedInstaller.UI.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Install location preview.
+        ///   Looks up a localized string similar to INSTALL LOCATION PREVIEW.
         /// </summary>
         public static string PreviewHeader_INSTALL_LOCATION_PREVIEW {
             get {
@@ -267,7 +267,7 @@ namespace NexusMods.Games.AdvancedInstaller.UI.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Select install location.
+        ///   Looks up a localized string similar to SELECT INSTALL LOCATION.
         /// </summary>
         public static string SelectLocationHeaderText_SELECT_INSTALL_LOCATION {
             get {
@@ -303,7 +303,7 @@ namespace NexusMods.Games.AdvancedInstaller.UI.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Suggested.
+        ///   Looks up a localized string similar to SUGGESTED.
         /// </summary>
         public static string SuggestedHeaderText_SUGGESTED {
             get {

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Resources/Language.resx
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Resources/Language.resx
@@ -43,13 +43,13 @@
         <value>Create new folder</value>
     </data>
     <data name="NewFilePill_NEW" xml:space="preserve">
-        <value>New</value>
+        <value>NEW</value>
     </data>
     <data name="Pill_DUPE_FOLDER" xml:space="preserve">
-        <value>Dupe folder</value>
+        <value>DUPE FOLDER</value>
     </data>
     <data name="Pill_FOLDER_MERGED" xml:space="preserve">
-        <value>Folder merged</value>
+        <value>FOLDER MERGED</value>
     </data>
     <data name="SelectLocationButton_Select_location" xml:space="preserve">
         <value>Select location</value>
@@ -70,16 +70,16 @@
         <value>Select which files to install from the mod archive on the left.</value>
     </data>
     <data name="SelectLocationHeaderText_SELECT_INSTALL_LOCATION" xml:space="preserve">
-        <value>Select install location</value>
+        <value>SELECT INSTALL LOCATION</value>
     </data>
     <data name="SelectLocationSubHeadingText_Select_where_to" xml:space="preserve">
         <value>Select where to install the mod file/folder.</value>
     </data>
     <data name="SuggestedHeaderText_SUGGESTED" xml:space="preserve">
-        <value>Suggested</value>
+        <value>SUGGESTED</value>
     </data>
     <data name="AllFoldersAreaHeaderText_ALL_FOLDERS" xml:space="preserve">
-        <value>All folders</value>
+        <value>ALL FOLDERS</value>
     </data>
     <data name="AllFoldersAreaSubHeaderText_Select_from_full" xml:space="preserve">
         <value>Select from the full folder structure</value>

--- a/src/NexusMods.App.UI/Controls/Trees/DiffTreeViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/Trees/DiffTreeViewModel.cs
@@ -207,9 +207,9 @@ public class DiffTreeViewModel : AViewModel<IFileTreeViewModel>, IFileTreeViewMo
             Columns =
             {
                 FileTreeNodeViewModel.CreateTreeSourceNameColumn(),
+                FileTreeNodeViewModel.CreateTreeSourceStateColumn(),
                 FileTreeNodeViewModel.CreateTreeSourceSizeColumn(),
                 FileTreeNodeViewModel.CreateTreeSourceFileCountColumn(),
-                FileTreeNodeViewModel.CreateTreeSourceStateColumn(),
             },
         };
     }

--- a/src/NexusMods.App.UI/Controls/Trees/FileTreeView.axaml
+++ b/src/NexusMods.App.UI/Controls/Trees/FileTreeView.axaml
@@ -14,18 +14,20 @@
     </Design.DataContext>
 
     <UserControl.Styles>
-        <!-- Note: Can't use nth-child on textblock itself. Not even actual control source does that. -->
-        <Style Selector="TreeDataGridColumnHeader:nth-child(1)">
+        <Style Selector="Border#StatusBarBorder">
+            <Setter Property="Background" Value="{StaticResource BrandTranslucentLight50}"></Setter>
+            
             <Style Selector="^ TextBlock">
-                <Setter Property="Margin" Value="24,0,0,0" />
+                <Setter Property="Theme" Value="{StaticResource BodyMDNormalTheme}" />
+                <Setter Property="Foreground" Value="{StaticResource NeutralSubduedBrush}" />
             </Style>
         </Style>
     </UserControl.Styles>
 
     <!-- Visual Tree -->
-    <Grid HorizontalAlignment="Stretch">
-
-        <TreeDataGrid Classes="TreeWhiteCaret"
+    <Grid HorizontalAlignment="Stretch" RowDefinitions="*, Auto">
+        
+        <TreeDataGrid Classes="Compact"
                       ShowColumnHeaders="True"
                       x:Name="ModFilesTreeDataGrid"
                       HorizontalAlignment="Stretch"
@@ -47,13 +49,14 @@
             </TreeDataGrid.Resources>
         </TreeDataGrid>
 
-        <Border Classes="Mid Rounded-b-lg"
+        <Border Classes="Rounded-b-lg"
                 VerticalAlignment="Bottom"
-                Padding="24, 8, 24, 8"
+                Padding="24, 0, 24, 0"
                 x:Name="StatusBarBorder"
-                Height="36">
+                Height="52"
+                Grid.Row="1">
             <ItemsControl x:Name="StatusBarItemsControl"
-                          VerticalAlignment="Center">
+                          VerticalAlignment="Stretch">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>
                         <StackPanel Orientation="Horizontal" />
@@ -63,13 +66,12 @@
                 <ItemsControl.ItemTemplate>
                     <DataTemplate DataType="system:String">
                         <StackPanel Orientation="Horizontal">
-                            <TextBlock Classes="BodyMDNormal ForegroundTranslucentSubdued" 
-                                       Text="{CompiledBinding}"
+                            <TextBlock Text="{CompiledBinding}"
                                        VerticalAlignment="Center"/>
                             <Border Classes="OutlineWeak" 
                                     BorderThickness="1,0,0,0" 
                                     Width="1"
-                                    Margin="8,0"/>
+                                    Margin="12,8"/>
                         </StackPanel>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>

--- a/src/NexusMods.App.UI/Controls/Trees/FileTreeView.axaml
+++ b/src/NexusMods.App.UI/Controls/Trees/FileTreeView.axaml
@@ -15,7 +15,7 @@
 
     <UserControl.Styles>
         <Style Selector="Border#StatusBarBorder">
-            <Setter Property="Background" Value="{StaticResource BrandTranslucentLight50}"></Setter>
+            <Setter Property="Background" Value="{StaticResource BrandTranslucentLight50}"/>
             
             <Style Selector="^ TextBlock">
                 <Setter Property="Theme" Value="{StaticResource BodyMDNormalTheme}" />
@@ -40,7 +40,13 @@
                     <files:FileTreeNodeView DataContext="{CompiledBinding}" />
                 </DataTemplate>
                 <DataTemplate x:Key="FileStateColumnTemplate" DataType="{x:Type files:IFileTreeNodeViewModel}">
-                    <TextBlock Text="{CompiledBinding FormattedChangeState}" VerticalAlignment="Center" >
+                    
+                    <TextBlock x:Name="ModFilesStateTextBlock" 
+                               Text="{CompiledBinding FormattedChangeState}"
+                               VerticalAlignment="Center" 
+                               Classes.ForegroundSuccessStrong="{CompiledBinding IsChangeAdded}"
+                               Classes.ForegroundInfoStrong="{CompiledBinding IsChangeModified}"
+                               Classes.ForegroundDangerStrong="{CompiledBinding IsChangeRemoved}">
                         <ToolTip.Tip>
                             <TextBlock Text="{CompiledBinding FormattedChangeStateToolTip}" />
                         </ToolTip.Tip>

--- a/src/NexusMods.App.UI/Controls/Trees/FileTreeView.axaml
+++ b/src/NexusMods.App.UI/Controls/Trees/FileTreeView.axaml
@@ -59,7 +59,7 @@
                 VerticalAlignment="Bottom"
                 Padding="24, 0, 24, 0"
                 x:Name="StatusBarBorder"
-                Height="52"
+                Height="32"
                 Grid.Row="1">
             <ItemsControl x:Name="StatusBarItemsControl"
                           VerticalAlignment="Stretch">

--- a/src/NexusMods.App.UI/Controls/Trees/Files/FileTreeNodeView.axaml
+++ b/src/NexusMods.App.UI/Controls/Trees/Files/FileTreeNodeView.axaml
@@ -10,34 +10,31 @@
                                 mc:Ignorable="d" d:DesignWidth="710" d:DesignHeight="44"
                                 x:Class="NexusMods.App.UI.Controls.Trees.Files.FileTreeNodeView"
                                 d:DataContext="{x:Static files:FileTreeNodeDesignViewModel.SampleFolder}">
+
     <!-- You can switch 'SampleFolder' to 'SampleFile' to get preview of file -->
     <Grid ColumnDefinitions="*, Auto" Margin="0,5,0,5">
         <Grid.Styles>
-            <Style Selector="icons|UnifiedIcon.FileTypeIcon">
-                <Setter Property="Margin" Value="8, 0, 0, 0" />
-            </Style>
-
-            <Style Selector="icons|UnifiedIcon.View">
+            <Style Selector="icons|UnifiedIcon#EntryIcon">
+                <Setter Property="Margin" Value="0" />
                 <Setter Property="Size" Value="20" />
             </Style>
-
             <Style Selector="Button.RightElements">
                 <Setter Property="Margin" Value="0,0,8,0" />
             </Style>
-
             <Style Selector="TextBlock#FileNameTextBlock">
                 <Setter Property="Margin" Value="4,0,8,0" />
+                <Setter Property="Foreground" Value="{StaticResource NeutralModerateBrush}" />
             </Style>
         </Grid.Styles>
 
         <!-- Left Elements -->
         <Grid Grid.Column="0" ClipToBounds="True" ColumnDefinitions="Auto,Auto" Name="FileElementGrid">
-            
+
             <!-- File / Directory Icon -->
-            <icons:UnifiedIcon Grid.Column="0" Classes="FileTypeIcon" x:Name="EntryIcon" VerticalAlignment="Center" />
+            <icons:UnifiedIcon Grid.Column="0" Classes="FileTypeIcon" x:Name="EntryIcon" />
 
             <!-- File Name -->
-            <TextBlock Grid.Column="1" Classes="BodyMDNormal" VerticalAlignment="Center"
+            <TextBlock Grid.Column="1" VerticalAlignment="Center"
                        TextTrimming="CharacterEllipsis"
                        x:Name="FileNameTextBlock" />
         </Grid>

--- a/src/NexusMods.App.UI/Controls/Trees/Files/FileTreeNodeViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/Trees/Files/FileTreeNodeViewModel.cs
@@ -205,7 +205,7 @@ public class FileTreeNodeViewModel : AViewModel<IFileTreeNodeViewModel>, IFileTr
         return new TemplateColumn<IFileTreeNodeViewModel>(
             Language.Helpers_GenerateHeader_State,
             "FileStateColumnTemplate",
-            width: new GridLength(125),
+            width: new GridLength(150),
             options: new TemplateColumnOptions<IFileTreeNodeViewModel>
             {
                 // Compares change state first, then by folder/file, then by name.

--- a/src/NexusMods.App.UI/Controls/Trees/Files/IFileTreeNodeViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/Trees/Files/IFileTreeNodeViewModel.cs
@@ -26,6 +26,21 @@ public interface IFileTreeNodeViewModel : IViewModelInterface, IExpandableItem, 
     bool IsDeletion { get; }
 
     /// <summary>
+    ///     Boolean value for FileChangeType.Added. Used for setting style classes.
+    /// </summary>
+    bool IsChangeAdded => ChangeType == FileChangeType.Added;
+    
+    /// <summary>
+    ///     Boolean value for FileChangeType.Modified. Used for setting style classes.
+    /// </summary>
+    bool IsChangeModified => ChangeType == FileChangeType.Modified;
+    
+    /// <summary>
+    ///     Boolean value for FileChangeType.Removed. Used for setting style classes.
+    /// </summary>
+    bool IsChangeRemoved => ChangeType == FileChangeType.Removed;
+
+    /// <summary>
     ///     Name of the file or folder segment.
     /// </summary>
     string Name { get; }

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/TreeDataGridStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/TreeDataGridStyles.axaml
@@ -1,7 +1,8 @@
-<Styles xmlns="https://github.com/avaloniaui"
+﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:converters1="clr-namespace:NexusMods.Themes.NexusFluentDark.Converters"
-        xmlns:icons="clr-namespace:NexusMods.Icons;assembly=NexusMods.Icons">
+        xmlns:icons="clr-namespace:NexusMods.Icons;assembly=NexusMods.Icons"
+        xmlns:files="clr-namespace:NexusMods.App.UI.Controls.Trees.Files;assembly=NexusMods.App.UI">
 
     <Styles.Resources>
         <SolidColorBrush x:Key="TreeDataGridGridLinesBrush" Color="{StaticResource SurfaceTranslucentMid}" Opacity="1" />
@@ -48,7 +49,7 @@
                 <Style Selector="^ /template/ icons|UnifiedIcon#ChevronIcon">
                     <Setter Property="Foreground" Value="{StaticResource NeutralStrongBrush}" />
                 </Style>    
-            </Style>
+            </Style>  
             
         </ControlTheme>
     </Styles.Resources>
@@ -83,12 +84,12 @@
                         <Setter Property="Size" Value="20"></Setter>
                     </Style>
                 </Style>
-        </Style>
+            </Style>
         </Style>
     </Style>
 
     <!-- No backgrounds for the advanced installer TreeDataGrid's -->
-
+    
     <Style Selector="TreeDataGrid#SelectTreeDataGrid, 
         TreeDataGrid#ModContentTreeDataGrid, 
         TreeDataGrid#LocationPreviewTreeDataGrid">
@@ -238,15 +239,20 @@
         <Style Selector="^ :is(TreeDataGridCell):nth-child(1)">
             <Setter Property="Padding" Value="12,0,0,0" />
             
-            <!-- Except for first column -->
             <Style Selector="^ Border#CellBorder > TextBlock">
+                <Setter Property="Foreground" Value="{StaticResource NeutralModerateBrush}" />
+            </Style>
+            
+            <Style Selector="^ files|FileTreeNodeView /template/ ContentPresenter#PART_ContentPresenter">
                 <Setter Property="Foreground" Value="{StaticResource NeutralModerateBrush}" />
             </Style>
         </Style>
 
         <!-- last cell -->
-        <Style Selector="^ :is(TreeDataGridCell):nth-last-child(1)">
+        <Style Selector="^ :is(TreeDataGridCell):nth-last-child(1):not(:nth-child(1))">
+            
             <Setter Property="Padding" Value="8,0,26,0" />
+            
             <Style Selector="^ ContentPresenter#PART_ContentPresenter">
                 <Setter Property="HorizontalContentAlignment" Value="Right" />
                 
@@ -347,7 +353,6 @@
                         <DockPanel>
                             <Border DockPanel.Dock="Left"
                                     Margin="0">
-                                    Width="20" Height="20">
                                 <ToggleButton Theme="{StaticResource TreeDataGridExpandCollapseChevron}"
                                               Focusable="False"
                                               IsChecked="{TemplateBinding IsExpanded, Mode=TwoWay}"
@@ -365,6 +370,12 @@
         <Style Selector="^ Border#CellBorder :is(TreeDataGridCell)">
             <!-- This goes from after the expander to the end of the cell, but parent cell padding is also applied. -->
             <Setter Property="Padding" Value="4,0,0,0" />
+        </Style>
+    </Style>
+    
+    <Style Selector="TreeDataGrid#ModFilesTreeDataGrid">
+        <Style Selector="^ icons|UnifiedIcon">
+            <Setter Property="Foreground" Value="{StaticResource NeutralModerateBrush}"></Setter>
         </Style>
     </Style>
 

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/TreeDataGridStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/TreeDataGridStyles.axaml
@@ -285,9 +285,9 @@
             <Setter Property="ZIndex" Value="100" />
             <Setter Property="Background" Value="{StaticResource SurfaceLowBrush}" />
 
-            <Style Selector="^ Border#RowBorder">
-                <Setter Property="BoxShadow" Value="{StaticResource DropShadowSM}" />
-            </Style>
+            <!-- <Style Selector="^ Border#RowBorder"> -->
+            <!--     <Setter Property="BoxShadow" Value="{StaticResource DropShadowSM}" /> -->
+            <!-- </Style> -->
         </Style>
 
         <!-- Child rows styling -->

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/TreeDataGridStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/TreeDataGridStyles.axaml
@@ -1,4 +1,4 @@
-﻿<Styles xmlns="https://github.com/avaloniaui"
+<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:converters1="clr-namespace:NexusMods.Themes.NexusFluentDark.Converters"
         xmlns:icons="clr-namespace:NexusMods.Icons;assembly=NexusMods.Icons">
@@ -18,8 +18,8 @@
         <!-- if we have this control theme here, we can override styles properly -->
         <ControlTheme x:Key="TreeDataGridExpandCollapseChevron" TargetType="ToggleButton">
             <Setter Property="Margin" Value="0" />
-            <Setter Property="Width" Value="20" />
-            <Setter Property="Height" Value="20" />
+            <Setter Property="Width" Value="24" />
+            <Setter Property="Height" Value="24" />
             <Setter Property="Foreground" Value="{StaticResource NeutralSubduedBrush}" />
             <Setter Property="Template">
                 <ControlTemplate>
@@ -27,7 +27,8 @@
                             Width="{TemplateBinding Width}"
                             Height="{TemplateBinding Height}"
                             HorizontalAlignment="Center"
-                            VerticalAlignment="Center">
+                            VerticalAlignment="Center"
+                            CornerRadius="{StaticResource Rounded}">
                         <!-- swapped out Path so we can use our UnifiedIcon -->
                         <icons:UnifiedIcon x:Name="ChevronIcon"
                                            Value="{x:Static icons:IconValues.ChevronRight}"
@@ -38,6 +39,17 @@
             <Style Selector="^:checked /template/ icons|UnifiedIcon#ChevronIcon">
                 <Setter Property="Value" Value="{x:Static icons:IconValues.ChevronDown}" />
             </Style>
+            
+            <Style Selector="^:pointerover">
+                <Style Selector="^ /template/ Border">
+                    <Setter Property="Background" Value="{StaticResource SurfaceTranslucentMidBrush}" />
+                </Style>  
+            
+                <Style Selector="^ /template/ icons|UnifiedIcon#ChevronIcon">
+                    <Setter Property="Foreground" Value="{StaticResource NeutralStrongBrush}" />
+                </Style>    
+            </Style>
+            
         </ControlTheme>
     </Styles.Resources>
 
@@ -49,7 +61,6 @@
         <Setter Property="BorderThickness" Value="0" />
 
         <Style Selector="^ TextBlock">
-            <Setter Property="Foreground" Value="{StaticResource NeutralSubduedBrush}" />
             <Setter Property="Theme" Value="{StaticResource BodyMDNormalTheme}" />
         </Style>
 
@@ -58,8 +69,31 @@
             <Setter Property="Height" Value="36" />
             <Setter Property="BorderBrush" Value="{StaticResource StrokeTranslucentWeakBrush}" />
         </Style>
+        
+        <!-- NOTE (insomnious): I think it makes sense to go with 'Compact' class at the parent TreeDataGrid level
+        so that we can keep the styles here in a single place to change what we need --> 
+        
+        <Style Selector="^.Compact">
+            <Style Selector="^ TreeDataGridRow">
+                <Setter Property="Height" Value="32"></Setter>
+                <Style Selector="^ ToggleButton">
+                    <Setter Property="Width" Value="20"></Setter>
+                    <Setter Property="Height" Value="20"></Setter>
+                    <Style Selector="^ /template/ icons|UnifiedIcon#ChevronIcon">
+                        <Setter Property="Size" Value="20"></Setter>
+                    </Style>
+                </Style>
+        </Style>
+        </Style>
     </Style>
 
+    <!-- No backgrounds for the advanced installer TreeDataGrid's -->
+
+    <Style Selector="TreeDataGrid#SelectTreeDataGrid, 
+        TreeDataGrid#ModContentTreeDataGrid, 
+        TreeDataGrid#LocationPreviewTreeDataGrid">
+        <Setter Property="Background" Value="{x:Null}" />
+    </Style>
 
     <!-- TreeDataGridColumnHeader -->
 
@@ -194,6 +228,10 @@
         <!-- all cells -->
         <Style Selector="^ :is(TreeDataGridCell)">
             <Setter Property="Padding" Value="8,0" />
+            
+            <Style Selector="^ Border#CellBorder > TextBlock">
+                <Setter Property="Foreground" Value="{StaticResource NeutralSubduedBrush}" />
+            </Style>
         </Style>
 
         <!-- first cell  -->
@@ -265,6 +303,14 @@
         </Style>
 
     </Style>
+    
+    <!-- TreeDataGridExpanderCell -->
+
+    <Style Selector="TreeDataGridTemplateCell">
+        <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter > TextBlock">
+            <Setter Property="Foreground" Value="{StaticResource NeutralSubduedBrush}" />
+        </Style>
+    </Style>
 
 
     <!-- TreeDataGridExpanderCell -->
@@ -300,7 +346,7 @@
 
                         <DockPanel>
                             <Border DockPanel.Dock="Left"
-                                    Margin="0"
+                                    Margin="0">
                                     Width="20" Height="20">
                                 <ToggleButton Theme="{StaticResource TreeDataGridExpandCollapseChevron}"
                                               Focusable="False"


### PR DESCRIPTION
Styling bugs fixed:
- Expander chevrons now have hover states and correctly sized
- Compact class for `TreeDataGrid` with narrower rows
- Get Advanced Installer back in line with Figma
- Status bar on Preview Changes no longer above the tree

Advanced Installer changes really are enough to be getting on and don't exactly meet how we do the other controls (styling where it ideally shouldn't be etc.). To take this further would be too much refactoring at this time. We will come back around to advanced installer at some point.
