### PR TITLE
Fix "login after exit" bug

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.NexusWebApi/ILoginManager.cs
+++ b/src/Abstractions/NexusMods.Abstractions.NexusWebApi/ILoginManager.cs
@@ -13,7 +13,15 @@ public interface ILoginManager
     /// </summary>
     Observable<UserInfo?> UserInfoObservable { get; }
 
+    /// <summary>
+    /// True if the user is a premium member
+    /// </summary>
     bool IsPremium { get; }
+    
+    /// <summary>
+    /// True if the user is logged in (via OAuth, not via API Key)
+    /// </summary>
+    bool IsOAuthLogin { get; }
 
     /// <summary>
     /// True if the user is logged in

--- a/src/Networking/NexusMods.Networking.NexusWebApi/LoginManager.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/LoginManager.cs
@@ -35,7 +35,11 @@ public sealed class LoginManager : IDisposable, ILoginManager
 
     private readonly IDisposable _observeDatomDisposable;
 
+    /// <inheritdoc />
     public bool IsPremium { get; private set; }
+
+    /// <inheritdoc />
+    public bool IsOAuthLogin => JWTToken.All(_conn.Db).Any();
 
     /// <summary>
     /// Constructor.

--- a/src/NexusMods.App.UI/Overlays/Login/StartupMessageBox/LoginMessageBoxViewModel.cs
+++ b/src/NexusMods.App.UI/Overlays/Login/StartupMessageBox/LoginMessageBoxViewModel.cs
@@ -32,6 +32,11 @@ public class LoginMessageBoxViewModel : AOverlayViewModel<ILoginMessageBoxViewMo
     
     public bool MaybeShow()
     {
+        // If we're already logged in via OAuth, don't show the login modal
+        if (_loginManager.IsOAuthLogin) 
+            return false;
+        
+        // If we've already shown the modal, don't show it again
         if (_settingsManager.Get<LoginSettings>().HasShownModal) return false;
         _settingsManager.Update<LoginSettings>(settings => settings with { HasShownModal = true });
         


### PR DESCRIPTION
Fixes https://github.com/Nexus-Mods/NexusMods.App/issues/2155

We had a bit of a race condition here that only presented itself in official builds (as they are more optimized). This PR should fix the issue by making a hard check on the existance of a OAuth login. If we have an OAuth login we won't try and show the login box. 