### PR TITLE
Improved: Additional Set of Uninstaller Improvements

### DIFF
--- a/src/NexusMods.App/Commandline/CleanupVerbs.cs
+++ b/src/NexusMods.App/Commandline/CleanupVerbs.cs
@@ -36,10 +36,6 @@ internal static class CleanupVerbs
         [Injected] ISettingsManager settingsManager,
         [Injected] IFileSystem fileSystem)
     {
-        // Prevent a race condition where `IRepository` is not fully done initializing.
-        // https://github.com/Nexus-Mods/NexusMods.App/issues/1396
-        Thread.Sleep(1000);
-        
         // Step 1: Revert the managed games to their original state
         var db = conn.Db;
         var managedInstallations = Loadout.All(db)

--- a/src/NexusMods.App/Commandline/CleanupVerbs.cs
+++ b/src/NexusMods.App/Commandline/CleanupVerbs.cs
@@ -91,11 +91,14 @@ internal static class CleanupVerbs
                 // switching backends out. At that point you'd add others here too.
                 JsonStorageBackend.GetConfigsFolderPath(fileSystem),
 
-                // The whole base DataModel folder.
+                // The DataModel folder.
                 DataModelSettings.GetStandardDataModelFolder(fileSystem),
 
                 // The whole base Download folder.
                 DownloadSettings.GetStandardDownloadsFolder(fileSystem),
+
+                // Local Application Data (where all app files default to).
+                DataModelSettings.GetLocalApplicationDataDirectory(fileSystem),
             }.Concat(dataModelSettings.ArchiveLocations.Select(path => path.ToPath(fileSystem)));
 
             if (fileSystem.OS.IsUnix())

--- a/src/NexusMods.App/Commandline/CleanupVerbs.cs
+++ b/src/NexusMods.App/Commandline/CleanupVerbs.cs
@@ -138,8 +138,9 @@ internal static class CleanupVerbs
         var scriptPath = Path.Combine(AppContext.BaseDirectory, "uninstall-helper.ps1");
 
         // Execute the PowerShell script
+        var args = $"-ExecutionPolicy Bypass -Command \"& \'{scriptPath}\' -FilesToDeletePath \'{filesToDeletePath}\' -DirectoriesToDeletePath \'{directoriesToDeletePath}\'\"";
         await Cli.Wrap("powershell")
-            .WithArguments($"-ExecutionPolicy Bypass -Command \"& \"{scriptPath}\" -FilesToDeletePath \"{filesToDeletePath}\" -DirectoriesToDeletePath \"{directoriesToDeletePath}\"\"")
+            .WithArguments(args)
             .ExecuteAsync();
 
         // Clean up the temporary files


### PR DESCRIPTION
## Fix: Remove Local Application Data

Very tiny patch.

Up until now, the uninstaller has been focusing on all locations defined within the App's config files; this is because it has historically been possible to re-route these to different locations on disk via various config knobs.

However, that leaves the base NMA folder stranded on the FileSystem, which means that users will get an unwanted prompt on re-install:

![image](https://github.com/user-attachments/assets/9109f540-b76e-417b-bfc9-ad138dc3f920)

This PR adds the 'Local Application Data' directory as one of the targets to wipe, ensuring no folders are left behind.

## Fix: Fix Windows Uninstall when App Location has Spaces

Uninstall on Windows now works if the path to the Application folder has spaces in it.
The path to the PowerShell script wasn't escaped properly, PS has rules for nested escapes, and that wasn't being handled properly.

## Fix: Remove Waiting Workaround from Old DataModel Bug

See deleted lines. We used to have a concurrency bug with `IRepository`, but that's been fixed since.