### PR TITLE
Improved: Empty State View

### DIFF
--- a/src/NexusMods.App.UI/Pages/LibraryPage/LibraryView.axaml.cs
+++ b/src/NexusMods.App.UI/Pages/LibraryPage/LibraryView.axaml.cs
@@ -57,6 +57,9 @@ public partial class LibraryView : ReactiveUserControl<ILibraryViewModel>
 
             this.BindCommand(ViewModel, vm => vm.OpenNexusModsCommand, view => view.EmptyLibraryLinkButton)
                 .AddTo(disposables);
+
+            this.BindCommand(ViewModel, vm => vm.OpenNexusModsCommand, view => view.OpenLinkBareIconButton)
+                .AddTo(disposables);
         });
     }
 }

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/UserControls/EmptyState/EmptyStateStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/UserControls/EmptyState/EmptyStateStyles.axaml
@@ -33,7 +33,7 @@
 
             <Style Selector="^ StackPanel#Panel">
                 <Setter Property="Orientation" Value="Vertical"/>
-                <Setter Property="Margin" Value="128 64 128 0"/>
+                <Setter Property="Margin" Value="16 64 16 0"/>
                 <Setter Property="Spacing" Value="{StaticResource Spacing-2}"/>
             </Style>
 


### PR DESCRIPTION
fixes #2159 (good enough to consider it a 'fix' for now)
fixes #2160 (adds missing hyperlink)

For the shrinking issue, the following margin is reduced:

![image](https://github.com/user-attachments/assets/58ea0252-cfed-4834-8edd-814f4bd8fb35)

Currently shrinking the window does this:

![image](https://github.com/user-attachments/assets/359a6051-1c38-4478-b9ac-45853b1bbcff)

With the PR it is shrunk down to `16` (from `128`):

![image](https://github.com/user-attachments/assets/b6efb1f3-54c7-40b6-948c-34b939eb7912)

The contents remain centered, 1:1 with before if not shrunk.

The movement of the title and link is still inconsistent, however that's due to an unrelated reason; the hyperlink is actually a button, and unlike the text, the button has a minimum size, and thus can't wrap around edges. Will leave to @insomnious to pick that one up since they volunteered.

Already got the thumbs up from @captainsandypants on Slack.