### PR TITLE
Updated markdown styles

### DIFF
--- a/src/NexusMods.App.UI/Controls/MarkdownRenderer/MarkdownRendererDesignViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/MarkdownRenderer/MarkdownRendererDesignViewModel.cs
@@ -28,61 +28,140 @@ public class MarkdownRendererDesignViewModel : AViewModel<IMarkdownRendererViewM
     [LanguageInjection("markdown")]
     private const string DefaultContents =
 """
-# Quid nostro
+# v0.6.2 - 2024-10-16
 
-## Velox tot frugum accipe
+**Important: To update the app, you must completely uninstall the old version, including all mods.** [Why do I have to uninstall everything to update the app?](https://nexus-mods.github.io/NexusMods.App/users/faq/#why-do-i-have-to-uninstall-everything-to-update-the-app)
 
-Lorem markdownum sacros si Iovis aquarum, oreris bene inmurmurat arborei
-propulsa labori invidiosa, sic tibi sic: tumulis. Pectoris ait plectrum fregit
-aegram. Cum *legit urit* nec solet corpora loquebatur cur, in vivaque quasque
-corpus **sagittas Numam** Lucifer mentesque, **falsa**. Vult plagis sospite
-veneni prodiga ratione, currus malus! Et sinat mersaeque fletque cycnus
-auxiliaris, sum **quid frondentis** sensit.
+***
 
-1. Moneo ora equos per monstro o foedera
-2. Confusura veneni lacertis pisce inmedicabile quid tenuaverat
-3. Ardere una quam paciscor alimenta liber
-4. Captivarum Venus
-5. Nunc iphis Orion aethera genitore doleas pro
+1. The app will display a diagnostic message if a P
+2. The app will display a diagnostic message if a P
+3. The app will display a diagnostic message if a P
 
-Insula illa optime in admonita exigit, clausit sua aut paelicis potiunda ipsius
-canes falsisque esset donare. In mea ima loquor, superest vocas densa cognoscere
-trepidum inque, restagnantis. Auras est accipiunt erant init turpi tenet isto
-voce teretesque facta, quae dederat vultus milite primo. Adspicit ignare
-saxumque, tenet fuga male tabuerint umbram *pariterque* nuda vinctumque pugna,
-exercita.
+---
 
-## Et tumida
+> Hello block quote
+>
+>> This release adds initial support for Baldur's Gate 3, detects GOG games installed through the Heroic Launcher on Linux and further develops the Collections feature.
+>>
+>> This release adds initial support for Baldur's Gate 3, detects GOG games installed through the Heroic Launcher on Linux and further develops the Collections feature.
 
-Ut abolere turba dignus, pone respondere comis credo moenia et Cragon nondum
-pallenti. Urbem Thracum medii praeclusaque vocanti et senemque per? Deo
-genuumque pater, in mihi ruborem: aut mutavit terris removi refert atque
-indignave veros, in, promittet! Foeda tempora lux Pholus sit Ligurum quis
-[cacumen tamen](http://et.io/cepit.html): hanc.
+```csharp
+this is a code block
+extra
+this is a code block
+```
 
-- Fuisti aptas
-- Furibunda arbore passus vulnera quinque Nox menti
-- Et gerebat praedae ut duxerat memoranda per
-- Nuper Vidi non crines non munusque accusasse
-- Trahit opibus vellet rudis
+This release adds initial support for Baldur's Gate 3, detects GOG games installed through the Heroic Launcher on Linux and further develops the Collections feature.
 
-## Habendi ignibus
+*If you are installing the app outside of the default location (Local App Data), the uninstallers for all previous versions may not work correctly. [How to manually reset your installation](https://nexus-mods.github.io/NexusMods.App/users/Uninstall/#manual-uninstall-fallback).*
 
-Ille artus, alma deus est vetus, totidem deprensum arbor lacrimaeque? Illis
-Canopo subit lucis tradit [ab](http://www.et-flore.com/pars-spirat.php) certis
-mortemque seraque in, **o** vestris omine. *Validum* Lapithaeae, ita orbem dum
-praesagaque, dictis, iam disci errore coercuit sit modo Hylactor! Rogat
-*iacentes et quaeque* fulva, sertis unguibus quoque possis. Suo Rhodopeius
-madefient, mitissima despectus diversa stratis.
+## Baldur's Gate 3 
+This version of the app adds Baldur's Gate 3 as the third supported game ([#2122](https://github.com/Nexus-Mods/NexusMods.App/pull/2122)). Currently, all common mod types will be installed correctly. Installations on Steam and GOG can be detected on Windows or Linux. 
 
-1. Diomede aquis
-2. Regna mea mota sic usae tu maior
-3. Nec hic adunci
+The app will display a diagnostic message if a PAK file lists a dependency in the meta.lsx file that is not currently installed. We plan to improve the available data shown to the users in future releases. 
 
-Sed esse, prima picum omnes nam patrii do resedit; petebat sed. Amores auras,
-potentia subsidunt auras nec: dicar cum dimotis. Fuit Thestias: quam sed hunc
-querella erat in inposita. Patuit nomen multi possum quosque erratica patefecit
-laudemur: umbrae praedae locus caecis siquidem et cuncti.
+The current implementation does not include load order support. You will need to go to "Mod Manager" from the main menu and enable your mods to have them take effect in the game. Load order support is planned for a future release. 
 
+*Note: When launching the GOG version of the game, the app will currently default to the Vulkan version. A choice between Vulkan and DX11 will be added in a future release. If you require the DX11 version, please launch from GOG Galaxy (Windows), Heroic Launcher (Linux) or via bg3_dx11.exe.*
+
+
+## Heroic Launcher
+Linux users can now manage GOG games installed or imported using the [Heroic Launcher](https://heroicgameslauncher.com/) ([#2103](https://github.com/Nexus-Mods/NexusMods.App/pull/2103)). Due to technical limitations, we've disabled REDmod deployment for Cyberpunk 2077 using Heroic, but it's possible to have the launcher run this process when starting the game. [Automated deployment for REDmods in Heroic](https://nexus-mods.github.io/NexusMods.App/users/games/Cyberpunk2077/#automated-deployment-for-redmods).
+
+## Collections
+**Important: Collections support is still an experimental feature and may not work as expected. Please check the Known Issues section if you choose to install a collection.**
+
+In this build, we've made further updates to the process of downloading and installing collections. The feature does not have parity with Vortex yet so cannot be used to install a collection fully. 
+
+![The new collections tile available from the "Collections WIP" tab.](./docs/changelog-assets/8ed9a020e1532940c4d57a2753eae55a.webp)
+
+The changes we've made include:
+* Updated the card design for collections (Above).
+* Added support for FOMOD presets and binary patching during installation.
+
+## Updating Mods
+We're starting work on showing when a mod has an update in the app. The backend to enable this feature is mostly complete and we will be adding the UI elements to support it in an upcoming release. 
+
+## Known Issues
+* Most collection installations will not complete successfully. This is due to several features that have not yet been implemented. 
+* The game version is not checked when adding a collection meaning you can install outdated mods without being warned. 
+* Trying to install a collection with an unsupported type of mod (e.g. non-Nexus Mods files) will fail with no error message. This is not supported in the current build.
+* Trying to install a collection as a non-Premium user will fail with no error message. This is not supported in the current build. 
+* Once a collection is added to the app, it cannot be removed from the left menu.
+* Collections allow users to modify the included mods but do not allow you to reset them to the original state. 
+* The first row of the My Mods or Library tables will sometimes be misaligned with the headers. Scrolling or adjusting any column width will correct this. 
+* The "Switch View" option does not persist in the Library/Installed Mods view.
+
+
+## Bugfixes
+* The app will now uninstall correctly when installed outside of the default directory on Windows. 
+* The correct WINE prefix will now be used for games on Linux. 
+* When the numerical badges in the left menu show 3 or more digits, the width of the badge will expand correctly.
+* Fixed an issue where batch actions would not work correctly when adding/removing/deleting mods from the Library or Loadout pages. 
+* The app will no longer re-download the user's avatar image every time a request is made to the Nexus Mods API. 
+
+## External Contributors
+* [@MistaOmega](https://github.com/MistaOmega): [#2118](https://github.com/Nexus-Mods/NexusMods.App/pull/2118), [#2119](https://github.com/Nexus-Mods/NexusMods.App/pull/2119), [#2128](https://github.com/Nexus-Mods/NexusMods.App/pull/2128), [#2130](https://github.com/Nexus-Mods/NexusMods.App/pull/2130)
+* [@Patriot99](https://github.com/Patriot99): [#2145](https://github.com/Nexus-Mods/NexusMods.App/pull/2145)
+* [@Michael-Kowata](https://github.com/Michael-Kowata): [#2163](https://github.com/Nexus-Mods/NexusMods.App/pull/2163)
+
+[View the release on GitHub](https://github.com/Nexus-Mods/NexusMods.App/releases/tag/v0.6.2)
+
+# v0.6.1 - 2024-09-24
+
+**Important: To update the app, you must completely uninstall the old version, including all mods. [Why do I have to uninstall everything to update the app?](https://nexus-mods.github.io/NexusMods.App/users/faq/#why-do-i-have-to-uninstall-everything-to-update-the-app)**
+
+This release adds a very basic implementation of downloading Collections, updates the UI to the new tree view and includes some enhancements when interacting with Windows applications via Linux. 
+
+## New UI for My Mods and Library
+The My Mods and Library pages have been completely reworked to use the new tree view. Mods are now grouped by the mod page on Nexus Mods, meaning if download several files from the same page they will be grouped together. A "Switch View" option has been added to the toolbar to toggle these groupings on or off. We are continuing to work towards to designs shown in the [previous changelog](./docs/changelog-assets/1b28e2fad5b5a6431a72c286d1bcd3fd.webp).
+
+![An image showing mods in the Library nested by mod page (left) or ungrouped (right)](./docs/changelog-assets/823627a8ccb068dc1559d62cd3326ebe.webp)
+
+## EXPERIMENTAL - Collections
+**Important: The feature is unfinished and not considered stable. It will not accurately install complex collections and is currently only functional for Premium users.**
+
+We've included a very early implementation of the Collections feature in this release. It's incomplete and will not install collections as the user has set them up in Vortex. Currently, only mods from Nexus Mods can be installed - anything from external websites or bundled with the collection will not install as expected. 
+
+![A collection for Cyberpunk 2077 installed into a loadout.](./docs/changelog-assets/8a591449d6a8cddc5d2bad7d1fd5c849.webp)
+
+Collections will appear as a separate list of mods in the left menu. Users can view all mods in the loadout from the new "Installed Mods" option at the top of the left menu. 
+
+To start out, this will only be available to Premium users, but we are working on the free user journey separately which requires considerably more UI elements to be created. This will be available in a future release.
+
+
+## Cyberpunk 2077 Enhancements
+As a further enhancement to support for Cyberpunk 2077, we will now detect if the REDmod DLC is missing and prompt the user to install it if required. 
+
+![The diagnostic message for REDmod shown in the Health Check.](./docs/changelog-assets/531dc13e8116620f8ded4a8a98b281da.webp)
+
+We've also fixed the issue which prevented REDmod from deploying automatically on Linux. This work also sets up a framework for running Windows apps and tools on a Linux system using [Protontricks](https://github.com/Matoking/protontricks) ([#1989](https://github.com/Nexus-Mods/NexusMods.App/pull/1989)).
+
+## Known Issues
+* When batch selecting mods in My Mods and using the remove button the app will occasionally fail to remove mods that are not currently visible in the UI due to scrolling. 
+* Trying to install a collection with an unsupported type of mod (e.g. Bundled or External) will fail with no error message. This is not supported in the current build.
+* Trying to install a collection as a non-Premium user will fail with no error message. This is not supported in the current build. 
+* Once a collection is added to the app, it cannot be removed from the left menu.
+* Collections allow users to modify the included mods but do not allow you to reset them to a the original state. 
+* The first row of the My Mods or Library tables will sometimes be misaligned with the headers. Scrolling or adjusting any column width will correct this. 
+* The "Switch View" option does not persist.
+
+## Other Features
+* The name of the active loadout will now appear in the top bar ([#1953](https://github.com/Nexus-Mods/NexusMods.App/pull/1953)).
+* The app now has a minimum window size of `360x360` to prevent it being resized to unusable dimensions ([#1947](https://github.com/Nexus-Mods/NexusMods.App/pull/1947)).
+
+## Bugfixes
+* Stardew Valley: Fixed enabled mods showing up as disabled in the diagnostics ([#1923](https://github.com/Nexus-Mods/NexusMods.App/pull/1953)).
+* Linux: Fixed the game not launching when running through Steam ([#1917](https://github.com/Nexus-Mods/NexusMods.App/pull/1917)).
+
+## Technical Changes 
+* Added a system for storing and displaying images in the app. 
+
+## External Contributors
+* [@Patriot99](https://github.com/Patriot99): [#1896](https://github.com/Nexus-Mods/NexusMods.App/pull/1896)
+* [@LoulouNoLegend](https://github.com/LoulouNoLegend): [#1997](https://github.com/Nexus-Mods/NexusMods.App/pull/1997), [#1998](https://github.com/Nexus-Mods/NexusMods.App/pull/1998), [#1999](https://github.com/Nexus-Mods/NexusMods.App/pull/1999)
+
+[View the release on GitHub](https://github.com/Nexus-Mods/NexusMods.App/releases/tag/v0.6.1)
 """;
 }

