### PR TITLE
Add a sanity check to the legacy database sanity checks

### DIFF
--- a/tests/NexusMods.DataModel.SchemaVersions.Tests/LegacyDatabaseSupportTests.cs
+++ b/tests/NexusMods.DataModel.SchemaVersions.Tests/LegacyDatabaseSupportTests.cs
@@ -34,11 +34,15 @@ public class LegacyDatabaseSupportTests(IServiceProvider provider, TemporaryFile
         
         await using var workingFolder = tempManager.CreateFolder();
         await extractor.ExtractAllAsync(path, workingFolder.Path);
-
+        
+        var datamodelFolder = workingFolder.Path.Combine("MnemonicDB.rocksdb");
+        datamodelFolder.DirectoryExists().Should().BeTrue("the extracted database folder should exist");
+        datamodelFolder.EnumerateFiles().Should().NotBeEmpty("the extracted database folder should contain files");
+        
         using var backend = new Backend();
         var settings = new DatomStoreSettings
         {
-            Path = workingFolder.Path.Combine("MnemonicDB.rocksdb"),
+            Path = datamodelFolder,
         };
         using var datomStore = new DatomStore(provider.GetRequiredService<ILogger<DatomStore>>(), settings, backend);
         var connection = new Connection(provider.GetRequiredService<ILogger<Connection>>(), datomStore, provider, provider.GetServices<IAnalyzer>());

--- a/tests/NexusMods.DataModel.SchemaVersions.Tests/SchemaFailsafes.cs
+++ b/tests/NexusMods.DataModel.SchemaVersions.Tests/SchemaFailsafes.cs
@@ -4,7 +4,7 @@ using NexusMods.DataModel.SchemaVersions;
 using NexusMods.Hashing.xxHash3;
 using NexusMods.MnemonicDB.Abstractions;
 
-namespace NexusMods.DataModel.Migrations.Tests;
+namespace NexusMods.DataModel.SchemaVersions.Tests;
 
 public class SchemaFailsafes(IConnection connection)
 {

--- a/tests/NexusMods.DataModel.SchemaVersions.Tests/Startup.cs
+++ b/tests/NexusMods.DataModel.SchemaVersions.Tests/Startup.cs
@@ -3,7 +3,7 @@ using NexusMods.Abstractions.Settings;
 using NexusMods.App;
 using NexusMods.Paths;
 
-namespace NexusMods.DataModel.Migrations.Tests;
+namespace NexusMods.DataModel.SchemaVersions.Tests;
 
 public class Startup
 {


### PR DESCRIPTION
Based on checking if the file is a ZIP file instead of a known string (that maybe could run afoul of newline/encoding issues?) same sort of thing as #2239 