### PR TITLE
New panel tabs and small bug fixes

### DIFF
--- a/src/NexusMods.App.UI/Controls/Alerts/Alert.axaml.cs
+++ b/src/NexusMods.App.UI/Controls/Alerts/Alert.axaml.cs
@@ -23,12 +23,12 @@ public class Alert : ContentControl
     }
 
     /// <summary>
-    /// Defines the Title property of the <see cref="Alert"/>. Defaults to "Default Title".
+    /// Defines the Title property of the <see cref="Alert"/>.
     /// </summary>
     public static readonly StyledProperty<string?> TitleProperty = AvaloniaProperty.Register<Alert, string?>(nameof(Title), defaultValue: "");
 
     /// <summary>
-    /// Defines the Body property of the <see cref="Alert"/>. Defaults to "Default Body".
+    /// Defines the Body property of the <see cref="Alert"/>..
     /// </summary>
     public static readonly StyledProperty<string?> BodyProperty = AvaloniaProperty.Register<Alert, string?>(nameof(Body), defaultValue: "");
 

--- a/src/NexusMods.App.UI/Controls/StandardButton.axaml.cs
+++ b/src/NexusMods.App.UI/Controls/StandardButton.axaml.cs
@@ -139,7 +139,7 @@ public class StandardButton : Button
     /// <summary>
     /// Defines the Type attached property of the <see cref="StandardButton"/>.
     /// </summary>
-    public static readonly AttachedProperty<Types> TypeProperty = AvaloniaProperty.RegisterAttached<StandardButton, TemplatedControl, Types>("Type", defaultValue: Types.None);
+    public static readonly AttachedProperty<Types> TypeProperty = AvaloniaProperty.RegisterAttached<StandardButton, TemplatedControl, Types>("Type", defaultValue: Types.Tertiary);
 
     /// <summary>
     /// Defines the Size attached property of the <see cref="StandardButton"/>.
@@ -149,7 +149,7 @@ public class StandardButton : Button
     /// <summary>
     /// Defines the Fill attached property of the <see cref="StandardButton"/>.
     /// </summary>
-    public static readonly AttachedProperty<Fills> FillProperty = AvaloniaProperty.RegisterAttached<StandardButton, TemplatedControl, Fills>("Fill", defaultValue: Fills.None);
+    public static readonly AttachedProperty<Fills> FillProperty = AvaloniaProperty.RegisterAttached<StandardButton, TemplatedControl, Fills>("Fill", defaultValue: Fills.Weak);
 
     /// <summary>
     /// Defines the ShowLabel attached property of the <see cref="StandardButton"/>.
@@ -202,7 +202,7 @@ public class StandardButton : Button
     }
 
     /// <summary>
-    /// Gets or sets the type of the <see cref="StandardButton"/>.
+    /// Gets or sets the type of the <see cref="StandardButton"/>. Defaults to <see cref="Types.Tertiary"/>.
     /// </summary>
     public Types Type
     {
@@ -211,7 +211,7 @@ public class StandardButton : Button
     }
 
     /// <summary>
-    /// Gets or sets the size of the <see cref="StandardButton"/>.
+    /// Gets or sets the size of the <see cref="StandardButton"/>. Defaults to <see cref="Sizes.Medium"/>.
     /// </summary>
     public Sizes Size
     {
@@ -220,7 +220,7 @@ public class StandardButton : Button
     }
 
     /// <summary>
-    /// Gets or sets the fill option of the <see cref="StandardButton"/>.
+    /// Gets or sets the fill option of the <see cref="StandardButton"/>. Defaults to <see cref="Fills.Weak"/>.
     /// </summary>
     public Fills Fill
     {

--- a/src/NexusMods.App.UI/Controls/StandardButton.axaml.cs
+++ b/src/NexusMods.App.UI/Controls/StandardButton.axaml.cs
@@ -41,7 +41,12 @@ public class StandardButton : Button
         /// <summary>
         /// Icons are displayed on both sides.
         /// </summary>
-        Both,
+        Both,  
+        
+        /// <summary>
+        /// Single icon is displayed with zero padding and no label.
+        /// </summary>
+        IconOnly,
     }
 
     /// <summary>
@@ -191,16 +196,16 @@ public class StandardButton : Button
         get => GetValue(RightIconProperty);
         set => SetValue(RightIconProperty, value);
     }
-
+    
     /// <summary>
-    /// Gets or sets a value indicating whether the label is shown on the <see cref="StandardButton"/>.
+    /// Gets or sets a value indicating whether the label is shown on the <see cref="StandardButton"/>. Defaults to True.
     /// </summary>
     public bool ShowLabel
     {
         get => GetValue(ShowLabelProperty);
         set => SetValue(ShowLabelProperty, value);
     }
-
+    
     /// <summary>
     /// Gets or sets the type of the <see cref="StandardButton"/>. Defaults to <see cref="Types.Tertiary"/>.
     /// </summary>
@@ -244,14 +249,14 @@ public class StandardButton : Button
         _leftIcon.Value = LeftIcon;
         _rightIcon.Value = RightIcon;
 
-        _label.IsVisible = ShowLabel;
+        _label.IsVisible = ShowLabel && ShowIcon != ShowIconOptions.IconOnly;
 
         // if Content is not null, display the Content just like a regular button would (using ContentPresenter).
         // Otherwise, build the button from the set properties
         _content.IsVisible = Content is not null;
         _border.IsVisible = Content is null;
         