--- a/src/NexusMods.App.UI/Controls/MarkdownRenderer/MarkdownRendererView.axaml
+++ b/src/NexusMods.App.UI/Controls/MarkdownRenderer/MarkdownRendererView.axaml
@@ -8,12 +8,13 @@
     xmlns:local="clr-namespace:NexusMods.App.UI.Controls.MarkdownRenderer"
     xmlns:md="clr-namespace:Markdown.Avalonia;assembly=Markdown.Avalonia"
     xmlns:ctxt="clr-namespace:ColorTextBlock.Avalonia;assembly=ColorTextBlock.Avalonia"
-    mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+    xmlns:controls="clr-namespace:Markdown.Avalonia.Controls;assembly=Markdown.Avalonia"
+    mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="800"
     x:Class="NexusMods.App.UI.Controls.MarkdownRenderer.MarkdownRendererView">
 
-    <Design.PreviewWith>
-        <local:MarkdownRendererDesignViewModel/>
-    </Design.PreviewWith>
+    <Design.DataContext>
+        <local:MarkdownRendererDesignViewModel />
+    </Design.DataContext>
 
     <!--
         NOTE(erri120): This control can only be styled directly, not through classes.
@@ -23,8 +24,9 @@
         and I'm not convinced it still works in the same way.
         https://github.com/whistyun/Markdown.Avalonia/blob/master/Markdown.Avalonia.Tight/StyleCollections/MarkdownStyleDefaultTheme.axaml
     -->
