### PR TITLE
Restructure collection metadata creation

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/GraphQLResolver.cs
+++ b/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/GraphQLResolver.cs
@@ -23,6 +23,8 @@ public readonly struct GraphQLResolver(ITransaction Tx, ReadOnlyModel Model)
     public static GraphQLResolver Create<THighLevel>(IDb db, ITransaction tx, 
         IWritableAttribute<THighLevel> primaryKeyAttribute, THighLevel primaryKeyValue) where THighLevel : notnull
     {
+        if (!primaryKeyAttribute.IsIndexed) throw new ArgumentException($"Attribute {primaryKeyAttribute.Id} is not indexed", nameof(primaryKeyAttribute));
+
         var existing = db.Datoms(primaryKeyAttribute, primaryKeyValue);
         var exists = existing.Count > 0;
         var id = existing.Count == 0 ? tx.TempId() : existing[0].E;
@@ -40,6 +42,9 @@ public readonly struct GraphQLResolver(ITransaction Tx, ReadOnlyModel Model)
         where THighLevel1 : notnull
         where THighLevel2 : notnull
     {
+        if (!pair1.A.IsIndexed) throw new ArgumentException($"Attribute {pair1.A.Id} is not indexed", nameof(pair1));
+        if (!pair2.A.IsIndexed) throw new ArgumentException($"Attribute {pair2.A.Id} is not indexed", nameof(pair2));
+
         var existing = referenceDb.Datoms(pair1, pair2);
         var exists = existing.Count > 0;
         var id = existing.Count == 0 ? tx.TempId() : existing[0];

--- a/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/Models/CollectionRevisionMetadata.cs
+++ b/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/Models/CollectionRevisionMetadata.cs
@@ -43,12 +43,12 @@ public partial class CollectionRevisionMetadata : IModelDefinition
     /// Total download size of all files in this revision, including the size of the revision's files.
     /// </summary>
     public static readonly SizeAttribute TotalSize = new(Namespace, nameof(TotalSize));
-    
+
     /// <summary>
     /// The overall rating of this revision (often displayed as a percentage).
     /// </summary>
-    public static readonly FloatAttribute OverallRating = new(Namespace, nameof(OverallRating));
-    
+    public static readonly FloatAttribute OverallRating = new(Namespace, nameof(OverallRating)) { IsOptional = true };
+
     /// <summary>
     /// The total number of ratings this revision has.
     /// </summary>

--- a/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/Models/User.cs
+++ b/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/Models/User.cs
@@ -31,5 +31,7 @@ public partial class User : IModelDefinition
     /// <summary>
     /// The user's avatar image.
     /// </summary>
-    public static readonly MemoryAttribute AvatarImage = new(Namespace, nameof(AvatarImage));
+    [Obsolete]
+    // TODO: use image pipeline
+    public static readonly MemoryAttribute AvatarImage = new(Namespace, nameof(AvatarImage)) {IsOptional = true};
 }

--- a/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/NexusModsCollectionLibraryFile.cs
+++ b/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/NexusModsCollectionLibraryFile.cs
@@ -1,6 +1,6 @@
 using JetBrains.Annotations;
 using NexusMods.Abstractions.Library.Models;
-using NexusMods.MnemonicDB.Abstractions.Attributes;
+using NexusMods.Abstractions.NexusModsLibrary.Attributes;
 using NexusMods.MnemonicDB.Abstractions.Models;
 
 namespace NexusMods.Abstractions.NexusModsLibrary;
@@ -13,9 +13,8 @@ namespace NexusMods.Abstractions.NexusModsLibrary;
 public partial class NexusModsCollectionLibraryFile : IModelDefinition
 {
     private const string Namespace = "NexusMods.Abstractions.NexusModsLibrary.Models.NexusModsCollectionLibraryFile";
-    
-    /// <summary>
-    /// The collection revision this file belongs to.
-    /// </summary>
-    public static readonly ReferenceAttribute<Models.CollectionRevisionMetadata> CollectionRevision = new(Namespace, nameof(CollectionRevision));
+
+    public static readonly CollectionsSlugAttribute CollectionSlug = new(Namespace, nameof(CollectionSlug)) { IsIndexed = true };
+
+    public static readonly RevisionNumberAttribute CollectionRevisionNumber = new(Namespace, nameof(CollectionRevisionNumber)) { IsIndexed = true };
 }

--- a/src/Networking/NexusMods.Networking.NexusWebApi/Extensions/FragmentExtensions.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/Extensions/FragmentExtensions.cs
@@ -18,14 +18,11 @@ public static class FragmentExtensions
     /// <summary>
     /// Resolves the IUserFragment to an entity in the database, inserting or updating as necessary.
     /// </summary>
-    public static async Task<EntityId> Resolve(this IUserFragment userFragment, IDb db, ITransaction tx, HttpClient client, CancellationToken token)
+    public static EntityId Resolve(this IUserFragment userFragment, IDb db, ITransaction tx)
     {
         var userResolver = GraphQLResolver.Create(db, tx, User.NexusId, (ulong)userFragment.MemberId);
         userResolver.Add(User.Name, userFragment.Name);
         userResolver.Add(User.Avatar, new Uri(userFragment.Avatar));
-        
-        var avatarImage = await DownloadImage(client, userFragment.Avatar, token);
-        userResolver.Add(User.AvatarImage,avatarImage);
         return userResolver.Id;
     }
 

--- a/src/Networking/NexusMods.Networking.NexusWebApi/NexusMods.Networking.NexusWebApi.csproj
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/NexusMods.Networking.NexusWebApi.csproj
@@ -14,6 +14,7 @@
     
     <ItemGroup>
       <ProjectReference Include="..\..\Abstractions\NexusMods.Abstractions.Cli\NexusMods.Abstractions.Cli.csproj" />
+      <ProjectReference Include="..\..\Abstractions\NexusMods.Abstractions.Collections\NexusMods.Abstractions.Collections.csproj" />
       <ProjectReference Include="..\..\Abstractions\NexusMods.Abstractions.Games\NexusMods.Abstractions.Games.csproj" />
       <ProjectReference Include="..\..\Abstractions\NexusMods.Abstractions.Jobs\NexusMods.Abstractions.Jobs.csproj" />
       <ProjectReference Include="..\..\Abstractions\NexusMods.Abstractions.NexusModsLibrary\NexusMods.Abstractions.NexusModsLibrary.csproj" />

--- a/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsCollectionDownloadJob.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsCollectionDownloadJob.cs
@@ -21,11 +21,6 @@ public class NexusModsCollectionDownloadJob : IJobDefinitionWithStart<NexusModsC
     /// The download destination.
     /// </summary>
     public required AbsolutePath Destination { get; set; }
-    
-    /// <summary>
-    /// The metadata of the collection revision.
-    /// </summary>
-    public CollectionRevisionMetadata.ReadOnly? Metadata { get; set; }
 
     /// <summary>
     /// The collection slug
@@ -88,7 +83,8 @@ public class NexusModsCollectionDownloadJob : IJobDefinitionWithStart<NexusModsC
     {
         _ = new NexusModsCollectionLibraryFile.New(tx, libraryFile.Id)
         {
-            CollectionRevisionId = Metadata,
+            CollectionSlug = Slug,
+            CollectionRevisionNumber = Revision,
             LibraryFile = libraryFile,
         };
         return ValueTask.CompletedTask;
@@ -97,7 +93,6 @@ public class NexusModsCollectionDownloadJob : IJobDefinitionWithStart<NexusModsC
     /// <inheritdoc />
     public async ValueTask<AbsolutePath> StartAsync(IJobContext<NexusModsCollectionDownloadJob> context)
     {
-        Metadata = await Library.GetOrAddCollectionRevision(Slug, Revision, context.CancellationToken);
         var downloadLinks = await ApiClient.CollectionDownloadLinksAsync(Slug, Revision, true, context.CancellationToken);
         DownloadJob = HttpDownloadJob.Create(ServiceProvider, downloadLinks.Data.DownloadLinks.First().Uri, downloadLinks.Data.DownloadLinks.First().Uri, Destination);
         return await DownloadJob;

--- a/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsLibrary.Collections.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsLibrary.Collections.cs
@@ -1,0 +1,139 @@
+using System.Text.Json;
+using NexusMods.Abstractions.Collections.Json;
+using NexusMods.Abstractions.Library.Models;
+using NexusMods.Abstractions.NexusModsLibrary;
+using NexusMods.Abstractions.NexusModsLibrary.Models;
+using NexusMods.Abstractions.NexusWebApi.Types;
+using NexusMods.Extensions.BCL;
+using NexusMods.MnemonicDB.Abstractions;
+using NexusMods.Networking.NexusWebApi.Extensions;
+using NexusMods.Paths;
+
+namespace NexusMods.Networking.NexusWebApi;
+
+public partial class NexusModsLibrary
+{
+    public async Task<CollectionRevisionMetadata.ReadOnly> GetOrAddCollectionRevision(
+        NexusModsCollectionLibraryFile.ReadOnly collectionLibraryFile,
+        CollectionSlug slug,
+        RevisionNumber revisionNumber,
+        CancellationToken cancellationToken)
+    {
+        var revisions = CollectionRevisionMetadata
+            .FindByRevisionNumber(_connection.Db, revisionNumber)
+            .Where(r => r.Collection.Slug == slug);
+
+        if (revisions.TryGetFirst(out var revision)) return revision;
+
+        var collectionRoot = await ParseCollectionJsonFile(collectionLibraryFile, cancellationToken);
+        var apiResult = await _gqlClient.CollectionRevisionInfo.ExecuteAsync(
+            slug: slug.Value,
+            revisionNumber: (int)revisionNumber.Value,
+            viewAdultContent: true,
+            cancellationToken: cancellationToken
+        );
+
+        var collectionRevisionInfo = apiResult.Data?.CollectionRevision;
+        if (collectionRevisionInfo is null) throw new NotImplementedException($"API call returned no data for `{slug}` `{revisionNumber}`");
+
+        using var tx = _connection.BeginTransaction();
+        var db = _connection.Db;
+
+        var collectionEntityId = UpdateCollectionInfo(db, tx, slug, collectionRevisionInfo.Collection);
+        var collectionRevisionEntityId = UpdateRevisionInfo(db, tx, revisionNumber, collectionEntityId, collectionRevisionInfo);
+
+        UpdateFiles(db, tx, collectionRevisionEntityId, collectionRevisionInfo);
+
+        var results = await tx.Commit();
+        return CollectionRevisionMetadata.Load(results.Db, results[collectionRevisionEntityId]);
+    }
+
+    private static void UpdateFiles(
+        IDb db,
+        ITransaction tx,
+        EntityId collectionRevisionEntityId,
+        ICollectionRevisionInfo_CollectionRevision revisionInfo)
+    {
+        // TODO: use data from collection json file
+
+        foreach (var apiModFile in revisionInfo.ModFiles)
+        {
+            var apiFileInfo = apiModFile.File!;
+
+            var modEntityId = apiFileInfo.Mod.Resolve(db, tx);
+            var fileEntityId = apiFileInfo.Resolve(db, tx, modEntityId);
+
+            var revisionFileResolver = GraphQLResolver.Create(db, tx, CollectionRevisionModFile.FileId, ulong.Parse(apiModFile.Id));
+            revisionFileResolver.Add(CollectionRevisionModFile.CollectionRevision, collectionRevisionEntityId);
+            revisionFileResolver.Add(CollectionRevisionModFile.NexusModFile, fileEntityId);
+            revisionFileResolver.Add(CollectionRevisionModFile.IsOptional, apiModFile.Optional);
+        }
+    }
+
+    private static EntityId UpdateRevisionInfo(
+        IDb db,
+        ITransaction tx,
+        RevisionNumber revisionNumber,
+        EntityId collectionEntityId,
+        ICollectionRevisionInfo_CollectionRevision revisionInfo)
+    {
+        var revisionId = RevisionId.From((ulong)revisionInfo.Id);
+        var resolver = GraphQLResolver.Create(db, tx, CollectionRevisionMetadata.RevisionId, revisionId);
+
+        resolver.Add(CollectionRevisionMetadata.RevisionId, revisionId);
+        resolver.Add(CollectionRevisionMetadata.RevisionNumber, revisionNumber);
+        resolver.Add(CollectionRevisionMetadata.CollectionId, collectionEntityId);
+        resolver.Add(CollectionRevisionMetadata.Downloads, (ulong)revisionInfo.TotalDownloads);
+
+        if (ulong.TryParse(revisionInfo.TotalSize, out var totalSize))
+            resolver.Add(CollectionRevisionMetadata.TotalSize, Size.From(totalSize));
+        else
+            resolver.Add(CollectionRevisionMetadata.TotalSize, Size.Zero);
+
+        if (float.TryParse(revisionInfo.OverallRating ?? "0.0", out var overallRating))
+            resolver.Add(CollectionRevisionMetadata.OverallRating, overallRating / 100);
+
+        resolver.Add(CollectionRevisionMetadata.TotalRatings, (ulong)(revisionInfo.OverallRatingCount ?? 0));
+        return resolver.Id;
+    }
+
+    private static EntityId UpdateCollectionInfo(
+        IDb db,
+        ITransaction tx,
+        CollectionSlug slug,
+        ICollectionRevisionInfo_CollectionRevision_Collection collectionInfo)
+    {
+        var resolver = GraphQLResolver.Create(db, tx, CollectionMetadata.Slug, slug);
+
+        resolver.Add(CollectionMetadata.Name, collectionInfo.Name);
+        resolver.Add(CollectionMetadata.Summary, collectionInfo.Summary);
+        resolver.Add(CollectionMetadata.Endorsements, (ulong)collectionInfo.Endorsements);
+
+        if (Uri.TryCreate(collectionInfo.TileImage?.ThumbnailUrl, UriKind.Absolute, out var tileImageUri))
+            resolver.Add(CollectionMetadata.TileImageUri, tileImageUri);
+
+        if (Uri.TryCreate(collectionInfo.HeaderImage?.Url, UriKind.Absolute, out var backgroundImageUri))
+            resolver.Add(CollectionMetadata.BackgroundImageUri, backgroundImageUri);
+
+        var user = collectionInfo.User.Resolve(db, tx);
+        resolver.Add(CollectionMetadata.Author, user);
+
+        return resolver.Id;
+    }
+
+    private async ValueTask<CollectionRoot> ParseCollectionJsonFile(
+        NexusModsCollectionLibraryFile.ReadOnly collectionLibraryFile,
+        CancellationToken cancellationToken)
+    {
+        if (!collectionLibraryFile.AsLibraryFile().TryGetAsLibraryArchive(out var archive))
+            throw new InvalidOperationException("The source collection is not a library archive");
+
+        var jsonFileEntity = archive.Children.FirstOrDefault(f => f.Path == "collection.json");
+
+        await using var data = await _fileStore.GetFileStream(jsonFileEntity.AsLibraryFile().Hash, token: cancellationToken);
+        var root = await JsonSerializer.DeserializeAsync<CollectionRoot>(data, _jsonSerializerOptions, cancellationToken: cancellationToken);
+
+        if (root is null) throw new InvalidOperationException("Unable to deserialize collection JSON file");
+        return root;
+    }
+}

--- a/src/NexusMods.App.Cli/Types/IpcHandlers/NxmIpcProtocolHandler.cs
+++ b/src/NexusMods.App.Cli/Types/IpcHandlers/NxmIpcProtocolHandler.cs
@@ -10,6 +10,7 @@ using NexusMods.Abstractions.NexusWebApi.Types;
 using NexusMods.Collections;
 using NexusMods.Extensions.BCL;
 using NexusMods.MnemonicDB.Abstractions;
+using NexusMods.MnemonicDB.Abstractions.IndexSegments;
 using NexusMods.Networking.HttpDownloader;
 using NexusMods.Networking.NexusWebApi;
 using NexusMods.Networking.NexusWebApi.Auth;
@@ -98,6 +99,7 @@ public class NxmIpcProtocolHandler : IIpcProtocolHandler
         var nexusModsLibrary = _serviceProvider.GetRequiredService<NexusModsLibrary>();
         var library = _serviceProvider.GetRequiredService<ILibraryService>();
         var gameRegistry = _serviceProvider.GetRequiredService<IGameRegistry>();
+        var connection = _serviceProvider.GetRequiredService<IConnection>();
         if (!gameRegistry.InstalledGames.TryGetFirst(g => g.Game.GameId == gameId, out var game))
             return;
                     
@@ -108,16 +110,26 @@ public class NxmIpcProtocolHandler : IIpcProtocolHandler
         var temporaryFileManager = _serviceProvider.GetRequiredService<TemporaryFileManager>();
         await using var destination = temporaryFileManager.CreateFile();
 
-        var downloadJob = nexusModsLibrary.CreateCollectionDownloadJob(destination, collectionUrl.Collection.Slug, collectionUrl.Revision,
-            CancellationToken.None
-        );
-        
-        var libraryFile = await library.AddDownload(downloadJob);
-        
-        if (!libraryFile.TryGetAsNexusModsCollectionLibraryFile(out var collectionFile))
-            throw new InvalidOperationException("The library file is not a NexusModsCollectionLibraryFile");
+        var slug = collectionUrl.Collection.Slug;
+        var revision = collectionUrl.Revision;
 
-        var installJob = await InstallCollectionJob.Create(_serviceProvider, loadout, collectionFile);
+        var db = connection.Db;
+        var list = db.Datoms(
+            (NexusModsCollectionLibraryFile.CollectionSlug, slug),
+            (NexusModsCollectionLibraryFile.CollectionRevisionNumber, revision)
+        );
+
+        if (!list.Select(id => NexusModsCollectionLibraryFile.Load(db, id)).TryGetFirst(x => x.IsValid(), out var collectionFile))
+        {
+            var downloadJob = nexusModsLibrary.CreateCollectionDownloadJob(destination, collectionUrl.Collection.Slug, collectionUrl.Revision, CancellationToken.None);
+            var libraryFile = await library.AddDownload(downloadJob);
+
+            if (!libraryFile.TryGetAsNexusModsCollectionLibraryFile(out collectionFile))
+                throw new InvalidOperationException("The library file is not a NexusModsCollectionLibraryFile");
+        }
+
+        var collectionRevision = await nexusModsLibrary.GetOrAddCollectionRevision(collectionFile, collectionUrl.Collection.Slug, collectionUrl.Revision, CancellationToken.None);
+        // var installJob = await InstallCollectionJob.Create(_serviceProvider, loadout, collectionFile);
     }
 
     private async Task HandleModUrl(CancellationToken cancel, NXMModUrl modUrl)

--- a/tests/Networking/NexusMods.Networking.NexusWebApi.Tests/NexusModsLibraryTests.cs
+++ b/tests/Networking/NexusMods.Networking.NexusWebApi.Tests/NexusModsLibraryTests.cs
@@ -36,8 +36,8 @@ public class NexusModsLibraryTests
         
         // Make sure the metadata is linked correctly
         libraryFile.TryGetAsNexusModsCollectionLibraryFile(out var collectionFile).Should().BeTrue();
-        collectionFile.CollectionRevision.RevisionNumber.Value.Should().Be(revisionNumber);
-        collectionFile.CollectionRevision.Collection.Slug.Value.Should().Be(slug);
+        collectionFile.CollectionRevisionNumber.Value.Should().Be(revisionNumber);
+        collectionFile.CollectionSlug.Value.Should().Be(slug);
 
         // The downloaded file should be the correct size
         libraryFile.Size.Value.Should().BeGreaterThan(0);


### PR DESCRIPTION
Most of the changes are just code cleanup and moving code from one place to another to make it easier to update later.

The most important change is the ordering. Previously, we'd get the metadata from the API before we even download the collection file. Now, we first download the file and then get the metadata from the API.

This PR is just a stepping stone that hopefully doesn't break anything, the next PR will use this as a base and re-do how we store metadata for collection files.