### PR TITLE
Fix Library deletions 

### DIFF
--- a/src/NexusMods.App.UI/Pages/LibraryPage/NexusModsModPageLibraryItemModel.cs
+++ b/src/NexusMods.App.UI/Pages/LibraryPage/NexusModsModPageLibraryItemModel.cs
@@ -1,5 +1,7 @@
+using DynamicData;
 using NexusMods.Abstractions.Library.Models;
 using NexusMods.Abstractions.MnemonicDB.Attributes.Extensions;
+using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.Paths;
 using ObservableCollections;
 using R3;
@@ -9,7 +11,8 @@ namespace NexusMods.App.UI.Pages.LibraryPage;
 public class NexusModsModPageLibraryItemModel : FakeParentLibraryItemModel
 {
     private readonly IDisposable _modelActivationDisposable;
-    public NexusModsModPageLibraryItemModel() : base(default(LibraryItemId))
+    public NexusModsModPageLibraryItemModel(IObservable<IChangeSet<LibraryItem.ReadOnly, EntityId>> libraryItemsObservable) 
+        : base(default(LibraryItemId), libraryItemsObservable)
     {
         _modelActivationDisposable = WhenModelActivated(this, static (model, disposables) =>
         {

--- a/src/NexusMods.App.UI/Pages/LocalFileDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/LocalFileDataProvider.cs
@@ -81,14 +81,15 @@ internal class LocalFileDataProvider : ILibraryDataProvider, ILoadoutDataProvide
                 // NOTE(erri120): LocalFiles have only one child, this can only be 0 or 1.
                 var numInstalledObservable = linkedLoadoutItemsObservable.IsEmpty().Select(isEmpty => isEmpty ? 0 : 1);
 
-                var model = new FakeParentLibraryItemModel(libraryFile.Id)
+                var model = new FakeParentLibraryItemModel(
+                    libraryFile.Id, 
+                    libraryItemsObservable: UIObservableExtensions.ReturnFactory(() => new ChangeSet<LibraryItem.ReadOnly, EntityId>([new Change<LibraryItem.ReadOnly, EntityId>(ChangeReason.Add, entityId, LibraryItem.Load(_connection.Db, entityId))])))
                 {
                     Name = libraryFile.AsLibraryItem().Name,
                     HasChildrenObservable = hasChildrenObservable,
                     ChildrenObservable = childrenObservable,
                     LinkedLoadoutItemsObservable = linkedLoadoutItemsObservable,
                     NumInstalledObservable = numInstalledObservable,
-                    LibraryItemsObservable = UIObservableExtensions.ReturnFactory(() => new ChangeSet<LibraryItem.ReadOnly, EntityId>([new Change<LibraryItem.ReadOnly, EntityId>(ChangeReason.Add, entityId, LibraryItem.Load(_connection.Db, entityId))])),
                 };
 
                 model.CreatedAtDate.Value = libraryFile.GetCreatedAt();

--- a/src/NexusMods.App.UI/Pages/NexusModsDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/NexusModsDataProvider.cs
@@ -104,14 +104,13 @@ internal class NexusModsDataProvider : ILibraryDataProvider, ILoadoutDataProvide
             .Prepend(false)
         ).QueryWhenChanged(static query => query.Items.Count(static b => b));
 
-        return new NexusModsModPageLibraryItemModel
+        return new NexusModsModPageLibraryItemModel(libraryFilesObservable)
         {
             Name = modPageMetadata.Name,
             HasChildrenObservable = hasChildrenObservable,
             ChildrenObservable = childrenObservable,
             LinkedLoadoutItemsObservable = linkedLoadoutItemsObservable,
             NumInstalledObservable = numInstalledObservable,
-            LibraryItemsObservable = libraryFilesObservable,
         };
     }
 


### PR DESCRIPTION
by ensuring that even never activated items have `LibraryItems` subscription set up.

Apparently it is possible to select rows while their models are never activated, if the Library is scrolled using the Scrollbar very quickly, as some rows will be skipped from rendering.
This means it is possible to select those rows and attempt to delete them, while their models were never activated, and so their data never properly populated.

This was unexpected, as it was assumed that for an item to be selected it would at some point have to appear into view at least once.

This moves the setting up of the subscription for `LibraryItems` property into the constructor instead of inside the `WhenActivated` block.