-    
+
     <md:MarkdownScrollViewer x:Name="MarkdownScrollViewer">
+
         <md:MarkdownScrollViewer.Styles>
             <!-- NOTE(erri120): designs from https://www.figma.com/design/NuC2DiIdnAZQQkYUSaK514/%F0%9F%93%B1Markdown-styles?node-id=10%3A12&t=mVpreGuSrLB54ms0-1 -->
             <!--
@@ -32,99 +34,203 @@
                 As a result of this, I copy-pasted our TextBlock themes, which means they can very easily get out-of-sync with the main themes.
             -->
 
-            <Style Selector="ctxt|CTextBlock.Heading1">
-                <Setter Property="FontFamily" Value="{StaticResource FontHeadlinesSemiBold}" />
-                <Setter Property="FontWeight" Value="SemiBold" />
-                <Setter Property="FontSize" Value="36" />
-                <Setter Property="LineHeight" Value="43.2" />
-                <Setter Property="Foreground" Value="{StaticResource NeutralStrongBrush}" />
-            </Style>
+            <Style Selector="StackPanel.Markdown_Avalonia_MarkdownViewer">
 
-            <Style Selector="ctxt|CTextBlock.Heading2">
-                <Setter Property="FontFamily" Value="{StaticResource FontHeadlinesSemiBold}" />
-                <Setter Property="FontWeight" Value="SemiBold" />
-                <Setter Property="FontSize" Value="24" />
-                <Setter Property="LineHeight" Value="30" />
-                <Setter Property="Foreground" Value="{StaticResource NeutralStrongBrush}" />
-            </Style>
+                <!-- will center the content but keep a fixed width column -->
+                <Setter Property="MaxWidth" Value="1000" />
+                <Setter Property="Spacing" Value="4" />
 