-        _leftIcon.IsVisible = ShowIcon is ShowIconOptions.Left or ShowIconOptions.Both;
+        _leftIcon.IsVisible = ShowIcon is ShowIconOptions.Left or ShowIconOptions.Both or ShowIconOptions.IconOnly;
         _rightIcon.IsVisible = ShowIcon is ShowIconOptions.Right or ShowIconOptions.Both;
     }
 }

--- a/src/NexusMods.App.UI/LeftMenu/Loadout/LoadoutLeftMenuView.axaml
+++ b/src/NexusMods.App.UI/LeftMenu/Loadout/LoadoutLeftMenuView.axaml
@@ -16,7 +16,7 @@
         <ItemsControl Grid.Row="0"  x:Name="MenuItemsControl">
             <ItemsControl.ItemsPanel>
                 <ItemsPanelTemplate>
-                    <StackPanel />
+                    <StackPanel Spacing="{StaticResource Spacing-1}" />
                 </ItemsPanelTemplate>
             </ItemsControl.ItemsPanel>
         </ItemsControl>

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutView.axaml
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutView.axaml
@@ -51,12 +51,10 @@
             <controls:EmptyState.Subtitle>
                 <StackPanel>
                     <TextBlock Text="{x:Static resources:Language.LoadoutGrid_EmptyModlistSubtitle_Add_from_library}" />
-                    <navigation:NavigationControl Classes="Square Primary" x:Name="ViewLibraryButton">
-                        <StackPanel Orientation="Horizontal" Spacing="{StaticResource Spacing-1}">
-                            <icons:UnifiedIcon Classes="ModLibrary ForegroundSubdued" VerticalAlignment="Center" Size="18" />
-                            <TextBlock Text="Library" />
-                        </StackPanel>
-                    </navigation:NavigationControl>
+                    <navigation:NavigationControl x:Name="ViewLibraryButton"
+                                                  Text="Library"
+                                                  ShowIcon="Left"
+                                                  LeftIcon="{x:Static icons:IconValues.ModLibrary}"/>
                 </StackPanel>
             </controls:EmptyState.Subtitle>
 

