### PR TITLE
Fix login observables triggering on every API call

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.NexusWebApi/ILoginManager.cs
+++ b/src/Abstractions/NexusMods.Abstractions.NexusWebApi/ILoginManager.cs
@@ -1,4 +1,5 @@
 using NexusMods.Abstractions.NexusWebApi.Types;
+using R3;
 
 namespace NexusMods.Abstractions.NexusWebApi;
 
@@ -7,26 +8,25 @@ namespace NexusMods.Abstractions.NexusWebApi;
 /// </summary>
 public interface ILoginManager
 {
-    
     /// <summary>
-    /// Allows you to subscribe to notifications of when the user information changes.
+    /// Observable about user info.
     /// </summary>
-    IObservable<UserInfo?> UserInfoObservable { get; }
+    Observable<UserInfo?> UserInfoObservable { get; }
 
     /// <summary>
     /// True if the user is logged in
     /// </summary>
-    IObservable<bool> IsLoggedInObservable { get; }
+    IObservable<bool> IsLoggedInObservable => UserInfoObservable.Select(static x => x is not null).DistinctUntilChanged().AsSystemObservable();
 
     /// <summary>
     /// True if the user is logged in and is a premium member
     /// </summary>
-    IObservable<bool> IsPremiumObservable { get; }
+    IObservable<bool> IsPremiumObservable => UserInfoObservable.WhereNotNull().Select(static x => x.IsPremium).DistinctUntilChanged().AsSystemObservable();
 
     /// <summary>
     /// The user's avatar
     /// </summary>
-    IObservable<Uri?> AvatarObservable { get; }
+    IObservable<Uri?> AvatarObservable => UserInfoObservable.Select(static x => x?.AvatarUrl).DistinctUntilChanged().AsSystemObservable();
 
     /// <summary>
     /// Show a browser and log into Nexus Mods

--- a/src/Networking/NexusMods.Networking.NexusWebApi/LoginManager.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/LoginManager.cs
@@ -1,6 +1,5 @@
-using System.Reactive.Concurrency;
 using System.Reactive.Linq;
-using DynamicData;
+using DynamicData.Aggregation;
 using JetBrains.Annotations;
 using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.NexusWebApi;
@@ -9,8 +8,10 @@ using NexusMods.Abstractions.NexusWebApi.Types;
 using NexusMods.CrossPlatform.ProtocolRegistration;
 using NexusMods.Extensions.BCL;
 using NexusMods.MnemonicDB.Abstractions;
+using NexusMods.MnemonicDB.Abstractions.Query;
 using NexusMods.MnemonicDB.Abstractions.TxFunctions;
 using NexusMods.Networking.NexusWebApi.Auth;
+using R3;
 
 namespace NexusMods.Networking.NexusWebApi;
 
@@ -26,25 +27,12 @@ public sealed class LoginManager : IDisposable, ILoginManager
     private readonly NexusApiClient _nexusApiClient;
     private readonly IAuthenticatingMessageFactory _msgFactory;
 
-    /// <summary>
-    /// Allows you to subscribe to notifications of when the user information changes.
-    /// </summary>
-    public IObservable<UserInfo?> UserInfoObservable { get; }
-    
-    /// <summary>
-    /// True if the user is logged in
-    /// </summary>
-    public IObservable<bool> IsLoggedInObservable => UserInfoObservable.Select(info => info is not null);
-    
-    /// <summary>
-    /// True if the user is logged in and is a premium member
-    /// </summary>
-    public IObservable<bool> IsPremiumObservable => UserInfoObservable.Select(info => info?.IsPremium ?? false);
+    private readonly BehaviorSubject<UserInfo?> _userInfo = new(initialValue: null);
 
-    /// <summary>
-    /// The user's avatar
-    /// </summary>
-    public IObservable<Uri?> AvatarObservable => UserInfoObservable.Select(info => info?.AvatarUrl);
+    /// <inheritdoc/>
+    public Observable<UserInfo?> UserInfoObservable => _userInfo;
+
+    private readonly IDisposable _observeDatomDisposable;
 
     /// <summary>
     /// Constructor.
@@ -64,16 +52,18 @@ public sealed class LoginManager : IDisposable, ILoginManager
         _protocolRegistration = protocolRegistration;
         _logger = logger;
 
-        UserInfoObservable = JWTToken.ObserveAll(_conn)
-            // We only care that it has changed, not the actual value
-            .QueryWhenChanged(values => values.Count > 0)
-            .ObserveOn(TaskPoolScheduler.Default)
-            .SelectMany(async hasValue  =>
-                {
-                    if (!hasValue) return null;
-                    return await Verify(CancellationToken.None);
-                }
-            );
+        _observeDatomDisposable = _conn
+            .ObserveDatoms(JWTToken.PrimaryAttribute)
+            .IsNotEmpty()
+            .ToObservable()
+            .DistinctUntilChanged()
+            .SubscribeAwait(async (hasValue, cancellationToken) =>
+            {
+                _cachedUserInfo.Evict();
+
+                if (!hasValue) _userInfo.OnNext(value: null);
+                else _userInfo.OnNext(await Verify(cancellationToken));
+            }, awaitOperation: AwaitOperation.Sequential, configureAwait: false);
     }
 
     private CachedObject<UserInfo> _cachedUserInfo = new(TimeSpan.FromHours(1));
