### PR TITLE
Retract JWT tokens before excising them so the UI updates properly

### DIFF
--- a/src/Networking/NexusMods.Networking.NexusWebApi/LoginManager.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/LoginManager.cs
@@ -153,11 +153,14 @@ public sealed class LoginManager : IDisposable, ILoginManager
     {
         _cachedUserInfo.Evict();
         var tokenEntities = JWTToken.All(_conn.Db).Select(e => e.Id).ToArray();
-        using var tx = _conn.BeginTransaction();
 
+        // Retract the entities first, so the UI updates, then excise them
+        using var tx = _conn.BeginTransaction();
         foreach (var entity in tokenEntities)
             tx.Delete(entity, false);
         await tx.Commit();
+
+
         await _conn.Excise(tokenEntities);
     }
     


### PR DESCRIPTION
As suspected, Excising doesn't properly update `ObserveDatoms` calls. This is somewhat expected because excise isn't a retraction or an addition it's the completely removal of the datoms. 

At least for now, for this specific use-case we now retract all the datoms for JWTTokens then excise them so the UI and the database are both updated properly. 


fixes: https://github.com/Nexus-Mods/NexusMods.App/issues/2265