### PR TITLE
Switch LocationId (and GamePaths) over to an ushort instead of a string

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.GameLocators/FNV1aHash.cs
+++ b/src/Abstractions/NexusMods.Abstractions.GameLocators/FNV1aHash.cs
@@ -1,0 +1,26 @@
+namespace NexusMods.Abstractions.GameLocators;
+
+/// <summary>
+/// A simple FNV1a hash implementation for hashing strings to 32-bit integers
+/// </summary>
+public static class FNV1aHash
+{
+    private const uint FNV1aPrime = 0x01000193U;
+
+    private const uint FNV1aOffsetBasis = 0x811C9DC5U;
+    
+    /// <summary>
+    /// Get the FNV1a hash of the given string
+    /// </summary>
+    public static uint Hash(ReadOnlySpan<char> data)
+    {
+        var hash = FNV1aOffsetBasis;
+        for(var i = 0; i < data.Length; i++)
+        {
+            hash ^= data[i];
+            hash *= FNV1aPrime;
+        }
+        return hash;
+    }
+    
+}

--- a/src/Abstractions/NexusMods.Abstractions.GameLocators/LocationId.cs
+++ b/src/Abstractions/NexusMods.Abstractions.GameLocators/LocationId.cs
@@ -1,11 +1,48 @@
-﻿namespace NexusMods.Abstractions.GameLocators;
+﻿using System.Collections.Immutable;
+using TransparentValueObjects;
+
+namespace NexusMods.Abstractions.GameLocators;
 
 /// <summary>
 /// The base folder for the GamePath, more values can easily be added here as needed
 /// </summary>
