### PR TITLE
Update steam redmod link

### DIFF
--- a/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/Emitters/MissingRedModEmitter.cs
+++ b/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/Emitters/MissingRedModEmitter.cs
@@ -9,7 +9,7 @@ namespace NexusMods.Games.RedEngine.Cyberpunk2077.Emitters;
 public partial class MissingRedModEmitter : ILoadoutDiagnosticEmitter
 {
     public static readonly NamedLink RedmodGenericLink = new("REDmod DLC", new Uri("https://www.cyberpunk.net/en/modding-support"));
-    public static readonly NamedLink RedmodSteamLink = new("REDmod DLC", new Uri("steam://run/2060310"));
+    public static readonly NamedLink RedmodSteamLink = new("REDmod DLC", new Uri("steam://store/2060310"));
     public static readonly NamedLink RedmodGOGLink = new("REDmod DLC", new Uri("goggalaxy://openStoreUrl/embed.gog.com/game/cyberpunk_2077_redmod"));
     public static readonly NamedLink RedmodEGSLink = new("REDmod DLC", new Uri("com.epicgames.launcher://store/p/cyberpunk-2077"));
 


### PR DESCRIPTION
Resolves #2224.

Opens the redmod steam page:
![2024-11-11_12-12-49](https://github.com/user-attachments/assets/4944703a-d7e5-4f27-bce4-a3a16b285450)
