### PR TITLE
Add support for installing BG3 mods

### DIFF
--- a/NexusMods.App.sln
+++ b/NexusMods.App.sln
@@ -258,6 +258,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NexusMods.Abstractions.Medi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NexusMods.Games.Larian", "src\Games\NexusMods.Games.Larian\NexusMods.Games.Larian.csproj", "{2A35EBB5-1CA6-4F5D-8CE8-352146C82C28}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NexusMods.Games.Larian.Tests", "tests\Games\NexusMods.Games.Larian.Tests\NexusMods.Games.Larian.Tests.csproj", "{425F7A13-99A2-4231-B0C1-C56EB819C174}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -668,6 +670,10 @@ Global
 		{2A35EBB5-1CA6-4F5D-8CE8-352146C82C28}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2A35EBB5-1CA6-4F5D-8CE8-352146C82C28}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2A35EBB5-1CA6-4F5D-8CE8-352146C82C28}.Release|Any CPU.Build.0 = Release|Any CPU
+		{425F7A13-99A2-4231-B0C1-C56EB819C174}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{425F7A13-99A2-4231-B0C1-C56EB819C174}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{425F7A13-99A2-4231-B0C1-C56EB819C174}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{425F7A13-99A2-4231-B0C1-C56EB819C174}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -787,6 +793,7 @@ Global
 		{8C817874-7A88-450E-B216-851A1B03684C} = {52AF9D62-7D5B-4AD0-BA12-86F2AA67428B}
 		{5CB6D02C-07D0-4C0D-BF5C-4E2E958A0612} = {0CB73565-1207-4A56-A79F-6A8E9BBD795C}
 		{2A35EBB5-1CA6-4F5D-8CE8-352146C82C28} = {70D38D24-79AE-4600-8E83-17F3C11BA81F}
+		{425F7A13-99A2-4231-B0C1-C56EB819C174} = {05B06AC1-7F2B-492F-983E-5BC63CDBF20D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9F9F8352-34DD-42C0-8564-EE9AF34A3501}

--- a/src/Abstractions/NexusMods.Abstractions.GameLocators/GameCapabilities/IModInstallDestination.cs
+++ b/src/Abstractions/NexusMods.Abstractions.GameLocators/GameCapabilities/IModInstallDestination.cs
@@ -1,4 +1,3 @@
-using NexusMods.Abstractions.Games.GameCapabilities;
 using NexusMods.Paths;
 
 namespace NexusMods.Abstractions.GameLocators.GameCapabilities;
@@ -56,11 +55,6 @@ public static class ModInstallDestinationHelpers
             {
                 // Locations has
                 DestinationGamePath = new GamePath(location.Key, ""),
-                KnownSourceFolderNames = Array.Empty<string>(),
-                KnownValidSubfolders = Array.Empty<string>(),
-                KnownValidFileExtensions = Array.Empty<Extension>(),
-                FileExtensionsToDiscard = Array.Empty<Extension>(),
-                SubPathsToDiscard = Array.Empty<RelativePath>()
             });
         }
     }

--- a/src/Abstractions/NexusMods.Abstractions.GameLocators/GameCapabilities/InstallFolderTarget.cs
+++ b/src/Abstractions/NexusMods.Abstractions.GameLocators/GameCapabilities/InstallFolderTarget.cs
@@ -1,8 +1,6 @@
-﻿using NexusMods.Abstractions.GameLocators;
-using NexusMods.Abstractions.GameLocators.GameCapabilities;
-using NexusMods.Paths;
+﻿using NexusMods.Paths;
 
-namespace NexusMods.Abstractions.Games.GameCapabilities;
+namespace NexusMods.Abstractions.GameLocators.GameCapabilities;
 
 /// <summary>
 /// Represents a target path for installing simple mods archives
@@ -21,32 +19,32 @@ public class InstallFolderTarget : IModInstallDestination
     /// <summary>
     /// List of known recognizable aliases that can be directly mapped to the <see cref="DestinationGamePath"/>.
     /// </summary>
-    public IEnumerable<string> KnownSourceFolderNames { get; init; } = Enumerable.Empty<string>();
+    public IEnumerable<RelativePath> KnownSourceFolderNames { get; init; } = [];
 
     /// <summary>
     /// List of known recognizable first level subfolders of the target <see cref="DestinationGamePath"/>.
     /// NOTE: Only include folders that are only likely to appear at this level of the folder hierarchy.
     /// </summary>
-    public IEnumerable<string> KnownValidSubfolders { get; init; } = Enumerable.Empty<string>();
+    public IEnumerable<RelativePath> Names { get; init; } = [];
 
     /// <summary>
     /// List of known recognizable file extensions for direct children of the target <see cref="DestinationGamePath"/>.
     /// NOTE: Only include file extensions that are only likely to appear at this level of the folder hierarchy.
     /// </summary>
-    public IEnumerable<Extension> KnownValidFileExtensions { get; init; } = Enumerable.Empty<Extension>();
+    public IEnumerable<Extension> KnownValidFileExtensions { get; init; } = [];
 
     /// <summary>
     /// List of subPaths of the target <see cref="DestinationGamePath"/> that should be discarded.
     /// </summary>
-    public IEnumerable<RelativePath> SubPathsToDiscard { get; init; } = Enumerable.Empty<RelativePath>();
+    public IEnumerable<RelativePath> SubPathsToDiscard { get; init; } = [];
 
     /// <summary>
     /// List of file extensions to discard when installing to this target.
     /// </summary>
-    public IEnumerable<Extension> FileExtensionsToDiscard { get; init; } = Enumerable.Empty<Extension>();
+    public IEnumerable<Extension> FileExtensionsToDiscard { get; init; } = [];
 
     /// <summary>
     /// Collection of Targets that are nested paths relative to <see cref="DestinationGamePath"/>.
     /// </summary>
-    public IEnumerable<InstallFolderTarget> SubTargets { get; init; } = Enumerable.Empty<InstallFolderTarget>();
+    public IEnumerable<InstallFolderTarget> SubTargets { get; init; } = [];
 }

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -177,7 +177,6 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
                 return file;
             })
             .Where(f => !f.TryGetAsDeletedFile(out _))