-[TransparentValueObjects.ValueObject<string>]
+[ValueObject<ushort>]
 public readonly partial struct LocationId
 {
+    private static ImmutableDictionary<ushort, string> _cache = ImmutableDictionary<ushort, string>.Empty;
+    
+    /// <summary>
+    /// Converts the string to a LocationId, if the string is not already interned it will be added to the cache, if a hash collision is
+    /// detected (highly unlikely) an exception will be thrown.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    public static LocationId From(string value)
+    {
+        var hash = FNV1aHash.Hash(value);
+        var mixed = (ushort) ((hash >> 16) ^ (hash & 0xFFFF));
+        if (_cache.TryGetValue(mixed, out var existing))
+        {
+            if (existing != value)
+            {
+                throw new InvalidOperationException($"Hash collision detected for '{value}' and '{existing}'");
+            }
+            return From(mixed);
+        }
+        
+        while (true)
+        {
+            var newCache = _cache.Add(mixed, value);
+            if (ReferenceEquals(Interlocked.CompareExchange(ref _cache, newCache, _cache), _cache))
+                break;
+        }
+        return From(mixed);
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => _cache[Value];
+    
     /// <summary>
     /// Unknown game folder type, used for default values.
     /// </summary>

--- a/src/Abstractions/NexusMods.Abstractions.MnemonicDB.Attributes/GamePathAttribute.cs
+++ b/src/Abstractions/NexusMods.Abstractions.MnemonicDB.Attributes/GamePathAttribute.cs
@@ -16,7 +16,7 @@ public class GamePathAttribute(string ns, string name) : ScalarAttribute<GamePat
     protected override string ToLowLevel(GamePath value)
     {
         // TODO: make this a reference or something
-        return $"{value.LocationId.Value}|{value.Path}";
+        return $"{value.LocationId}|{value.Path}";
     }
 
     /// <inheritdoc />

--- a/src/Abstractions/NexusMods.Abstractions.MnemonicDB.Attributes/GamePathParentAttribute.cs
+++ b/src/Abstractions/NexusMods.Abstractions.MnemonicDB.Attributes/GamePathParentAttribute.cs
@@ -10,16 +10,16 @@ namespace NexusMods.Abstractions.MnemonicDB.Attributes;
 /// An attribute that combines an EntityId, LocationId and RelativePath into a single attribute. This is used to represent GamePaths prefixed
 /// with a parent entity so that range queries only return the paths that are children of the parent entity.
 /// </summary>
-public class GamePathParentAttribute(string ns, string name) : TupleAttribute<EntityId, ulong, LocationId, string, RelativePath, string>(ValueTags.Reference, ValueTags.Ascii, ValueTags.Utf8, ns, name) 
+public class GamePathParentAttribute(string ns, string name) : TupleAttribute<EntityId, ulong, LocationId, ushort, RelativePath, string>(ValueTags.Reference, ValueTags.UInt16, ValueTags.Utf8, ns, name) 
 {
     /// <inheritdoc />
-    protected override (EntityId, LocationId, RelativePath) FromLowLevel((ulong, string, string) value)
+    protected override (EntityId, LocationId, RelativePath) FromLowLevel((ulong, ushort, string) value)
     {
         return (EntityId.From(value.Item1), LocationId.From(value.Item2), RelativePath.FromUnsanitizedInput(value.Item3));
     }
 
     /// <inheritdoc />
-    protected override (ulong, string, string) ToLowLevel((EntityId, LocationId, RelativePath) value)
+    protected override (ulong, ushort, string) ToLowLevel((EntityId, LocationId, RelativePath) value)
     {
         return (value.Item1.Value, value.Item2.Value, value.Item3);
     }

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/Preview/TreeEntry/PreviewTreeEntryViewModel.cs
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/Preview/TreeEntry/PreviewTreeEntryViewModel.cs
@@ -45,7 +45,7 @@ public class PreviewTreeEntryViewModel : AViewModel<IPreviewTreeEntryViewModel>,
 
         IsRoot = GamePath.Path == RelativePath.Empty;
         Parent = IsRoot ? IPreviewTreeEntryViewModel.RootParentGamePath : GamePath.Parent;
-        DisplayName = gamePath.FileName == RelativePath.Empty ? gamePath.LocationId.Value : gamePath.FileName;
+        DisplayName = gamePath.FileName == RelativePath.Empty ? gamePath.LocationId.ToString() : gamePath.FileName;
         IsFolderDupe = gamePath.FileName == gamePath.Parent.FileName && gamePath.FileName != RelativePath.Empty;
         IsFolderMerged = false;
         IsRemovable = true;

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/SelectLocation/SuggestedEntry/SuggestedEntryViewModel.cs
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/SelectLocation/SuggestedEntry/SuggestedEntryViewModel.cs
@@ -37,7 +37,7 @@ public class SuggestedEntryViewModel : AViewModel<ISuggestedEntryViewModel>, ISu
         AssociatedLocation = associatedLocation;
         RelativeToTopLevelLocation = relativeToTopLevelLocation;
 
-        Title = title == string.Empty ? associatedLocation.Value : title;
+        Title = title == string.Empty ? associatedLocation.Value.ToString() : title;
         Subtitle = subtitle == string.Empty ? AbsolutePath.ToString() : subtitle;
 
         CreateMappingCommand = ReactiveCommand.Create(() => { });

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/SelectLocation/TreeEntry/SelectableTreeEntryViewModel.cs
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/SelectLocation/TreeEntry/SelectableTreeEntryViewModel.cs
@@ -41,7 +41,7 @@ public class SelectableTreeEntryViewModel : AViewModel<ISelectableTreeEntryViewM
         IsRoot = GamePath.Path == RelativePath.Empty;
         // Use invalid parent path for root node, to avoid matching another node by accident.
         Parent = IsRoot ? ISelectableTreeEntryViewModel.RootParentGamePath : GamePath.Parent;
-        DisplayName = gamePath.FileName == RelativePath.Empty ? gamePath.LocationId.Value : gamePath.FileName;
+        DisplayName = gamePath.FileName == RelativePath.Empty ? gamePath.LocationId.ToString() : gamePath.FileName;
         InputText = string.Empty;
 
         CreateMappingCommand = ReactiveCommand.Create(() => { });

--- a/src/NexusMods.DataModel/JsonConverters/GamePathConverter.cs
+++ b/src/NexusMods.DataModel/JsonConverters/GamePathConverter.cs
@@ -29,7 +29,7 @@ public class GamePathConverter : JsonConverter<GamePath>
     public override void Write(Utf8JsonWriter writer, GamePath value, JsonSerializerOptions options)
     {
         writer.WriteStartArray();
-        writer.WriteStringValue(value.LocationId.Value);
+        writer.WriteStringValue(value.LocationId.ToString());
         writer.WriteStringValue(value.Path.ToString());
         writer.WriteEndArray();
     }


### PR DESCRIPTION
A longstanding problem with efficiency with `LocationId`, is that internally it stores the location as a string (not even interned incidentally). With MnemonicDB this is even worse as we store GamePaths as tuples, which results in the stored value being a composite value of two variable sized strings. We can clean all this up fairly simply, and that's what this patch does:

* Stores LocationId now as a ushort
* The ushort is calculated via a FNV1a (32bit) hash with the upper and lower halves combined with an XOR
* When a string is converted to a LocationId we hash it, then make sure it doesn't collide with existing values
* Performance of creating LocationIds from strings will be slightly slower with this method but the most performance critical parts of the code use `ushorts` and not strings
* The LocationId struct overrides the ToString value to provide a nice conversion back to the original string value

All told this is a fairly small code change that I don't think has much of an impact on anything besides a sizable reduction memory usage and a massive improvement in serialization in MnemonicDB