### PR TITLE
Fix two bugs found in testing

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,8 +14,8 @@
     <PackageVersion Include="NexusMods.Hashing.xxHash3" Version="3.0.2" />
     <PackageVersion Include="NexusMods.Hashing.xxHash3.Paths" Version="3.0.2" />
     <PackageVersion Include="NexusMods.Paths" Version="0.10.0" />
-    <PackageVersion Include="NexusMods.MnemonicDB.Abstractions" Version="0.9.93" />
-    <PackageVersion Include="NexusMods.MnemonicDB" Version="0.9.93" />
+    <PackageVersion Include="NexusMods.MnemonicDB.Abstractions" Version="0.9.95" />
+    <PackageVersion Include="NexusMods.MnemonicDB" Version="0.9.95" />
     <PackageVersion Include="NexusMods.Paths.Extensions.Nx" Version="0.10.0" />
     <PackageVersion Include="NexusMods.Paths.TestingHelpers" Version="0.10.0" />
     <PackageVersion Include="NexusMods.Archives.Nx" Version="0.6.1" />
@@ -128,7 +128,7 @@
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="ini-parser-netstandard" Version="2.5.2" />
     <PackageVersion Include="Mutagen.Bethesda.Skyrim" Version="0.44.0" />
-    <PackageVersion Include="NexusMods.MnemonicDB.SourceGenerator" Version="0.9.93" />
+    <PackageVersion Include="NexusMods.MnemonicDB.SourceGenerator" Version="0.9.95" />
     <PackageVersion Include="NLog.Extensions.Logging" Version="5.3.11" />
     <PackageVersion Include="OneOf" Version="3.0.271" />
     <PackageVersion Include="ReactiveUI.Fody" Version="19.5.41" />


### PR DESCRIPTION
This PR updates to the latest MnemonicDB release which fixes 2 major issues in the app: 

1) General performance - the `GlobalCompare` method in MnemonicDB was performing 2 allocations on every compare. This was having a massive impact on everything from reads to writes. This issue has been resolved
2) Timestamp regression - we were storing transaction timestamps incorrectly, resulting in the `400 years from now` bug in the UI

Resolves #2211, #2207