@@ -163,6 +153,6 @@ public sealed class LoginManager : IDisposable, ILoginManager
     public void Dispose()
     {
         _verifySemaphore.Dispose();
+        _observeDatomDisposable.Dispose();
     }
-    
 }

--- a/src/Networking/NexusMods.Networking.NexusWebApi/Services.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/Services.cs
@@ -38,13 +38,10 @@ public static class Services
         }
         collection.AddSingleton<OAuth>();
         collection.AddSingleton<IIDGenerator, IDGenerator>();
-        
-        // JWToken
-        collection.AddAttributeCollection(typeof(JWTToken));
-        
-        // Nexus API Key
-        collection.AddAttributeCollection(typeof(ApiKey));
-        
+
+        collection.AddJWTTokenModel();
+        collection.AddApiKeyModel();
+
         collection
             .AddNexusModsLibraryModels()
             .AddSingleton<NexusModsLibrary>()

--- a/src/NexusMods.App/TelemetryProvider.cs
+++ b/src/NexusMods.App/TelemetryProvider.cs
@@ -1,19 +1,16 @@
 using System.Reactive.Disposables;
 using DynamicData;
-using DynamicData.Aggregation;
-using DynamicData.Binding;
 using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.FileStore.Downloads;
-using NexusMods.Abstractions.Games.DTO;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Loadouts.Mods;
 using NexusMods.Abstractions.MnemonicDB.Attributes;
+using NexusMods.Abstractions.NexusWebApi;
 using NexusMods.Abstractions.Telemetry;
 using NexusMods.App.BuildInfo;
 using NexusMods.App.UI;
 using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.MnemonicDB.Abstractions.Query;
-using NexusMods.Networking.NexusWebApi;
 using NexusMods.Paths;
 using OneOf;
 
@@ -29,7 +26,7 @@ internal sealed class TelemetryProvider : ITelemetryProvider, IDisposable
         _connection = serviceProvider.GetRequiredService<IConnection>();
         
         // membership status
-        var loginManager = serviceProvider.GetRequiredService<LoginManager>();
+        var loginManager = serviceProvider.GetRequiredService<ILoginManager>();
         loginManager.IsPremiumObservable.SubscribeWithErrorLogging(value => _isPremium = value).DisposeWith(_disposable);
 
         // download size


### PR DESCRIPTION
The code used to trigger the observables in `ILoginManager` every time the token was used in an API call. This meant that we were downloading the avatar for every API call...