### PR TITLE
Switch GraphQL calls to fragments

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/GraphQLResolver.cs
+++ b/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/GraphQLResolver.cs
@@ -20,14 +20,14 @@ public readonly struct GraphQLResolver(ITransaction Tx, ReadOnlyModel Model)
     /// <summary>
     /// Create a new resolver using the given primary key attribute and value.
     /// </summary>
-    public static GraphQLResolver Create<THighLevel, TLowLevel>(IDb referenceDb, ITransaction tx, ScalarAttribute<THighLevel, TLowLevel> primaryKeyAttribute, THighLevel primaryKeyValue) where THighLevel : notnull
+    public static GraphQLResolver Create<THighLevel, TLowLevel>(IDb db, ITransaction tx, ScalarAttribute<THighLevel, TLowLevel> primaryKeyAttribute, THighLevel primaryKeyValue) where THighLevel : notnull
     {
-        var existing = referenceDb.Datoms(primaryKeyAttribute, primaryKeyValue);
+        var existing = db.Datoms(primaryKeyAttribute, primaryKeyValue);
         var exists = existing.Count > 0;
         var id = existing.Count == 0 ? tx.TempId() : existing[0].E;
         if (!exists)
             tx.Add(id, primaryKeyAttribute, primaryKeyValue);
-        return new GraphQLResolver(tx, new ReadOnlyModel(referenceDb, id));
+        return new GraphQLResolver(tx, new ReadOnlyModel(db, id));
     }
     
     /// <summary>

--- a/src/Networking/NexusMods.Networking.NexusWebApi/Extensions/FragmentExtensions.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/Extensions/FragmentExtensions.cs
@@ -1,0 +1,70 @@
+using NexusMods.Abstractions.Games.DTO;
+using NexusMods.Abstractions.NexusModsLibrary;
+using NexusMods.Abstractions.NexusModsLibrary.Models;
+using NexusMods.Abstractions.NexusWebApi.Types;
+using NexusMods.MnemonicDB.Abstractions;
+using NexusMods.Paths;
+
+namespace NexusMods.Networking.NexusWebApi.Extensions;
+
+/// <summary>
+/// Extensions to GraphQL fragments.
+/// </summary>
+public static class FragmentExtensions
+{
+    /// <summary>
+    /// Resolves the IUserFragment to an entity in the database, inserting or updating as necessary.
+    /// </summary>
+    public static async Task<EntityId> Resolve(this IUserFragment userFragment, IDb db, ITransaction tx, HttpClient client, CancellationToken token)
+    {
+        var userResolver = GraphQLResolver.Create(db, tx, User.NexusId, (ulong)userFragment.MemberId);
+        userResolver.Add(User.Name, userFragment.Name);
+        userResolver.Add(User.Avatar, new Uri(userFragment.Avatar));
+        
+        var avatarImage = await DownloadImage(client, userFragment.Avatar, token);
+        userResolver.Add(User.AvatarImage,avatarImage);
+        return userResolver.Id;
+    }
+    
+    /// <summary>
+    /// Resolves the IModFragment to an entity in the database, inserting or updating as necessary.
+    /// </summary>
+    public static EntityId Resolve(this IModFileFragment modFileFragment, IDb db, ITransaction tx, EntityId modEId)
+    {
+        var nexusFileResolver = GraphQLResolver.Create(db, tx, (NexusModsFileMetadata.FileId, FileId.From((ulong)modFileFragment.FileId)), (NexusModsFileMetadata.ModPageId,  modEId));
+        nexusFileResolver.Add(NexusModsFileMetadata.ModPageId, modEId);
+        nexusFileResolver.Add(NexusModsFileMetadata.Name, modFileFragment.Name);
+        nexusFileResolver.Add(NexusModsFileMetadata.Version, modFileFragment.Version);
+        if (ulong.TryParse(modFileFragment.SizeInBytes, out var size))
+            nexusFileResolver.Add(NexusModsFileMetadata.Size, Size.From(size));
+        return nexusFileResolver.Id;
+    }
+
+    /// <summary>
+    /// Resolves the IModFragment to an entity in the database, inserting or updating as necessary.
+    /// </summary>
+    public static EntityId Resolve(this IModFragment modFragment, IDb db, ITransaction tx)
+    {
+        var nexusModResolver = GraphQLResolver.Create(db, tx, NexusModsModPageMetadata.ModId,
+            ModId.From((ulong)modFragment.ModId));
+        
+        nexusModResolver.Add(NexusModsModPageMetadata.Name, modFragment.Name);
+        nexusModResolver.Add(NexusModsModPageMetadata.GameDomain, GameDomain.From(modFragment.Game.DomainName));
+
+        if (Uri.TryCreate(modFragment.PictureUrl, UriKind.Absolute, out var fullSizedPictureUri))
+            nexusModResolver.Add(NexusModsModPageMetadata.FullSizedPictureUri, fullSizedPictureUri);
+
+        if (Uri.TryCreate(modFragment.ThumbnailUrl, UriKind.Absolute, out var thumbnailUri))
+            nexusModResolver.Add(NexusModsModPageMetadata.ThumbnailUri, thumbnailUri);
+        return nexusModResolver.Id;
+    }
+
+    private static async Task<byte[]> DownloadImage(HttpClient client, string? uri, CancellationToken token)
+    {
+        if (uri is null) return [];
+        if (!Uri.TryCreate(uri, UriKind.Absolute, out var imageUri)) return [];
+        
+        return await client.GetByteArrayAsync(imageUri, token);
+    }
+    
+}

