### PR TITLE
Rework installing a collection

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/Models/CollectionDownload.cs
+++ b/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/Models/CollectionDownload.cs
@@ -27,4 +27,9 @@ public partial class CollectionDownload : IModelDefinition
     /// Whether the download is optional.
     /// </summary>
     public static readonly BooleanAttribute IsOptional = new(Namespace, nameof(IsOptional));
+
+    /// <summary>
+    /// Index into the source array.
+    /// </summary>
+    public static readonly Int32Attribute ArrayIndex = new(Namespace, nameof(ArrayIndex)) { IsIndexed = true };
 }

--- a/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/Models/CollectionDownloadBundled.cs
+++ b/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/Models/CollectionDownloadBundled.cs
@@ -1,5 +1,4 @@
 using JetBrains.Annotations;
-using NexusMods.Abstractions.MnemonicDB.Attributes;
 using NexusMods.MnemonicDB.Abstractions.Attributes;
 using NexusMods.MnemonicDB.Abstractions.Models;
 
@@ -7,9 +6,12 @@ namespace NexusMods.Abstractions.NexusModsLibrary.Models;
 
 [PublicAPI]
 [Include<CollectionDownload>]
-public partial class ColletionDownloadBundled : IModelDefinition
+public partial class CollectionDownloadBundled : IModelDefinition
 {
     private const string Namespace = "NexusMods.NexusModsLibrary.CollectionDownloadBundled";
 
+    /// <summary>
+    /// Bundled path.
+    /// </summary>
     public static readonly RelativePathAttribute BundledPath = new(Namespace, nameof(BundledPath));
 }

--- a/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/Models/CollectionMetadata.cs
+++ b/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/Models/CollectionMetadata.cs
@@ -1,5 +1,8 @@
 using NexusMods.Abstractions.NexusModsLibrary.Attributes;
+using NexusMods.Abstractions.NexusWebApi.Types;
+using NexusMods.Abstractions.NexusWebApi.Types.V2;
 using NexusMods.Abstractions.Resources.DB;
+using NexusMods.Abstractions.Telemetry;
 using NexusMods.MnemonicDB.Abstractions.Attributes;
 using NexusMods.MnemonicDB.Abstractions.Models;
 
@@ -21,6 +24,11 @@ public partial class CollectionMetadata : IModelDefinition
     /// The name of the collection.
     /// </summary>
     public static readonly StringAttribute Name = new(Namespace, nameof(Name));
+
+    /// <summary>
+    /// The id of the game.
+    /// </summary>
+    public static readonly GameIdAttribute GameId = new(Namespace, nameof(GameId)) { IsIndexed = true };
 
     /// <summary>
     /// The short description of the collection
@@ -71,4 +79,9 @@ public partial class CollectionMetadata : IModelDefinition
     /// The background image resource.
     /// </summary>
     public static readonly ReferenceAttribute<PersistedDbResource> BackgroundImageResource = new(Namespace, nameof(BackgroundImageResource)) { IsOptional = true };
+
+    public partial struct ReadOnly
+    {
+        public Uri GetUri(GameDomain gameDomain) => NexusModsUrlBuilder.CreateCollectionsUri(gameDomain, Slug);
+    }
 }

--- a/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/NexusModsFileMetadata.cs
+++ b/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/NexusModsFileMetadata.cs
@@ -56,7 +56,7 @@ public partial class NexusModsFileMetadata : IModelDefinition
             // NOTE(erri120): This URI shows a single download button for the exact file
             // The nmm=1 turns the button into a nxm:// link, without nmm=1 the button will download the file through the browser
             // Example: https://www.nexusmods.com/stardewvalley/mods/29140?tab=files&file_id=115276&nmm=1
-            return NexusModsUrlBuilder.CreateCollectionsUri($"{ModPage.GetBaseUrl()}?tab=files&file_id={Uid.FileId}&nmm=1");
+            return NexusModsUrlBuilder.CreateGenericUri($"{ModPage.GetBaseUrl()}?tab=files&file_id={Uid.FileId}&nmm=1");
         }
     }
 }

--- a/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/Services.cs
+++ b/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/Services.cs
@@ -24,7 +24,7 @@ public static class Services
             .AddCollectionDownloadModel()
             .AddCollectionDownloadExternalModel()
             .AddCollectionDownloadNexusModsModel()
-            .AddColletionDownloadBundledModel()
+            .AddCollectionDownloadBundledModel()
             .AddCollectionCategoryModel()
             .AddUserModel()
             .AddNexusModsCollectionLibraryFileModel();

--- a/src/Abstractions/NexusMods.Abstractions.NexusWebApi/IGameDomainToGameIdMappingCache.cs
+++ b/src/Abstractions/NexusMods.Abstractions.NexusWebApi/IGameDomainToGameIdMappingCache.cs
@@ -40,4 +40,9 @@ public interface IGameDomainToGameIdMappingCache
     ///     cache hit unless the translation is being done for the first time ever.
     /// </remarks>
     Optional<GameDomain> TryGetDomain(GameId gameId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Puts the values into the cache.
+    /// </summary>
+    ValueTask InsertAsync(GameDomain gameDomain, GameId gameId);
 }

--- a/src/Abstractions/NexusMods.Abstractions.Telemetry/NexusModsURLBuilder.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Telemetry/NexusModsURLBuilder.cs
@@ -1,5 +1,6 @@
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.WebUtilities;
+using NexusMods.Abstractions.NexusWebApi.Types;
 
 namespace NexusMods.Abstractions.Telemetry;
 
@@ -46,7 +47,7 @@ public static class NexusModsUrlBuilder
     /// </remarks>
     public static Uri CreateGenericUri(string baseUrl) => CreateUri(baseUrl);
 
-    public static Uri CreateCollectionsUri(string baseUrl) => CreateUri(baseUrl, campaign: "collections");
+    public static Uri CreateCollectionsUri(GameDomain gameDomain, CollectionSlug collectionSlug) => CreateUri($"https://next.nexusmods.com/{gameDomain}/collections/{collectionSlug}", campaign: "collections");
 
     /// <summary>
     /// Creates a new URI pointing to a mod on Nexus Mods. This should only be used

--- a/src/Networking/NexusMods.Networking.NexusWebApi/GraphQL/CollectionRevisionInfo.graphql
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/GraphQL/CollectionRevisionInfo.graphql
@@ -47,6 +47,11 @@ query CollectionRevisionInfo($slug: String!, $revisionNumber: Int!, $viewAdultCo
             user {
                 ...UserFragment
             }
+            game {
+                id
+                name
+                domainName
+            }
         }
     }
 }

--- a/src/Networking/NexusMods.Networking.NexusWebApi/LoginManager.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/LoginManager.cs
@@ -97,6 +97,7 @@ public sealed class LoginManager : IDisposable, ILoginManager
         var userInfo = await _msgFactory.Verify(_nexusApiClient, cancellationToken);
         _cachedUserInfo.Store(userInfo);
 
+        IsPremium = userInfo?.IsPremium ?? false;
         return userInfo;
     }
 

--- a/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsLibrary.Collections.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsLibrary.Collections.cs
@@ -253,9 +253,9 @@ public partial class NexusModsLibrary
         var resolver = GraphQLResolver.Create(db, tx, CollectionMetadata.Slug, slug);
 
         resolver.Add(CollectionMetadata.Name, collectionInfo.Name);
+        resolver.Add(CollectionMetadata.GameId, GameId.From((uint)collectionInfo.Game.Id));
         resolver.Add(CollectionMetadata.Summary, collectionInfo.Summary);
         resolver.Add(CollectionMetadata.Endorsements, (ulong)collectionInfo.Endorsements);
-
         resolver.Add(CollectionMetadata.TotalDownloads, (ulong)collectionInfo.TotalDownloads);
 
         if (Uri.TryCreate(collectionInfo.TileImage?.ThumbnailUrl, UriKind.Absolute, out var tileImageUri))

--- a/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsLibrary.Collections.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsLibrary.Collections.cs
@@ -172,7 +172,7 @@ public partial class NexusModsLibrary
 
         var fileId = new UidForFile(fileId: collectionMod.Source.FileId, gameId: gameIds[collectionMod.DomainName]);
 
-        Debug.Assert(resolvedEntitiesLookup.ContainsKey(fileId), message: "Should've resolved all mod files ealier");
+        Debug.Assert(resolvedEntitiesLookup.ContainsKey(fileId), message: "Should've resolved all mod files earlier");
         var (_, fileMetadataId) = resolvedEntitiesLookup[fileId];
 
         _ = new CollectionDownloadNexusMods.New(tx, downloadEntity.Id)