--- a/src/NexusMods.App.UI/Resources/Language.Designer.cs
+++ b/src/NexusMods.App.UI/Resources/Language.Designer.cs
@@ -654,7 +654,7 @@ namespace NexusMods.App.UI.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The Downloads page is currently being reworked and will be replaced in a future update. We apologize for the inconvenience..
+        ///   Looks up a localized string similar to The Downloads page is currently being reworked and will be replaced in a future update. We apologise for the inconvenience..
         /// </summary>
         public static string DownloadsView_UnderDevelopment {
             get {
@@ -1945,7 +1945,7 @@ namespace NexusMods.App.UI.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Connect your Nexus Mods accoun.
+        ///   Looks up a localized string similar to Connect your Nexus Mods account.
         /// </summary>
         public static string TopBarActions__LOG_IN_ToolTip {
             get {

--- a/src/NexusMods.App.UI/Resources/Language.resx
+++ b/src/NexusMods.App.UI/Resources/Language.resx
@@ -163,7 +163,7 @@
         <value>Download history</value>
     </data>
     <data name="DownloadsView_UnderDevelopment" xml:space="preserve">
-        <value>The Downloads page is currently being reworked and will be replaced in a future update. We apologize for the inconvenience.</value>
+        <value>The Downloads page is currently being reworked and will be replaced in a future update. We apologise for the inconvenience.</value>
     </data>
     <data name="NexusLoginOverlayView__Please_Click_Authorize" xml:space="preserve">
         <value>Please click "Authorize" on the website</value>

--- a/src/NexusMods.App.UI/WorkspaceSystem/NewTabPage/NewTabPageView.axaml
+++ b/src/NexusMods.App.UI/WorkspaceSystem/NewTabPage/NewTabPageView.axaml
@@ -15,14 +15,15 @@
 
     <ScrollViewer>
         <StackPanel Margin="24" Orientation="Vertical" Spacing="24">
-            
+
             <alerts:Alert x:Name="InfoAlert"
-                            Title="View Pages Side by Side" 
-                            Body="Add panels to view 2 or more pages at once by clicking the “add panel” button in the top bar or by right clicking a page and selecting “Open in new panel”"
-                            Severity="Info"
-                            ShowDismiss="True"/>
-            
+                          Title="View Pages Side by Side"
+                          Body="Add panels to view 2 or more pages at once by clicking the “add panel” button in the top bar or by right clicking a page and selecting “Open in new panel”"
+                          Severity="Info"
+                          ShowDismiss="True" />
+
             <ItemsControl x:Name="Sections">
+
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>
                         <WrapPanel />
@@ -31,36 +32,27 @@
 
                 <ItemsControl.ItemTemplate>
                     <DataTemplate DataType="{x:Type workspace:INewTabPageSectionViewModel}">
-                        <StackPanel Classes="Spacing-3" MinWidth="160" MaxWidth="375" Margin="0 0 24 24">
+                        <StackPanel Classes="Spacing-3" MinWidth="160" MaxWidth="375" Margin="0 0 48 48">
                             <TextBlock x:Name="SectionNameTextBlock" Text="{CompiledBinding SectionName}"
-                                       Classes="HeadingSMSemi" />
+                                       Theme="{StaticResource HeadingXSSemiTheme}" />
+
 
                             <ItemsControl x:Name="Items" ItemsSource="{CompiledBinding Items}">
+
                                 <ItemsControl.ItemsPanel>
                                     <ItemsPanelTemplate>
-                                        <StackPanel Classes="Spacing-2" />
+                                        <StackPanel Spacing="{StaticResource Spacing-2}" />
                                     </ItemsPanelTemplate>
                                 </ItemsControl.ItemsPanel>
 
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate DataType="{x:Type workspace:INewTabPageSectionItemViewModel}">
 
-                                        <Border Classes="Mid Rounded">
-                                            <navigation:NavigationControl
-                                                Height="56"
-                                                Padding="0"
-                                                Width="375"
-                                                Background="{StaticResource SurfaceMidBrush}"
-                                                Command="{CompiledBinding SelectItemCommand}">
-
-                                                <StackPanel Margin="16" Orientation="Horizontal" Classes="Spacing-1">
-                                                    <icons:UnifiedIcon Size="24" Value="{CompiledBinding Icon}" />
-                                                    <TextBlock x:Name="NameTextBlock"
-                                                               Text="{CompiledBinding Name}"
-                                                               Classes="BodyLGBold" />
-                                                </StackPanel>
-                                            </navigation:NavigationControl>
-                                        </Border>
+                                        <navigation:NavigationControl
+                                            ShowIcon="Left"
+                                            LeftIcon="{CompiledBinding Icon}"
+                                            Text="{CompiledBinding Name}"
+                                            Command="{CompiledBinding SelectItemCommand}" />
 
                                     </DataTemplate>
                                 </ItemsControl.ItemTemplate>

--- a/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelView.axaml
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelView.axaml
@@ -6,6 +6,8 @@
     xmlns:reactive="http://reactiveui.net"
     xmlns:workspace="clr-namespace:NexusMods.App.UI.WorkspaceSystem"
     xmlns:resources="clr-namespace:NexusMods.App.UI.Resources"
+    xmlns:controls="clr-namespace:NexusMods.App.UI.Controls"
+    xmlns:icons="clr-namespace:NexusMods.Icons;assembly=NexusMods.Icons"
     mc:Ignorable="d" d:DesignWidth="1000" d:DesignHeight="400"
     x:Class="NexusMods.App.UI.WorkspaceSystem.PanelView"
     Width="0" Height="0">
@@ -43,12 +45,17 @@
                                     </ItemsControl>
                                 </StackPanel>
                                 <Separator x:Name="OneTabLine" Grid.Column="1"/>
+                                
                                 <Border Grid.Column="2" x:Name="AddTabButton1Container"
-                                        HorizontalAlignment="Stretch">
-                                    <Button x:Name="AddTabButton1"
-                                            Margin="12 12 10 12"
-                                            Classes="PanelTitlebar AddTab" >
-                                    </Button>
+                                        HorizontalAlignment="Stretch"
+                                        Padding="12,0,0,0">
+                                    
+                                    <controls:StandardButton x:Name="AddTabButton1"
+                                                             ShowLabel="False"
+                                                             ShowIcon="Left"
+                                                             LeftIcon="{x:Static icons:IconValues.Add}"
+                                                             Fill="None" />
+                                    
                                 </Border>
                                 <ToolTip.Tip>
                                     <TextBlock Text="{x:Static resources:Language.Panel_Add_tab_ToolTip}" />
@@ -57,17 +64,21 @@
 
                         </ScrollViewer>
 
-                        <Border Grid.Column="2" x:Name="TabHeaderAddAndScrollBorder">
+                        <Border Grid.Column="2" x:Name="TabHeaderAddAndScrollBorder"
+                                Padding="12,0,0,0">
                             <StackPanel Orientation="Horizontal">
-                                <Button
-                                    x:Name="AddTabButton2"
-                                    Margin="12 12 10 12"
-                                    Classes="PanelTitlebar AddTab" />
-
-                                <Button
-                                    x:Name="ScrollRightButton"
-                                    Margin="10 12 12 12"
-                                    Classes="PanelTitlebar ScrollRight" />
+                                
+                                <controls:StandardButton x:Name="AddTabButton2"
+                                                         ShowLabel="False"
+                                                         ShowIcon="Left"
+                                                         LeftIcon="{x:Static icons:IconValues.Add}"
+                                                         Fill="None" />
+                                
+                                <controls:StandardButton x:Name="ScrollRightButton"
+                                                         ShowLabel="False"
+                                                         ShowIcon="Left"
+                                                         LeftIcon="{x:Static icons:IconValues.ChevronRight}"
+                                                         Fill="None" />
                             </StackPanel>
                         </Border>
                     </Grid>
@@ -77,7 +88,8 @@
                             x:Name="TabHeaderSideArea"
                             Orientation="Horizontal"
                             Classes="Spacing-3"
-                            Margin="12, 12, 12, 12">
+                            Margin="6, 0, 8, 0">
+                            <!-- NOTE(insomnious): needs an extra 2 on the right margin to account for the 2px border -->
                             
                             <!-- TODO: Remove this hiding Border when PoppedOut panels are implemented -->
                             <Border IsVisible="False">
@@ -85,8 +97,11 @@
                                         Classes="PanelTitlebar OpenInWindow" />
                             </Border>
 
-                            <Button x:Name="ClosePanelButton"
-                                    Classes="PanelTitlebar Close" />
+                            <controls:StandardButton x:Name="ClosePanelButton"
+                                                     ShowLabel="False"
+                                                     ShowIcon="Left"
+                                                     LeftIcon="{x:Static icons:IconValues.Close}"
+                                                     Fill="None" />
                         </StackPanel>
                     </Border>
                 </Grid>

--- a/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelView.axaml
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelView.axaml
@@ -8,9 +8,8 @@
     xmlns:resources="clr-namespace:NexusMods.App.UI.Resources"
     xmlns:controls="clr-namespace:NexusMods.App.UI.Controls"
     xmlns:icons="clr-namespace:NexusMods.Icons;assembly=NexusMods.Icons"
-    mc:Ignorable="d" d:DesignWidth="1000" d:DesignHeight="400"
-    x:Class="NexusMods.App.UI.WorkspaceSystem.PanelView"
-    Width="0" Height="0">
+    mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="400"
+    x:Class="NexusMods.App.UI.WorkspaceSystem.PanelView">
 
     <Border x:Name="PanelBorder" Classes="Rounded-lg Low">
         <Grid RowDefinitions="Auto, *">
@@ -18,18 +17,21 @@
                 <Grid ColumnDefinitions="*, Auto">
                     <Grid Grid.Column="0" ColumnDefinitions="Auto, *, Auto">
                         <Border Grid.Column="0" x:Name="ScrollLeftButtonBorder">
-                            <Button x:Name="ScrollLeftButton"
-                                    Margin="24 12 12 12"
-                                    Classes="PanelTitlebar ScrollLeft" />
+                            <controls:StandardButton x:Name="ScrollLeftButton"
+                                 ShowIcon="IconOnly"
+                                 LeftIcon="{x:Static icons:IconValues.ChevronLeft}"
+                                 Fill="None"
+                                 Margin="8,0,8,0"/>
                         </Border>
 
                         <ScrollViewer Grid.Column="1"
                                       x:Name="TabHeaderScrollViewer"
                                       VerticalScrollBarVisibility="Disabled"
-                                      HorizontalScrollBarVisibility="Auto">
+                                      HorizontalScrollBarVisibility="Auto"
+                                      >
                             <Grid ColumnDefinitions="Auto, Auto, *">
                                 <StackPanel Grid.Column="0" Orientation="Horizontal">
-                                    <ItemsControl x:Name="TabHeaders" Height="52">
+                                    <ItemsControl x:Name="TabHeaders" Height="36">
                                         <ItemsControl.ItemsPanel>
                                             <ItemsPanelTemplate>
                                                 <StackPanel Classes="Spacing-none" 
@@ -44,17 +46,17 @@
                                         </ItemsControl.ItemTemplate>
                                     </ItemsControl>
                                 </StackPanel>
-                                <Separator x:Name="OneTabLine" Grid.Column="1"/>
+                                
+                                <Separator x:Name="OneTabLine" Grid.Column="1" Margin="4,0,0,0"/>
                                 
                                 <Border Grid.Column="2" x:Name="AddTabButton1Container"
-                                        HorizontalAlignment="Stretch"
-                                        Padding="12,0,0,0">
+                                        HorizontalAlignment="Stretch">
                                     
                                     <controls:StandardButton x:Name="AddTabButton1"
-                                                             ShowLabel="False"
-                                                             ShowIcon="Left"
+                                                             ShowIcon="IconOnly"
                                                              LeftIcon="{x:Static icons:IconValues.Add}"
-                                                             Fill="None" />
+                                                             Fill="None"
+                                                             Margin="8,0,0,0"/>
                                     
                                 </Border>
                                 <ToolTip.Tip>
@@ -64,19 +66,17 @@
 
                         </ScrollViewer>
 
-                        <Border Grid.Column="2" x:Name="TabHeaderAddAndScrollBorder"
-                                Padding="12,0,0,0">
-                            <StackPanel Orientation="Horizontal">
+                        <Border Grid.Column="2" x:Name="TabHeaderAddAndScrollBorder">
+                            <StackPanel Orientation="Horizontal" Spacing="{StaticResource Spacing-1}">
                                 
                                 <controls:StandardButton x:Name="AddTabButton2"
-                                                         ShowLabel="False"
-                                                         ShowIcon="Left"
+                                                         ShowIcon="IconOnly"
                                                          LeftIcon="{x:Static icons:IconValues.Add}"
-                                                         Fill="None" />
+                                                         Fill="None"
+                                                         Margin="8,0,0,0" />
                                 
                                 <controls:StandardButton x:Name="ScrollRightButton"
-                                                         ShowLabel="False"
-                                                         ShowIcon="Left"
+                                                         ShowIcon="IconOnly"
                                                          LeftIcon="{x:Static icons:IconValues.ChevronRight}"
                                                          Fill="None" />
                             </StackPanel>
@@ -98,8 +98,7 @@
                             </Border>
 
                             <controls:StandardButton x:Name="ClosePanelButton"
-                                                     ShowLabel="False"
-                                                     ShowIcon="Left"
+                                                     ShowIcon="IconOnly"
                                                      LeftIcon="{x:Static icons:IconValues.Close}"
                                                      Fill="None" />
                         </StackPanel>

--- a/src/NexusMods.App.UI/WorkspaceSystem/PanelTabHeader/PanelTabHeaderView.axaml
+++ b/src/NexusMods.App.UI/WorkspaceSystem/PanelTabHeader/PanelTabHeaderView.axaml
@@ -8,39 +8,40 @@
     xmlns:workspace="clr-namespace:NexusMods.App.UI.WorkspaceSystem"
     xmlns:icons="clr-namespace:NexusMods.Icons;assembly=NexusMods.Icons"
     xmlns:controls="clr-namespace:NexusMods.App.UI.Controls"
-    mc:Ignorable="d" d:DesignWidth="232" d:DesignHeight="52"
+    mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="60"
     x:Class="NexusMods.App.UI.WorkspaceSystem.PanelTabHeaderView">
 
     <Design.DataContext>
         <workspace:PanelTabHeaderDesignViewModel />
     </Design.DataContext>
 
-    <Border x:Name="Container">
-        <StackPanel Orientation="Horizontal">
-            <StackPanel Orientation="Horizontal"
-                        Classes="Spacing-2"
-                        Height="52"
-                        Margin="24, 0, 12, 0">
-                <StackPanel Orientation="Horizontal"
-                            Classes="Spacing-1_5"
-                            VerticalAlignment="Center">
-                    <icons:UnifiedIcon x:Name="Icon"/>
-                    <TextBlock x:Name="TitleTextBlock"
-                               Classes="BodyMDBold"
-                               MaxWidth="122"
-                               TextWrapping="NoWrap"
-                               TextTrimming="CharacterEllipsis"/>
-                </StackPanel>
+    <Border x:Name="Container" HorizontalAlignment="Left">
 
-                <controls:StandardButton x:Name="CloseTabButton"
-                                         ShowLabel="False"
-                                         ShowIcon="Left"
-                                         LeftIcon="{x:Static icons:IconValues.Close}"
-                                         Fill="None" />
+        <DockPanel MinWidth="100" MaxWidth="260"
+                   Height="36"
+                   LastChildFill="False">
 
-            </StackPanel>
+            <controls:StandardButton x:Name="CloseTabButton"
+                                     ShowIcon="IconOnly"
+                                     LeftIcon="{x:Static icons:IconValues.Close}"
+                                     Fill="None"
+                                     Size="Small"
+                                     DockPanel.Dock="Right" Margin="0, 0, 8, 0" />
 
-        </StackPanel>
+            <DockPanel
+                VerticalAlignment="Center"
+                HorizontalAlignment="Left"
+                Margin="16,0,0,0">
+                <icons:UnifiedIcon x:Name="Icon" DockPanel.Dock="Left" />
+                <TextBlock x:Name="TitleTextBlock"
+                           Theme="{StaticResource BodySMBoldTheme}"
+                           TextWrapping="NoWrap"
+                           TextTrimming="CharacterEllipsis"
+                           Margin="8,0,8,0" />
+            </DockPanel>
+
+        </DockPanel>
+
     </Border>
 
 </reactive:ReactiveUserControl>

--- a/src/NexusMods.App.UI/WorkspaceSystem/PanelTabHeader/PanelTabHeaderView.axaml
+++ b/src/NexusMods.App.UI/WorkspaceSystem/PanelTabHeader/PanelTabHeaderView.axaml
@@ -7,6 +7,7 @@
     xmlns:reactive="http://reactiveui.net"
     xmlns:workspace="clr-namespace:NexusMods.App.UI.WorkspaceSystem"
     xmlns:icons="clr-namespace:NexusMods.Icons;assembly=NexusMods.Icons"
+    xmlns:controls="clr-namespace:NexusMods.App.UI.Controls"
     mc:Ignorable="d" d:DesignWidth="232" d:DesignHeight="52"
     x:Class="NexusMods.App.UI.WorkspaceSystem.PanelTabHeaderView">
 
@@ -19,7 +20,7 @@
             <StackPanel Orientation="Horizontal"
                         Classes="Spacing-2"
                         Height="52"
-                        Margin="24, 0, 24, 0">
+                        Margin="24, 0, 12, 0">
                 <StackPanel Orientation="Horizontal"
                             Classes="Spacing-1_5"
                             VerticalAlignment="Center">
@@ -31,7 +32,11 @@
                                TextTrimming="CharacterEllipsis"/>
                 </StackPanel>
 
-                <Button x:Name="CloseTabButton" Classes="PanelTitlebar Close" />
+                <controls:StandardButton x:Name="CloseTabButton"
+                                         ShowLabel="False"
+                                         ShowIcon="Left"
+                                         LeftIcon="{x:Static icons:IconValues.Close}"
+                                         Fill="None" />
 
             </StackPanel>
 

--- a/src/NexusMods.App.UI/WorkspaceSystem/PanelTabHeader/PanelTabHeaderView.axaml.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/PanelTabHeader/PanelTabHeaderView.axaml.cs
@@ -35,7 +35,6 @@ public partial class PanelTabHeaderView : ReactiveUserControl<IPanelTabHeaderVie
                 .Subscribe(title =>
                 {
                     ToolTip.SetTip(this, title);
-                    ToolTip.SetShowDelay(this, (int)TimeSpan.FromMilliseconds(500).TotalMilliseconds);
                 })
                 .DisposeWith(disposables);
 

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Resources/ControlThemes/StandardButtonControlTheme.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Resources/ControlThemes/StandardButtonControlTheme.axaml
@@ -9,6 +9,18 @@
                 <StackPanel Spacing="4">
                     <Button IsEnabled="False">Test</Button>
                     <controls:StandardButton IsEnabled="False" />
+                    <StackPanel Orientation="Horizontal">
+                        <controls:StandardButton ShowIcon="IconOnly" />
+                        <controls:StandardButton ShowIcon="IconOnly" Size="Small" />
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal">
+                        <controls:StandardButton ShowIcon="IconOnly" LeftIcon="{x:Static icons:IconValues.Close}" />
+                        <controls:StandardButton ShowIcon="IconOnly" LeftIcon="{x:Static icons:IconValues.Close}" Size="Small" />
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal">
+                        <controls:StandardButton ShowIcon="IconOnly" Type="Primary" Fill="Strong"/>
+                        <controls:StandardButton ShowIcon="IconOnly" Type="Primary" Size="Small" />
+                    </StackPanel>
                     <controls:StandardButton>
                         <StackPanel>
                             <TextBlock>Test 1</TextBlock>
@@ -25,7 +37,8 @@
                                              LeftIcon="{x:Static icons:IconValues.Nexus}" />
                     <controls:StandardButton ShowIcon="Left" LeftIcon="{x:Static icons:IconValues.Nexus}" />
                     <controls:StandardButton ShowIcon="Left" LeftIcon="{x:Static icons:IconValues.AvatarTest}" />
-                    <controls:StandardButton IsEnabled="False" ShowIcon="Left" LeftIcon="{x:Static icons:IconValues.AvatarTest}" />
+                    <controls:StandardButton IsEnabled="False" ShowIcon="Left"
+                                             LeftIcon="{x:Static icons:IconValues.AvatarTest}" />
                 </StackPanel>
 
                 <Grid ColumnDefinitions="*,12,*" RowDefinitions="32,Auto,10,Auto,Auto,Auto" ShowGridLines="False">
@@ -294,12 +307,23 @@
             <Style Selector="^:disabled">
                 <Setter Property="Opacity" Value="0.4" />
             </Style>
+            
+            <!-- icon only variants -->
+            <Style Selector="^[ShowIcon=IconOnly]">
+                <Setter Property="Padding" Value="0" />
+                
+                <Style Selector="^ /template/ Border">
+                    <!-- NOTE(insomnious): fixed size as we know how big the icons are -->
+                    <Setter Property="Height" Value="24" />
+                    <Setter Property="Width" Value="24" />
+                </Style>
+            </Style>
         </Style>
 
         <!-- small variants -->
         <Style Selector="^[Size=Small]">
             <Setter Property="Padding" Value="{DynamicResource ButtonPaddingSmall}" />
-
+            
             <Style Selector="^ StackPanel">
                 <Setter Property="Spacing" Value="{StaticResource Spacing-0.5}"></Setter>
             </Style>
@@ -315,6 +339,17 @@
                     <!-- needs a little horizontal padding to fully match figma -->
                     <Setter Property="Padding" Value="1 0" />
                     <Setter Property="Theme" Value="{StaticResource BodyMDNormalTheme}" />
+                </Style>
+            </Style>
+            
+            <!-- icon only variants -->
+            <Style Selector="^[ShowIcon=IconOnly]">
+                <Setter Property="Padding" Value="0" />
+                
+                <Style Selector="^ /template/ Border">
+                    <!-- NOTE(insomnious): fixed size as we know how big the icons are -->
+                    <Setter Property="Height" Value="20" />
+                    <Setter Property="Width" Value="20" />
                 </Style>
             </Style>
         </Style>

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/UserControls/EmptyState/EmptyStateStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/UserControls/EmptyState/EmptyStateStyles.axaml
@@ -8,7 +8,6 @@
                 <controls:EmptyState.Subtitle>
                     <TextBlock>There is nothing here, you should better do something about this.</TextBlock>
                 </controls:EmptyState.Subtitle>
-
                 <TextBlock>There is something here</TextBlock>
             </controls:EmptyState>
 
@@ -20,55 +19,54 @@
                         <TextBlock>More text</TextBlock>
                     </StackPanel>
                 </controls:EmptyState.Subtitle>
-
                 <TextBlock>There is something here</TextBlock>
             </controls:EmptyState>
         </StackPanel>
-
     </Design.PreviewWith>
 
     <Style Selector="controls|EmptyState">
         <Style Selector="^ /template/ Border#EmptyStateBorder">
-            <Setter Property="IsVisible" Value="False"/>
+            <Setter Property="IsVisible" Value="False" />
 
             <Style Selector="^ StackPanel#Panel">
-                <Setter Property="Orientation" Value="Vertical"/>
-                <Setter Property="Margin" Value="16 64 16 0"/>
-                <Setter Property="Spacing" Value="{StaticResource Spacing-2}"/>
+                <Setter Property="Orientation" Value="Vertical" />
+                <Setter Property="Margin" Value="16 64 16 0" />
+                <Setter Property="Spacing" Value="{StaticResource Spacing-2}" />
             </Style>
 
             <Style Selector="^ icons|UnifiedIcon#Icon">
-                <Setter Property="Size" Value="36"/>
+                <Setter Property="Size" Value="36" />
             </Style>
 
             <Style Selector="^ TextBlock#HeaderTextBlock">
-                <Setter Property="Theme" Value="{StaticResource BodyXLBoldTheme}"/>
-                <Setter Property="HorizontalAlignment" Value="Center"/>
+                <Setter Property="Theme" Value="{StaticResource BodyXLBoldTheme}" />
+                <Setter Property="HorizontalAlignment" Value="Center" />
                 <Setter Property="VerticalAlignment" Value="Center" />
-                <Setter Property="Foreground" Value="{StaticResource NeutralSubdued}"/>
-                <Setter Property="TextWrapping" Value="Wrap"/>
+                <Setter Property="Foreground" Value="{StaticResource NeutralSubdued}" />
+                <Setter Property="TextWrapping" Value="Wrap" />
             </Style>
 
             <Style Selector="^ ContentPresenter#SubtitleContentPresenter">
-                <Style Selector="^ StackPanel">
-                    <Setter Property="Orientation" Value="Horizontal"/>
-                    <Setter Property="Spacing" Value="2"/>
-                    <Setter Property="HorizontalAlignment" Value="Center"/>
-                </Style>
 
-                <Style Selector="^ TextBlock">
-                    <Setter Property="Theme" Value="{StaticResource BodyLGNormalTheme}"/>
+                <Style Selector="^ > StackPanel">
+                    <Setter Property="Orientation" Value="Horizontal" />
+                    <Setter Property="Spacing" Value="{StaticResource Spacing-2}" />
                     <Setter Property="HorizontalAlignment" Value="Center" />
-                    <Setter Property="VerticalAlignment" Value="Center"/>
-                    <Setter Property="Foreground" Value="{StaticResource NeutralSubdued}" />
-                    <Setter Property="TextWrapping" Value="Wrap" />
-                    <Setter Property="TextAlignment" Value="Center"/>
+
+                    <Style Selector="^ > TextBlock">
+                        <Setter Property="Theme" Value="{StaticResource BodyLGNormalTheme}" />
+                        <Setter Property="HorizontalAlignment" Value="Center" />
+                        <Setter Property="VerticalAlignment" Value="Center" />
+                        <Setter Property="Foreground" Value="{StaticResource NeutralSubdued}" />
+                        <Setter Property="TextWrapping" Value="Wrap" />
+                        <Setter Property="TextAlignment" Value="Center" />
+                    </Style>
                 </Style>
             </Style>
         </Style>
 
         <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
-            <Setter Property="IsVisible" Value="True"/>
+            <Setter Property="IsVisible" Value="True" />
         </Style>
 
         <Style Selector="^ /template/ icons|UnifiedIcon#Icon">
@@ -76,17 +74,16 @@
         </Style>
 
         <Style Selector="^:icon /template/ icons|UnifiedIcon#Icon">
-            <Setter Property="IsVisible" Value="True"/>
+            <Setter Property="IsVisible" Value="True" />
         </Style>
 
         <Style Selector="^:active /template/ Border#EmptyStateBorder">
-            <Setter Property="IsVisible" Value="True"/>
+            <Setter Property="IsVisible" Value="True" />
         </Style>
 
         <Style Selector="^:active /template/ ContentPresenter#ContentPresenter">
-            <Setter Property="IsVisible" Value="False"/>
+            <Setter Property="IsVisible" Value="False" />
         </Style>
     </Style>
 
 </Styles>
-

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/UserControls/WorkspaceSystem/PanelTabHeaderStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/UserControls/WorkspaceSystem/PanelTabHeaderStyles.axaml
@@ -2,36 +2,58 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:ui="clr-namespace:NexusMods.App.UI.WorkspaceSystem;assembly=NexusMods.App.UI"
         xmlns:icons="clr-namespace:NexusMods.Icons;assembly=NexusMods.Icons"
-        xmlns:reactive="http://reactiveui.net">
+        xmlns:reactive="http://reactiveui.net"
+        xmlns:controls="clr-namespace:NexusMods.App.UI.Controls;assembly=NexusMods.App.UI">
+
+    <Design.PreviewWith>
+        <ui:PanelTabHeaderView />
+    </Design.PreviewWith>
 
     <!-- Add Styles Here -->
     <Style Selector="ui|PanelTabHeaderView">
 
+        <!-- unselected -->
         <Style Selector="^ Border#Container:not(.Selected)">
             <Setter Property="Background" Value="Transparent" />
-        
+
             <Style Selector="^ icons|UnifiedIcon#Icon">
                 <Setter Property="Foreground" Value="{StaticResource NeutralSubduedBrush}" />
-                <Setter Property="Size" Value="20" />
+                <Setter Property="Size" Value="16" />
             </Style>
-        
+
             <Style Selector="^ TextBlock">
                 <Setter Property="Foreground" Value="{StaticResource NeutralSubduedBrush}" />
                 <Setter Property="VerticalAlignment" Value="Center" />
             </Style>
+
+            <Style Selector="^ controls|StandardButton#CloseTabButton">
+                <Setter Property="Opacity" Value="0" />
+            </Style>
+
+            <Style Selector="^:pointerover">
+                <Style Selector="^ controls|StandardButton#CloseTabButton">
+                    <Setter Property="Opacity" Value="1" />
+                </Style>
+            </Style>
+
         </Style>
-        
+
+        <!-- selected -->
         <Style Selector="^ Border#Container.Selected">
             <Setter Property="Background" Value="{StaticResource SurfaceLowBrush}" />
-        
+
             <Style Selector="^ icons|UnifiedIcon#Icon">
                 <Setter Property="Foreground" Value="{StaticResource NeutralStrongBrush}" />
-                <Setter Property="Size" Value="20" />
+                <Setter Property="Size" Value="16" />
             </Style>
-        
+
             <Style Selector="^ TextBlock">
                 <Setter Property="Foreground" Value="{StaticResource NeutralStrongBrush}" />
                 <Setter Property="VerticalAlignment" Value="Center" />
+            </Style>
+
+            <Style Selector="^ controls|StandardButton#CloseTabButton">
+                <Setter Property="Opacity" Value="1" />
             </Style>
         </Style>
     </Style>

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/UserControls/WorkspaceSystem/PanelTabHeaderStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/UserControls/WorkspaceSystem/PanelTabHeaderStyles.axaml
@@ -9,26 +9,26 @@
 
         <Style Selector="^ Border#Container:not(.Selected)">
             <Setter Property="Background" Value="Transparent" />
-
-            <Style Selector="^ icons|UnifiedIcon">
+        
+            <Style Selector="^ icons|UnifiedIcon#Icon">
                 <Setter Property="Foreground" Value="{StaticResource NeutralSubduedBrush}" />
                 <Setter Property="Size" Value="20" />
             </Style>
-
+        
             <Style Selector="^ TextBlock">
                 <Setter Property="Foreground" Value="{StaticResource NeutralSubduedBrush}" />
                 <Setter Property="VerticalAlignment" Value="Center" />
             </Style>
         </Style>
-
+        
         <Style Selector="^ Border#Container.Selected">
             <Setter Property="Background" Value="{StaticResource SurfaceLowBrush}" />
-
-            <Style Selector="^ icons|UnifiedIcon">
+        
+            <Style Selector="^ icons|UnifiedIcon#Icon">
                 <Setter Property="Foreground" Value="{StaticResource NeutralStrongBrush}" />
                 <Setter Property="Size" Value="20" />
             </Style>
-
+        
             <Style Selector="^ TextBlock">
                 <Setter Property="Foreground" Value="{StaticResource NeutralStrongBrush}" />
                 <Setter Property="VerticalAlignment" Value="Center" />

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/UserControls/WorkspaceSystem/PanelViewStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/UserControls/WorkspaceSystem/PanelViewStyles.axaml
@@ -1,7 +1,7 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:ui="clr-namespace:NexusMods.App.UI.WorkspaceSystem;assembly=NexusMods.App.UI">
-
+    
     <Style Selector="ui|PanelView">
         <Style Selector="^ ItemsControl#TabContents">
             <Setter Property="Padding" Value="0" />
@@ -13,7 +13,7 @@
 
             <Style Selector="^ Separator#OneTabLine">
                 <Setter Property="Margin" Value="0"/>
-                <Setter Property="Height" Value="28"/>
+                <Setter Property="Height" Value="20"/>
                 <Setter Property="Width" Value="1"/>
                 <Setter Property="Background" Value="{StaticResource StrokeTranslucentWeak}"/>
             </Style>
@@ -29,6 +29,7 @@
 
         <!-- multiple panels -->
         <Style Selector="^:not(:alone)">
+            
             <!-- selected -->
             <Style Selector="^:selected">
                 <Style Selector="^ Border#PanelBorder">
@@ -66,8 +67,8 @@
 
         <!-- multiple tabs -->
         <Style Selector="^:not(:one-tab) Border#TabHeaderBorder">
-            <Setter Property="CornerRadius" Value="{StaticResource Rounded-t-lg}" />
-            <Setter Property="Background" Value="{StaticResource SurfaceBaseBrush}" />
+            <!-- <Setter Property="CornerRadius" Value="{StaticResource Rounded-t-lg}" /> -->
+            <Setter Property="Background" Value="{StaticResource BrandTranslucentDark300Brush}" />
 
             <Style Selector="^ Separator#OneTabLine">
                 <Setter Property="IsVisible" Value="False"/>


### PR DESCRIPTION
Closes https://github.com/Nexus-Mods/NexusMods.App/issues/2214

Small tweaks in lots of different files I'm afraid.

In order to support the more compact tab designs ([Figma](https://www.figma.com/design/wgspwsneBneQn9ywd3dVhC/%F0%9F%93%B1%F0%9F%A7%AA-Design-test-area?node-id=2655-130591&t=zNOfk1iDPFDXa5ae-1)), needed to bit the bullet and add the icon button ([Figma](https://www.figma.com/design/RGRSmIC4KoVlIosQB5YmQY/%F0%9F%93%B1%F0%9F%A7%B1-App-components?m=auto&node-id=2-1912)) to our components. It shares 99% of Standard Button so thought it made sense to add it as a property, and decided on adding a new option for `ShowIcon=IconOnly`. Interested to hear opinions as we could of also had it's own property like `IconOnly=True`.

Buttons on New Tab page working visually as buttons again now