### PR TITLE
Don't migrate on the CLI

### DIFF
--- a/src/NexusMods.App/Program.cs
+++ b/src/NexusMods.App/Program.cs
@@ -60,15 +60,16 @@ public class Program
         );
         var services = host.Services;
 
-        // Run the migrations
-        var migration = services.GetRequiredService<MigrationService>();
-        migration.Run().Wait();
+        if (startupMode.RunAsMain)
+        {
+            // Run the migrations
+            var migration = services.GetRequiredService<MigrationService>();
+            migration.Run().Wait();
+        }
 
-        
         // Okay to do wait here, as we are in the main process thread.
         host.StartAsync().Wait(timeout: TimeSpan.FromMinutes(5));
-        
-        
+
         // Start the CLI server if we are the main process.
         var cliServer = services.GetService<CliServer>();
         cliServer?.StartCliServerAsync().Wait(timeout: TimeSpan.FromSeconds(5));


### PR DESCRIPTION
Fixes an issue where running the CLI causes an exception because our "slim-client" used for NXM protocol invocations doesn't have the data model registered.