-            <Style Selector="ctxt|CTextBlock.Heading3">
-                <Setter Property="FontFamily" Value="{StaticResource FontHeadlinesSemiBold}" />
-                <Setter Property="FontWeight" Value="SemiBold" />
-                <Setter Property="FontSize" Value="18" />
-                <Setter Property="LineHeight" Value="22.5" />
-                <Setter Property="Foreground" Value="{StaticResource NeutralStrongBrush}" />
-            </Style>
-
-            <Style Selector="ctxt|CTextBlock.Heading4">
-                <Setter Property="FontFamily" Value="{StaticResource FontBodySemiBold}" />
-                <Setter Property="FontWeight" Value="SemiBold" />
-                <Setter Property="FontSize" Value="16" />
-                <Setter Property="LineHeight" Value="24" />
-                <Setter Property="Foreground" Value="{StaticResource NeutralStrongBrush}" />
-            </Style>
-
-            <Style Selector="ctxt|CTextBlock.Heading5">
-                <Setter Property="FontFamily" Value="{StaticResource FontHeadlinesSemiBold}" />
-                <Setter Property="FontWeight" Value="SemiBold" />
-                <Setter Property="FontSize" Value="12" />
-                <Setter Property="LineHeight" Value="16.5" />
-                <Setter Property="Foreground" Value="{StaticResource NeutralStrongBrush}" />
-            </Style>
-
-            <Style Selector="ctxt|CTextBlock.Heading6">
-                <Setter Property="FontFamily" Value="{StaticResource FontHeadlinesSemiBold}" />
-                <Setter Property="FontWeight" Value="SemiBold" />
-                <Setter Property="FontSize" Value="10" />
-                <Setter Property="LineHeight" Value="15" />
-                <Setter Property="Foreground" Value="{StaticResource NeutralStrongBrush}" />
-            </Style>
-
-            <Style Selector="ctxt|CTextBlock.Paragraph">
-                <Setter Property="FontFamily" Value="{StaticResource FontBodyRegular}" />
-                <Setter Property="FontWeight" Value="Normal" />
-                <Setter Property="FontSize" Value="14" />
-
-                <!--
-                    NOTE(erri120): LineHeight can't be used because every image gets put into a paragraph.
-                    Setting LineHeight would also force the image height to that value.
-                    The library we're using has many issues like this where the ideal solution would be to
-                    apply styles to a parent control from the child control or from the parent control by
-                    somehow checking if it has certain child controls.
-                -->
-                <!-- <Setter Property="LineHeight" Value="21" /> -->
-                <Setter Property="Foreground" Value="{StaticResource NeutralModerateBrush}" />
-            </Style>
-
-            <!-- TODO: bold -->
-            <!-- TODO: italic -->
-            <!-- TODO: bold and italic -->
-            <!-- TODO: block quote -->
-            <!-- TODO: nested block quote -->
-            <!-- TODO: numbered list -->
-            <!-- TODO: list -->
-
-            <Style Selector=".Markdown_Avalonia_MarkdownViewer ctxt|CCode">
-                <Setter Property="MonospaceFontFamily" Value="{StaticResource FontBodyCode}" />
-                <Setter Property="FontSize" Value="13" />
-                <Setter Property="CornerRadius" Value="{StaticResource Rounded}" />
-                <Setter Property="Padding" Value="4,2" />
-                <Setter Property="Margin" Value="2,0" />
-                <Setter Property="Foreground" Value="{StaticResource NeutralModerateBrush}" />
-                <Setter Property="Background" Value="{StaticResource SurfaceHighBrush}" />
-            </Style>
-
-            <Style Selector=".Markdown_Avalonia_MarkdownViewer ctxt|CHyperlink">
-                <Setter Property="IsUnderline" Value="True"/>
-                <Setter Property="Foreground" Value="{StaticResource PrimaryModerate}"/>
-                <Setter Property="HoverForeground" Value="{StaticResource PrimaryStrong}"/>
-                <Style Selector="^:hover">
-                    <Setter Property="IsUnderline" Value="False"/>
+                <Style Selector="^ ctxt|CImage">
+                    <Setter Property="LayoutHeight" Value="300" />
+                    <Setter Property="SaveAspectRatio" Value="True" />
                 </Style>