--- a/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsLibrary.Collections.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsLibrary.Collections.cs
@@ -273,7 +273,10 @@ public partial class NexusModsLibrary
         return resolver.Id;
     }
 
-    private async ValueTask<CollectionRoot> ParseCollectionJsonFile(
+    /// <summary>
+    /// Parses the collection json file.
+    /// </summary>
+    public async ValueTask<CollectionRoot> ParseCollectionJsonFile(
         NexusModsCollectionLibraryFile.ReadOnly collectionLibraryFile,
         CancellationToken cancellationToken)
     {

--- a/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsLibrary.Collections.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsLibrary.Collections.cs
@@ -126,10 +126,13 @@ public partial class NexusModsLibrary
         GameIdCache gameIds,
         ResolvedEntitiesLookup resolvedEntitiesLookup)
     {
-        foreach (var collectionMod in collectionRoot.Mods)
+        for (var i = 0; i < collectionRoot.Mods.Length; i++)
         {
+            var collectionMod = collectionRoot.Mods[i];
+
             var downloadEntity = new CollectionDownload.New(tx)
             {
+                ArrayIndex = i,
                 CollectionRevisionId = collectionRevisionEntityId,
                 IsOptional = collectionMod.Optional,
                 Name = collectionMod.Name,

--- a/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsLibrary.Collections.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsLibrary.Collections.cs
@@ -206,7 +206,7 @@ public partial class NexusModsLibrary
     {
         var source = collectionMod.Source;
 
-        _ = new ColletionDownloadBundled.New(tx, downloadEntity.Id)
+        _ = new CollectionDownloadBundled.New(tx, downloadEntity.Id)
         {
             CollectionDownload = downloadEntity,
             BundledPath = source.FileExpression,

--- a/src/Networking/NexusMods.Networking.NexusWebApi/V1Interop/GameDomainToGameIdMappingCache.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/V1Interop/GameDomainToGameIdMappingCache.cs
@@ -145,7 +145,8 @@ public sealed class GameDomainToGameIdMappingCache : IGameDomainToGameIdMappingC
         }
     }
 
-    private async ValueTask InsertAsync(GameDomain gameDomain, GameId gameId)
+    /// <inheritdoc/>
+    public async ValueTask InsertAsync(GameDomain gameDomain, GameId gameId)
     {
         // Note(sewer): In theory, there's a race condition in here if multiple threads
         //              try to insert at once. However that should not be a concern here,

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadDesignViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadDesignViewModel.cs
@@ -38,4 +38,7 @@ public class CollectionDownloadDesignViewModel : APageViewModel<ICollectionDownl
 
     public ReactiveCommand<Unit> DownloadAllCommand { get; } = new ReactiveCommand();
     public ReactiveCommand<Unit> InstallCollectionCommand { get; } = new ReactiveCommand();
+    public ReactiveCommand<Unit> CommandDeleteCollection { get; } = new ReactiveCommand();
+    public ReactiveCommand<Unit> CommandDeleteAllDownloads { get; } = new ReactiveCommand();
+    public ReactiveCommand<Unit> CommandViewOnNexusMods { get; } = new ReactiveCommand();
 }

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadPage.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadPage.cs
@@ -1,12 +1,10 @@
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
-using NexusMods.Abstractions.Library;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.NexusModsLibrary.Models;
 using NexusMods.Abstractions.Serialization.Attributes;
 using NexusMods.App.UI.WorkspaceSystem;
 using NexusMods.MnemonicDB.Abstractions;
-using NexusMods.Networking.NexusWebApi;
 
 namespace NexusMods.App.UI.Pages.CollectionDownload;
 

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadPage.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadPage.cs
@@ -1,6 +1,7 @@
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.Library;
+using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.NexusModsLibrary.Models;
 using NexusMods.Abstractions.Serialization.Attributes;
 using NexusMods.App.UI.WorkspaceSystem;
@@ -12,6 +13,7 @@ namespace NexusMods.App.UI.Pages.CollectionDownload;
 [JsonName(nameof(CollectionDownloadPageContext))]
 public record CollectionDownloadPageContext : IPageFactoryContext
 {
+    public required LoadoutId TargetLoadout { get; init; }
     public required CollectionRevisionMetadataId CollectionRevisionMetadataId { get; init; }
 }
 
@@ -35,8 +37,9 @@ public class CollectionDownloadPageFactory : APageFactory<ICollectionDownloadVie
 
         return new CollectionDownloadViewModel(
             windowManager: WindowManager,
-            ServiceProvider,
-            revisionMetadata: metadata
+            serviceProvider: ServiceProvider,
+            revisionMetadata: metadata,
+            targetLoadout: context.TargetLoadout
         );
     }
 }

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadView.axaml
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadView.axaml
@@ -17,28 +17,28 @@
 
     <reactiveUi:ReactiveUserControl.Resources>
         <MenuFlyout x:Key="CollectionMenuFlyout">
-            <MenuItem>
+            <MenuItem x:Name="MenuItemViewOnNexusMods">
                 <MenuItem.Header>
                     <panels:FlexPanel>
                         <TextBlock>View on Nexus Mods</TextBlock>
                     </panels:FlexPanel>
                 </MenuItem.Header>
             </MenuItem>
-            <MenuItem>
+            <MenuItem x:Name="MenuItemViewInLibrary">
                 <MenuItem.Header>
                     <panels:FlexPanel>
                         <TextBlock>View in Library</TextBlock>
                     </panels:FlexPanel>
                 </MenuItem.Header>
             </MenuItem>
-            <MenuItem>
+            <MenuItem x:Name="MenuItemDeleteAllDownloads">
                 <MenuItem.Header>
                     <panels:FlexPanel>
                         <TextBlock>Delete all downloads</TextBlock>
                     </panels:FlexPanel>
                 </MenuItem.Header>
             </MenuItem>
-            <MenuItem>
+            <MenuItem x:Name="MenuItemDeleteCollection">
                 <MenuItem.Header>
                     <panels:FlexPanel>
                         <TextBlock>Delete Collection</TextBlock>

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadView.axaml.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadView.axaml.cs
@@ -27,6 +27,18 @@ public partial class CollectionDownloadView : ReactiveUserControl<ICollectionDow
             this.BindCommand(ViewModel, vm => vm.DownloadAllCommand, view => view.DownloadAllButton)
                 .DisposeWith(d);
 
+            this.BindCommand(ViewModel, vm => vm.CommandDeleteCollection, view => view.MenuItemDeleteCollection)
+                .DisposeWith(d);
+
+            this.BindCommand(ViewModel, vm => vm.CommandDeleteAllDownloads, view => view.MenuItemDeleteAllDownloads)
+                .DisposeWith(d);
+
+            this.BindCommand(ViewModel, vm => vm.CommandViewOnNexusMods, view => view.MenuItemViewOnNexusMods)
+                .DisposeWith(d);
+
+            // TODO:
+            MenuItemViewInLibrary.IsEnabled = false;
+
             this.OneWayBind(ViewModel, vm => vm.TreeDataGridAdapter.Source.Value, view => view.RequiredDownloadsTree.Source)
                 .DisposeWith(d);
 

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadView.axaml.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadView.axaml.cs
@@ -21,6 +21,9 @@ public partial class CollectionDownloadView : ReactiveUserControl<ICollectionDow
 
         this.WhenActivated(d =>
         {
+            this.BindCommand(ViewModel, vm => vm.InstallCollectionCommand, view => view.InstallButton)
+                .DisposeWith(d);
+
             this.BindCommand(ViewModel, vm => vm.DownloadAllCommand, view => view.DownloadAllButton)
                 .DisposeWith(d);
 

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadViewModel.cs
@@ -5,6 +5,7 @@ using Avalonia.Media.Imaging;
 using DynamicData;
 using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.Jobs;
+using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.NexusModsLibrary.Models;
 using NexusMods.Abstractions.NexusWebApi;
 using NexusMods.Abstractions.NexusWebApi.Types;
@@ -36,7 +37,8 @@ public class CollectionDownloadViewModel : APageViewModel<ICollectionDownloadVie
     public CollectionDownloadViewModel(
         IWindowManager windowManager,
         IServiceProvider serviceProvider,
-        CollectionRevisionMetadata.ReadOnly revisionMetadata) : base(windowManager)
+        CollectionRevisionMetadata.ReadOnly revisionMetadata,
+        LoadoutId targetLoadout) : base(windowManager)
     {
         var connection = serviceProvider.GetRequiredService<IConnection>();
         var nexusModsDataProvider = serviceProvider.GetRequiredService<NexusModsDataProvider>();

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadViewModel.cs
@@ -24,10 +24,11 @@ using R3;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
 using Observable = System.Reactive.Linq.Observable;
+using ReactiveCommand = R3.ReactiveCommand;
 
 namespace NexusMods.App.UI.Pages.CollectionDownload;
 
-public class CollectionDownloadViewModel : APageViewModel<ICollectionDownloadViewModel>, ICollectionDownloadViewModel
+public sealed class CollectionDownloadViewModel : APageViewModel<ICollectionDownloadViewModel>, ICollectionDownloadViewModel
 {
     private readonly CollectionRevisionMetadata.ReadOnly _revision;
     private readonly CollectionMetadata.ReadOnly _collection;
@@ -77,7 +78,14 @@ public class CollectionDownloadViewModel : APageViewModel<ICollectionDownloadVie
             configureAwait: false
         );
 
-        InstallCollectionCommand = new ReactiveCommand<Unit>(canExecuteSource: R3.Observable.Return(false), initialCanExecute: false);
+        InstallCollectionCommand = new ReactiveCommand(
+            executeAsync: async (_, _) =>
+            {
+                await InstallCollectionJob.Create(serviceProvider, targetLoadout, revisionMetadata);
+            },
+            awaitOperation: AwaitOperation.Drop,
+            configureAwait: false
+        );
 
         this.WhenActivated(disposables =>
         {

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadViewModel.cs
@@ -87,6 +87,10 @@ public sealed class CollectionDownloadViewModel : APageViewModel<ICollectionDown
             configureAwait: false
         );
 
+        CommandDeleteCollection = new ReactiveCommand(canExecuteSource: R3.Observable.Return(false), initialCanExecute: false);
+        CommandDeleteAllDownloads = new ReactiveCommand(canExecuteSource: R3.Observable.Return(false), initialCanExecute: false);
+        CommandViewOnNexusMods = new ReactiveCommand(canExecuteSource: R3.Observable.Return(false), initialCanExecute: false);
+
         this.WhenActivated(disposables =>
         {
             TreeDataGridAdapter.Activate();
@@ -162,6 +166,9 @@ public sealed class CollectionDownloadViewModel : APageViewModel<ICollectionDown
 
     public ReactiveCommand<Unit> DownloadAllCommand { get; }
     public ReactiveCommand<Unit> InstallCollectionCommand { get; }
+    public ReactiveCommand<Unit> CommandDeleteCollection { get; }
+    public ReactiveCommand<Unit> CommandDeleteAllDownloads { get; }
+    public ReactiveCommand<Unit> CommandViewOnNexusMods { get; }
 }
 
 public record DownloadMessage(DownloadableItem Item);

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/ICollectionDownloadViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/ICollectionDownloadViewModel.cs
@@ -89,4 +89,10 @@ public interface ICollectionDownloadViewModel : IPageViewModelInterface
     /// Command to install the collection.
     /// </summary>
     R3.ReactiveCommand<R3.Unit> InstallCollectionCommand { get; }
+
+    R3.ReactiveCommand<R3.Unit> CommandDeleteCollection { get; }
+
+    R3.ReactiveCommand<R3.Unit> CommandDeleteAllDownloads { get; }
+
+    R3.ReactiveCommand<R3.Unit> CommandViewOnNexusMods { get; }
 }

--- a/src/NexusMods.App.UI/Pages/LibraryPage/Collections/CollectionCardViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LibraryPage/Collections/CollectionCardViewModel.cs
@@ -1,5 +1,6 @@
 using Avalonia.Media.Imaging;
 using NexusMods.Abstractions.Jobs;
+using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.NexusModsLibrary.Models;
 using NexusMods.Abstractions.NexusWebApi.Types;
 using NexusMods.Abstractions.Resources;
@@ -28,7 +29,8 @@ public class CollectionCardViewModel : AViewModel<ICollectionCardViewModel>, ICo
         IWindowManager windowManager,
         WorkspaceId workspaceId,
         IConnection connection,
-        RevisionId revision)
+        RevisionId revision,
+        LoadoutId targetLoadout)
     {
         _revision = CollectionRevisionMetadata.FindByRevisionId(connection.Db, revision).First();
         _collection = _revision.Collection;
@@ -41,6 +43,7 @@ public class CollectionCardViewModel : AViewModel<ICollectionCardViewModel>, ICo
             {
                 Context = new CollectionDownloadPageContext
                 {
+                    TargetLoadout = targetLoadout,
                     CollectionRevisionMetadataId = _revision,
                 },
                 FactoryId = CollectionDownloadPageFactory.StaticId,

--- a/src/NexusMods.App.UI/Pages/LibraryPage/Collections/CollectionsPage.cs
+++ b/src/NexusMods.App.UI/Pages/LibraryPage/Collections/CollectionsPage.cs
@@ -32,10 +32,12 @@ public class CollectionsPageFactory : APageFactory<ICollectionsViewModel, Collec
     public override ICollectionsViewModel CreateViewModel(CollectionsPageContext context)
     {
         var vm = new CollectionsViewModel(
-            ServiceProvider,
-            ServiceProvider.GetRequiredService<IConnection>(),
-            ServiceProvider.GetRequiredService<IWindowManager>()
+            serviceProvider: ServiceProvider,
+            conn: ServiceProvider.GetRequiredService<IConnection>(),
+            windowManager: ServiceProvider.GetRequiredService<IWindowManager>(),
+            targetLoadout: context.LoadoutId
         );
+
         return vm;
     }
 

--- a/src/NexusMods.App.UI/Pages/LibraryPage/Collections/CollectionsViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LibraryPage/Collections/CollectionsViewModel.cs
@@ -22,12 +22,20 @@ public class CollectionsViewModel : APageViewModel<ICollectionsViewModel>, IColl
         TabIcon = IconValues.ModLibrary;
         TabTitle = "Collections (WIP)";
 
+        var loadout = Loadout.Load(conn.Db, targetLoadout);
+        var gameId = loadout.Installation.GameId;
+
         this.WhenActivated(d =>
         {
             var tileImagePipeline = ImagePipelines.GetCollectionTileImagePipeline(serviceProvider);
             var userAvatarPipeline = ImagePipelines.GetUserAvatarPipeline(serviceProvider);
 
             CollectionMetadata.ObserveAll(conn)
+                .FilterImmutable(collection =>
+                {
+                    if (!CollectionMetadata.GameId.TryGetValue(collection, out var collectionGameId)) return true;
+                    return collectionGameId == gameId;
+                })
                 .Transform(ICollectionCardViewModel (coll) => new CollectionCardViewModel(
                     tileImagePipeline: tileImagePipeline,
                     userAvatarPipeline: userAvatarPipeline,

--- a/src/NexusMods.App.UI/Pages/LibraryPage/Collections/CollectionsViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LibraryPage/Collections/CollectionsViewModel.cs
@@ -7,6 +7,7 @@ using NexusMods.Icons;
 using NexusMods.MnemonicDB.Abstractions;
 using ReactiveUI;
 using System.Reactive.Disposables;
+using NexusMods.Abstractions.Loadouts;
 
 namespace NexusMods.App.UI.Pages.LibraryPage.Collections;
 
@@ -15,7 +16,8 @@ public class CollectionsViewModel : APageViewModel<ICollectionsViewModel>, IColl
     public CollectionsViewModel(
         IServiceProvider serviceProvider,
         IConnection conn,
-        IWindowManager windowManager) : base(windowManager)
+        IWindowManager windowManager,
+        LoadoutId targetLoadout) : base(windowManager)
     {
         TabIcon = IconValues.ModLibrary;
         TabTitle = "Collections (WIP)";
@@ -32,7 +34,8 @@ public class CollectionsViewModel : APageViewModel<ICollectionsViewModel>, IColl
                     windowManager: WindowManager,
                     workspaceId: WorkspaceId,
                     connection: conn,
-                    revision: coll.Revisions.First().RevisionId)
+                    revision: coll.Revisions.First().RevisionId,
+                    targetLoadout: targetLoadout)
                 )
                 .Bind(out _collections)
                 .Subscribe()

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutItemModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutItemModel.cs
@@ -66,8 +66,8 @@ public class LoadoutItemModel : TreeDataGridItemModel<LoadoutItemModel, EntityId
 
     private static string FormatDate(DateTimeOffset now, DateTimeOffset date)
     {
-        if (date == DateTime.UnixEpoch || date == default(DateTime)) return "-";
-        return date.Humanize(dateToCompareAgainst: now > date ? now : DateTime.Now);
+        if (date == DateTimeOffset.UnixEpoch || date == default(DateTimeOffset)) return "-";
+        return date.Humanize(dateToCompareAgainst: now > date ? now : TimeProvider.System.GetLocalNow());
     }
 
     private bool _isDisposed;

--- a/src/NexusMods.App.UI/Pages/NexusModsDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/NexusModsDataProvider.cs
@@ -5,9 +5,7 @@ using DynamicData.Aggregation;
 using DynamicData.Kernel;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
-using NexusMods.Abstractions.Collections;
 using NexusMods.Abstractions.Jobs;
-using NexusMods.Abstractions.Library.Models;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.NexusModsLibrary;
 using NexusMods.Abstractions.NexusModsLibrary.Models;
@@ -78,7 +76,7 @@ public class NexusModsDataProvider : ILibraryDataProvider, ILoadoutDataProvider
     {
         var isInLibraryObservable = CollectionDownloader.IsDownloadedObservable(_connection, nexusModsDownload)
             .ToObservable()
-            .Prepend(nexusModsDownload, static download => CollectionDownloader.IsDownloaded(download));
+            .Prepend(nexusModsDownload, static download => CollectionDownloader.IsDownloaded(download, download.Db));
 
         var downloadJobObservable = _jobMonitor.GetObservableChangeSet<NexusModsDownloadJob>()
             .FilterImmutable(job =>
@@ -116,7 +114,7 @@ public class NexusModsDataProvider : ILibraryDataProvider, ILoadoutDataProvider
     {
         var isInLibraryObservable = CollectionDownloader.IsDownloadedObservable(_connection, externalDownload)
             .ToObservable()
-            .Prepend(externalDownload, static download => CollectionDownloader.IsDownloaded(download));
+            .Prepend(externalDownload, static download => CollectionDownloader.IsDownloaded(download, download.Db));
 
         var downloadJobObservable = _jobMonitor.GetObservableChangeSet<ExternalDownloadJob>()
             .FilterImmutable(job =>

--- a/src/NexusMods.App/TelemetryProvider.cs
+++ b/src/NexusMods.App/TelemetryProvider.cs
@@ -74,7 +74,7 @@ internal sealed class TelemetryProvider : ITelemetryProvider, IDisposable
 
         return Loadout.All(db)
             .Where(static loadout => loadout.IsVisible())
-            .Select(loadout => new Counters.LoadoutModCount(loadout.Installation.Name, dict[loadout.LoadoutId]))
+            .Select(loadout => new Counters.LoadoutModCount(loadout.Installation.Name, dict.GetValueOrDefault(loadout.LoadoutId, 0)))
             .ToArray();
     }
 

--- a/src/NexusMods.Collections/CollectionDownloader.cs
+++ b/src/NexusMods.Collections/CollectionDownloader.cs
@@ -255,6 +255,39 @@ public class CollectionDownloader
     }
 
     /// <summary>
+    /// Checks whether the items in the collection were downloaded.
+    /// </summary>
+    public static bool IsFullyDownloaded(CollectionRevisionMetadata.ReadOnly revisionMetadata, bool onlyRequired, IDb db)
+    {
+        foreach (var download in revisionMetadata.Downloads)
+        {
+            if (onlyRequired && download.IsOptional) continue;
+            if (!IsDownloaded(download, db)) return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Checks whether the item was already downloaded.
+    /// </summary>
+    public static bool IsDownloaded(CollectionDownload.ReadOnly download, IDb db)
+    {
+        if (download.TryGetAsCollectionDownloadNexusMods(out var nexusModsDownload))
+        {
+            return IsDownloaded(nexusModsDownload, db);
+        }
+
+        if (download.TryGetAsCollectionDownloadExternal(out var externalDownload))
+        {
+            return IsDownloaded(externalDownload, db);
+        }
+
+        if (download.IsCollectionDownloadBundled()) return true;
+        return false;
+    }
+
+    /// <summary>
     /// Downloads everything in the revision.
     /// </summary>
     public async ValueTask DownloadAll(

--- a/src/NexusMods.Collections/CollectionDownloader.cs
+++ b/src/NexusMods.Collections/CollectionDownloader.cs
@@ -14,7 +14,6 @@ using NexusMods.Abstractions.NexusWebApi;
 using NexusMods.CrossPlatform.Process;
 using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.MnemonicDB.Abstractions.Query;
-using NexusMods.MnemonicDB.Abstractions.ValueSerializers;
 using NexusMods.Networking.NexusWebApi;
 using NexusMods.Paths;
 
@@ -199,7 +198,7 @@ public class CollectionDownloader
     {
         db ??= download.Db;
         var datoms = db.Datoms(NexusModsLibraryItem.FileMetadata, download.FileMetadata);
-        if (datoms.Count > 0)
+        if (datoms.Count == 0)
         {
             item = default(NexusModsLibraryItem.ReadOnly);
             return false;

--- a/src/NexusMods.Collections/CollectionDownloader.cs
+++ b/src/NexusMods.Collections/CollectionDownloader.cs
@@ -135,14 +135,13 @@ public class CollectionDownloader
     /// <summary>
     /// Checks whether the item was already downloaded.
     /// </summary>
-    public static bool IsDownloaded(CollectionDownloadExternal.ReadOnly download, IDb? db = null) => TryGetDownloadedItem(download, out _, db);
+    public static bool IsDownloaded(CollectionDownloadExternal.ReadOnly download, IDb db) => TryGetDownloadedItem(download, db, out _);
 
     /// <summary>
     /// Tries to get the downloaded item.
     /// </summary>
-    public static bool TryGetDownloadedItem(CollectionDownloadExternal.ReadOnly download, out LibraryFile.ReadOnly item, IDb? db = null)
+    public static bool TryGetDownloadedItem(CollectionDownloadExternal.ReadOnly download, IDb db, out LibraryFile.ReadOnly item)
     {
-        db ??= download.Db;
         var directDownloadDatoms = db.Datoms(DirectDownloadLibraryFile.Md5, download.Md5);
         if (directDownloadDatoms.Count > 0)
         {
@@ -189,14 +188,13 @@ public class CollectionDownloader
     /// <summary>
     /// Checks whether the item was already downloaded.
     /// </summary>
-    public static bool IsDownloaded(CollectionDownloadNexusMods.ReadOnly download, IDb? db = null) => TryGetDownloadedItem(download, out _, db);
+    public static bool IsDownloaded(CollectionDownloadNexusMods.ReadOnly download, IDb db) => TryGetDownloadedItem(download, db, out _);
 
     /// <summary>
     /// Tries to get the downloaded item.
     /// </summary>
-    public static bool TryGetDownloadedItem(CollectionDownloadNexusMods.ReadOnly download, out NexusModsLibraryItem.ReadOnly item, IDb? db = null)
+    public static bool TryGetDownloadedItem(CollectionDownloadNexusMods.ReadOnly download, IDb db, out NexusModsLibraryItem.ReadOnly item)
     {
-        db ??= download.Db;
         var datoms = db.Datoms(NexusModsLibraryItem.FileMetadata, download.FileMetadata);
         if (datoms.Count == 0)
         {
@@ -262,7 +260,7 @@ public class CollectionDownloader
     public async ValueTask DownloadAll(
         CollectionRevisionMetadata.ReadOnly revisionMetadata,
         bool onlyRequired,
-        IDb? db = null,
+        IDb db,
         int maxDegreeOfParallelism = -1,
         CancellationToken cancellationToken = default)
     {

--- a/src/NexusMods.Collections/InstallCollectionJob.cs
+++ b/src/NexusMods.Collections/InstallCollectionJob.cs
@@ -1,8 +1,6 @@
 using System.Collections.Concurrent;
 using System.IO.Hashing;
 using System.Security.Cryptography;
-using System.Text.Json;
-using DynamicData.Kernel;
 using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.Collections;
 using NexusMods.Abstractions.Collections.Json;
@@ -16,183 +14,179 @@ using NexusMods.Abstractions.Library.Models;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.MnemonicDB.Attributes;
 using NexusMods.Abstractions.NexusModsLibrary;
-using NexusMods.Abstractions.NexusWebApi;
+using NexusMods.Abstractions.NexusModsLibrary.Models;
 using NexusMods.Games.FOMOD;
 using NexusMods.Hashing.xxHash3;
-using NexusMods.Abstractions.NexusWebApi.Types.V2;
-using NexusMods.Abstractions.NexusWebApi.Types.V2.Uid;
-using NexusMods.Extensions.BCL;
 using NexusMods.MnemonicDB.Abstractions;
-using NexusMods.MnemonicDB.Abstractions.TxFunctions;
 using NexusMods.Networking.NexusWebApi;
-using NexusMods.Networking.NexusWebApi.V1Interop;
 using NexusMods.Paths;
 using NexusMods.Paths.Extensions;
 
 namespace NexusMods.Collections;
 
-using ModInstructions = (Mod Mod, LibraryFile.ReadOnly? LibraryFile);
+using ModAndDownload = (Mod Mod, CollectionDownload.ReadOnly Download);
 
-
+/// <summary>
+/// Job for installing a collection.
+/// </summary>
 public class InstallCollectionJob : IJobDefinitionWithStart<InstallCollectionJob, NexusCollectionLoadoutGroup.ReadOnly>
 { 
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public required NexusModsCollectionLibraryFile.ReadOnly SourceCollection { get; init; }
-    
+    private LibraryArchive.ReadOnly SourceCollectionArchive => SourceCollection.AsLibraryFile().ToLibraryArchive();
+    public required CollectionRevisionMetadata.ReadOnly RevisionMetadata { get; init; }
     public required IFileStore FileStore { get; init; }
-    
-    public required JsonSerializerOptions JsonSerializerOptions { get; init; }
-    public required ILibraryService LibraryService { get; set; }
-    public required IConnection Connection { get; set; }
-    public required NexusModsLibrary NexusModsLibrary { get; set; }
-    
-    public required TemporaryFileManager TemporaryFileManager { get; set; }
-    
-    public required LoadoutId TargetLoadout { get; set; }
-    public required IServiceProvider SerivceProvider { get; set; }
-    public required IGameDomainToGameIdMappingCache DomainMappingCache { get; set; }
-    
-    public static IJobTask<InstallCollectionJob, NexusCollectionLoadoutGroup.ReadOnly> Create(IServiceProvider provider, LoadoutId target, NexusModsCollectionLibraryFile.ReadOnly source)
+    public required ILibraryService LibraryService { get; init; }
+    public required IConnection Connection { get; init; }
+    public required LoadoutId TargetLoadout { get; init; }
+    public required IServiceProvider ServiceProvider { get; init; }
+    public required NexusModsLibrary NexusModsLibrary { get; init; }
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
+
+    /// <summary>
+    /// Factory.
+    /// </summary>
+    public static IJobTask<InstallCollectionJob, NexusCollectionLoadoutGroup.ReadOnly> Create(
+        IServiceProvider provider,
+        LoadoutId target,
+        NexusModsCollectionLibraryFile.ReadOnly source,
+        CollectionRevisionMetadata.ReadOnly revisionMetadata)
     {
         var monitor = provider.GetRequiredService<IJobMonitor>();
         var job = new InstallCollectionJob
         {
             TargetLoadout = target,
             SourceCollection = source,
-            SerivceProvider = provider,
+            RevisionMetadata = revisionMetadata,
+            ServiceProvider = provider,
             FileStore = provider.GetRequiredService<IFileStore>(),
-            JsonSerializerOptions = provider.GetRequiredService<JsonSerializerOptions>(),
             LibraryService = provider.GetRequiredService<ILibraryService>(),
-            NexusModsLibrary = provider.GetRequiredService<NexusModsLibrary>(),
             Connection = provider.GetRequiredService<IConnection>(),
-            TemporaryFileManager = provider.GetRequiredService<TemporaryFileManager>(),
-            DomainMappingCache = provider.GetRequiredService<IGameDomainToGameIdMappingCache>(),
+            NexusModsLibrary = provider.GetRequiredService<NexusModsLibrary>(),
         };
+
         return monitor.Begin<InstallCollectionJob, NexusCollectionLoadoutGroup.ReadOnly>(job);
     }
     
     /// <summary>
-    /// Starts the install of a collection.
+    /// Installs the collection.
     /// </summary>
-    /// <param name="context"></param>
-    /// <returns></returns>
-    /// <exception cref="InvalidOperationException"></exception>
     public async ValueTask<NexusCollectionLoadoutGroup.ReadOnly> StartAsync(IJobContext<InstallCollectionJob> context)
     {
-        // Collections are essentially zip files with a collection.json file in them along with several other files.
-        // So we can treat them as a library archive, and then extract the collection.json file from them.
-        if (!SourceCollection.AsLibraryFile().TryGetAsLibraryArchive(out var archive))
-            throw new InvalidOperationException("The source collection is not a library archive.");
-        
-        // Find the collection.json file and deserialize it.
-        var file = archive.Children.FirstOrDefault(f => f.Path == "collection.json");
-        CollectionRoot? root;
+        var root = await NexusModsLibrary.ParseCollectionJsonFile(SourceCollection, context.CancellationToken);
+        var modsAndDownloads = GatherDownloads(root);
 
+        NexusCollectionLoadoutGroup.ReadOnly collectionGroup;
+        using (var tx = Connection.BeginTransaction())
         {
-            await using var data = await FileStore.GetFileStream(file.AsLibraryFile().Hash);
-            root = await JsonSerializer.DeserializeAsync<CollectionRoot>(data, JsonSerializerOptions);
-        }
-        
-        if (root is null)
-            throw new InvalidOperationException("Failed to deserialize the collection.json file.");
-
-        // The collection.json file includes the mods by various ids and other info, so first we'll link those to library archives.
-        ConcurrentBag<ModInstructions> toInstall = new();
-
-        await Parallel.ForEachAsync(root.Mods, context.CancellationToken, async (mod, _) => toInstall.Add(await EnsureDownloaded(mod)));
-
-        // Now create the collection in the loadout
-        using var tx = Connection.BeginTransaction();
-        
-        var group = new NexusCollectionLoadoutGroup.New(tx, out var id)
-        {
-            LibraryFileId = SourceCollection,
-            CollectionGroup = new CollectionGroup.New(tx, id)
+            var group = new NexusCollectionLoadoutGroup.New(tx, out var id)
             {
-                IsReadOnly = true,
-                LoadoutItemGroup = new LoadoutItemGroup.New(tx, id)
+                LibraryFileId = SourceCollection,
+                CollectionGroup = new CollectionGroup.New(tx, id)
                 {
-                    IsGroup = true,
-                    LoadoutItem = new LoadoutItem.New(tx, id)
+                    IsReadOnly = true,
+                    LoadoutItemGroup = new LoadoutItemGroup.New(tx, id)
                     {
-                        Name = root.Info.Name,
-                        LoadoutId = TargetLoadout,
-                    }
-                }
-            }
-        };
-        
-        var groupResult = await tx.Commit();
-        var groupRemapped = groupResult.Remap(group);
-        
-        var insalled = new ConcurrentBag<(ModInstructions, LoadoutItemGroup.ReadOnly)>();
-        
-        // Now install the mods
-        await Parallel.ForEachAsync(toInstall, context.CancellationToken, async (file, _) =>
-            {
-                // Bit strange, but Install Mod will want to find the collection group, so we'll have to rebase entity it will get the DB from
-                if (file.LibraryFile.HasValue) 
-                    file = (file.Mod, file.LibraryFile!.Value.Rebase());
-                var mod = await InstallMod(TargetLoadout, file, groupRemapped.AsCollectionGroup().AsLoadoutItemGroup(), archive);
-                insalled.Add((file, mod));
-            }
-        );
-        
-        using var tx2 = Connection.BeginTransaction();
-        foreach (var (instructions, modGroup) in insalled)
-        {
-            tx2.Add(modGroup.Id, LoadoutItem.Name, instructions.Mod.Name);
+                        IsGroup = true,
+                        LoadoutItem = new LoadoutItem.New(tx, id)
+                        {
+                            Name = root.Info.Name,
+                            LoadoutId = TargetLoadout,
+                        },
+                    },
+                },
+            };
+
+            var groupResult = await tx.Commit();
+            collectionGroup = groupResult.Remap(group);
         }
 
-        await tx2.Commit();
-        
-        return groupRemapped;
+        var installed = new ConcurrentBag<(ModAndDownload, LoadoutItemGroup.ReadOnly)>();
+        await Parallel.ForEachAsync(modsAndDownloads, context.CancellationToken, async (modAndDownload, _) =>
+        {
+            var result = await InstallMod(modAndDownload, TargetLoadout, collectionGroup.AsCollectionGroup().AsLoadoutItemGroup());
+            installed.Add((modAndDownload, result));
+        });
+
+        using (var tx = Connection.BeginTransaction())
+        {
+            foreach (var (tuple, modGroup) in installed)
+            {
+                tx.Add(modGroup.Id, LoadoutItem.Name, tuple.Mod.Name);
+            }
+
+            await tx.Commit();
+        }
+
+        return collectionGroup;
     }
-    
-    private async Task<LoadoutItemGroup.ReadOnly> InstallMod(LoadoutId loadoutId, ModInstructions file, LoadoutItemGroup.ReadOnly group, LibraryArchive.ReadOnly collectionArchive)
+
+    private List<ModAndDownload> GatherDownloads(CollectionRoot root)
     {
-        if (file.LibraryFile is null && file.Mod.Source.Type == ModSourceType.bundle)
-            return await InstallBundledMod(loadoutId, file.Mod, group, collectionArchive);
-        
-        // If the mod has a hashes entry, then we'll treat it as a replicated mod, and not use the library service to install it.
-        if (file.Mod.Hashes.Any())
-            return await InstallReplicatedMod(loadoutId, file, group);
-        
-        // If there are predefined fomod choices, then we'll use the FomodXmlInstaller to install it.
-        if (file.Mod.Choices is { Type: ChoicesType.fomod })
-            return await InstallFomodWithPredefinedChoices(loadoutId, file, group);
+        var map = RevisionMetadata.Downloads.ToDictionary(static download => download.ArrayIndex, static download => download);
+        var list = new List<ModAndDownload>();
 
-        // Otherwise, we'll just use the library service to install it.
-        return await LibraryService.InstallItem(file.LibraryFile!.Value.AsLibraryItem(), loadoutId, parent: group.LoadoutItemGroupId);
+        for (var i = 0; i < root.Mods.Length; i++)
+        {
+            var mod = root.Mods[i];
+            if (!map.TryGetValue(i, out var download)) throw new NotImplementedException();
+            list.Add((mod, download));
+        }
+
+        return list;
     }
 
-    private async Task<LoadoutItemGroup.ReadOnly> InstallBundledMod(LoadoutId loadoutId, Mod fileMod, LoadoutItemGroup.ReadOnly group, LibraryArchive.ReadOnly collectionArchive)
+    private async Task<LoadoutItemGroup.ReadOnly> InstallMod(
+        ModAndDownload modAndDownload,
+        LoadoutId loadoutId,
+        LoadoutItemGroup.ReadOnly group)
+    {
+        var (mod, download) = modAndDownload;
+        if (download.TryGetAsCollectionDownloadBundled(out var bundledDownload))
+        {
+            return await InstallBundledMod(loadoutId, bundledDownload, group);
+        }
+
+        if (mod.Hashes.Length > 0)
+        {
+            return await InstallReplicatedMod(loadoutId, modAndDownload, group);
+        }
+
+        if (mod.Choices is { Type: ChoicesType.fomod })
+        {
+            return await InstallFomodWithPredefinedChoices(loadoutId, modAndDownload, group);
+        }
+
+        var libraryFile = GetLibraryFile(download);
+        return await LibraryService.InstallItem(libraryFile.AsLibraryItem(), loadoutId, parent: group.LoadoutItemGroupId);
+    }
+
+    private async Task<LoadoutItemGroup.ReadOnly> InstallBundledMod(
+        LoadoutId loadoutId,
+        CollectionDownloadBundled.ReadOnly download,
+        LoadoutItemGroup.ReadOnly group)
     {
         // Bundled mods are found inside the collection archive, so we'll have to find the files that are prefixed with the mod's source file expression.
-        var prefixPath = "bundled".ToRelativePath().Join(fileMod.Source.FileExpression);
-        // These are the files to install
-        var prefixFiles = collectionArchive.Children.Where(f => f.Path.InFolder(prefixPath)).ToArray();        
+        var prefixPath = "bundled".ToRelativePath().Join(download.BundledPath);
+        var prefixFiles = SourceCollectionArchive.Children.Where(f => f.Path.InFolder(prefixPath)).ToArray();
 
         using var tx = Connection.BeginTransaction();
 
-        if (!collectionArchive.AsLibraryFile().TryGetAsNexusModsCollectionLibraryFile(out var collectionFile))
-            throw new InvalidOperationException("The source collection is not a NexusModsCollectionLibraryFile.");
-        
-        // Create the mod group
         var modGroup = new NexusCollectionBundledLoadoutGroup.New(tx, out var id)
         {
-            CollectionLibraryFileId = collectionFile,
+            CollectionLibraryFileId = SourceCollection,
             LoadoutItemGroup = new LoadoutItemGroup.New(tx, id)
             {
                 IsGroup = true,
                 LoadoutItem = new LoadoutItem.New(tx, id)
                 {
-                    Name = fileMod.Name,
+                    Name = download.AsCollectionDownload().Name,
                     LoadoutId = loadoutId,
                     ParentId = group.Id,
                 },
             },
         };
-        
+
         foreach (var file in prefixFiles)
         {
             // Remove the prefix path from the file path
@@ -215,7 +209,7 @@ public class InstallCollectionJob : IJobDefinitionWithStart<InstallCollectionJob
                 },
             };
         }
-        
+
         var result = await tx.Commit();
         return result.Remap(modGroup).AsLoadoutItemGroup();
     }
@@ -223,34 +217,37 @@ public class InstallCollectionJob : IJobDefinitionWithStart<InstallCollectionJob
     /// <summary>
     /// Install a fomod with predefined choices.
     /// </summary>
-    private async Task<LoadoutItemGroup.ReadOnly> InstallFomodWithPredefinedChoices(LoadoutId loadoutId, ModInstructions file, LoadoutItemGroup.ReadOnly collectionGroup)
+    private async Task<LoadoutItemGroup.ReadOnly> InstallFomodWithPredefinedChoices(
+        LoadoutId loadoutId,
+        ModAndDownload modAndDownload,
+        LoadoutItemGroup.ReadOnly collectionGroup)
     {
-        // Get the archive from the library file
-        if (!file.LibraryFile!.Value.TryGetAsLibraryArchive(out var archive))
-            throw new InvalidOperationException("The library file is not a library archive.");
+        var (mod, download) = modAndDownload;
 
-        // Create the installer
-        var fomodInstaller = FomodXmlInstaller.Create(SerivceProvider, new GamePath(LocationId.Game, ""));
-        
-        // Create the mod group and install the mod
+        var libraryFile = GetLibraryFile(download);
+        if (!libraryFile.TryGetAsLibraryArchive(out var libraryArchive))
+            throw new NotImplementedException();
+
+        var fomodInstaller = FomodXmlInstaller.Create(ServiceProvider, new GamePath(LocationId.Game, ""));
+
         using var tx = Connection.BeginTransaction();
         var group = new LoadoutItemGroup.New(tx, out var id)
         {
             IsGroup = true,
             LoadoutItem = new LoadoutItem.New(tx, id)
             {
-                Name = file.Mod.Name,
+                Name = download.Name,
                 LoadoutId = loadoutId,
                 ParentId = collectionGroup.Id,
             },
         };
+
         var loadout = new Loadout.ReadOnly(Connection.Db, loadoutId);
 
-        var options = file.Mod.Choices!.Options;
-        await fomodInstaller.ExecuteAsync(archive, group, tx, loadout, options, CancellationToken.None);
-        
+        var options = mod.Choices!.Options;
+        await fomodInstaller.ExecuteAsync(libraryArchive, group, tx, loadout, options, CancellationToken.None);
+
         var result = await tx.Commit();
-        
         return result.Remap(group);
     }
 
@@ -259,41 +256,39 @@ public class InstallCollectionJob : IJobDefinitionWithStart<InstallCollectionJob
     /// the target locations of the mod files. The MD5 hashes are the hashes of the files. So it's a fromHash->toPath
     /// situation. We don't store the MD5 hashes in the database, so we'll have to calculate them on the fly.
     /// </summary>
-    private async Task<LoadoutItemGroup.ReadOnly> InstallReplicatedMod(LoadoutId loadoutId, ModInstructions file, LoadoutItemGroup.ReadOnly parentGroup)
+    private async Task<LoadoutItemGroup.ReadOnly> InstallReplicatedMod(
+        LoadoutId loadoutId,
+        ModAndDownload modAndDownload,
+        LoadoutItemGroup.ReadOnly parentGroup)
     {
+        var (mod, download) = modAndDownload;
+
         // So collections hash everything by MD5, so we'll have to collect MD5 information for the files in the archive.
         // We don't do this during indexing into the library because this is the only case where we need MD5 hashes.
         ConcurrentDictionary<Md5HashValue, HashMapping> hashes = new();
-        
-        // Get the archive from the library file
-        if (!file.LibraryFile!.Value.TryGetAsLibraryArchive(out var archive))
-            throw new InvalidOperationException("The library file is not a library archive.");
-        
-        // Get the collection archive
-        if (!SourceCollection.AsLibraryFile().TryGetAsLibraryArchive(out var collectionArchive))
-            throw new InvalidOperationException("The source collection is not a library archive.");
 
-        // Hash all the files in the mod
-        await Parallel.ForEachAsync(archive.Children, async (child, token) =>
+        var libraryFile = GetLibraryFile(download);
+        if (!libraryFile.TryGetAsLibraryArchive(out var libraryArchive))
+            throw new NotImplementedException();
+
+        await Parallel.ForEachAsync(libraryArchive.Children, async (child, token) =>
+        {
+            await using var stream = await FileStore.GetFileStream(child.AsLibraryFile().Hash, token);
+            using var hasher = MD5.Create();
+            var hash = await hasher.ComputeHashAsync(stream, token);
+            var md5 = Md5HashValue.From(hash);
+
+            var file = child.AsLibraryFile();
+            hashes[md5] = new HashMapping()
             {
-                await using var stream = await FileStore.GetFileStream(child.AsLibraryFile().Hash, token);
-                using var hasher = MD5.Create();
-                var hash = await hasher.ComputeHashAsync(stream, token);
-                var md5 = Md5HashValue.From(hash);
+                Hash = file.Hash,
+                Size = file.Size,
+            };
+        });
 
-                var libraryFile = child.AsLibraryFile();
-                hashes[md5] = new HashMapping()
-                {
-                    Hash = libraryFile.Hash,
-                    Size = libraryFile.Size,
-                };
-            }
-        );
-        
         // If we have any binary patching to do, then we'll do that now.
-        if (file.Mod.Patches.Any()) 
-            await PatchFiles(file.Mod, archive, collectionArchive, hashes);
-        
+        if (mod.Patches.Count > 0) await PatchFiles(mod, libraryArchive, SourceCollectionArchive, hashes);
+
         using var tx = Connection.BeginTransaction();
         
         // Create the group
@@ -302,7 +297,7 @@ public class InstallCollectionJob : IJobDefinitionWithStart<InstallCollectionJob
             IsGroup = true,
             LoadoutItem = new LoadoutItem.New(tx, id)
             {
-                Name = file.Mod.Name,
+                Name = download.Name,
                 LoadoutId = loadoutId,
                 ParentId = parentGroup.Id,
             },
@@ -311,19 +306,19 @@ public class InstallCollectionJob : IJobDefinitionWithStart<InstallCollectionJob
         // Link the group to the loadout
         _ = new LibraryLinkedLoadoutItem.New(tx, id)
         {
-            LibraryItemId = file.LibraryFile!.Value.AsLibraryItem(),
+            LibraryItemId = libraryFile.AsLibraryItem(),
             LoadoutItemGroup = group,
         };
 
         // Now we map the files to their locations based on the hashes
-        foreach (var pair in file.Mod.Hashes)
+        foreach (var pair in mod.Hashes)
         {
             // Try and find the hash we are looking for
             if (!hashes.TryGetValue(pair.MD5, out var libraryItem))
                 throw new InvalidOperationException("The hash was not found in the archive.");
 
             // Map the file to the specific path
-            var item = new LoadoutFile.New(tx, out var fileId)
+            _ = new LoadoutFile.New(tx, out var fileId)
             {
                 Hash = libraryItem.Hash,
                 Size = libraryItem.Size,
@@ -339,7 +334,7 @@ public class InstallCollectionJob : IJobDefinitionWithStart<InstallCollectionJob
                 },
             };
         }
-        
+
         var result = await tx.Commit();
         return result.Remap(group);
     }
@@ -347,7 +342,10 @@ public class InstallCollectionJob : IJobDefinitionWithStart<InstallCollectionJob
     /// <summary>
     /// This will go through and generate all the patch files for the given archive based on the mod's patches.
     /// </summary>
-    private async Task PatchFiles(Mod modInfo, LibraryArchive.ReadOnly modArchive, LibraryArchive.ReadOnly collectionArchive, 
+    private async Task PatchFiles(
+        Mod modInfo,
+        LibraryArchive.ReadOnly modArchive,
+        LibraryArchive.ReadOnly collectionArchive,
         ConcurrentDictionary<Md5HashValue, HashMapping> hashes)
     {
         // Index all the files in the collection zip file and the mod archive by their paths so we can find them easily.
@@ -404,92 +402,36 @@ public class InstallCollectionJob : IJobDefinitionWithStart<InstallCollectionJob
         // Backup the patched files
         await FileStore.BackupFiles(patchedFiles, deduplicate: true);
     }
-    private Dictionary<RelativePath, LibraryFile.ReadOnly> IndexChildren(LibraryArchive.ReadOnly archive)
+
+    private static Dictionary<RelativePath, LibraryFile.ReadOnly> IndexChildren(LibraryArchive.ReadOnly archive)
     {
-        Dictionary<RelativePath, LibraryFile.ReadOnly> children = new();
-        foreach (var child in archive.Children)
-        {
-            children[RelativePath.FromUnsanitizedInput(child.Path)] = child.AsLibraryFile();
-        }
+        var children = archive.Children
+            .Select(static child => (child.Path, child.AsLibraryFile()))
+            .ToDictionary(static kv => kv.Item1, static kv => kv.Item2);
 
         return children;
     }
 
-    private async Task<ModInstructions> EnsureDownloaded(Mod mod)
+    private static LibraryFile.ReadOnly GetLibraryFile(CollectionDownload.ReadOnly download)
     {
-        return mod.Source.Type switch
+        if (download.TryGetAsCollectionDownloadNexusMods(out var nexusModsDownload))
         {
-            ModSourceType.browse => await EnsureBrowseModIsDirectDownloaded(mod),
-            ModSourceType.direct => await EnsureDirectMod(mod),
-            ModSourceType.nexus => await EnsureNexusModDownloaded(mod),
-            // Nothing to downoad for a bundle
-            ModSourceType.bundle => (mod, null),
-            _ => throw new NotSupportedException($"The mod source type '{mod.Source.Type}' is not supported.")
-        };
-    }
+            if (!CollectionDownloader.TryGetDownloadedItem(nexusModsDownload, out var item))
+                throw new NotImplementedException();
 
-    private async Task<ModInstructions> EnsureBrowseModIsDirectDownloaded(Mod mod)
-    {
-        var db = Connection.Db;
-        if (DirectDownloadLibraryFile.FindByMd5(db, mod.Source.Md5).TryGetFirst(out var found))
-            return (mod, found.AsLibraryFile());
-        
-        // There's a small chance that the file may be downloadable via a direct download, so we'll try that
-        // by getting doing a HEAD request to the URL and checking the content type/size
-        
-        var request = new HttpRequestMessage(HttpMethod.Head, mod.Source.Url);
-        using var response = await SerivceProvider.GetRequiredService<HttpClient>().SendAsync(request);
-        if (!response.IsSuccessStatusCode)
-            throw new InvalidOperationException("The mod could not be downloaded.");
-        
-        var contentType = response.Content.Headers.ContentType?.MediaType;
-        if (contentType is null || !contentType.StartsWith("application/"))
-            throw new InvalidOperationException("The mod is not a direct download.");
-        
-        if (!response.Content.Headers.ContentLength.HasValue)
-            throw new InvalidOperationException("The mod does not have a content length.");
-        
-        var size = Size.FromLong(response.Content.Headers.ContentLength.Value);
-        if (size != mod.Source.FileSize)
-            throw new InvalidOperationException("The mod's file size does not match the expected size.");
-        
-        return await EnsureDirectMod(mod);
-    }
-
-
-    private async Task<ModInstructions> EnsureDirectMod(Mod mod)
-    {
-        var db = Connection.Db;
-        if (DirectDownloadLibraryFile.FindByMd5(db, mod.Source.Md5).TryGetFirst(out var found))
-            return (mod, found.AsLibraryFile());
-        
-        await using var tempPath = TemporaryFileManager.CreateFile();
-        
-        var job = ExternalDownloadJob.Create(SerivceProvider, mod.Source.Url!, mod.Source.Md5, mod.Name);
-        var libraryFile = await LibraryService.AddDownload(job);
-
-        return (mod, libraryFile);
-    }
-
-    private async Task<ModInstructions> EnsureNexusModDownloaded(Mod mod)
-    {
-        var db = Connection.Db;
-        var gameId = (await DomainMappingCache.TryGetIdAsync(mod.DomainName, default(CancellationToken))).Value;
-        var uid = new UidForFile(mod.Source.FileId, gameId);
-        var file = NexusModsFileMetadata.FindByUid(db, uid)
-            .Where(f => f.ModPage.Uid.ModId == mod.Source.ModId)
-            .FirstOrOptional(f => f.LibraryFiles.Any());
-
-        if (file.HasValue)
-        {
-            if (file.Value.LibraryFiles.First().AsLibraryItem().TryGetAsLibraryFile(out var firstLibraryFile)) 
-                return (mod, firstLibraryFile);
+            var libraryFile = LibraryFile.Load(item.Db, item.Id);
+            if (!libraryFile.IsValid()) throw new NotImplementedException();
+            return libraryFile;
         }
 
-        await using var tempPath = TemporaryFileManager.CreateFile();
+        if (download.TryGetAsCollectionDownloadExternal(out var externalDownload))
+        {
+            if (!CollectionDownloader.TryGetDownloadedItem(externalDownload, out var item))
+                throw new NotImplementedException();
 
-        var downloadJob = await NexusModsLibrary.CreateDownloadJob(tempPath, gameId, mod.Source.ModId, mod.Source.FileId);
-        var libraryFile = await LibraryService.AddDownload(downloadJob);
-        return (mod, libraryFile);
+            return item;
+        }
+
+        throw new NotImplementedException();
     }
 }

--- a/src/NexusMods.Collections/Verbs.cs
+++ b/src/NexusMods.Collections/Verbs.cs
@@ -41,11 +41,12 @@ internal static class Verbs
         var downloadJob = nexusModsLibrary.CreateCollectionDownloadJob(destination, CollectionSlug.From(slug), RevisionNumber.From((ulong)revision), token);
         
         var libraryFile = await libraryService.AddDownload(downloadJob);
-        
+
         if (!libraryFile.TryGetAsNexusModsCollectionLibraryFile(out var collectionFile))
             throw new InvalidOperationException("The library file is not a NexusModsCollectionLibraryFile");
 
-        var installJob = await InstallCollectionJob.Create(serviceProvider, loadout, collectionFile);
+        var revisionMetadata = await nexusModsLibrary.GetOrAddCollectionRevision(collectionFile, CollectionSlug.From(slug), RevisionNumber.From((ulong)revision), token);
+        var installJob = await InstallCollectionJob.Create(serviceProvider, loadout, collectionFile, revisionMetadata);
 
         return 0;
     }

--- a/tests/NexusMods.Collections.Tests/CollectionInstallTests.cs
+++ b/tests/NexusMods.Collections.Tests/CollectionInstallTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using NexusMods.Abstractions.GameLocators;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.NexusModsLibrary;
@@ -11,7 +10,6 @@ namespace NexusMods.Collections.Tests;
 [Trait("RequiresNetworking", "True")]
 public class CollectionInstallTests(ITestOutputHelper helper) : ACyberpunkIsolatedGameTest<CollectionInstallTests>(helper)
 {
-
     [Theory]
     // Includes a basic collection
     [InlineData("jjctqn", 1)]
@@ -36,7 +34,9 @@ public class CollectionInstallTests(ITestOutputHelper helper) : ACyberpunkIsolat
             throw new InvalidOperationException("The library file is not a NexusModsCollectionLibraryFile");
 
         var loadout = await CreateLoadout();
-        var installJob = await InstallCollectionJob.Create(ServiceProvider, loadout, collectionFile);
+
+        var revisionMetadata = await NexusModsLibrary.GetOrAddCollectionRevision(collectionFile, CollectionSlug.From(slug), RevisionNumber.From((ulong)revisionNumber), CancellationToken.None);
+        var installJob = await InstallCollectionJob.Create(ServiceProvider, loadout, collectionFile, revisionMetadata);
 
         loadout = loadout.Rebase();
 

--- a/tests/NexusMods.DataModel.SchemaVersions.Tests/LegacyDatabaseSupportTests.TestDatabase_name=SDV.4_11_2024.rocksdb.zip.verified.txt
+++ b/tests/NexusMods.DataModel.SchemaVersions.Tests/LegacyDatabaseSupportTests.TestDatabase_name=SDV.4_11_2024.rocksdb.zip.verified.txt
@@ -1,7 +1,7 @@
 ﻿{
   Name: SDV.4_11_2024.rocksdb.zip,
   OldFingerprint: None,
-  NewFingerprint: 0xF1622F7029D5B117,
+  NewFingerprint: 0xDC3041F8AE1C27E9,
   LoadoutItemGroups: 201,
   Files: 16729,
   Created: 2024-11-04 17:45:27

--- a/tests/NexusMods.DataModel.SchemaVersions.Tests/LegacyDatabaseSupportTests.TestDatabase_name=SDV.4_11_2024.rocksdb.zip.verified.txt
+++ b/tests/NexusMods.DataModel.SchemaVersions.Tests/LegacyDatabaseSupportTests.TestDatabase_name=SDV.4_11_2024.rocksdb.zip.verified.txt
@@ -1,7 +1,7 @@
 ﻿{
   Name: SDV.4_11_2024.rocksdb.zip,
   OldFingerprint: None,
-  NewFingerprint: 0xDDB40DA5E2BBCE23,
+  NewFingerprint: 0xF1622F7029D5B117,
   LoadoutItemGroups: 201,
   Files: 16729,
   Created: 2024-11-04 17:45:27

--- a/tests/NexusMods.DataModel.SchemaVersions.Tests/Schema.verified.md
+++ b/tests/NexusMods.DataModel.SchemaVersions.Tests/Schema.verified.md
@@ -3,8 +3,8 @@ This schema is written to a markdown file for both documentation and validation 
 models in the app, then validate the tests to update this file. 
 
 ## Statistics
-   - Fingerprint: 0x1A0740A80D5D60A9
-   - Total attributes: 143
+   - Fingerprint: 0x951E9D4C14F1ED67
+   - Total attributes: 144
    - Total namespaces: 58
    
 ## Attributes
@@ -90,6 +90,7 @@ models in the app, then validate the tests to update this file.
 | NexusMods.Networking.NexusWebApi.Auth.JWTToken/RefreshToken                        | Utf8                    | False   | False | False     | 
 | NexusMods.NexusModsLibrary.CollectionCategory/Name                                 | Utf8                    | True    | False | False     | 
 | NexusMods.NexusModsLibrary.CollectionCategory/NexusId                              | UInt64                  | True    | False | False     | 
+| NexusMods.NexusModsLibrary.CollectionDownload/ArrayIndex                           | Int32                   | True    | False | False     | 
 | NexusMods.NexusModsLibrary.CollectionDownload/CollectionRevision                   | Reference               | False   | False | False     | 
 | NexusMods.NexusModsLibrary.CollectionDownload/IsOptional                           | UInt8                   | False   | False | False     | 
 | NexusMods.NexusModsLibrary.CollectionDownload/Name                                 | Utf8                    | False   | False | False     | 

--- a/tests/NexusMods.DataModel.SchemaVersions.Tests/Schema.verified.md
+++ b/tests/NexusMods.DataModel.SchemaVersions.Tests/Schema.verified.md
@@ -3,8 +3,8 @@ This schema is written to a markdown file for both documentation and validation 
 models in the app, then validate the tests to update this file. 
 
 ## Statistics
-   - Fingerprint: 0x951E9D4C14F1ED67
-   - Total attributes: 144
+   - Fingerprint: 0x60C019D68BA4BF2F
+   - Total attributes: 145
    - Total namespaces: 58
    
 ## Attributes
@@ -106,6 +106,7 @@ models in the app, then validate the tests to update this file.
 | NexusMods.NexusModsLibrary.CollectionMetadata/BackgroundImageUri                   | Utf8                    | False   | False | False     | 
 | NexusMods.NexusModsLibrary.CollectionMetadata/Category                             | Reference               | False   | False | False     | 
 | NexusMods.NexusModsLibrary.CollectionMetadata/Endorsements                         | UInt64                  | False   | False | False     | 
+| NexusMods.NexusModsLibrary.CollectionMetadata/GameId                               | UInt32                  | True    | False | False     | 
 | NexusMods.NexusModsLibrary.CollectionMetadata/Name                                 | Utf8                    | False   | False | False     | 
 | NexusMods.NexusModsLibrary.CollectionMetadata/Slug                                 | Ascii                   | True    | False | False     | 
 | NexusMods.NexusModsLibrary.CollectionMetadata/Summary                              | Utf8                    | False   | False | False     | 


### PR DESCRIPTION
Part of #2254.

If you want to test this, you can't use collections that you've added previously. You must delete old collections and re-add them.

- Reworks how collections are installed.
- Fixes exceptions related to dates
- Filters collections by game
- Delete collections (doesn't remove the library items, it just removes the entities)
- Visit collections on Nexus Mods