--- a/src/Networking/NexusMods.Networking.NexusWebApi/GraphQL/CollectionRevisionInfo.graphql
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/GraphQL/CollectionRevisionInfo.graphql
@@ -1,3 +1,4 @@
+#import { UserFragment, ModFragment, ModFileFragment } from './CommonFragments.graphql';
 
 # Pulls all the information we need about a collection revision.
 query CollectionRevisionInfo($slug: String!, $revisionNumber: Int!, $viewAdultContent: Boolean!)
@@ -20,18 +21,9 @@ query CollectionRevisionInfo($slug: String!, $revisionNumber: Int!, $viewAdultCo
             gameId,
             fileId,
             file {
-                name,
-                modId,
-                fileId,
-                version,
-                sizeInBytes,
+                ...ModFileFragment
                 mod {
-                    name
-                    game {
-                        domainName
-                    }
-                    thumbnailUrl
-                    pictureUrl
+                    ...ModFragment
                 }
             }
             updatePolicy,
@@ -53,11 +45,8 @@ query CollectionRevisionInfo($slug: String!, $revisionNumber: Int!, $viewAdultCo
                 id
             }
             user {
-                name
-                avatar
-                memberId
+                ...UserFragment
             }
-            
         }
     }
 }

--- a/src/Networking/NexusMods.Networking.NexusWebApi/GraphQL/CommonFragments.graphql
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/GraphQL/CommonFragments.graphql
@@ -1,0 +1,24 @@
+
+fragment UserFragment on User {
+  name
+  avatar
+  memberId  
+}
+
+fragment ModFileFragment on ModFile {
+    name,
+    modId,
+    fileId,
+    version,
+    sizeInBytes
+}
+
+fragment ModFragment on Mod {
+    modId
+    name
+    game {
+        domainName
+    }
+    thumbnailUrl
+    pictureUrl
+}

--- a/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsLibrary.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsLibrary.cs
@@ -12,6 +12,7 @@ using NexusMods.Abstractions.NexusWebApi.Types;
 using NexusMods.Extensions.BCL;
 using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.Networking.HttpDownloader;
+using NexusMods.Networking.NexusWebApi.Extensions;
 using NexusMods.Paths;
 using User = NexusMods.Abstractions.NexusModsLibrary.Models.User;
 
@@ -48,28 +49,15 @@ public class NexusModsLibrary
 
         using var tx = _connection.BeginTransaction();
 
-        var modInfo = await _apiClient.ModInfoAsync(gameDomain.ToString(), modId, cancellationToken);
-
-        var newModPage = new NexusModsModPageMetadata.New(tx)
+        var modInfo = await _gqlClient.ModInfo.ExecuteAsync(gameDomain.ToString(), (int)modId.Value, cancellationToken);
+        EntityId first = default;
+        foreach (var node in modInfo.Data!.LegacyModsByDomain.Nodes)
         {
-            Name = modInfo.Data.Name,
-            ModId = modId,
-            GameDomain = gameDomain,
-        };
-
-        if (Uri.TryCreate(modInfo.Data.PictureUrl, UriKind.Absolute, out var fullSizedPictureUri))
-        {
-            newModPage.FullSizedPictureUri = fullSizedPictureUri;
-
-            var thumbnailUrl = modInfo.Data.PictureUrl.Replace("/images/", "/images/thumbnails/", StringComparison.OrdinalIgnoreCase);
-            if (Uri.TryCreate(thumbnailUrl, UriKind.Absolute, out var thumbnailUri))
-            {
-                newModPage.ThumbnailUri = thumbnailUri;
-            }
+            first = node.Resolve(_connection.Db, tx);
         }
-
+        
         var txResults = await tx.Commit();
-        return txResults.Remap(newModPage);
+        return NexusModsModPageMetadata.Load(txResults.Db, txResults[first]);
     }
     
     /// <summary>
