### PR TITLE
Small fixes and Export CLI method

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,8 +12,8 @@
     <PackageVersion Include="Nerdbank.FullDuplexStream" Version="1.1.12" />
     <PackageVersion Include="Nerdbank.Streams" Version="2.11.74" />
     <PackageVersion Include="NexusMods.Paths" Version="0.10.0" />
-    <PackageVersion Include="NexusMods.MnemonicDB.Abstractions" Version="0.9.86" />
-    <PackageVersion Include="NexusMods.MnemonicDB" Version="0.9.86" />
+    <PackageVersion Include="NexusMods.MnemonicDB.Abstractions" Version="0.9.89" />
+    <PackageVersion Include="NexusMods.MnemonicDB" Version="0.9.89" />
     <PackageVersion Include="NexusMods.Hashing.xxHash64" Version="2.0.2" />
     <PackageVersion Include="NexusMods.Paths.Extensions.Nx" Version="0.10.0" />
     <PackageVersion Include="NexusMods.Paths.TestingHelpers" Version="0.10.0" />
@@ -127,7 +127,7 @@
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="ini-parser-netstandard" Version="2.5.2" />
     <PackageVersion Include="Mutagen.Bethesda.Skyrim" Version="0.44.0" />
-    <PackageVersion Include="NexusMods.MnemonicDB.SourceGenerator" Version="0.9.86" />
+    <PackageVersion Include="NexusMods.MnemonicDB.SourceGenerator" Version="0.9.89" />
     <PackageVersion Include="NLog.Extensions.Logging" Version="5.3.11" />
     <PackageVersion Include="OneOf" Version="3.0.271" />
     <PackageVersion Include="ReactiveUI.Fody" Version="19.5.41" />

--- a/src/Abstractions/NexusMods.Abstractions.FileStore/Downloads/DownloadAnalysis.cs
+++ b/src/Abstractions/NexusMods.Abstractions.FileStore/Downloads/DownloadAnalysis.cs
@@ -10,6 +10,7 @@ using NexusMods.MnemonicDB.Abstractions.Models;
 using NexusMods.MnemonicDB.Storage;
 using NexusMods.Paths;
 using ModFileTreeNode = NexusMods.Paths.Trees.KeyedBox<NexusMods.Paths.RelativePath, NexusMods.Abstractions.FileStore.Trees.ModFileTree>;
+using ULongAttribute = NexusMods.Abstractions.MnemonicDB.Attributes.ULongAttribute;
 
 namespace NexusMods.Abstractions.FileStore.Downloads;
 

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts/Files/Metadata.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts/Files/Metadata.cs
@@ -1,6 +1,7 @@
 using NexusMods.Abstractions.MnemonicDB.Attributes;
 using NexusMods.MnemonicDB.Abstractions.Attributes;
 using NexusMods.MnemonicDB.Abstractions.Models;
+using ULongAttribute = NexusMods.Abstractions.MnemonicDB.Attributes.ULongAttribute;
 
 namespace NexusMods.Abstractions.Loadouts.Files;
 

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts/Loadout.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts/Loadout.cs
@@ -12,6 +12,7 @@ using NexusMods.MnemonicDB.Abstractions.BuiltInEntities;
 using NexusMods.MnemonicDB.Abstractions.Models;
 using NexusMods.MnemonicDB.Abstractions.TxFunctions;
 using File = NexusMods.Abstractions.Loadouts.Files.File;
+using ULongAttribute = NexusMods.Abstractions.MnemonicDB.Attributes.ULongAttribute;
 
 namespace NexusMods.Abstractions.Loadouts;
 

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts/Mods/Mod.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts/Mods/Mod.cs
@@ -10,6 +10,7 @@ using NexusMods.MnemonicDB.Abstractions.Models;
 using NexusMods.MnemonicDB.Abstractions.TxFunctions;
 using NexusMods.MnemonicDB.Storage;
 using File = NexusMods.Abstractions.Loadouts.Files.File;
+using ULongAttribute = NexusMods.Abstractions.MnemonicDB.Attributes.ULongAttribute;
 
 namespace NexusMods.Abstractions.Loadouts.Mods;
 

