### PR TITLE
Fix data not being initialized for some rows in LoadoutView when fast scrolling through

### DIFF
--- a/src/NexusMods.App.UI/Pages/LocalFileDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/LocalFileDataProvider.cs
@@ -158,11 +158,10 @@ internal class LocalFileDataProvider : ILibraryDataProvider, ILoadoutDataProvide
                         return isEnabled.HasValue ? isEnabled.Value : null;
                     }).DistinctUntilChanged(x => x is null ? -1 : x.Value ? 1 : 0);
 
-                LoadoutItemModel model = new FakeParentLoadoutItemModel
+                LoadoutItemModel model = new FakeParentLoadoutItemModel(loadoutItemIdsObservable)
                 {
                     NameObservable = Observable.Return(libraryFile.AsLibraryItem().Name),
                     InstalledAtObservable = installedAtObservable,
-                    LoadoutItemIdsObservable = loadoutItemIdsObservable,
                     IsEnabledObservable = isEnabledObservable,
 
                     HasChildrenObservable = Observable.Return(true),

--- a/src/NexusMods.App.UI/Pages/NexusModsDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/NexusModsDataProvider.cs
@@ -180,11 +180,10 @@ internal class NexusModsDataProvider : ILibraryDataProvider, ILoadoutDataProvide
                         return isEnabled.HasValue ? isEnabled.Value : null;
                     }).DistinctUntilChanged(x => x is null ? -1 : x.Value ? 1 : 0);
 
-                LoadoutItemModel model = new FakeParentLoadoutItemModel
+                LoadoutItemModel model = new FakeParentLoadoutItemModel(loadoutItemIdsObservable)
                 {
                     NameObservable = Observable.Return(modPage.Name),
                     InstalledAtObservable = installedAtObservable,
-                    LoadoutItemIdsObservable = loadoutItemIdsObservable,
                     IsEnabledObservable = isEnabledObservable,
 
                     HasChildrenObservable = hasChildrenObservable,


### PR DESCRIPTION
When scrolling very fast, it is possible to reach the bottom of a long loadout list and select all items without some items being activated and thus properly populated. 
This makes sure the needed data is populated to prevent issues with mass deletion or other operations.