### PR TITLE
Fix for Alert Body being rendered incorrectly if only containing whitespace

### DIFF
--- a/src/NexusMods.App.UI/Controls/Alerts/Alert.axaml.cs
+++ b/src/NexusMods.App.UI/Controls/Alerts/Alert.axaml.cs
@@ -228,7 +228,7 @@ public class Alert : ContentControl
 
         // turn off elements based on properties
         _dismissButton.IsVisible = ShowDismiss;
-        _bodyTextBorder.IsVisible = ShowBody && string.IsNullOrEmpty(Body);
+        _bodyTextBorder.IsVisible = ShowBody && !string.IsNullOrWhiteSpace(Body);
         _actionsRowBorder.IsVisible = Content != null && ShowActions;
 
         // set the text


### PR DESCRIPTION
This hides the whole block (fixing any layout spacing weirdness) if no actual text to render