@@ -88,7 +76,6 @@ public class NexusModsLibrary
         var db = _connection.Db;
         var collectionInfo = info.Data!.CollectionRevision.Collection;
         var collectionTileImage = DownloadImage(collectionInfo.TileImage?.ThumbnailUrl, token);
-        var avatarImage = DownloadImage(collectionInfo.User.Avatar, token);
         var collectionBackgroundImage = DownloadImage(collectionInfo.HeaderImage?.Url, token);
 
         // Remap the collection info
@@ -99,13 +86,8 @@ public class NexusModsLibrary
         collectionResolver.Add(CollectionMetadata.TileImage, await collectionTileImage);
         collectionResolver.Add(CollectionMetadata.BackgroundImage, await collectionBackgroundImage);
         
-        // Remap the user info
-        var userResolver = GraphQLResolver.Create(db, tx, User.NexusId, (ulong)collectionInfo.User.MemberId);
-        userResolver.Add(User.Name, collectionInfo.User.Name);
-        userResolver.Add(User.Avatar, new Uri(collectionInfo.User.Avatar));
-        userResolver.Add(User.AvatarImage, await avatarImage);
-        
-        collectionResolver.Add(CollectionMetadata.Author, userResolver.Id);
+        var user = await collectionInfo.User.Resolve(db, tx, _httpClient, token);
+        collectionResolver.Add(CollectionMetadata.Author, user);
         
         // Remap the revision info
         var revisionInfo = info.Data!.CollectionRevision;
@@ -121,38 +103,21 @@ public class NexusModsLibrary
         foreach (var file in revisionInfo.ModFiles)
         {
             var fileInfo = file.File!;
-            var modInfo = fileInfo.Mod;
-            var nexusModResolver = GraphQLResolver.Create(db, tx, NexusModsModPageMetadata.ModId, ModId.From((ulong)fileInfo.ModId));
-            nexusModResolver.Add(NexusModsModPageMetadata.Name, modInfo.Name);
-            nexusModResolver.Add(NexusModsModPageMetadata.GameDomain, GameDomain.From(modInfo.Game.DomainName));
             
-            if (Uri.TryCreate(modInfo.PictureUrl, UriKind.Absolute, out var fullSizedPictureUri))
-                nexusModResolver.Add(NexusModsModPageMetadata.FullSizedPictureUri, fullSizedPictureUri);
-            
-            if (Uri.TryCreate(modInfo.ThumbnailUrl, UriKind.Absolute, out var thumbnailUri))
-                nexusModResolver.Add(NexusModsModPageMetadata.ThumbnailUri, thumbnailUri);
-            
-            
-            var nexusFileResolver = GraphQLResolver.Create(db, tx, (NexusModsFileMetadata.FileId, FileId.From((ulong)fileInfo.FileId)), (NexusModsFileMetadata.ModPageId, nexusModResolver.Id));
-            nexusFileResolver.Add(NexusModsFileMetadata.ModPageId, nexusModResolver.Id);
-            nexusFileResolver.Add(NexusModsFileMetadata.Name, fileInfo.Name);
-            nexusFileResolver.Add(NexusModsFileMetadata.Version, fileInfo.Version);
-            nexusFileResolver.Add(NexusModsFileMetadata.Size, Size.FromLong(long.Parse(fileInfo.SizeInBytes!)));
+            var modEId = fileInfo.Mod.Resolve(db, tx);
+            var modfile = fileInfo.Resolve(db, tx, modEId);
             
             var revisionFileResolver = GraphQLResolver.Create(db, tx, CollectionRevisionModFile.FileId, ulong.Parse(file.Id));
             revisionFileResolver.Add(CollectionRevisionModFile.CollectionRevision, revisionResolver.Id);
-            revisionFileResolver.Add(CollectionRevisionModFile.NexusModFile, nexusFileResolver.Id);
+            revisionFileResolver.Add(CollectionRevisionModFile.NexusModFile, modfile);
             revisionFileResolver.Add(CollectionRevisionModFile.IsOptional, file.Optional);
         }
         
         var txResults = await tx.Commit();
         return CollectionRevisionMetadata.Load(txResults.Db, txResults[revisionResolver.Id]);
     }
-
-    /// <summary>
-    /// Load an image from a URI
-    /// </summary>
-    public async Task<byte[]> DownloadImage(string? uri, CancellationToken token)
+    
+    private async Task<byte[]> DownloadImage(string? uri, CancellationToken token)
     {
         if (uri is null) return [];
         if (!Uri.TryCreate(uri, UriKind.Absolute, out var imageUri)) return [];


### PR DESCRIPTION
Switches GraphQL calls over to using fragments. 

With our GQL library (StrawberryShake), any fragments become C# interfaces. This then allows us to reuse code across various GQL calls by casting subsections of the restults to a fragment interface then calling methods to upsert the data. 

Nothing semantically changes here, just a reorganization of the code. 