### PR TITLE
Fix off-screen row updates in the Library

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.MnemonicDB.Attributes/Extensions/EntityExtensions.cs
+++ b/src/Abstractions/NexusMods.Abstractions.MnemonicDB.Attributes/Extensions/EntityExtensions.cs
@@ -18,16 +18,19 @@ public static class EntityExtensions
     {
         return model.Max(m => m.T);
     }
-    
-    
+
+
     /// <summary>
     /// Gets the timestamp of the transaction that created the model.
     /// </summary>
     /// <param name="model"></param>
+    /// <param name="dateTime">A default value to return if the model doesn't exist.</param>
     /// <returns></returns>
-    public static DateTime GetCreatedAt<T>(this T model)
+    public static DateTime GetCreatedAt<T>(this T model, DateTime? dateTime = null)
     where T : IReadOnlyModel
     {
+        if (model.Count == 0)
+            return dateTime ?? DateTime.MinValue;
         var tx = new Transaction.ReadOnly(model.Db, EntityId.From(model.Min(m => m.T).Value));
         return Transaction.Timestamp.Get(tx);
     }

--- a/src/Abstractions/NexusMods.Abstractions.MnemonicDB.Attributes/Extensions/EntityExtensions.cs
+++ b/src/Abstractions/NexusMods.Abstractions.MnemonicDB.Attributes/Extensions/EntityExtensions.cs
@@ -10,7 +10,6 @@ namespace NexusMods.Abstractions.MnemonicDB.Attributes.Extensions;
 /// </summary>
 public static class EntityExtensions
 {
-    
     /// <summary>
     /// Gets the largest transaction id in the model.
     /// </summary>
@@ -18,7 +17,6 @@ public static class EntityExtensions
     {
         return model.Max(m => m.T);
     }
-
 
     /// <summary>
     /// Gets the timestamp of the transaction that created the model.
@@ -34,7 +32,6 @@ public static class EntityExtensions
         var tx = new Transaction.ReadOnly(model.Db, EntityId.From(model.Min(m => m.T).Value));
         return Transaction.Timestamp.Get(tx);
     }
-    
     
     /// <summary>
     /// Tries to parse an entity id from a hex string.

--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridAdapter.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridAdapter.cs
@@ -54,7 +54,7 @@ public abstract class TreeDataGridAdapter<TModel, TKey> : ReactiveR3Object
                 .AddTo(disposables);
 
             self.Roots
-                .ObserveCountChanged(true)
+                .ObserveCountChanged(notifyCurrentCount: true)
                 .Subscribe(self, static (count, self) => self.IsSourceEmpty.Value = count == 0)
                 .AddTo(disposables);
 

--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridAdapter.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridAdapter.cs
@@ -54,7 +54,7 @@ public abstract class TreeDataGridAdapter<TModel, TKey> : ReactiveR3Object
                 .AddTo(disposables);
 
             self.Roots
-                .ObserveCountChanged()
+                .ObserveCountChanged(true)
                 .Subscribe(self, static (count, self) => self.IsSourceEmpty.Value = count == 0)
                 .AddTo(disposables);
 

--- a/src/NexusMods.App.UI/Pages/LibraryPage/FakeParentLibraryItemModel.cs
+++ b/src/NexusMods.App.UI/Pages/LibraryPage/FakeParentLibraryItemModel.cs
@@ -33,7 +33,7 @@ public class FakeParentLibraryItemModel : LibraryItemModel
             model.NumInstalledObservable
                 .ToObservable()
                 .CombineLatest(
-                    source2: model.LibraryItems.ObserveCountChanged(),
+                    source2: model.LibraryItems.ObserveCountChanged(true),
                     source3: model.WhenAnyValue(static model => model.IsExpanded).ToObservable(),
                     source4: model.IsInstalledInLoadout,
                     static (a,b,c , _) => (a,b,c)

--- a/src/NexusMods.App.UI/Pages/LibraryPage/FakeParentLibraryItemModel.cs
+++ b/src/NexusMods.App.UI/Pages/LibraryPage/FakeParentLibraryItemModel.cs
@@ -33,7 +33,7 @@ public class FakeParentLibraryItemModel : LibraryItemModel
             model.NumInstalledObservable
                 .ToObservable()
                 .CombineLatest(
-                    source2: model.LibraryItems.ObserveCountChanged(true),
+                    source2: model.LibraryItems.ObserveCountChanged(notifyCurrentCount: true),
                     source3: model.WhenAnyValue(static model => model.IsExpanded).ToObservable(),
                     source4: model.IsInstalledInLoadout,
                     static (a,b,c , _) => (a,b,c)

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutViewModel.cs
@@ -164,7 +164,7 @@ public class LoadoutViewModel : APageViewModel<ILoadoutViewModel>, ILoadoutViewM
                 configureAwait: false).AddTo(disposables);
 
                 // Compute the target group for the ViewFilesCommand
-                Adapter.SelectedModels.ObserveCountChanged()
+                Adapter.SelectedModels.ObserveCountChanged(true)
                     .Select(this, static (count, vm) => count == 1 ? vm.Adapter.SelectedModels.First() : null)
                     .ObserveOnThreadPool()
                     .Select(_connection,

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutViewModel.cs
@@ -164,7 +164,7 @@ public class LoadoutViewModel : APageViewModel<ILoadoutViewModel>, ILoadoutViewM
                 configureAwait: false).AddTo(disposables);
 
                 // Compute the target group for the ViewFilesCommand
-                Adapter.SelectedModels.ObserveCountChanged(true)
+                Adapter.SelectedModels.ObserveCountChanged(notifyCurrentCount: true)
                     .Select(this, static (count, vm) => count == 1 ? vm.Adapter.SelectedModels.First() : null)
                     .ObserveOnThreadPool()
                     .Select(_connection,

--- a/src/NexusMods.Collections/NexusMods.Collections.csproj
+++ b/src/NexusMods.Collections/NexusMods.Collections.csproj
@@ -4,6 +4,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Abstractions\NexusMods.Abstractions.Collections\NexusMods.Abstractions.Collections.csproj" />
+      <ProjectReference Include="..\Abstractions\NexusMods.Abstractions.FileExtractor\NexusMods.Abstractions.FileExtractor.csproj" />
       <ProjectReference Include="..\Abstractions\NexusMods.Abstractions.Jobs\NexusMods.Abstractions.Jobs.csproj" />
       <ProjectReference Include="..\Abstractions\NexusMods.Abstractions.Library\NexusMods.Abstractions.Library.csproj" />
       <ProjectReference Include="..\ArchiveManagement\NexusMods.FileExtractor\NexusMods.FileExtractor.csproj" />


### PR DESCRIPTION
The install/installed status of a row is dependent on the number of connect loadout items. `ObserveCountChanged()` does not notify of the current count on a subscription (by default). So when a row was re-activated the installed status of the row defaulted to the status when it was last seen on screen, and would only update if the status changed again in the future. This PR adds `notifyCurrentCount:true` to these invocations to fix this problem. 

Also updates `GetCreatedAt` so it no longer crashes Rx chains during deletion of entities. 

fixes: #2141 and #2140