### PR TITLE
Improved: Uninstall Experience

### DIFF
--- a/src/NexusMods.App/Commandline/CleanupVerbs.cs
+++ b/src/NexusMods.App/Commandline/CleanupVerbs.cs
@@ -12,6 +12,7 @@ using NexusMods.Abstractions.Settings;
 using NexusMods.CrossPlatform;
 using NexusMods.DataModel;
 using NexusMods.MnemonicDB.Abstractions;
+using NexusMods.Networking.Downloaders;
 using NexusMods.Paths;
 using NexusMods.ProxyConsole.Abstractions;
 using NexusMods.ProxyConsole.Abstractions.VerbDefinitions;
@@ -91,7 +92,10 @@ internal static class CleanupVerbs
                 JsonStorageBackend.GetConfigsFolderPath(fileSystem),
 
                 // The whole base DataModel folder.
-                DataModelSettings.GetStandardDataModelFolder(fileSystem)
+                DataModelSettings.GetStandardDataModelFolder(fileSystem),
+
+                // The whole base Download folder.
+                DownloadSettings.GetStandardDownloadsFolder(fileSystem),
             }.Concat(dataModelSettings.ArchiveLocations.Select(path => path.ToPath(fileSystem)));
 
             if (fileSystem.OS.IsUnix())

--- a/src/NexusMods.App/Commandline/CleanupVerbs.cs
+++ b/src/NexusMods.App/Commandline/CleanupVerbs.cs
@@ -50,7 +50,7 @@ internal static class CleanupVerbs
             try
             {
                 var synchronizer = installation.GetGame().Synchronizer;
-                await synchronizer.UnManage(installation);
+                await synchronizer.UnManage(installation, false);
                 await renderer.Text($"Reverted {installation.Game.Name} to its original state");
             }
             catch (Exception ex)


### PR DESCRIPTION
This PR makes a slight improvement to the uninstall experience.

1. Disables GC when unmanaging game during uninstall, as it's not needed, since the uninstaller will wipe the archives anyway.
2. Deletes the `Downloads` folder during the uninstall procedure.

Currently trying to reproduce the uninstall issue, I cannot either on Linux or Windows at the moment. So this PR should also serve me CI builds to get installer.