### PR TITLE
Fixed: Loadout Left Menu Badge Not Decrementing on Library Item Delete

### DIFF
--- a/src/NexusMods.App.UI/LeftMenu/Loadout/LoadoutLeftMenuViewModel.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Loadout/LoadoutLeftMenuViewModel.cs
@@ -177,8 +177,8 @@ public class LoadoutLeftMenuViewModel : AViewModel<ILoadoutLeftMenuViewModel>, I
             LibraryUserFilters.ObserveFilteredLibraryItems(connection: conn)
                 .RemoveKey()
                 .OnUI()
-                .WhereReasonsAre(ListChangeReason.Add, ListChangeReason.AddRange)
-                .SubscribeWithErrorLogging(changeSet => NewDownloadModelCount += changeSet.Adds)
+                .WhereReasonsAre(ListChangeReason.Add, ListChangeReason.AddRange, ListChangeReason.Remove, ListChangeReason.RemoveRange)
+                .SubscribeWithErrorLogging(changeSet => NewDownloadModelCount = Math.Max(0, NewDownloadModelCount + (changeSet.Adds - changeSet.Removes)))
                 .DisposeWith(disposable);
 
             // NOTE(erri120): No new downloads when the Left Menu gets loaded. Must be set here because the observable stream


### PR DESCRIPTION
fixes #2028

Decrements the badge number when a library item is deleted.

I'll keep:
- https://github.com/Nexus-Mods/NexusMods.App/issues/2016#issue-2521093393

Open, we should auto clear if library is already open; so I'll do that next.