--- a/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/CollectionTag.cs
+++ b/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/CollectionTag.cs
@@ -1,6 +1,7 @@
 using NexusMods.Abstractions.MnemonicDB.Attributes;
 using NexusMods.MnemonicDB.Abstractions.Attributes;
 using NexusMods.MnemonicDB.Abstractions.Models;
+using ULongAttribute = NexusMods.Abstractions.MnemonicDB.Attributes.ULongAttribute;
 
 namespace NexusMods.Abstractions.NexusModsLibrary;
 

--- a/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/Models/CollectionMetadata.cs
+++ b/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/Models/CollectionMetadata.cs
@@ -3,6 +3,7 @@ using NexusMods.Abstractions.NexusModsLibrary.Attributes;
 using NexusMods.Abstractions.Resources.DB;
 using NexusMods.MnemonicDB.Abstractions.Attributes;
 using NexusMods.MnemonicDB.Abstractions.Models;
+using ULongAttribute = NexusMods.Abstractions.MnemonicDB.Attributes.ULongAttribute;
 
 namespace NexusMods.Abstractions.NexusModsLibrary.Models;
 

--- a/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/Models/CollectionRevisionMetadata.cs
+++ b/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/Models/CollectionRevisionMetadata.cs
@@ -2,6 +2,7 @@ using NexusMods.Abstractions.MnemonicDB.Attributes;
 using NexusMods.Abstractions.NexusModsLibrary.Attributes;
 using NexusMods.MnemonicDB.Abstractions.Attributes;
 using NexusMods.MnemonicDB.Abstractions.Models;
+using ULongAttribute = NexusMods.Abstractions.MnemonicDB.Attributes.ULongAttribute;
 
 namespace NexusMods.Abstractions.NexusModsLibrary.Models;
 

--- a/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/Models/CollectionRevisionModFile.cs
+++ b/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/Models/CollectionRevisionModFile.cs
@@ -1,6 +1,7 @@
 using NexusMods.Abstractions.MnemonicDB.Attributes;
 using NexusMods.MnemonicDB.Abstractions.Attributes;
 using NexusMods.MnemonicDB.Abstractions.Models;
+using ULongAttribute = NexusMods.Abstractions.MnemonicDB.Attributes.ULongAttribute;
 
 namespace NexusMods.Abstractions.NexusModsLibrary.Models;
 

--- a/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/Models/User.cs
+++ b/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/Models/User.cs
@@ -2,6 +2,7 @@ using NexusMods.Abstractions.MnemonicDB.Attributes;
 using NexusMods.Abstractions.NexusModsLibrary.Attributes;
 using NexusMods.MnemonicDB.Abstractions.Attributes;
 using NexusMods.MnemonicDB.Abstractions.Models;
+using ULongAttribute = NexusMods.Abstractions.MnemonicDB.Attributes.ULongAttribute;
 
 namespace NexusMods.Abstractions.NexusModsLibrary.Models;
 

--- a/src/Networking/NexusMods.Networking.NexusWebApi/LoginManager.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/LoginManager.cs
@@ -150,12 +150,7 @@ public sealed class LoginManager : IDisposable, ILoginManager
     public async Task Logout()
     {
         _cachedUserInfo.Evict();
-        using var tx = _conn.BeginTransaction();
-        foreach (var token in JWTToken.All(_conn.Db))
-        {
-            tx.Delete(token.Id, true);
-        }
-        await tx.Commit();
+        await _conn.Excise(JWTToken.All(_conn.Db).Select(e => e.Id).ToArray());
     }
     
     

--- a/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsLibrary.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsLibrary.cs
@@ -145,7 +145,6 @@ public class NexusModsLibrary
         var fileEntities = NexusModsFileMetadata.FindByUid(_connection.Db, uid);
         if (fileEntities.TryGetFirst(x => x.ModPageId == modPage, out var file)) return file;
 
-        var uid = UidForFile.FromUlong((ulong)fileId);
         using var tx = _connection.BeginTransaction();
 
         var filesResponse = await _apiClient.ModFilesAsync(gameDomain.ToString(), modPage.Uid.ModId, cancellationToken);

--- a/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsLibrary.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsLibrary.cs
@@ -145,11 +145,12 @@ public class NexusModsLibrary
         var fileEntities = NexusModsFileMetadata.FindByUid(_connection.Db, uid);
         if (fileEntities.TryGetFirst(x => x.ModPageId == modPage, out var file)) return file;
 