-            </Style>
-            
-            <Style Selector=".Markdown_Avalonia_MarkdownViewer ctxt|CImage">
-                <Setter Property="SaveAspectRatio" Value="True"/>
+
+                <Style Selector="^ ctxt|CTextBlock">
+
+                    <!-- set CTextBlock defaults to paragraph -->
+                    <Setter Property="Foreground" Value="{StaticResource NeutralTranslucentModerateBrush}" />
+                    <Setter Property="FontFamily" Value="{StaticResource FontBodyRegular}" />
+                    <Setter Property="FontWeight" Value="Normal" />
+                    <Setter Property="FontSize" Value="14" />
+                    <Setter Property="Margin" Value="0, 0, 0, 12" />
+                    <Setter Property="LineSpacing" Value="4" />
+                    <!-- <Setter Property="LineHeight" Value="25" /> -->
+                    <!--
+                            NOTE(erri120): LineHeight can't be used because every image gets put into a paragraph.
+                            Setting LineHeight would also force the image height to that value.
+                            The library we're using has many issues like this where the ideal solution would be to
+                            apply styles to a parent control from the child control or from the parent control by
+                            somehow checking if it has certain child controls.
+                            
+                            NOTE(insomnious): LineSpacing is getting a bit closer to what we want, it's only affecting
+                            text paragraphs and not the images inside of them.
+                    -->
+
+                    <!-- heading 1 -->
+                    <Style Selector="^.Heading1">
+                        <Setter Property="Foreground" Value="{StaticResource NeutralStrongBrush}" />
+                        <Setter Property="FontFamily" Value="{StaticResource FontHeadlinesSemiBold}" />
+                        <Setter Property="FontWeight" Value="SemiBold" />
+                        <Setter Property="FontSize" Value="36" />
+                        <Setter Property="LineHeight" Value="43.2" />
+                        <Setter Property="Margin" Value="0, 0, 0, 8" />
+                    </Style>
+
+                    <!-- heading 2 -->
+                    <Style Selector="^.Heading2">
+                        <Setter Property="Foreground" Value="{StaticResource NeutralStrongBrush}" />
+                        <Setter Property="FontFamily" Value="{StaticResource FontHeadlinesSemiBold}" />
+                        <Setter Property="FontWeight" Value="SemiBold" />
+                        <Setter Property="FontSize" Value="24" />
+                        <Setter Property="LineHeight" Value="30" />
+                        <Setter Property="Margin" Value="0, 0, 0, 8" />
+                    </Style>
+
+                    <!-- heading 3 -->
+                    <Style Selector="^.Heading3">
+                        <Setter Property="Foreground" Value="{StaticResource NeutralStrongBrush}" />
+                        <Setter Property="FontFamily" Value="{StaticResource FontHeadlinesSemiBold}" />
+                        <Setter Property="FontWeight" Value="SemiBold" />
+                        <Setter Property="FontSize" Value="18" />
+                        <Setter Property="LineHeight" Value="22.5" />
+                        <Setter Property="Margin" Value="0, 0, 0, 4" />
+                    </Style>
+
+                    <!-- heading 4 -->
+                    <Style Selector="^.Heading4">
+                        <Setter Property="Foreground" Value="{StaticResource NeutralStrongBrush}" />
+                        <Setter Property="FontFamily" Value="{StaticResource FontBodySemiBold}" />
+                        <Setter Property="FontWeight" Value="SemiBold" />
+                        <Setter Property="FontSize" Value="16" />
+                        <Setter Property="LineHeight" Value="24" />
+                        <Setter Property="Margin" Value="0, 0, 0, 8" />
+                    </Style>
+
+                    <!-- heading 5 -->
+                    <Style Selector="^.Heading5">
+                        <Setter Property="Foreground" Value="{StaticResource NeutralStrongBrush}" />
+                        <Setter Property="FontFamily" Value="{StaticResource FontHeadlinesSemiBold}" />
+                        <Setter Property="FontWeight" Value="SemiBold" />
+                        <Setter Property="FontSize" Value="12" />
+                        <Setter Property="LineHeight" Value="16.5" />
+                        <Setter Property="Margin" Value="0, 0, 0, 8" />
+                    </Style>
+
+                    <!-- heading 6 -->
+                    <Style Selector="^.Heading6">
+                        <Setter Property="Foreground" Value="{StaticResource NeutralStrongBrush}" />
+                        <Setter Property="FontFamily" Value="{StaticResource FontHeadlinesSemiBold}" />
+                        <Setter Property="FontWeight" Value="SemiBold" />
+                        <Setter Property="FontSize" Value="10" />
+                        <Setter Property="LineHeight" Value="15" />
+                        <Setter Property="Margin" Value="0, 0, 0, 8" />
+                    </Style>
+
+                    <!-- paragraph -->
+                    <Style Selector="^.Paragraph">
+
+
+                        <!-- bold -->
+                        <Style Selector="^ ctxt|CBold">
+                            <!-- <Setter Property="Background" Value="Red" /> -->
+                            <!-- <Setter Property="FontSize" Value="20" /> -->
+                        </Style>
+
+                        <!-- italic -->
+                        <Style Selector="^ ctxt|CItalic">
+                            <!-- <Setter Property="Background" Value="Blue" /> -->
+                            <!-- <Setter Property="FontSize" Value="20" /> -->
+                        </Style>
+
+                        <!-- bold and italic -->
+                        <Style Selector="^ ctxt|CBold ctxt|CItalic">
+                            <!-- <Setter Property="Background" Value="Green" /> -->
+                            <!-- <Setter Property="FontSize" Value="20" /> -->
+                        </Style>
+                    </Style>
+
+                </Style>
+
+                <!-- inline code -->
+                <Style Selector="^ ctxt|CCode">
+                    <Setter Property="MonospaceFontFamily" Value="{StaticResource FontBodyCode}" />
+                    <Setter Property="FontSize" Value="13" />
+                    <Setter Property="CornerRadius" Value="{StaticResource Rounded}" />
+                    <Setter Property="Padding" Value="4,2" />
+                    <Setter Property="Margin" Value="2,0" />
+                    <Setter Property="Foreground" Value="{StaticResource NeutralModerateBrush}" />
+                    <Setter Property="Background" Value="{StaticResource SurfaceHighBrush}" />
+                </Style>
+
+                <!-- links and their states -->
+                <Style Selector="^ ctxt|CHyperlink">
+                    <Setter Property="IsUnderline" Value="True" />
+                    <Setter Property="Foreground" Value="{StaticResource PrimaryModerate}" />
+                    <Setter Property="HoverForeground" Value="{StaticResource PrimaryStrong}" />
+                    <Style Selector="^:hover">
+                        <Setter Property="IsUnderline" Value="False" />
+                    </Style>
+                </Style>
+
+                <!-- code block (separate to inline code) -->
+                <Style Selector="^ Border.CodeBlock">
+                    <Setter Property="Padding" Value="8,8" />
+                    <Setter Property="Margin" Value="8,16" />
+                    <Setter Property="BorderThickness" Value="0" />
+                    <Setter Property="CornerRadius" Value="4" />
+                    <Setter Property="Background" Value="{StaticResource SurfaceHighBrush}" />
+
+                    <Style Selector="^ TextBlock">
+                        <Setter Property="FontFamily" Value="{StaticResource FontBodyCode}" />
+                        <Setter Property="FontSize" Value="13" />
+                        <Setter Property="LineHeight" Value="19.5" />
+                        <Setter Property="Padding" Value="0" />
+                        <Setter Property="Margin" Value="0" />
+                        <Setter Property="Foreground" Value="{StaticResource NeutralModerateBrush}" />
+                    </Style>
+                </Style>
+
+                <!-- blockquote -->
+                <Style Selector="^ Border.Blockquote">
+                    <Setter Property="Background" Value="{StaticResource SurfaceTranslucentLowBrush}" />
+                    <Setter Property="BorderBrush" Value="{StaticResource StrokeTranslucentModerateBrush}" />
+                    <Setter Property="BorderThickness" Value="3,0,0,0" />
+                    <Setter Property="CornerRadius" Value="4" />
+                    <Setter Property="Padding" Value="4,8" />
+                    <Setter Property="Margin" Value="0,4,0,12" />
+
+                    <Style Selector="^ StackPanel.Blockquote">
+                        <Setter Property="Spacing" Value="16" />
+
+                        <Style Selector="^ ctxt|CTextBlock">
+                            <Setter Property="Foreground" Value="{StaticResource NeutralModerateBrush}" />
+                            <Setter Property="TextAlignment" Value="Left" />
+                            <Setter Property="Margin" Value="0" />
+                            <Setter Property="LineSpacing" Value="4" />
+                        </Style>
+                    </Style>
+                </Style>
+
+                <!-- lists -->
+                <Style Selector="^ Grid.List">
+                    <Setter Property="Margin" Value="4,0,4, 12" />
+
+                    <Style Selector="^ ctxt|CTextBlock">
+                        <Setter Property="TextAlignment" Value="Left" />
+                        <Setter Property="Margin" Value="4,0,4,8" />
+                        <Setter Property="LineSpacing" Value="4" />
+                    </Style>
+                </Style>
+
+                <!-- rule -->
+                <Style Selector="^ controls|Rule">
+                    <Setter Property="Background" Value="{StaticResource NeutralWeakBrush}" />
+                    <Setter Property="Margin" Value="0,0,0,12" />
+                    <Setter Property="Opacity" Value="0.1" />
+                    <Setter Property="LineMargin" Value="0" />
+                    <Setter Property="SingleLineWidth" Value="2" />
+                    <Setter Property="BoldLineWidth" Value="2" />
+                </Style>
             </Style>
 
             <!-- TODO: tables -->
