### PR TITLE
Fixed: Skip Diagnostics on Disabled Mods in Bannerlord

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Loadouts/Models/LoadoutItem.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts/Models/LoadoutItem.cs
@@ -36,6 +36,7 @@ public partial class LoadoutItem : IModelDefinition
     /// </summary>
     public static readonly ReferenceAttribute<LoadoutItemGroup> Parent = new(Namespace, nameof(Parent)) { IsIndexed = true, IsOptional = true };
 
+    [PublicAPI]
     public partial struct ReadOnly
     {
         /// <summary>

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts/Models/LoadoutItem.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts/Models/LoadoutItem.cs
@@ -35,4 +35,32 @@ public partial class LoadoutItem : IModelDefinition
     /// Optional parent of the item.
     /// </summary>
     public static readonly ReferenceAttribute<LoadoutItemGroup> Parent = new(Namespace, nameof(Parent)) { IsIndexed = true, IsOptional = true };
+
+    public partial struct ReadOnly
+    {
+        /// <summary>
+        /// Returns true if this item or any of the item's parents are disables.
+        /// </summary>
+        public bool IsDisabledOrParentsDisabled()
+        {
+            var disabled = this.IsDisabled;
+            if (disabled)
+                return true;
+
+            var currentItem = this;
+            while (currentItem.HasParent())
+            {
+                currentItem = currentItem.Parent.AsLoadoutItem();
+                if (currentItem.IsDisabled)
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// True if this item contains a parent, else false.
+        /// </summary>
+        public bool HasParent() => this.Contains(LoadoutItem.Parent);
+    }
 }

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts/Models/LoadoutItem.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts/Models/LoadoutItem.cs
@@ -40,26 +40,6 @@ public partial class LoadoutItem : IModelDefinition
     public partial struct ReadOnly
     {
         /// <summary>
-        /// Returns true if this item or any of the item's parents are disables.
-        /// </summary>
-        public bool IsDisabledOrParentsDisabled()
-        {
-            var disabled = this.IsDisabled;
-            if (disabled)
-                return true;
-
-            var currentItem = this;
-            while (currentItem.HasParent())
-            {
-                currentItem = currentItem.Parent.AsLoadoutItem();
-                if (currentItem.IsDisabled)
-                    return true;
-            }
-
-            return false;
-        }
-
-        /// <summary>
         /// True if this item contains a parent, else false.
         /// </summary>
         public bool HasParent() => this.Contains(LoadoutItem.Parent);

--- a/src/Games/NexusMods.Games.MountAndBlade2Bannerlord/Diagnostics/BannerlordDiagnosticEmitter.cs
+++ b/src/Games/NexusMods.Games.MountAndBlade2Bannerlord/Diagnostics/BannerlordDiagnosticEmitter.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.Diagnostics;
 using NexusMods.Abstractions.Diagnostics.Emitters;
 using NexusMods.Abstractions.Loadouts;
+using NexusMods.Abstractions.Loadouts.Extensions;
 using NexusMods.Abstractions.Resources;
 using NexusMods.Games.MountAndBlade2Bannerlord.Models;
 namespace NexusMods.Games.MountAndBlade2Bannerlord.Diagnostics;
@@ -41,7 +42,7 @@ internal partial class BannerlordDiagnosticEmitter : ILoadoutDiagnosticEmitter
             // Note(sewer): We create a LoadoutItemGroup for each module, which is a child of the one
             //              used for the archive. Since in theory the item can be disabled at any level
             //              in the tree, we need to check if the parent is disabled.
-            var isEnabled = !loadoutItem.IsDisabledOrParentsDisabled();
+            var isEnabled = loadoutItem.IsEnabled();
             isEnabledDict[module.Item2] = isEnabled;
         }
         

--- a/src/Games/NexusMods.Games.MountAndBlade2Bannerlord/Diagnostics/BannerlordDiagnosticEmitter.cs
+++ b/src/Games/NexusMods.Games.MountAndBlade2Bannerlord/Diagnostics/BannerlordDiagnosticEmitter.cs
@@ -36,7 +36,12 @@ internal partial class BannerlordDiagnosticEmitter : ILoadoutDiagnosticEmitter
         foreach (var module in modulesAndMods)
         {
             var mod = module.Item1;
-            var isEnabled = !mod.AsLoadoutItemGroup().AsLoadoutItem().IsDisabled;
+            var loadoutItem = mod.AsLoadoutItemGroup().AsLoadoutItem();
+            
+            // Note(sewer): We create a LoadoutItemGroup for each module, which is a child of the one
+            //              used for the archive. Since in theory the item can be disabled at any level
+            //              in the tree, we need to check if the parent is disabled.
+            var isEnabled = !loadoutItem.IsDisabledOrParentsDisabled();
             isEnabledDict[module.Item2] = isEnabled;
         }
         
@@ -50,6 +55,9 @@ internal partial class BannerlordDiagnosticEmitter : ILoadoutDiagnosticEmitter
         foreach (var moduleAndMod in isEnabledDict)
         {
             var moduleInfo = moduleAndMod.Key;
+            if (!moduleAndMod.Value)
+                continue;
+
             // Note(sewer): All modules are valid by definition
             //              All modules are selected by definition.
             foreach (var diagnostic in ModuleUtilities.ValidateModuleEx(modulesOnly, moduleInfo, module => isEnabledDict.ContainsKey(module), _ => true, false).Select(x => CreateDiagnostic(x)))


### PR DESCRIPTION
fixes #2295

- https://github.com/Nexus-Mods/NexusMods.App/issues/2295