### PR TITLE
Corrected tooltip foreground

### DIFF
--- a/src/NexusMods.App.UI/LeftMenu/Items/ApplyControlView.axaml
+++ b/src/NexusMods.App.UI/LeftMenu/Items/ApplyControlView.axaml
@@ -41,7 +41,7 @@
                     Height="44"
                     x:Name="ApplyButton">
                 <ToolTip.Tip>
-                    <TextBlock Text="{x:Static resources:Language.ApplyControlView_Apply_ToolTip}" />
+                    <TextBlock Text="{x:Static resources:Language.ApplyControlView_Apply_ToolTip}" Foreground="White" />
                 </ToolTip.Tip>
                 <StackPanel Orientation="Horizontal"
                             HorizontalAlignment="Center"

--- a/src/NexusMods.App.UI/LeftMenu/Items/ApplyControlView.axaml
+++ b/src/NexusMods.App.UI/LeftMenu/Items/ApplyControlView.axaml
@@ -41,7 +41,7 @@
                     Height="44"
                     x:Name="ApplyButton">
                 <ToolTip.Tip>
-                    <TextBlock Text="{x:Static resources:Language.ApplyControlView_Apply_ToolTip}" Foreground="White" />
+                    <TextBlock Text="{x:Static resources:Language.ApplyControlView_Apply_ToolTip}" Foreground="{StaticResource NeutralStrong}" />
                 </ToolTip.Tip>
                 <StackPanel Orientation="Horizontal"
                             HorizontalAlignment="Center"


### PR DESCRIPTION
Closes #2123 

Just a foreground mismatch.
Another issue with the style-inheritance, like seen on #1822 i think

![image](https://github.com/user-attachments/assets/c25ab078-f2a8-420c-b1a4-aae0bd4b001d)