@@ -133,4 +239,3 @@
     </md:MarkdownScrollViewer>
 
 </reactive:ReactiveUserControl>
-

--- a/src/NexusMods.App.UI/Pages/Changelog/ChangelogPageViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/Changelog/ChangelogPageViewModel.cs
@@ -151,8 +151,8 @@ public record ParsedChangelog
     {
         var span = changelog.AsSpan();
 
-        const string linePrefix = "## ";
-        const string versionPrefix = "[v";
+        const string linePrefix = "# ";
+        const string versionPrefix = "v";
 
         var sectionIndices = new List<int>();
         var versions = new List<KeyValuePair<Version, int>>();
@@ -179,7 +179,7 @@ public record ParsedChangelog
             if (!slice.StartsWith(versionPrefix) || slice.Length < versionPrefix.Length) continue;
             slice = slice.Slice(start: versionPrefix.Length);
 
-            var index = slice.IndexOf(']');
+            var index = slice.IndexOf(' ');
             if (index == -1) continue;
 
             slice = slice.Slice(start: 0, length: index);

--- a/src/NexusMods.App.UI/Pages/Diagnostics/Details/DiagnosticDetailsView.axaml
+++ b/src/NexusMods.App.UI/Pages/Diagnostics/Details/DiagnosticDetailsView.axaml
@@ -7,14 +7,15 @@
     xmlns:reactiveUi="http://reactiveui.net"
     xmlns:diagnostics="clr-namespace:NexusMods.App.UI.Pages.Diagnostics"
     xmlns:icons="clr-namespace:NexusMods.Icons;assembly=NexusMods.Icons"
-    mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+    mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="450"
     x:Class="NexusMods.App.UI.Pages.Diagnostics.DiagnosticDetailsView">
 
     <Design.DataContext>
         <diagnostics:DiagnosticDetailsDesignViewModel />
     </Design.DataContext>
     
-    <Border Padding="24">
+    <!-- NOTE(insomnious): if we need any more styling than this, we should move it to a separate style file -->
+    <Border Padding="24" MaxWidth="1000">
         <StackPanel Orientation="Vertical"
                     HorizontalAlignment="Stretch"
                     Classes="Spacing-3">


### PR DESCRIPTION
Fixes #2134

Fixed markdown styles and better documented how to tweak them
Changed parsing to match new changelog specs (won't work until #2176 is merged)

Left some placeholder `Style` selectors for completeness and for if we need to go back


