### PR TITLE
Added: Support for running Protontricks via Flatpak (and extra)

### DIFF
--- a/src/Games/NexusMods.Games.Generic/GameToolRunner.cs
+++ b/src/Games/NexusMods.Games.Generic/GameToolRunner.cs
@@ -21,13 +21,13 @@ namespace NexusMods.Games.Generic;
 public class GameToolRunner
 {
     private readonly IProcessFactory _processFactory;
-    private readonly ProtontricksDependency? _protontricks;
+    private readonly ProtontricksNativeDependency? _protontricks;
 
     /// <summary/>
     public GameToolRunner(IServiceProvider provider)
     {
         _processFactory = provider.GetRequiredService<IProcessFactory>();
-        _protontricks = provider.GetService<ProtontricksDependency>();
+        _protontricks = provider.GetService<ProtontricksNativeDependency>();
     }
 
     /// <summary>

--- a/src/Games/NexusMods.Games.Generic/GameToolRunner.cs
+++ b/src/Games/NexusMods.Games.Generic/GameToolRunner.cs
@@ -21,13 +21,13 @@ namespace NexusMods.Games.Generic;
 public class GameToolRunner
 {
     private readonly IProcessFactory _processFactory;
-    private readonly ProtontricksNativeDependency? _protontricks;
+    private readonly AggregateProtontricksDependency? _protontricks;
 
     /// <summary/>
     public GameToolRunner(IServiceProvider provider)
     {
         _processFactory = provider.GetRequiredService<IProcessFactory>();
-        _protontricks = provider.GetService<ProtontricksNativeDependency>();
+        _protontricks = provider.GetService<AggregateProtontricksDependency>();
     }
 
     /// <summary>
@@ -49,7 +49,7 @@ public class GameToolRunner
             && install.LocatorResultMetadata is SteamLocatorResultMetadata steamLocatorResultMetadata)
         {
             var appId = steamLocatorResultMetadata.AppId;
-            command = _protontricks.MakeLaunchCommand(command, appId);
+            command = await _protontricks.MakeLaunchCommand(command, appId);
             return await _processFactory.ExecuteAsync(command, logProcessOutput, cancellationToken);
         }
 

--- a/src/Games/NexusMods.Games.MountAndBlade2Bannerlord/Diagnostics/MissingProtontricksEmitter.cs
+++ b/src/Games/NexusMods.Games.MountAndBlade2Bannerlord/Diagnostics/MissingProtontricksEmitter.cs
@@ -15,10 +15,10 @@ public partial class MissingProtontricksEmitter : ILoadoutDiagnosticEmitter
     /// <summary>
     /// This will be null on non-Linux OSes.
     /// </summary>
-    private ProtontricksNativeDependency? _protontricksDependency;
+    private readonly AggregateProtontricksDependency? _protontricksDependency;
     
     /// <summary/>
-    public MissingProtontricksEmitter(IServiceProvider serviceProvider) => _protontricksDependency = serviceProvider.GetService<ProtontricksNativeDependency>();
+    public MissingProtontricksEmitter(IServiceProvider serviceProvider) => _protontricksDependency = serviceProvider.GetService<AggregateProtontricksDependency>();
 
     public async IAsyncEnumerable<Diagnostic> Diagnose(
         Loadout.ReadOnly loadout,

--- a/src/Games/NexusMods.Games.MountAndBlade2Bannerlord/Diagnostics/MissingProtontricksEmitter.cs
+++ b/src/Games/NexusMods.Games.MountAndBlade2Bannerlord/Diagnostics/MissingProtontricksEmitter.cs
@@ -15,10 +15,10 @@ public partial class MissingProtontricksEmitter : ILoadoutDiagnosticEmitter
     /// <summary>
     /// This will be null on non-Linux OSes.
     /// </summary>
-    private ProtontricksDependency? _protontricksDependency;
+    private ProtontricksNativeDependency? _protontricksDependency;
     
     /// <summary/>
-    public MissingProtontricksEmitter(IServiceProvider serviceProvider) => _protontricksDependency = serviceProvider.GetService<ProtontricksDependency>();
+    public MissingProtontricksEmitter(IServiceProvider serviceProvider) => _protontricksDependency = serviceProvider.GetService<ProtontricksNativeDependency>();
 
     public async IAsyncEnumerable<Diagnostic> Diagnose(
         Loadout.ReadOnly loadout,

--- a/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/Emitters/MissingProtontricksForRedModEmitter.cs
+++ b/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/Emitters/MissingProtontricksForRedModEmitter.cs
@@ -16,10 +16,10 @@ public partial class MissingProtontricksForRedModEmitter : ILoadoutDiagnosticEmi
     /// <summary>
     /// This will be null on non-Linux OSes.
     /// </summary>
-    private ProtontricksDependency? _protontricksDependency;
+    private ProtontricksNativeDependency? _protontricksDependency;
     
     /// <summary/>
-    public MissingProtontricksForRedModEmitter(IServiceProvider serviceProvider) => _protontricksDependency = serviceProvider.GetService<ProtontricksDependency>();
+    public MissingProtontricksForRedModEmitter(IServiceProvider serviceProvider) => _protontricksDependency = serviceProvider.GetService<ProtontricksNativeDependency>();
 
     public async IAsyncEnumerable<Diagnostic> Diagnose(
         Loadout.ReadOnly loadout,

--- a/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/Emitters/MissingProtontricksForRedModEmitter.cs
+++ b/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/Emitters/MissingProtontricksForRedModEmitter.cs
@@ -16,10 +16,10 @@ public partial class MissingProtontricksForRedModEmitter : ILoadoutDiagnosticEmi
     /// <summary>
     /// This will be null on non-Linux OSes.
     /// </summary>
-    private ProtontricksNativeDependency? _protontricksDependency;
+    private AggregateProtontricksDependency? _protontricksDependency;
     
     /// <summary/>
-    public MissingProtontricksForRedModEmitter(IServiceProvider serviceProvider) => _protontricksDependency = serviceProvider.GetService<ProtontricksNativeDependency>();
+    public MissingProtontricksForRedModEmitter(IServiceProvider serviceProvider) => _protontricksDependency = serviceProvider.GetService<AggregateProtontricksDependency>();
 
     public async IAsyncEnumerable<Diagnostic> Diagnose(
         Loadout.ReadOnly loadout,

--- a/src/NexusMods.CrossPlatform/NexusMods.CrossPlatform.csproj
+++ b/src/NexusMods.CrossPlatform/NexusMods.CrossPlatform.csproj
@@ -57,6 +57,12 @@
         <Compile Update="Process\ProtontricksFlatpakDependency.cs">
             <DependentUpon>ExecutableRuntimeDependency.cs</DependentUpon>
         </Compile>
+        <Compile Update="Process\IProtontricksDependency.cs">
+            <DependentUpon>ExecutableRuntimeDependency.cs</DependentUpon>
+        </Compile>
+        <Compile Update="Process\AggregateProtontricksDependency.cs">
+            <DependentUpon>ExecutableRuntimeDependency.cs</DependentUpon>
+        </Compile>
         <Compile Update="Process\AggregateExecutableRuntimeDependency.cs">
             <DependentUpon>IRuntimeDependency.cs</DependentUpon>
         </Compile>

--- a/src/NexusMods.CrossPlatform/NexusMods.CrossPlatform.csproj
+++ b/src/NexusMods.CrossPlatform/NexusMods.CrossPlatform.csproj
@@ -45,7 +45,7 @@
       <Compile Update="ProtocolRegistration\ProtocolRegistrationWindows.cs">
         <DependentUpon>IProtocolRegistration.cs</DependentUpon>
       </Compile>
-        <Compile Update="Process\ProtontricksDependency.cs">
+        <Compile Update="Process\ProtontricksNativeDependency.cs">
             <DependentUpon>ExecutableRuntimeDependency.cs</DependentUpon>
         </Compile>
         <Compile Update="Process\XDGOpenDependency.cs">
@@ -53,6 +53,12 @@
         </Compile>
         <Compile Update="Process\XDGSettingsDependency.cs">
             <DependentUpon>ExecutableRuntimeDependency.cs</DependentUpon>
+        </Compile>
+        <Compile Update="Process\ProtontricksFlatpakDependency.cs">
+            <DependentUpon>ExecutableRuntimeDependency.cs</DependentUpon>
+        </Compile>
+        <Compile Update="Process\AggregateExecutableRuntimeDependency.cs">
+            <DependentUpon>IRuntimeDependency.cs</DependentUpon>
         </Compile>
         <Compile Update="Process\ExecutableRuntimeDependency.cs">
             <DependentUpon>IRuntimeDependency.cs</DependentUpon>

--- a/src/NexusMods.CrossPlatform/Process/AggregateExecutableRuntimeDependency.cs
+++ b/src/NexusMods.CrossPlatform/Process/AggregateExecutableRuntimeDependency.cs
@@ -1,0 +1,124 @@
+using System.Runtime.InteropServices;
+using DynamicData.Kernel;
+using NexusMods.Paths;
+
+namespace NexusMods.CrossPlatform.Process;
+
+/// <summary>
+/// Represents a runtime dependency that aggregates multiple executable runtime dependencies,
+/// using the first available implementation.
+/// </summary>
+public class AggregateExecutableRuntimeDependency : IRuntimeDependency
+{
+    private readonly ExecutableRuntimeDependency[] _dependencies;
+    private ExecutableRuntimeDependency? _activeDependency;
+
+    /// <inheritdoc />
+    public string DisplayName { get; }
+
+    /// <inheritdoc />
+    public string Description { get; }
+
+    /// <inheritdoc />
+    public Uri Homepage { get; }
+
+    /// <inheritdoc />
+    public OSPlatform[] SupportedPlatforms { get; }
+
+    /// <inheritdoc />
+    public RuntimeDependencyType DependencyType => RuntimeDependencyType.Executable;
+    
+    /// <summary>
+    /// Creates a new aggregate runtime dependency.
+    /// </summary>
+    /// <param name="displayName">Display name for the aggregate dependency</param>
+    /// <param name="description">Description of the functionality provided</param>
+    /// <param name="homepage">Homepage URL for the software</param>
+    /// <param name="dependencies">Array of alternative implementations that can satisfy this dependency</param>
+    public AggregateExecutableRuntimeDependency(
+        string displayName,
+        string description,
+        Uri homepage,
+        ExecutableRuntimeDependency[] dependencies)
+    {
+        if (dependencies.Length == 0)
+            throw new ArgumentException("At least one dependency must be provided", nameof(dependencies));
+
+        _dependencies = dependencies;
+        DisplayName = displayName;
+        Description = description;
+        Homepage = homepage;
+        SupportedPlatforms = dependencies
+            .SelectMany(d => d.SupportedPlatforms)
+            .Distinct()
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Gets the currently active dependency implementation that is both installed and supports the current operating system.
+    /// </summary>
+    private async ValueTask<ExecutableRuntimeDependency?> GetActiveDependencyAsync(CancellationToken cancellationToken = default)
+    {
+        if (_activeDependency != null)
+            return _activeDependency;
+
+        foreach (var dependency in _dependencies)
+        {
+            try
+            {
+                // Verify the inner dependency supports our OS.
+                if (!dependency.SupportedPlatforms.Contains(OSInformation.Shared.Platform))
+                    continue;
+
+                var result = await dependency.QueryInstallationInformation(cancellationToken);
+                if (!result.HasValue) 
+                    continue;
+
+                _activeDependency = dependency;
+                return dependency;
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+
+        return null;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<Optional<RuntimeDependencyInformation>> QueryInstallationInformation(CancellationToken cancellationToken)
+    {
+        var active = await GetActiveDependencyAsync(cancellationToken);
+        if (active == null)
+            return Optional<RuntimeDependencyInformation>.None;
+
+        return await active.QueryInstallationInformation(cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets all available dependencies that are currently installed.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token</param>
+    public async ValueTask<IReadOnlyList<ExecutableRuntimeDependency>> GetAvailableDependenciesAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var available = new List<ExecutableRuntimeDependency>();
+
+        foreach (var dependency in _dependencies)
+        {
+            try
+            {
+                var result = await dependency.QueryInstallationInformation(cancellationToken);
+                if (result.HasValue)
+                    available.Add(dependency);
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+
+        return available;
+    }
+}

--- a/src/NexusMods.CrossPlatform/Process/AggregateProtontricksDependency.cs
+++ b/src/NexusMods.CrossPlatform/Process/AggregateProtontricksDependency.cs
@@ -1,0 +1,43 @@
+using CliWrap;
+
+namespace NexusMods.CrossPlatform.Process;
+
+/// <summary>
+/// Aggregates multiple Protontricks implementations, using either the native or Flatpak version
+/// depending on availability.
+/// </summary>
+public class AggregateProtontricksDependency : AggregateExecutableRuntimeDependency, IProtontricksDependency
+{
+    /// <summary>
+    /// Creates a new instance of the aggregate Protontricks dependency.
+    /// </summary>
+    /// <param name="processFactory">The process factory used to execute commands.</param>
+    public AggregateProtontricksDependency(IProcessFactory processFactory) 
+        : base(
+            displayName: "Protontricks",
+            description: "Manage Proton games and their dependencies",
+            homepage: new Uri("https://github.com/Matoking/protontricks"),
+            dependencies: new ExecutableRuntimeDependency[]
+            {
+                new ProtontricksNativeDependency(processFactory),
+                new ProtontricksFlatpakDependency(processFactory),
+            })
+    {
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<Command> MakeLaunchCommand(Command command, long appId)
+    {
+        var availableDependencies = await GetAvailableDependenciesAsync();
+        var protontricks = availableDependencies.FirstOrDefault() as IProtontricksDependency;
+        if (protontricks == null)
+            throw new InvalidOperationException("No Protontricks implementation is available on this system");
+
+        return await protontricks.MakeLaunchCommand(command, appId);
+    }
+
+    /// <summary>
+    /// Gets whether any Protontricks implementation is available on the system.
+    /// </summary>
+    public async Task<bool> IsAvailable() => (await QueryInstallationInformation(CancellationToken.None)).HasValue;
+}

--- a/src/NexusMods.CrossPlatform/Process/IProtontricksDependency.cs
+++ b/src/NexusMods.CrossPlatform/Process/IProtontricksDependency.cs
@@ -1,0 +1,14 @@
+using CliWrap;
+namespace NexusMods.CrossPlatform.Process;
+
+/// <summary>
+/// Common interface for invoking Protontricks across the <see cref="ProtontricksFlatpakDependency"/> and <see cref="ProtontricksNativeDependency"/>.
+/// </summary>
+public interface IProtontricksDependency
+{
+    /// <summary>
+    /// Transforms an existing command into a command which invokes the Flatpak version of
+    /// protontricks-launch with the original command as the target.
+    /// </summary>
+    public ValueTask<Command> MakeLaunchCommand(Command command, long appId);
+}

--- a/src/NexusMods.CrossPlatform/Process/ProtontricksFlatpakDependency.cs
+++ b/src/NexusMods.CrossPlatform/Process/ProtontricksFlatpakDependency.cs
@@ -1,0 +1,73 @@
+using System.Runtime.InteropServices;
+using CliWrap;
+namespace NexusMods.CrossPlatform.Process;
+
+/// <summary>
+///     Protontricks is a tool that helps manage Proton games and their dependencies.
+///     This implementation specifically targets the Flatpak version of Protontricks,
+///     commonly found on Steam Deck (SteamOS) and other Linux distributions.
+/// </summary>
+public class ProtontricksFlatpakDependency : ExecutableRuntimeDependency
+{
+    private const string FlatpakPackageId = "com.github.Matoking.protontricks";
+
+    /// <inheritdoc />
+    public override string DisplayName => "protontricks (flatpak)";
+    /// <inheritdoc />
+    public override string Description => "Manage Proton games and their dependencies (Flatpak version)";
+    /// <inheritdoc />
+    public override Uri Homepage { get; } = new("https://github.com/Matoking/protontricks");
+    /// <inheritdoc />
+    public override OSPlatform[] SupportedPlatforms { get; } = [OSPlatform.Linux];
+
+    /// <inheritdoc />
+    public ProtontricksFlatpakDependency(IProcessFactory processFactory) : base(processFactory) { }
+
+    /// <inheritdoc />
+    protected override RuntimeDependencyInformation ToInformation(ReadOnlySpan<char> output) => ProtontricksNativeDependency.ToInformationImpl(output);
+
+    /// <inheritdoc />
+    protected override Command BuildQueryCommand(PipeTarget outputPipeTarget)
+    {
+        var command = Cli.Wrap("flatpak")
+            .WithArguments($"run {FlatpakPackageId} --version")
+            .WithStandardOutputPipe(outputPipeTarget);
+        return command;
+    }
+
+    /// <summary>
+    /// Transforms an existing command into a command which invokes the Flatpak version of
+    /// protontricks-launch with the original command as the target.
+    /// </summary>
+    public Command MakeLaunchCommand(Command command, long appId)
+    {
+        // Escape the original command and arguments for use within flatpak
+        var escapedCommand = $"\"{command.TargetFilePath}\" {command.Arguments}".Replace("\"", "\\\"");
+        var args = $"run {FlatpakPackageId} protontricks-launch --appid {appId} {escapedCommand}";
+        
+        return new Command("flatpak", args,
+            command.WorkingDirPath, command.Credentials, command.EnvironmentVariables,
+            command.Validation, command.StandardInputPipe, command.StandardOutputPipe, command.StandardErrorPipe);
+    }
+
+    /// <summary>
+    /// Checks if the Protontricks Flatpak is installed on the system.
+    /// </summary>
+    /// <returns>True if the Flatpak is installed, false otherwise.</returns>
+    public async Task<bool> IsFlatpakInstalledAsync()
+    {
+        try
+        {
+            var result = await Cli.Wrap("flatpak")
+                .WithArguments($"info {FlatpakPackageId}")
+                .WithValidation(CommandResultValidation.None)
+                .ExecuteAsync();
+            
+            return result.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/src/NexusMods.CrossPlatform/Process/ProtontricksFlatpakDependency.cs
+++ b/src/NexusMods.CrossPlatform/Process/ProtontricksFlatpakDependency.cs
@@ -29,6 +29,8 @@ public class ProtontricksFlatpakDependency : ExecutableRuntimeDependency, IProto
     /// <inheritdoc />
     protected override Command BuildQueryCommand(PipeTarget outputPipeTarget)
     {
+        // This will return a non-zero code if neither flatpak or protontricks are installed
+        // Which in turn will be recognised as a missing dependency.
         var command = Cli.Wrap("flatpak")
             .WithArguments($"run {FlatpakPackageId} --version")
             .WithStandardOutputPipe(outputPipeTarget);
@@ -45,26 +47,5 @@ public class ProtontricksFlatpakDependency : ExecutableRuntimeDependency, IProto
         return ValueTask.FromResult(new Command("flatpak", args,
             command.WorkingDirPath, command.Credentials, command.EnvironmentVariables,
             command.Validation, command.StandardInputPipe, command.StandardOutputPipe, command.StandardErrorPipe));
-    }
-
-    /// <summary>
-    /// Checks if the Protontricks Flatpak is installed on the system.
-    /// </summary>
-    /// <returns>True if the Flatpak is installed, false otherwise.</returns>
-    public async Task<bool> IsFlatpakInstalledAsync()
-    {
-        try
-        {
-            var result = await Cli.Wrap("flatpak")
-                .WithArguments($"info {FlatpakPackageId}")
-                .WithValidation(CommandResultValidation.None)
-                .ExecuteAsync();
-            
-            return result.ExitCode == 0;
-        }
-        catch
-        {
-            return false;
-        }
     }
 }

--- a/src/NexusMods.CrossPlatform/Process/ProtontricksFlatpakDependency.cs
+++ b/src/NexusMods.CrossPlatform/Process/ProtontricksFlatpakDependency.cs
@@ -7,7 +7,7 @@ namespace NexusMods.CrossPlatform.Process;
 ///     This implementation specifically targets the Flatpak version of Protontricks,
 ///     commonly found on Steam Deck (SteamOS) and other Linux distributions.
 /// </summary>
-public class ProtontricksFlatpakDependency : ExecutableRuntimeDependency
+public class ProtontricksFlatpakDependency : ExecutableRuntimeDependency, IProtontricksDependency
 {
     private const string FlatpakPackageId = "com.github.Matoking.protontricks";
 
@@ -39,15 +39,12 @@ public class ProtontricksFlatpakDependency : ExecutableRuntimeDependency
     /// Transforms an existing command into a command which invokes the Flatpak version of
     /// protontricks-launch with the original command as the target.
     /// </summary>
-    public Command MakeLaunchCommand(Command command, long appId)
+    public ValueTask<Command> MakeLaunchCommand(Command command, long appId)
     {
-        // Escape the original command and arguments for use within flatpak
-        var escapedCommand = $"\"{command.TargetFilePath}\" {command.Arguments}".Replace("\"", "\\\"");
-        var args = $"run {FlatpakPackageId} protontricks-launch --appid {appId} {escapedCommand}";
-        
-        return new Command("flatpak", args,
+        var args = $"run --command=protontricks-launch {FlatpakPackageId} --appid {appId} \"{command.TargetFilePath}\" {command.Arguments}";
+        return ValueTask.FromResult(new Command("flatpak", args,
             command.WorkingDirPath, command.Credentials, command.EnvironmentVariables,
-            command.Validation, command.StandardInputPipe, command.StandardOutputPipe, command.StandardErrorPipe);
+            command.Validation, command.StandardInputPipe, command.StandardOutputPipe, command.StandardErrorPipe));
     }
 
     /// <summary>

--- a/src/NexusMods.CrossPlatform/Process/ProtontricksNativeDependency.cs
+++ b/src/NexusMods.CrossPlatform/Process/ProtontricksNativeDependency.cs
@@ -2,14 +2,17 @@ using System.Runtime.InteropServices;
 using CliWrap;
 namespace NexusMods.CrossPlatform.Process;
 
-/// <inheritdoc />
+/// <summary>
+///     Protontricks is a tool that helps manage Proton games and their dependencies.
+///     This works with the native version of Protontricks.
+/// </summary>
 /// <remarks>
 /// There is an implicit assumption made here that if `protontricks` is installed,
 /// then `protontricks-launch` is also available. Should it not be available, then
 /// it means that `protontricks` was incorrectly packaged by the package maintainer
 /// for a specific repo.
 /// </remarks>
-public class ProtontricksDependency : ExecutableRuntimeDependency
+public class ProtontricksNativeDependency : ExecutableRuntimeDependency
 {
     /// <inheritdoc />
     public override string DisplayName => "protontricks";
@@ -19,16 +22,21 @@ public class ProtontricksDependency : ExecutableRuntimeDependency
     public override Uri Homepage { get; } = new("https://github.com/Matoking/protontricks");
     /// <inheritdoc />
     public override OSPlatform[] SupportedPlatforms { get; } = [OSPlatform.Linux];
-    
-    public ProtontricksDependency(IProcessFactory processFactory) : base(processFactory) { }
 
+    /// <inheritdoc />
+    public ProtontricksNativeDependency(IProcessFactory processFactory) : base(processFactory) { }
+
+    /// <inheritdoc />
     protected override Command BuildQueryCommand(PipeTarget outputPipeTarget)
     {
         var command = Cli.Wrap("protontricks").WithArguments("--version").WithStandardOutputPipe(outputPipeTarget);
         return command;
     }
 
-    protected override RuntimeDependencyInformation ToInformation(ReadOnlySpan<char> output)
+    /// <inheritdoc />
+    protected override RuntimeDependencyInformation ToInformation(ReadOnlySpan<char> output) => ToInformationImpl(output);
+
+    internal static RuntimeDependencyInformation ToInformationImpl(ReadOnlySpan<char> output)
     {
         if (TryParseVersion(output, out var rawVersion, out var version))
         {

--- a/src/NexusMods.CrossPlatform/Process/ProtontricksNativeDependency.cs
+++ b/src/NexusMods.CrossPlatform/Process/ProtontricksNativeDependency.cs
@@ -12,7 +12,7 @@ namespace NexusMods.CrossPlatform.Process;
 /// it means that `protontricks` was incorrectly packaged by the package maintainer
 /// for a specific repo.
 /// </remarks>
-public class ProtontricksNativeDependency : ExecutableRuntimeDependency
+public class ProtontricksNativeDependency : ExecutableRuntimeDependency, IProtontricksDependency
 {
     /// <inheritdoc />
     public override string DisplayName => "protontricks";
@@ -78,11 +78,11 @@ public class ProtontricksNativeDependency : ExecutableRuntimeDependency
     /// Transforms an existing command into a command which invoked `protontricks-launch` with the original command
     /// as the target.
     /// </summary>
-    public Command MakeLaunchCommand(Command command, long appId)
+    public ValueTask<Command> MakeLaunchCommand(Command command, long appId)
     {
         var args = $"--appid {appId} \"{command.TargetFilePath}\" {command.Arguments}";
-        return new Command("protontricks-launch", args, 
+        return ValueTask.FromResult(new Command("protontricks-launch", args, 
             command.WorkingDirPath, command.Credentials, command.EnvironmentVariables, 
-            command.Validation, command.StandardInputPipe, command.StandardOutputPipe, command.StandardErrorPipe);
+            command.Validation, command.StandardInputPipe, command.StandardOutputPipe, command.StandardErrorPipe));
     }
 }

--- a/src/NexusMods.CrossPlatform/Services.cs
+++ b/src/NexusMods.CrossPlatform/Services.cs
@@ -52,8 +52,8 @@ public static class Services
             // Running Games/Tools
             services.AddSingleton<ProtontricksNativeDependency>();
             services.AddSingleton<ProtontricksFlatpakDependency>();
-            services.AddSingleton<IRuntimeDependency, ProtontricksNativeDependency>();
-            services.AddSingleton<IRuntimeDependency, ProtontricksFlatpakDependency>();
+            services.AddSingleton<AggregateProtontricksDependency>();
+            services.AddSingleton<IRuntimeDependency, AggregateProtontricksDependency>();
         }
 
         return services.AddHostedService<RuntimeDependencyChecker>();

--- a/src/NexusMods.CrossPlatform/Services.cs
+++ b/src/NexusMods.CrossPlatform/Services.cs
@@ -50,8 +50,10 @@ public static class Services
             services.AddSingleton<IRuntimeDependency, UpdateDesktopDatabaseDependency>();
 
             // Running Games/Tools
-            services.AddSingleton<ProtontricksDependency>();
-            services.AddSingleton<IRuntimeDependency, ProtontricksDependency>();
+            services.AddSingleton<ProtontricksNativeDependency>();
+            services.AddSingleton<ProtontricksFlatpakDependency>();
+            services.AddSingleton<IRuntimeDependency, ProtontricksNativeDependency>();
+            services.AddSingleton<IRuntimeDependency, ProtontricksFlatpakDependency>();
         }
 
         return services.AddHostedService<RuntimeDependencyChecker>();

--- a/tests/NexusMods.CrossPlatform.Tests/AggregateExecutableRuntimeDependencyTests.cs
+++ b/tests/NexusMods.CrossPlatform.Tests/AggregateExecutableRuntimeDependencyTests.cs
@@ -1,0 +1,263 @@
+using System.Runtime.InteropServices;
+using CliWrap;
+using DynamicData.Kernel;
+using FluentAssertions;
+using NexusMods.CrossPlatform.Process;
+using NexusMods.Paths;
+
+namespace NexusMods.CrossPlatform.Tests;
+
+public class AggregateExecutableRuntimeDependencyTests
+{
+    private const string TestDisplayName = "Test Dependency";
+    private const string TestDescription = "A test dependency";
+    private static readonly Uri TestUri = new("https://www.youtube.com/watch?v=o-YBDTqX_ZU");
+    
+    private readonly IProcessFactory _processFactory;
+    private readonly FakeExecutableDependency _dependency1;
+    private readonly FakeExecutableDependency _dependency2;
+    private readonly AggregateExecutableRuntimeDependency _sut;
+
+    public AggregateExecutableRuntimeDependencyTests()
+    {
+        _processFactory = new FakeProcessFactory(0);
+        _dependency1 = new FakeExecutableDependency(_processFactory, [OSPlatform.Windows]);
+        _dependency2 = new FakeExecutableDependency(_processFactory, [OSPlatform.Linux]);
+        
+        _sut = new AggregateExecutableRuntimeDependency(
+            TestDisplayName,
+            TestDescription,
+            TestUri,
+            [_dependency1, _dependency2]);
+    }
+
+    [Fact]
+    public void Constructor_ShouldThrowArgumentException_WhenNoDependenciesProvided()
+    {
+        var act = () => new AggregateExecutableRuntimeDependency(
+            TestDisplayName,
+            TestDescription,
+            TestUri,
+            []);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("At least one dependency must be provided*");
+    }
+
+    [Fact]
+    public void Constructor_ShouldInitializeProperties_WithProvidedValues()
+    {
+        _sut.DisplayName.Should().Be(TestDisplayName);
+        _sut.Description.Should().Be(TestDescription);
+        _sut.Homepage.Should().Be(TestUri);
+        _sut.DependencyType.Should().Be(RuntimeDependencyType.Executable);
+    }
+
+    [Fact]
+    public void SupportedPlatforms_ShouldCombineAndDeduplicate_PlatformsFromAllDependencies()
+    {
+        var dep1 = new FakeExecutableDependency(_processFactory, [OSPlatform.Windows, OSPlatform.Linux]);
+        var dep2 = new FakeExecutableDependency(_processFactory, [OSPlatform.Linux, OSPlatform.OSX]);
+
+        var aggregate = new AggregateExecutableRuntimeDependency(
+            TestDisplayName,
+            TestDescription,
+            TestUri,
+            [dep1, dep2]);
+
+        aggregate.SupportedPlatforms.Should()
+            .BeEquivalentTo([OSPlatform.Windows, OSPlatform.Linux, OSPlatform.OSX]);
+    }
+
+    [Fact]
+    public async Task QueryInstallationInformation_ShouldReturnNone_WhenNoDependencyIsAvailable()
+    {
+        _dependency1.SetAvailable(false);
+        _dependency2.SetAvailable(false);
+
+        var result = await _sut.QueryInstallationInformation(CancellationToken.None);
+
+        result.HasValue.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task QueryInstallationInformation_ShouldReturnFirstAvailableDependency()
+    {
+        var expectedInfo = new RuntimeDependencyInformation 
+        { 
+            RawVersion = "1.0.0",
+            Version = new Version(1, 0, 0),
+        };
+        
+        _dependency1.SetAvailable(false);
+        _dependency2.SetAvailable(true, expectedInfo);
+
+        var result = await _sut.QueryInstallationInformation(CancellationToken.None);
+
+        result.HasValue.Should().BeTrue();
+        result.Value.Should().BeEquivalentTo(expectedInfo);
+    }
+
+    [Fact]
+    public async Task QueryInstallationInformation_ShouldCacheActiveDependency()
+    {
+        // Create a dependency that supports all platforms
+        var dependency1 = new FakeExecutableDependency(
+            _processFactory, 
+            [OSPlatform.Windows, OSPlatform.Linux, OSPlatform.OSX]);
+        var dependency2 = new FakeExecutableDependency(
+            _processFactory, 
+            [OSPlatform.Windows, OSPlatform.Linux, OSPlatform.OSX]);
+
+        var sut = new AggregateExecutableRuntimeDependency(
+            TestDisplayName,
+            TestDescription,
+            TestUri,
+            [dependency1, dependency2]);
+
+        dependency1.SetAvailable(false);
+        dependency2.SetAvailable(true);
+
+        // First call should query both dependencies since they support the current platform
+        var firstResult = await sut.QueryInstallationInformation(CancellationToken.None);
+    
+        dependency1.QueryCount.Should().BeGreaterThan(0);
+        dependency2.QueryCount.Should().BeGreaterThan(0);
+        firstResult.HasValue.Should().BeTrue();
+
+        var dep1Count = dependency1.QueryCount;
+        var dep2Count = dependency2.QueryCount;
+
+        // Second call should use cached active dependency
+        var secondResult = await sut.QueryInstallationInformation(CancellationToken.None);
+    
+        dependency1.QueryCount.Should().Be(dep1Count);  // Should not be queried again
+        dependency2.QueryCount.Should().BeGreaterThan(dep2Count); // Should be queried again since it was active
+        secondResult.HasValue.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetAvailableDependencies_ShouldReturnAllAvailableDependencies()
+    {
+        _dependency1.SetAvailable(true);
+        _dependency2.SetAvailable(true);
+
+        var result = await _sut.GetAvailableDependenciesAsync(CancellationToken.None);
+
+        result.Should().HaveCount(2);
+        result.Should().Contain(_dependency1);
+        result.Should().Contain(_dependency2);
+    }
+
+    [Fact]
+    public async Task GetAvailableDependencies_ShouldHandleFailingDependencies()
+    {
+        _dependency1.SetThrowException(true);
+        _dependency2.SetAvailable(true);
+
+        var result = await _sut.GetAvailableDependenciesAsync(CancellationToken.None);
+
+        result.Should().HaveCount(1);
+        result.Should().Contain(_dependency2);
+    }
+    
+    [Fact]
+    public async Task QueryInstallationInformation_ShouldSkipDependenciesThatDontSupportCurrentOS()
+    {
+        // Create dependencies with specific platform support
+        var windowsDep = new FakeExecutableDependency(_processFactory, [OSPlatform.Windows]);
+        var linuxDep = new FakeExecutableDependency(_processFactory, [OSPlatform.Linux]);
+        var macOSDep = new FakeExecutableDependency(_processFactory, [OSPlatform.OSX]);
+    
+        windowsDep.SetAvailable(true);
+        linuxDep.SetAvailable(true);
+        macOSDep.SetAvailable(true);
+
+        var aggregate = new AggregateExecutableRuntimeDependency(
+            TestDisplayName,
+            TestDescription,
+            TestUri,
+            [windowsDep, linuxDep, macOSDep]);
+
+        var result = await aggregate.QueryInstallationInformation(CancellationToken.None);
+
+        // Verify that only the dependency matching the current OS is considered
+        if (OSInformation.Shared.Platform == OSPlatform.Windows)
+        {
+            windowsDep.QueryCount.Should().BeGreaterThan(0);
+            linuxDep.QueryCount.Should().Be(0);
+            macOSDep.QueryCount.Should().Be(0);
+            result.HasValue.Should().BeTrue();
+        }
+        else if (OSInformation.Shared.Platform == OSPlatform.Linux)
+        {
+            windowsDep.QueryCount.Should().Be(0);
+            linuxDep.QueryCount.Should().BeGreaterThan(0);
+            macOSDep.QueryCount.Should().Be(0);
+            result.HasValue.Should().BeTrue();
+        }
+        else if (OSInformation.Shared.Platform == OSPlatform.OSX)
+        {
+            windowsDep.QueryCount.Should().Be(0);
+            linuxDep.QueryCount.Should().Be(0);
+            macOSDep.QueryCount.Should().BeGreaterThan(0);
+            result.HasValue.Should().BeTrue();
+        }
+        else
+        {
+            // On other platforms, no dependencies should be available
+            windowsDep.QueryCount.Should().Be(0);
+            linuxDep.QueryCount.Should().Be(0);
+            macOSDep.QueryCount.Should().Be(0);
+            result.HasValue.Should().BeFalse();
+        }
+    }
+
+    private class FakeExecutableDependency : ExecutableRuntimeDependency
+    {
+        private readonly OSPlatform[] _platforms;
+        private bool _isAvailable;
+        private bool _throwException;
+        private RuntimeDependencyInformation? _information;
+        
+        public int QueryCount { get; private set; }
+
+        public override string DisplayName => "Fake Dependency";
+        public override string Description => "A fake dependency for testing";
+        public override Uri Homepage => new("https://example.com");
+        public override OSPlatform[] SupportedPlatforms => _platforms;
+
+        public FakeExecutableDependency(IProcessFactory processFactory, OSPlatform[] platforms) 
+            : base(processFactory)
+        {
+            _platforms = platforms;
+        }
+
+        public void SetAvailable(bool isAvailable, RuntimeDependencyInformation? information = null)
+        {
+            _isAvailable = isAvailable;
+            _information = information ?? new RuntimeDependencyInformation();
+        }
+
+        public void SetThrowException(bool throwException)
+        {
+            _throwException = throwException;
+        }
+
+        protected override async ValueTask<Optional<RuntimeDependencyInformation>> QueryInstallationInformationImpl(
+            CancellationToken cancellationToken)
+        {
+            QueryCount++;
+            if (_throwException)
+                throw new Exception("Simulated failure");
+
+            if (!_isAvailable)
+                return Optional<RuntimeDependencyInformation>.None;
+
+            return _information!;
+        }
+
+        protected override Command BuildQueryCommand(PipeTarget outputPipeTarget) => throw new NotImplementedException();
+        protected override RuntimeDependencyInformation ToInformation(ReadOnlySpan<char> output) => throw new NotImplementedException();
+    }
+}

--- a/tests/NexusMods.CrossPlatform.Tests/AggregateExecutableRuntimeDependencyTests.cs
+++ b/tests/NexusMods.CrossPlatform.Tests/AggregateExecutableRuntimeDependencyTests.cs
@@ -83,16 +83,25 @@ public class AggregateExecutableRuntimeDependencyTests
     [Fact]
     public async Task QueryInstallationInformation_ShouldReturnFirstAvailableDependency()
     {
+        var dep1 = new FakeExecutableDependency(_processFactory, [OSPlatform.Windows, OSPlatform.Linux, OSPlatform.OSX]);
+        var dep2 = new FakeExecutableDependency(_processFactory, [OSPlatform.Windows, OSPlatform.Linux, OSPlatform.OSX]);
+
+        var aggregate = new AggregateExecutableRuntimeDependency(
+            TestDisplayName,
+            TestDescription,
+            TestUri,
+            [dep1, dep2]);
+        
         var expectedInfo = new RuntimeDependencyInformation 
         { 
             RawVersion = "1.0.0",
             Version = new Version(1, 0, 0),
         };
         
-        _dependency1.SetAvailable(false);
-        _dependency2.SetAvailable(true, expectedInfo);
+        dep1.SetAvailable(false);
+        dep2.SetAvailable(true, expectedInfo);
 
-        var result = await _sut.QueryInstallationInformation(CancellationToken.None);
+        var result = await aggregate.QueryInstallationInformation(CancellationToken.None);
 
         result.HasValue.Should().BeTrue();
         result.Value.Should().BeEquivalentTo(expectedInfo);

--- a/tests/NexusMods.CrossPlatform.Tests/ProtontricksTests.cs
+++ b/tests/NexusMods.CrossPlatform.Tests/ProtontricksTests.cs
@@ -10,7 +10,7 @@ public class ProtontricksTests
     [InlineData("protontricks", null)]
     public void TestTryParseVersion(string input, string? expectedRawVersion)
     {
-        _ = ProtontricksDependency.TryParseVersion(input, out var rawVersion, out _);
+        _ = ProtontricksNativeDependency.TryParseVersion(input, out var rawVersion, out _);
         rawVersion.Should().Be(expectedRawVersion);
     }
 }


### PR DESCRIPTION
This PR adds the following:

- An `AggregateExecutableRuntimeDependency`.
    - This allows us to represent multiple of `ExecutableRuntimeDependency` as a simple runtime dependency.
    - Practical usages include:
        - Multiplexing (e.g. Flatpak & Native) as part of single dependency.
        - Per-OS dependencies (e.g. Run separate command on Linux and OSX).
        
- `AggregateProtontricksDependency`, which executes on either `Flatpak protontricks` or `Native protontricks`, depending on which is available.

-------

Remarks: 

If the user's has custom library directories, they may need to run `flatpak override --user --filesystem=host com.github.Matoking.protontricks` (or similar) to give flatpak's version of `protontricks` access to alternate directories.