### PR TITLE
Fix StardewValley "Mod x overwrites game files" health check spam

### DIFF
--- a/src/Games/NexusMods.Games.StardewValley/Diagnostics.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Diagnostics.cs
@@ -278,7 +278,7 @@ of the mod from {NexusModsLink}.
         .WithSeverity(DiagnosticSeverity.Suggestion)
         .WithSummary("Mod {GroupName} overwrites game files")
         .WithDetails("""
-Mod {Mod} overwrites game files. This can cause compatibility issues and have other
+Mod {GroupName} overwrites game files. This can cause compatibility issues and have other
 unintended side-effects. See the {SMAPIWikiLink} for details.
 
 You can resolve this diagnostic by replacing {Group} with a SMAPI mod that doesn't

--- a/src/Games/NexusMods.Games.StardewValley/Emitters/ModOverwritesGameFilesEmitter.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/ModOverwritesGameFilesEmitter.cs
@@ -32,7 +32,7 @@ public class ModOverwritesGameFilesEmitter : ILoadoutDiagnosticEmitter
             })
             .Where(file => ((GamePath)file.AsLoadoutItemWithTargetPath().TargetPath).StartsWith(ContentDirectoryPath))
             .Select(file => file.AsLoadoutItemWithTargetPath().AsLoadoutItem().Parent)
-            .ToArray();
+            .DistinctBy(item => item.Id);
 
         foreach (var group in groups)
         {


### PR DESCRIPTION
This health check was being being emitted for every overwriting file.
The PR only emits one health check for each mod (itemGroup).

- deduped on mod
- fixed exception when trying to open details, due to incorrect markdown placeholder (mod -> groupName)

![image](https://github.com/user-attachments/assets/7a30e56d-ab27-4c06-a4b2-05d5ae65f492)