+        var uid = UidForFile.FromUlong((ulong)fileId);
         using var tx = _connection.BeginTransaction();
 
         var filesResponse = await _apiClient.ModFilesAsync(gameDomain.ToString(), modPage.Uid.ModId, cancellationToken);
         var files = filesResponse.Data.Files;
-
+        
         if (!files.TryGetFirst(x => x.FileId == fileId, out var fileInfo))
             throw new NotImplementedException();
 

--- a/src/NexusMods.Collections/InstallCollectionJob.cs
+++ b/src/NexusMods.Collections/InstallCollectionJob.cs
@@ -419,7 +419,7 @@ public class InstallCollectionJob : IJobDefinitionWithStart<InstallCollectionJob
 
         if (file.HasValue)
         {
-            if (!file.Value.LibraryFiles.First().AsLibraryItem().TryGetAsLibraryFile(out var firstLibraryFile)) 
+            if (file.Value.LibraryFiles.First().AsLibraryItem().TryGetAsLibraryFile(out var firstLibraryFile)) 
                 return (mod, firstLibraryFile);
         }
 

--- a/src/NexusMods.DataModel/CommandLine/Verbs/ImportExport.cs
+++ b/src/NexusMods.DataModel/CommandLine/Verbs/ImportExport.cs
@@ -1,0 +1,37 @@
+using System.IO.Compression;
+using Microsoft.Extensions.DependencyInjection;
+using NexusMods.Abstractions.Cli;
+using NexusMods.MnemonicDB.Abstractions;
+using NexusMods.Paths;
+using NexusMods.ProxyConsole.Abstractions;
+using NexusMods.ProxyConsole.Abstractions.VerbDefinitions;
+
+namespace NexusMods.DataModel.CommandLine.Verbs;
+
+/// <summary>
+/// Routines for importing and exporting the data model
+/// </summary>
+public static class ImportExport
+{
+    /// <summary>
+    /// Register the import/export verbs
+    /// </summary>
+    /// <param name="services"></param>
+    /// <returns></returns>
+    public static IServiceCollection AddImportExportVerbs(this IServiceCollection services) =>
+        services.AddVerb(() => Export);
+    
+    [Verb("export", "Export the data model to a file")]
+    private static async Task<int> Export([Injected] IRenderer renderer, 
+        [Injected] IConnection connection,
+        [Option("o", "output", "Output file, the contents will be compressed with deflate")] AbsolutePath output)
+    {
+        await using var stream = output.Create();
+        await renderer.RenderAsync(Renderable.Text("Exporting data model to file"));
+        await using var deflateStream = new DeflateStream(stream, CompressionLevel.Optimal); 
+        await connection.DatomStore.ExportAsync(deflateStream);
+        await renderer.RenderAsync(Renderable.Text("Exported data model to file"));
+        return 0;
+    }
+
+}

--- a/src/NexusMods.DataModel/CommandLine/Verbs/ImportExport.cs
+++ b/src/NexusMods.DataModel/CommandLine/Verbs/ImportExport.cs
@@ -21,7 +21,7 @@ public static class ImportExport
     public static IServiceCollection AddImportExportVerbs(this IServiceCollection services) =>
         services.AddVerb(() => Export);
     
-    [Verb("export", "Export the data model to a file")]
+    [Verb("export-datamodel", "Export the data model to a file")]
     private static async Task<int> Export([Injected] IRenderer renderer, 
         [Injected] IConnection connection,
         [Option("o", "output", "Output file, the contents will be compressed with deflate")] AbsolutePath output)

--- a/src/NexusMods.DataModel/Services.cs
+++ b/src/NexusMods.DataModel/Services.cs
@@ -123,6 +123,7 @@ public static class Services
 
         // Verbs
         coll.AddLoadoutManagementVerbs()
+            .AddImportExportVerbs()
             .AddToolVerbs();
 
         return coll;


### PR DESCRIPTION
Updates MnemonicDB to the latest version (fixes the UTF8 decode error), also adds an `Export` CLI method for exporting the MnemonicDB database to a file so that we can use the data for testing in MnemonicDB