-            .Where(f => !IsIgnoredPath(f.TargetPath))
             .OfTypeLoadoutFile();
         
         return BuildSyncTree(currentState, previousTree, grouped);

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/AdvancedManualInstallerUI.cs
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/AdvancedManualInstallerUI.cs
@@ -48,7 +48,6 @@ public class AdvancedManualInstallerUI : ALibraryArchiveInstaller, IAdvancedInst
         CancellationToken cancellationToken)
     {
         if (Headless) return new NotSupported();
-
         var tree = LibraryArchiveTree.Create(libraryArchive);
         var (shouldInstall, deploymentData) = await GetDeploymentDataAsync(Language.AdvancedInstaller_Manual_Mod, tree, loadout);
 

--- a/src/Games/NexusMods.Games.Generic/Extensions/LibraryArchiveTreeExtensions.cs
+++ b/src/Games/NexusMods.Games.Generic/Extensions/LibraryArchiveTreeExtensions.cs
@@ -1,0 +1,33 @@
+using NexusMods.Paths.Trees;
+using NexusMods.Paths.Trees.Traits;
+
+namespace NexusMods.Games.Generic.Extensions;
+
+public static class LibraryArchiveTreeExtensions
+{
+    public static IEnumerable<KeyedBox<TKey, TSelf>> EnumerateFilesBfsWhereBranch<TSelf, TKey>(
+        this KeyedBox<TKey, TSelf> item,
+        Func<KeyedBox<TKey, TSelf>, bool> predicate)
+        where TKey : notnull
+        where TSelf : struct, IHaveAFileOrDirectory, IHaveBoxedChildrenWithKey<TKey, TSelf>, IHaveKey<TKey>
+    {
+        var queue = new Queue<KeyedBox<TKey, TSelf>>();
+        foreach (var child in item.Children())
+        {
+            queue.Enqueue(child.Value);
+        }
+
+        while (queue.TryDequeue(out var current))
+        {
+            if (!predicate(current)) continue;
+
+            if (current.IsFile())
+            {
+                yield return current;
+            }
+
+            foreach (var grandChild in current.Item.Children)
+                queue.Enqueue(grandChild.Value);
+        }
+    }
+}

--- a/src/Games/NexusMods.Games.Generic/Installers/GenericPatternMatchInstaller.cs
+++ b/src/Games/NexusMods.Games.Generic/Installers/GenericPatternMatchInstaller.cs
@@ -15,6 +15,14 @@ namespace NexusMods.Games.Generic.Installers;
 
 using InstallDataTuple = (LoadoutItemGroup.New loadoutGroup, ITransaction transaction, Loadout.ReadOnly loadout);
 
+
+/// <summary>
+/// Generic mod installer for mods that only need to have their contents placed to a specific game location
+/// (<see cref="InstallFolderTarget"/>).
+/// Tries to match the mod archive folder structure to <see cref="InstallFolderTarget"/> requirements.
+///
+/// Example: myMod/Textures/myTexture.dds -> Skyrim/Data/Textures/myTexture.dds
+/// </summary>
 public class GenericPatternMatchInstaller : ALibraryArchiveInstaller
 {
     public GenericPatternMatchInstaller(IServiceProvider serviceProvider) :

--- a/src/Games/NexusMods.Games.Generic/Installers/GenericPatternMatchInstaller.cs
+++ b/src/Games/NexusMods.Games.Generic/Installers/GenericPatternMatchInstaller.cs
@@ -1,0 +1,187 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NexusMods.Abstractions.GameLocators.GameCapabilities;
+using NexusMods.Abstractions.Library.Installers;
+using NexusMods.Abstractions.Library.Models;
+using NexusMods.Abstractions.Loadouts;
+using NexusMods.MnemonicDB.Abstractions;
+using NexusMods.Paths;
+using NexusMods.Paths.Trees;
+using NexusMods.Paths.Trees.Traits;
+
+namespace NexusMods.Games.Generic.Installers;
+
+using InstallDataTuple = (LoadoutItemGroup.New loadoutGroup, ITransaction transaction, Loadout.ReadOnly loadout);
+
+public class GenericPatternMatchInstaller : ALibraryArchiveInstaller
+{
+    public GenericPatternMatchInstaller(IServiceProvider serviceProvider) :
+        base(serviceProvider, serviceProvider.GetRequiredService<ILogger<GenericPatternMatchInstaller>>())
+    {
+    }
+
+    public InstallFolderTarget[] InstallFolderTargets { get; init; } = [];
+
+    public override ValueTask<InstallerResult> ExecuteAsync(
+        LibraryArchive.ReadOnly libraryArchive,
+        LoadoutItemGroup.New loadoutGroup,
+        ITransaction transaction,
+        Loadout.ReadOnly loadout,
+        CancellationToken cancellationToken)
+    {
+        var installDataTuple = (loadoutGroup, transaction, loadout);
+        if (InstallFolderTargets.Length == 0)
+            return ValueTask.FromResult<InstallerResult>(new NotSupported());
+
+        var tree = libraryArchive.GetTree();
+
+        return InstallFolderTargets.Any(target => TryInstallForTarget(target, tree, installDataTuple))
+            ? ValueTask.FromResult<InstallerResult>(new Success())
+            : ValueTask.FromResult<InstallerResult>(new NotSupported());
+    }
+
+    private bool TryInstallForTarget(InstallFolderTarget target, KeyedBox<RelativePath, LibraryArchiveTree> tree, InstallDataTuple installDataTuple)
+    {
+        foreach (var node in tree.EnumerateChildrenBfs())
+        {
+            if (!TryGetMatch(node.Value, target, out var match)) continue;
+            DoInstall(match ?? tree, target, installDataTuple);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryGetMatch(KeyedBox<RelativePath, LibraryArchiveTree> node, InstallFolderTarget target, [NotNullWhen(true)] out KeyedBox<RelativePath, LibraryArchiveTree>? match)
+    {
+        match = null;
+
+        if (node.IsFile())
+        {
+            // Check if file has a known child file extension
+            if (target.KnownValidFileExtensions.Contains(node.Key().Extension))
+            {
+                match = node.Parent()!;
+                return true;
+            }
+        }
+        else
+        {
+            // Check if the directory name is a known source folder
+            if (target.KnownSourceFolderNames.Contains(node.Key().Name))
+            {
+                match = node;
+                return true;
+            }
+
+            // Check if the directory name is a known subfolder
+            if (target.Names.Contains(node.Key().Name))
+            {
+                match = node.Parent()!;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private void DoInstall(KeyedBox<RelativePath, LibraryArchiveTree> tree, InstallFolderTarget target, InstallDataTuple installDataTuple)
+    {
+        var dropDepth = tree.Depth();
+        var (loadoutGroup, transaction, loadout) = installDataTuple;
+
+        // Discard files and directories based on the target configuration
+        var fileNodes = tree.EnumerateFilesBfsWhereBranch(node =>
+            {
+                if (node.IsDirectory())
+                {
+                    var relativePath = node.Item.Path.DropFirst(dropDepth);
+                    // prune branch if directory is in the discard list
+                    if (target.SubPathsToDiscard.Contains(relativePath))
+                    {
+                        return false;
+                    }
+                }
+                else
+                {
+                    // prune file if file extension is in the discard list
+                    if (target.FileExtensionsToDiscard.Contains(node.Key().Extension))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+        );
+
+        // Add the files to the loadout
+        foreach (var fileNode in fileNodes)
+        {
+            // rebase the path to the target location
+            var relativePath = fileNode.Item.Path.DropFirst(dropDepth);
+            relativePath = target.DestinationGamePath.Path.Join(relativePath);
+
+            GenerateFileItem(target,
+                transaction,
+                loadout,
+                relativePath,
+                loadoutGroup,
+                fileNode
+            );
+        }
+    }
+
+    protected virtual void GenerateFileItem(
+        InstallFolderTarget target,
+        ITransaction transaction,
+        Loadout.ReadOnly loadout,
+        RelativePath relativePath,
+        LoadoutItemGroup.New loadoutGroup,
+        KeyedBox<RelativePath, LibraryArchiveTree> fileNode)
+    {
+        var _ = new LoadoutFile.New(transaction, out var id)
+        {
+            LoadoutItemWithTargetPath = new LoadoutItemWithTargetPath.New(transaction, id)
+            {
+                TargetPath = (loadout.Id, target.DestinationGamePath.LocationId, relativePath),
+                LoadoutItem = new LoadoutItem.New(transaction, id)
+                {
+                    Name = relativePath.Name,
+                    LoadoutId = loadout.Id,
+                    ParentId = loadoutGroup.Id,
+                },
+            },
+            Hash = fileNode.Item.LibraryFile.Value.Hash,
+            Size = fileNode.Item.LibraryFile.Value.Size,
+        };
+    }
+}
+
+internal static class KeyedBoxExtensions
+{
+    public static IEnumerable<KeyedBox<RelativePath, LibraryArchiveTree>> EnumerateFilesBfsWhereBranch(
+        this KeyedBox<RelativePath, LibraryArchiveTree> item,
+        Func<KeyedBox<RelativePath, LibraryArchiveTree>, bool> predicate)
+    {
+        var queue = new Queue<KeyedBox<RelativePath, LibraryArchiveTree>>();
+        foreach (var child in item.Children())
+        {
+            queue.Enqueue(child.Value);
+        }
+
+        while (queue.TryDequeue(out var current))
+        {
+            if (!predicate(current)) continue;
+
+            if (current.IsFile())
+            {
+                yield return current;
+            }
+
+            foreach (var grandChild in current.Item.Children)
+                queue.Enqueue(grandChild.Value);
+        }
+    }
+}

--- a/src/Games/NexusMods.Games.Generic/Installers/GenericPatternMatchInstaller.cs
+++ b/src/Games/NexusMods.Games.Generic/Installers/GenericPatternMatchInstaller.cs
@@ -5,6 +5,7 @@ using NexusMods.Abstractions.GameLocators.GameCapabilities;
 using NexusMods.Abstractions.Library.Installers;
 using NexusMods.Abstractions.Library.Models;
 using NexusMods.Abstractions.Loadouts;
+using NexusMods.Games.Generic.Extensions;
 using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.Paths;
 using NexusMods.Paths.Trees;
@@ -156,32 +157,5 @@ public class GenericPatternMatchInstaller : ALibraryArchiveInstaller
             Hash = fileNode.Item.LibraryFile.Value.Hash,
             Size = fileNode.Item.LibraryFile.Value.Size,
         };
-    }
-}
-
-internal static class KeyedBoxExtensions
-{
-    public static IEnumerable<KeyedBox<RelativePath, LibraryArchiveTree>> EnumerateFilesBfsWhereBranch(
-        this KeyedBox<RelativePath, LibraryArchiveTree> item,
-        Func<KeyedBox<RelativePath, LibraryArchiveTree>, bool> predicate)
-    {
-        var queue = new Queue<KeyedBox<RelativePath, LibraryArchiveTree>>();
-        foreach (var child in item.Children())
-        {
-            queue.Enqueue(child.Value);
-        }
-
-        while (queue.TryDequeue(out var current))
-        {
-            if (!predicate(current)) continue;
-
-            if (current.IsFile())
-            {
-                yield return current;
-            }
-
-            foreach (var grandChild in current.Item.Children)
-                queue.Enqueue(grandChild.Value);
-        }
     }
 }

--- a/src/Games/NexusMods.Games.Larian/BaldursGate3/BaldursGate3.cs
+++ b/src/Games/NexusMods.Games.Larian/BaldursGate3/BaldursGate3.cs
@@ -7,7 +7,9 @@ using NexusMods.Abstractions.Games;
 using NexusMods.Abstractions.Games.DTO;
 using NexusMods.Abstractions.IO;
 using NexusMods.Abstractions.IO.StreamFactories;
+using NexusMods.Abstractions.Library.Installers;
 using NexusMods.Abstractions.Loadouts.Synchronizers;
+using NexusMods.Games.Generic.Installers;
 using NexusMods.Paths;
 
 namespace NexusMods.Games.Larian.BaldursGate3;
@@ -17,13 +19,13 @@ public class BaldursGate3 : AGame, ISteamGame, IGogGame
     private readonly IServiceProvider _serviceProvider;
     private readonly IOSInformation _osInformation;
     public override string Name => "Baldur's Gate 3";
-    
+
     public IEnumerable<uint> SteamIds => [1086940u];
     public IEnumerable<long> GogIds => [1456460669];
 
     public static GameDomain GameDomain => GameDomain.From("baldursgate3");
     public override GameDomain Domain => GameDomain;
-    
+
     public BaldursGate3(IServiceProvider provider) : base(provider)
     {
         _serviceProvider = provider;
@@ -42,9 +44,9 @@ public class BaldursGate3 : AGame, ISteamGame, IGogGame
         var result = new Dictionary<LocationId, AbsolutePath>()
         {
             { LocationId.Game, installation.Path },
-            { LocationId.From("Mods"), fileSystem.GetKnownPath(KnownPath.HomeDirectory).Combine("Larian Studios/Baldur's Gate 3/Mods") },
-            { LocationId.From("PlayerProfiles"), fileSystem.GetKnownPath(KnownPath.HomeDirectory).Combine("Larian Studios/Baldur's Gate 3/PlayerProfiles/Public") },
-            { LocationId.From("ScriptExtenderConfig"), fileSystem.GetKnownPath(KnownPath.HomeDirectory).Combine("Larian Studios/Baldur's Gate 3/ScriptExtender") },
+            { LocationId.From("Mods"), fileSystem.GetKnownPath(KnownPath.LocalApplicationDataDirectory).Combine("Larian Studios/Baldur's Gate 3/Mods") },
+            { LocationId.From("PlayerProfiles"), fileSystem.GetKnownPath(KnownPath.LocalApplicationDataDirectory).Combine("Larian Studios/Baldur's Gate 3/PlayerProfiles/Public") },
+            { LocationId.From("ScriptExtenderConfig"), fileSystem.GetKnownPath(KnownPath.LocalApplicationDataDirectory).Combine("Larian Studios/Baldur's Gate 3/ScriptExtender") },
         };
         return result;
     }
@@ -52,15 +54,46 @@ public class BaldursGate3 : AGame, ISteamGame, IGogGame
     /// <inheritdoc />
     public override List<IModInstallDestination> GetInstallDestinations(IReadOnlyDictionary<LocationId, AbsolutePath> locations)
     {
-        // TODO: fill this in for Generic installer
-        return [];
+        return
+        [
+        ];
     }
-    
+
+    public override ILibraryItemInstaller[] LibraryItemInstallers =>
+    [
+        new GenericPatternMatchInstaller(_serviceProvider)
+        {
+            InstallFolderTargets =
+            [
+                new InstallFolderTarget
+                {
+                    // Pak mods
+                    DestinationGamePath = new GamePath(LocationId.From("Mods"), ""),
+                    KnownValidFileExtensions = [new Extension(".pak")],
+                },
+                new InstallFolderTarget
+                {
+                    // bin and NativeMods mods
+                    DestinationGamePath = new GamePath(LocationId.Game, "bin"),
+                    KnownSourceFolderNames = ["bin"],
+                    Names = ["NativeMods"],
+                },
+                new InstallFolderTarget
+                {
+                    // loose files Data mods
+                    DestinationGamePath = new GamePath(LocationId.Game, "Data"),
+                    KnownSourceFolderNames = ["Data"],
+                    Names = ["Generated", "Public"],
+                },
+            ],
+        },
+    ];
+
     protected override ILoadoutSynchronizer MakeSynchronizer(IServiceProvider provider)
     {
         return new BaldursGate3Synchronizer(provider);
     }
-    
+
     // TODO: We are using Icon for both Spine and GameWidget and GameImage is unused. We should use GameImage for the GameWidget, but need to update all the games to have better images.
     public override IStreamFactory Icon =>
         new EmbededResourceStreamFactory<BaldursGate3>("NexusMods.Games.Larian.Resources.BaldursGate3.icon.png");

--- a/src/Games/NexusMods.Games.Larian/BaldursGate3/BaldursGate3.cs
+++ b/src/Games/NexusMods.Games.Larian/BaldursGate3/BaldursGate3.cs
@@ -10,6 +10,7 @@ using NexusMods.Abstractions.IO.StreamFactories;
 using NexusMods.Abstractions.Library.Installers;
 using NexusMods.Abstractions.Loadouts.Synchronizers;
 using NexusMods.Games.Generic.Installers;
+using NexusMods.Games.Larian.BaldursGate3.Installers;
 using NexusMods.Paths;
 
 namespace NexusMods.Games.Larian.BaldursGate3;
@@ -61,6 +62,7 @@ public class BaldursGate3 : AGame, ISteamGame, IGogGame
 
     public override ILibraryItemInstaller[] LibraryItemInstallers =>
     [
+        new BG3SEInstaller(_serviceProvider),
         new GenericPatternMatchInstaller(_serviceProvider)
         {
             InstallFolderTargets =

--- a/src/Games/NexusMods.Games.Larian/BaldursGate3/BaldursGate3.cs
+++ b/src/Games/NexusMods.Games.Larian/BaldursGate3/BaldursGate3.cs
@@ -68,27 +68,37 @@ public class BaldursGate3 : AGame, ISteamGame, IGogGame
         {
             InstallFolderTargets =
             [
+                // Pak mods
+                // Examples:
+                // - <see href="https://www.nexusmods.com/baldursgate3/mods/366?tab=description">ImpUI (ImprovedUI) Patch7Ready</see>
+                // - <see href="https://www.nexusmods.com/baldursgate3/mods/11373?tab=description">NPC Visual Overhaul (WIP) - NPC VO</see>
                 new InstallFolderTarget
                 {
-                    // Pak mods
                     DestinationGamePath = new GamePath(LocationId.From("Mods"), ""),
                     KnownValidFileExtensions = [new Extension(".pak")],
                     FileExtensionsToDiscard =
                     [
-                        KnownExtensions.Txt, KnownExtensions.Md, KnownExtensions.Pdf, KnownExtensions.Png, 
+                        KnownExtensions.Txt, KnownExtensions.Md, KnownExtensions.Pdf, KnownExtensions.Png,
                         KnownExtensions.Json, new Extension(".lnk"),
                     ],
                 },
+
+                // bin and NativeMods mods
+                // Examples:
+                // - <see href="https://www.nexusmods.com/baldursgate3/mods/944">Native Mod Loader</see>
+                // - <see href="https://www.nexusmods.com/baldursgate3/mods/668?tab=files">Achievement Enabler</see>
                 new InstallFolderTarget
                 {
-                    // bin and NativeMods mods
                     DestinationGamePath = new GamePath(LocationId.Game, "bin"),
                     KnownSourceFolderNames = ["bin"],
                     Names = ["NativeMods"],
                 },
+
+                // loose files Data mods
+                // Examples:
+                // - <see href="https://www.nexusmods.com/baldursgate3/mods/555?tab=description">Fast XP</see>
                 new InstallFolderTarget
                 {
-                    // loose files Data mods
                     DestinationGamePath = new GamePath(LocationId.Game, "Data"),
                     KnownSourceFolderNames = ["Data"],
                     Names = ["Generated", "Public"],

--- a/src/Games/NexusMods.Games.Larian/BaldursGate3/BaldursGate3.cs
+++ b/src/Games/NexusMods.Games.Larian/BaldursGate3/BaldursGate3.cs
@@ -12,6 +12,7 @@ using NexusMods.Abstractions.Loadouts.Synchronizers;
 using NexusMods.Games.Generic.Installers;
 using NexusMods.Games.Larian.BaldursGate3.Installers;
 using NexusMods.Paths;
+using NexusMods.Paths.Utilities;
 
 namespace NexusMods.Games.Larian.BaldursGate3;
 
@@ -72,6 +73,11 @@ public class BaldursGate3 : AGame, ISteamGame, IGogGame
                     // Pak mods
                     DestinationGamePath = new GamePath(LocationId.From("Mods"), ""),
                     KnownValidFileExtensions = [new Extension(".pak")],
+                    FileExtensionsToDiscard =
+                    [
+                        KnownExtensions.Txt, KnownExtensions.Md, KnownExtensions.Pdf, KnownExtensions.Png, 
+                        KnownExtensions.Json, new Extension(".lnk"),
+                    ],
                 },
                 new InstallFolderTarget
                 {

--- a/src/Games/NexusMods.Games.Larian/BaldursGate3/BaldursGate3Synchronizer.cs
+++ b/src/Games/NexusMods.Games.Larian/BaldursGate3/BaldursGate3Synchronizer.cs
@@ -10,6 +10,7 @@ public class BaldursGate3Synchronizer : ALoadoutSynchronizer
     private readonly BaldursGate3Settings _settings;
     
     private static GamePath GameFolder => new(LocationId.Game, "");
+    private static GamePath DataFolder => new(LocationId.Game, "Data");
     private static GamePath PublicPlayerProfiles => new(LocationId.From("PlayerProfiles"), "");
     
     private static GamePath ModSettingsFile => new(LocationId.From("PlayerProfiles"), "modsettings.lsx");
@@ -24,7 +25,11 @@ public class BaldursGate3Synchronizer : ALoadoutSynchronizer
     public override bool IsIgnoredPath(GamePath path)
     {
         // Always ignore all PlayerProfile files except the modsettings file.
-        return path.InFolder(PublicPlayerProfiles) && path.Path != ModSettingsFile.Path;
+        if (path.InFolder(PublicPlayerProfiles))
+            return path.Path != ModSettingsFile.Path;
+        if (path.InFolder(DataFolder))
+            return true;
+        return false;
     }
     
     public override bool IsIgnoredBackupPath(GamePath path)

--- a/src/Games/NexusMods.Games.Larian/BaldursGate3/BaldursGate3Synchronizer.cs
+++ b/src/Games/NexusMods.Games.Larian/BaldursGate3/BaldursGate3Synchronizer.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.GameLocators;
 using NexusMods.Abstractions.Loadouts.Synchronizers;
 using NexusMods.Abstractions.Settings;
+using NexusMods.Paths;
 
 namespace NexusMods.Games.Larian.BaldursGate3;
 
@@ -15,6 +16,8 @@ public class BaldursGate3Synchronizer : ALoadoutSynchronizer
     
     private static GamePath ModSettingsFile => new(LocationId.From("PlayerProfiles"), "modsettings.lsx");
     
+    private static Extension PakExtension => new Extension(".pak");
+    
 
     public BaldursGate3Synchronizer(IServiceProvider provider) : base(provider)
     {
@@ -27,9 +30,10 @@ public class BaldursGate3Synchronizer : ALoadoutSynchronizer
         // Always ignore all PlayerProfile files except the modsettings file.
         if (path.InFolder(PublicPlayerProfiles))
             return path.Path != ModSettingsFile.Path;
-        if (path.InFolder(DataFolder))
-            return true;
-        return false;
+        
+        if (_settings.DoFullGameBackup) return false;
+
+        return path.InFolder(DataFolder) && path.Extension == PakExtension;
     }
     
     public override bool IsIgnoredBackupPath(GamePath path)

--- a/src/Games/NexusMods.Games.Larian/BaldursGate3/Installers/BG3SEInstaller.cs
+++ b/src/Games/NexusMods.Games.Larian/BaldursGate3/Installers/BG3SEInstaller.cs
@@ -10,6 +10,11 @@ using NexusMods.Paths.Trees.Traits;
 
 namespace NexusMods.Games.Larian.BaldursGate3.Installers;
 
+/// <summary>
+/// Installer for the Baldur's Gate 3 Script Extender
+/// <see href="https://github.com/Norbyte/bg3se">BG3SE GitHub Repository</see>
+/// <see href="https://www.nexusmods.com/baldursgate3/mods/2172">BG3SE Nexus Mods Page</see>
+/// </summary>
 public class BG3SEInstaller : ALibraryArchiveInstaller
 {
     public BG3SEInstaller(IServiceProvider serviceProvider) :

--- a/src/Games/NexusMods.Games.Larian/BaldursGate3/Installers/BG3SEInstaller.cs
+++ b/src/Games/NexusMods.Games.Larian/BaldursGate3/Installers/BG3SEInstaller.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NexusMods.Abstractions.Library.Installers;
+using NexusMods.Abstractions.Library.Models;
+using NexusMods.Abstractions.Loadouts;
+using NexusMods.MnemonicDB.Abstractions;
+using NexusMods.Paths.Trees.Traits;
+
+namespace NexusMods.Games.Larian.BaldursGate3.Installers;
+
+public class BG3SEInstaller : ALibraryArchiveInstaller
+{
+    public BG3SEInstaller(IServiceProvider serviceProvider) : 
+        base(serviceProvider, serviceProvider.GetRequiredService<ILogger<BG3SEInstaller>>())
+    {
+    }
+
+    public override ValueTask<InstallerResult> ExecuteAsync(
+        LibraryArchive.ReadOnly libraryArchive,
+        LoadoutItemGroup.New loadoutGroup,
+        ITransaction transaction,
+        Loadout.ReadOnly loadout,
+        CancellationToken cancellationToken)
+    {
+        var tree = libraryArchive.GetTree();
+        var nodes = tree.FindSubPathsByKeyUpward(["DWrite.dll"]);
+        if (nodes.Count == 0)
+            return ValueTask.FromResult<InstallerResult>(new NotSupported());
+        var dllNode = nodes[0];
+        var parent = dllNode.Parent() ?? tree;
+
+        return ValueTask.FromResult<InstallerResult>(new NotSupported());
+    }
+}

--- a/src/Games/NexusMods.Games.Larian/BaldursGate3/Installers/BG3SEInstaller.cs
+++ b/src/Games/NexusMods.Games.Larian/BaldursGate3/Installers/BG3SEInstaller.cs
@@ -1,16 +1,18 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using NexusMods.Abstractions.GameLocators;
 using NexusMods.Abstractions.Library.Installers;
 using NexusMods.Abstractions.Library.Models;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.MnemonicDB.Abstractions;
+using NexusMods.Paths;
 using NexusMods.Paths.Trees.Traits;
 
 namespace NexusMods.Games.Larian.BaldursGate3.Installers;
 
 public class BG3SEInstaller : ALibraryArchiveInstaller
 {
-    public BG3SEInstaller(IServiceProvider serviceProvider) : 
+    public BG3SEInstaller(IServiceProvider serviceProvider) :
         base(serviceProvider, serviceProvider.GetRequiredService<ILogger<BG3SEInstaller>>())
     {
     }
@@ -29,6 +31,30 @@ public class BG3SEInstaller : ALibraryArchiveInstaller
         var dllNode = nodes[0];
         var parent = dllNode.Parent() ?? tree;
 
-        return ValueTask.FromResult<InstallerResult>(new NotSupported());
+        List<LoadoutFile.New> results = [];
+        foreach (var fileNode in parent.EnumerateFilesBfs())
+        {
+            var relativePath = new RelativePath("Bin").Join(fileNode.Value.Item.Path.DropFirst(parent.Depth()));
+            var loadoutFile = new LoadoutFile.New(transaction, out var id)
+            {
+                LoadoutItemWithTargetPath = new LoadoutItemWithTargetPath.New(transaction, id)
+                {
+                    TargetPath = (loadout.Id, LocationId.Game, relativePath),
+                    LoadoutItem = new LoadoutItem.New(transaction, id)
+                    {
+                        Name = relativePath.Name,
+                        LoadoutId = loadout.Id,
+                        ParentId = loadoutGroup.Id,
+                    },
+                },
+                Hash = fileNode.Value.Item.LibraryFile.Value.Hash,
+                Size = fileNode.Value.Item.LibraryFile.Value.Size,
+            };
+            results.Add(loadoutFile);
+        }
+
+        return results.Count > 0
+            ? ValueTask.FromResult<InstallerResult>(new Success())
+            : ValueTask.FromResult<InstallerResult>(new NotSupported());
     }
 }

--- a/src/Games/NexusMods.Games.Larian/BaldursGate3/RunGameTools/BG3RunGameTool.cs
+++ b/src/Games/NexusMods.Games.Larian/BaldursGate3/RunGameTools/BG3RunGameTool.cs
@@ -1,0 +1,10 @@
+using NexusMods.Abstractions.Games;
+
+namespace NexusMods.Games.Larian.BaldursGate3.RunGameTools;
+
+public class BG3RunGameTool : RunGameTool<BaldursGate3>
+{
+    public BG3RunGameTool(IServiceProvider serviceProvider, BaldursGate3 game) : base(serviceProvider, game)
+    {
+    }
+}

--- a/src/Games/NexusMods.Games.Larian/BaldursGate3/Services.cs
+++ b/src/Games/NexusMods.Games.Larian/BaldursGate3/Services.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.Games;
+using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Settings;
+using NexusMods.Games.Larian.BaldursGate3.RunGameTools;
 
 namespace NexusMods.Games.Larian.BaldursGate3;
 
@@ -10,6 +12,7 @@ public static class Services
     {
         services
             .AddGame<BaldursGate3>()
+            .AddSingleton<ITool, BG3RunGameTool>()
             .AddSettings<BaldursGate3Settings>();
 
         return services;

--- a/src/Games/NexusMods.Games.Larian/NexusMods.Games.Larian.csproj
+++ b/src/Games/NexusMods.Games.Larian/NexusMods.Games.Larian.csproj
@@ -3,6 +3,7 @@
     <ItemGroup>
       <ProjectReference Include="..\..\Abstractions\NexusMods.Abstractions.Games\NexusMods.Abstractions.Games.csproj" />
       <ProjectReference Include="..\..\Abstractions\NexusMods.Abstractions.Settings\NexusMods.Abstractions.Settings.csproj" />
+      <ProjectReference Include="..\NexusMods.Games.Generic\NexusMods.Games.Generic.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/Games/NexusMods.Games.AdvancedInstaller.Tests/ModInstallDestinationTests.cs
+++ b/tests/Games/NexusMods.Games.AdvancedInstaller.Tests/ModInstallDestinationTests.cs
@@ -1,7 +1,6 @@
 using FluentAssertions;
 using NexusMods.Abstractions.GameLocators;
 using NexusMods.Abstractions.GameLocators.GameCapabilities;
-using NexusMods.Abstractions.Games.GameCapabilities;
 using NexusMods.Paths;
 
 namespace NexusMods.Games.AdvancedInstaller.Tests;
@@ -57,7 +56,7 @@ public class ModInstallDestinationTests
     static readonly InstallFolderTarget GameRootInstallFolderTarget = new()
     {
         DestinationGamePath = new GamePath(LocationId.Game, RelativePath.Empty),
-        KnownValidSubfolders = new[] { "data"  },
-        SubTargets = new[] { DataInstallFolderTarget }
+        Names = [ "data" ],
+        SubTargets = [DataInstallFolderTarget]
     };
 }

--- a/tests/Games/NexusMods.Games.Larian.Tests/BaldursGate3/BG3InstallerTests.CanInstallBG3Mods_testCaseName=BG3 Script Extender.verified.txt
+++ b/tests/Games/NexusMods.Games.Larian.Tests/BaldursGate3/BG3InstallerTests.CanInstallBG3Mods_testCaseName=BG3 Script Extender.verified.txt
@@ -1,0 +1,12 @@
+﻿[
+  {
+    FromPath: DWrite.dll,
+    Hash: 0x8EF806095E9F8F9B,
+    ToGamePath: {Game}/Bin/DWrite.dll
+  },
+  {
+    FromPath: ScriptExtenderSettings.json,
+    Hash: 0x273ED670FBF4332F,
+    ToGamePath: {Game}/Bin/ScriptExtenderSettings.json
+  }
+]

--- a/tests/Games/NexusMods.Games.Larian.Tests/BaldursGate3/BG3InstallerTests.CanInstallBG3Mods_testCaseName=Bin Mod.verified.txt
+++ b/tests/Games/NexusMods.Games.Larian.Tests/BaldursGate3/BG3InstallerTests.CanInstallBG3Mods_testCaseName=Bin Mod.verified.txt
@@ -1,0 +1,7 @@
+﻿[
+  {
+    FromPath: bin/bink2w64.dll,
+    Hash: 0xC6363140D5333C3E,
+    ToGamePath: {Game}/bin/bink2w64.dll
+  }
+]

--- a/tests/Games/NexusMods.Games.Larian.Tests/BaldursGate3/BG3InstallerTests.CanInstallBG3Mods_testCaseName=Data Mod.verified.txt
+++ b/tests/Games/NexusMods.Games.Larian.Tests/BaldursGate3/BG3InstallerTests.CanInstallBG3Mods_testCaseName=Data Mod.verified.txt
@@ -1,0 +1,12 @@
+﻿[
+  {
+    FromPath: Recommended/Data/Generated/Public/Shared/Content/Assets/Characters/Character Editor Presets/Origin Presets/[PAK]_Shadowheart/_merged.lsf,
+    Hash: 0x8ED74FCCE6291C5E,
+    ToGamePath: {Game}/Data/Generated/Public/Shared/Content/Assets/Characters/Character Editor Presets/Origin Presets/[PAK]_Shadowheart/_merged.lsf
+  },
+  {
+    FromPath: Recommended/Data/Generated/Public/Shared/Assets/Characters/_Models/Humans/_Female/_Hair/Resources/HAIR_HUM_F_Shadowheart_Spring.gr2,
+    Hash: 0x3103D39FC0AEBDE5,
+    ToGamePath: {Game}/Data/Generated/Public/Shared/Assets/Characters/_Models/Humans/_Female/_Hair/Resources/HAIR_HUM_F_Shadowheart_Spring.gr2
+  }
+]

--- a/tests/Games/NexusMods.Games.Larian.Tests/BaldursGate3/BG3InstallerTests.CanInstallBG3Mods_testCaseName=Data Public Mod with nested Data folder.verified.txt
+++ b/tests/Games/NexusMods.Games.Larian.Tests/BaldursGate3/BG3InstallerTests.CanInstallBG3Mods_testCaseName=Data Public Mod with nested Data folder.verified.txt
@@ -1,0 +1,12 @@
+﻿[
+  {
+    FromPath: Public/Shared/Stats/Generated/Data/XPData.txt,
+    Hash: 0x649540DCE31F2D3A,
+    ToGamePath: {Game}/Data/Public/Shared/Stats/Generated/Data/XPData.txt
+  },
+  {
+    FromPath: Public/SharedDev/Stats/Generated/Data/XPData.txt,
+    Hash: 0xBA2BFF7CA4B1C424,
+    ToGamePath: {Game}/Data/Public/SharedDev/Stats/Generated/Data/XPData.txt
+  }
+]

--- a/tests/Games/NexusMods.Games.Larian.Tests/BaldursGate3/BG3InstallerTests.CanInstallBG3Mods_testCaseName=Data Public Mod with nested Data folder.verified.txt
+++ b/tests/Games/NexusMods.Games.Larian.Tests/BaldursGate3/BG3InstallerTests.CanInstallBG3Mods_testCaseName=Data Public Mod with nested Data folder.verified.txt
@@ -1,12 +1,12 @@
 ﻿[
   {
-    FromPath: Public/Shared/Stats/Generated/Data/XPData.txt,
-    Hash: 0x649540DCE31F2D3A,
-    ToGamePath: {Game}/Data/Public/Shared/Stats/Generated/Data/XPData.txt
+    FromPath: Public/Shared/Stats/Generated/Data/XPData1.txt,
+    Hash: 0xC98EB6BC4E8661F0,
+    ToGamePath: {Game}/Data/Public/Shared/Stats/Generated/Data/XPData1.txt
   },
   {
-    FromPath: Public/SharedDev/Stats/Generated/Data/XPData.txt,
-    Hash: 0xBA2BFF7CA4B1C424,
-    ToGamePath: {Game}/Data/Public/SharedDev/Stats/Generated/Data/XPData.txt
+    FromPath: Public/SharedDev/Stats/Generated/Data/XPData2.txt,
+    Hash: 0x9345F61E5A6C7013,
+    ToGamePath: {Game}/Data/Public/SharedDev/Stats/Generated/Data/XPData2.txt
   }
 ]

--- a/tests/Games/NexusMods.Games.Larian.Tests/BaldursGate3/BG3InstallerTests.CanInstallBG3Mods_testCaseName=Multiple Pak files Mod.verified.txt
+++ b/tests/Games/NexusMods.Games.Larian.Tests/BaldursGate3/BG3InstallerTests.CanInstallBG3Mods_testCaseName=Multiple Pak files Mod.verified.txt
@@ -1,0 +1,12 @@
+﻿[
+  {
+    FromPath: myMod1.pak,
+    Hash: 0x12382AC3D91AF5AC,
+    ToGamePath: {Mods}/myMod1.pak
+  },
+  {
+    FromPath: myMod2.pak,
+    Hash: 0x39F52D14C582063C,
+    ToGamePath: {Mods}/myMod2.pak
+  }
+]

--- a/tests/Games/NexusMods.Games.Larian.Tests/BaldursGate3/BG3InstallerTests.CanInstallBG3Mods_testCaseName=NativeMods Mod.verified.txt
+++ b/tests/Games/NexusMods.Games.Larian.Tests/BaldursGate3/BG3InstallerTests.CanInstallBG3Mods_testCaseName=NativeMods Mod.verified.txt
@@ -1,0 +1,12 @@
+﻿[
+  {
+    FromPath: NativeMods/BG3NativeCameraTweaks.dll,
+    Hash: 0x9D3A484CEE5E5A51,
+    ToGamePath: {Game}/bin/NativeMods/BG3NativeCameraTweaks.dll
+  },
+  {
+    FromPath: BG3NativeCameraTweaks.toml,
+    Hash: 0xF52CC272D80C600A,
+    ToGamePath: {Game}/bin/BG3NativeCameraTweaks.toml
+  }
+]

--- a/tests/Games/NexusMods.Games.Larian.Tests/BaldursGate3/BG3InstallerTests.CanInstallBG3Mods_testCaseName=Nested Pak Mod.verified.txt
+++ b/tests/Games/NexusMods.Games.Larian.Tests/BaldursGate3/BG3InstallerTests.CanInstallBG3Mods_testCaseName=Nested Pak Mod.verified.txt
@@ -1,0 +1,7 @@
+﻿[
+  {
+    FromPath: Mods/myMod.pak,
+    Hash: 0x33C4706972EAAE6E,
+    ToGamePath: {Mods}/myMod.pak
+  }
+]

--- a/tests/Games/NexusMods.Games.Larian.Tests/BaldursGate3/BG3InstallerTests.CanInstallBG3Mods_testCaseName=Simple Pak Mod.verified.txt
+++ b/tests/Games/NexusMods.Games.Larian.Tests/BaldursGate3/BG3InstallerTests.CanInstallBG3Mods_testCaseName=Simple Pak Mod.verified.txt
@@ -1,0 +1,7 @@
+﻿[
+  {
+    FromPath: myMod.pak,
+    Hash: 0x23BC397CD47BAFDA,
+    ToGamePath: {Mods}/myMod.pak
+  }
+]

--- a/tests/Games/NexusMods.Games.Larian.Tests/BaldursGate3/BG3InstallerTests.cs
+++ b/tests/Games/NexusMods.Games.Larian.Tests/BaldursGate3/BG3InstallerTests.cs
@@ -1,0 +1,84 @@
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.DependencyInjection;
+using NexusMods.Games.Generic.Installers;
+using NexusMods.Games.Larian.BaldursGate3;
+using NexusMods.Games.Larian.BaldursGate3.Installers;
+using NexusMods.Games.TestFramework;
+using NexusMods.Paths;
+using NexusMods.StandardGameLocators.TestHelpers;
+using Xunit.Abstractions;
+
+namespace NexusMods.Games.Larian.Tests.BaldursGate3;
+
+public class BG3InstallerTests(ITestOutputHelper outputHelper) : ALibraryArchiveInstallerTests<BG3InstallerTests, Larian.BaldursGate3.BaldursGate3>(outputHelper)
+{
+    protected override IServiceCollection AddServices(IServiceCollection services)
+    {
+        return base.AddServices(services)
+            .AddBaldursGate3()
+            .AddUniversalGameLocator<Larian.BaldursGate3.BaldursGate3>(new Version("1.6.1"));
+    }
+
+
+    /// <summary>
+    /// Test cases, key is the name, the values are the archive file paths.
+    /// </summary>
+    public static readonly List<(string TestName, Type InstallerType, string[] Paths)> TestCases =
+    [
+        ("BG3 Script Extender", typeof(BG3SEInstaller), ["DWrite.dll", "ScriptExtenderSettings.json"]),
+        ("Simple Pak Mod", typeof(GenericPatternMatchInstaller), ["myMod.pak", "info.json"]),
+        ("Nested Pak Mod", typeof(GenericPatternMatchInstaller), ["Mods/myMod.pak", "Mods/info.json", "readme.txt"]),
+        ("Multiple Pak files Mod", typeof(GenericPatternMatchInstaller), ["myMod1.pak", "myMod2.pak", "info.json", "readme.txt"]),
+        ("Bin Mod", typeof(GenericPatternMatchInstaller), ["bin/bink2w64.dll", "bink2w64_original.dll"]),
+        ("NativeMods Mod", typeof(GenericPatternMatchInstaller), [
+            "NativeMods/BG3NativeCameraTweaks.dll",
+            "BG3NativeCameraTweaks.toml",
+        ]),
+        ("Data Mod", typeof(GenericPatternMatchInstaller), [
+            "Recommended/Data/Generated/Public/Shared/Assets/Characters/_Models/Humans/_Female/_Hair/Resources/HAIR_HUM_F_Shadowheart_Spring.gr2",
+            "Recommended/Data/Generated/Public/Shared/Content/Assets/Characters/Character Editor Presets/Origin Presets/[PAK]_Shadowheart/_merged.lsf"
+        ]),
+        ("Data Public Mod with nested Data folder", typeof(GenericPatternMatchInstaller), [
+            "Public/Shared/Stats/Generated/Data/XPData.txt",
+            "Public/SharedDev/Stats/Generated/Data/XPData.txt",
+        ]),
+    ];
+
+    public static IEnumerable<object[]> TestCaseData()
+    {
+        return TestCases.Select(row => (object[]) [row.TestName, row.InstallerType, row.Paths]);
+    }
+
+
+    [Theory]
+    [MemberData(nameof(TestCaseData))]
+    public async Task CanInstallBG3Mods(string testCaseName, Type installerType, string[] archivePaths)
+    {
+        var loadout = await CreateLoadout();
+        var archive = await AddFromPaths(archivePaths);
+        var group = await Install(installerType, loadout, archive);
+
+        await VerifyChildren(ChildrenFilesAndHashes(group), archivePaths).UseParameters(testCaseName);
+    }
+
+
+    private static SettingsTask VerifyChildren(
+        IEnumerable<(RelativePath FromPath, Hashing.xxHash64.Hash Hash, Abstractions.GameLocators.GamePath GamePath)> childrenFilesAndHashes,
+        string[] archivePaths,
+        [CallerFilePath] string sourceFile = "")
+    {
+        var asArray = childrenFilesAndHashes.ToArray();
+
+        return Verify(asArray.Select(row =>
+                    new
+                    {
+                        FromPath = row.FromPath.ToString(),
+                        Hash = row.Hash.ToString(),
+                        ToGamePath = row.GamePath.ToString(),
+                    }
+                // ReSharper disable once ExplicitCallerInfoArgument
+            ),
+            sourceFile: sourceFile
+        );
+    }
+}

--- a/tests/Games/NexusMods.Games.Larian.Tests/BaldursGate3/BG3InstallerTests.cs
+++ b/tests/Games/NexusMods.Games.Larian.Tests/BaldursGate3/BG3InstallerTests.cs
@@ -36,11 +36,11 @@ public class BG3InstallerTests(ITestOutputHelper outputHelper) : ALibraryArchive
         ]),
         ("Data Mod", typeof(GenericPatternMatchInstaller), [
             "Recommended/Data/Generated/Public/Shared/Assets/Characters/_Models/Humans/_Female/_Hair/Resources/HAIR_HUM_F_Shadowheart_Spring.gr2",
-            "Recommended/Data/Generated/Public/Shared/Content/Assets/Characters/Character Editor Presets/Origin Presets/[PAK]_Shadowheart/_merged.lsf"
+            "Recommended/Data/Generated/Public/Shared/Content/Assets/Characters/Character Editor Presets/Origin Presets/[PAK]_Shadowheart/_merged.lsf",
         ]),
         ("Data Public Mod with nested Data folder", typeof(GenericPatternMatchInstaller), [
-            "Public/Shared/Stats/Generated/Data/XPData.txt",
-            "Public/SharedDev/Stats/Generated/Data/XPData.txt",
+            "Public/Shared/Stats/Generated/Data/XPData1.txt",
+            "Public/SharedDev/Stats/Generated/Data/XPData2.txt",
         ]),
     ];
 

--- a/tests/Games/NexusMods.Games.Larian.Tests/NexusMods.Games.Larian.Tests.csproj
+++ b/tests/Games/NexusMods.Games.Larian.Tests/NexusMods.Games.Larian.Tests.csproj
@@ -1,0 +1,7 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Abstractions\NexusMods.Abstractions.GuidedInstallers\NexusMods.Abstractions.GuidedInstallers.csproj" />
+    <ProjectReference Include="..\..\..\src\Games\NexusMods.Games.Larian\NexusMods.Games.Larian.csproj" />
+    <ProjectReference Include="..\NexusMods.Games.TestFramework\NexusMods.Games.TestFramework.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Games/NexusMods.Games.Larian.Tests/Startup.cs
+++ b/tests/Games/NexusMods.Games.Larian.Tests/Startup.cs
@@ -6,9 +6,7 @@ using NexusMods.Abstractions.GuidedInstallers;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Serialization;
 using NexusMods.App.BuildInfo;
-using NexusMods.Games.FOMOD;
 using NexusMods.Games.Larian.BaldursGate3;
-using NexusMods.Games.RedEngine;
 using NexusMods.Games.TestFramework;
 using NexusMods.StandardGameLocators.TestHelpers;
 
@@ -21,7 +19,7 @@ public class Startup
         container
             .AddSingleton<IGuidedInstaller, NullGuidedInstaller>()
             .AddDefaultServicesForTesting()
-            .AddUniversalGameLocator<BaldursGate3.BaldursGate3>(new Version("1.61"))
+            .AddUniversalGameLocator<Larian.BaldursGate3.BaldursGate3>(new Version("1.61"))
             .AddBaldursGate3()
             .AddLogging(builder => builder.AddXUnit())
             .AddGames()

--- a/tests/Games/NexusMods.Games.Larian.Tests/Startup.cs
+++ b/tests/Games/NexusMods.Games.Larian.Tests/Startup.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NexusMods.Abstractions.FileStore;
+using NexusMods.Abstractions.Games;
+using NexusMods.Abstractions.GuidedInstallers;
+using NexusMods.Abstractions.Loadouts;
+using NexusMods.Abstractions.Serialization;
+using NexusMods.App.BuildInfo;
+using NexusMods.Games.FOMOD;
+using NexusMods.Games.Larian.BaldursGate3;
+using NexusMods.Games.RedEngine;
+using NexusMods.Games.TestFramework;
+using NexusMods.StandardGameLocators.TestHelpers;
+
+namespace NexusMods.Games.Larian.Tests;
+
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection container)
+    {
+        container
+            .AddSingleton<IGuidedInstaller, NullGuidedInstaller>()
+            .AddDefaultServicesForTesting()
+            .AddUniversalGameLocator<BaldursGate3.BaldursGate3>(new Version("1.61"))
+            .AddBaldursGate3()
+            .AddLogging(builder => builder.AddXUnit())
+            .AddGames()
+            .AddSerializationAbstractions()
+            .AddLoadoutAbstractions()
+            .AddFileStoreAbstractions()
+            .Validate();
+    }
+}


### PR DESCRIPTION
Part of #1262 

This adds support for the following types of mods:
- BG3 Script Extender
- Pak mods
- Loose files Data mods
- NativeMods loader
- NativeMods `dll` mods

I tried covering most cases, like multiple pak files, loose files with nested Data folders and checked a bunch of mods.

Also added tests to verify the correct installation of all the supported mod types.