### PR TITLE
Fix the login twice bug

### DIFF
--- a/src/NexusMods.App.UI/Overlays/AOverlayViewModel.cs
+++ b/src/NexusMods.App.UI/Overlays/AOverlayViewModel.cs
@@ -34,7 +34,7 @@ where TInner : class, IViewModelInterface
     private readonly TaskCompletionSource _taskCompletionSource = new();
     public Task CompletionTask => _taskCompletionSource.Task;
 
-    public void Close()
+    public virtual void Close()
     {
         Debug.Assert(Controller != null, "Controller != null");
         if (Status == Status.Closed)

--- a/src/NexusMods.App.UI/Overlays/Login/StartupMessageBox/LoginMessageBoxViewModel.cs
+++ b/src/NexusMods.App.UI/Overlays/Login/StartupMessageBox/LoginMessageBoxViewModel.cs
@@ -27,13 +27,19 @@ public class LoginMessageBoxViewModel : AOverlayViewModel<ILoginMessageBoxViewMo
         CancelCommand = ReactiveCommand.Create(Close);
     }
 
+    public override void Close()
+    {
+        _settingsManager.Update<LoginSettings>(settings => settings with { HasShownModal = true });
+        base.Close();
+    }
+
     public ReactiveCommand<Unit, Unit> OkCommand { get; }
     public ReactiveCommand<Unit, Unit> CancelCommand { get; }
     
     public bool MaybeShow()
     {
-        if (_settingsManager.Get<LoginSettings>().HasShownModal) return false;
-        _settingsManager.Update<LoginSettings>(settings => settings with { HasShownModal = true });
+        if (_settingsManager.Get<LoginSettings>().HasShownModal) 
+            return false;
         
         _overlayController.Enqueue(this);
         return true;


### PR DESCRIPTION
Still not totally sure what's going on here, but this solution is cleaner. The end result is that we move the `Update` on the "HasShownModal" into the `Close` handler of the modal. All the other modals do it this way, and it's something to do with setting this value during startup (which gets called from the constructor of the main window) that is causing this issue. 

Clean enough of a fix for the release.

Also makes the MnemonicDB settings manager async vs sync.