### PR TITLE
Load order header button

### DIFF
--- a/src/NexusMods.App.UI/Pages/ItemContentsFileTree/ItemContentsFileTreeView.axaml
+++ b/src/NexusMods.App.UI/Pages/ItemContentsFileTree/ItemContentsFileTreeView.axaml
@@ -15,12 +15,11 @@
     <Grid RowDefinitions="Auto, *">
         <Border Grid.Row="0" Classes="Toolbar">
             <StackPanel>
-                <navigation:NavigationControl x:Name="OpenEditorMenuItem">
-                    <StackPanel>
-                        <icons:UnifiedIcon Value="{x:Static icons:IconValues.FileEdit}" />
-                        <TextBlock Text="Edit file" />
-                    </StackPanel>
-                </navigation:NavigationControl>
+                <navigation:NavigationControl x:Name="OpenEditorMenuItem"
+                                              Text="Edit File"
+                                              LeftIcon="{x:Static icons:IconValues.FileEdit}"
+                                              ShowIcon="Left"
+                                              Size="Small"/>
             </StackPanel>
         </Border>
 

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/ILoadOrderViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/ILoadOrderViewModel.cs
@@ -56,6 +56,16 @@ public interface ILoadOrderViewModel : IViewModelInterface
     ListSortDirection SortDirectionCurrent { get; set; }
     
     /// <summary>
+    /// Switch the current sort direction to the inverse
+    /// </summary>
+    ReactiveCommand<Unit, Unit> SwitchSortDirectionCommand { get; }
+    
+    /// <summary>
+    /// True if current sort direction is ascending, false if descending
+    /// </summary>
+    bool IsAscending { get; }
+    
+    /// <summary>
     /// Whether the winning item is at the top or bottom of the list
     /// </summary>
     /// <remarks>

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderView.axaml
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderView.axaml
@@ -166,12 +166,12 @@
                                                        Foreground="{StaticResource NeutralSubduedBrush}" />
                                 </Border>
                                 <StackPanel Orientation="Vertical" VerticalAlignment="Center">
-                                    <TextBlock x:Name="ItemName"
+                                    <TextBlock x:Name="ModName"
                                                Text="{CompiledBinding ModName}"
                                                Theme="{StaticResource BodySMNormalTheme}"
-                                               Foreground="{StaticResource NeutralTranslucentModerateBrush}" />
-                                    <TextBlock x:Name="ItemName2"
-                                               Text="{CompiledBinding DisplayName}" />
+                                               Foreground="{StaticResource NeutralTranslucentModerateBrush}"/>
+                                    <TextBlock x:Name="DisplayName"
+                                               Text="{CompiledBinding DisplayName}"/>
                                 </StackPanel>
                             </StackPanel>
                         </DataTemplate>

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderView.axaml
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderView.axaml
@@ -25,7 +25,7 @@
             <!-- toolbar -->
             <Border Grid.Row="0" Classes="Toolbar">
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Center">
-                    <ComboBox x:Name="SortDirectionComboBox" SelectedIndex="0" Classes="Secondary Compact">
+                    <ComboBox x:Name="SortDirectionComboBox" SelectedIndex="0" Classes="Secondary Compact" IsVisible="False">
                         <ComboBoxItem>
                             <StackPanel Orientation="Horizontal">
                                 <icons:UnifiedIcon Value="{x:Static icons:IconValues.SortAscending}" Size="20" />
@@ -39,7 +39,7 @@
                             </StackPanel>
                         </ComboBoxItem>
                     </ComboBox>
-                    <Border Width="1" Height="28" Margin="4,0" Background="{StaticResource StrokeTranslucentWeakBrush}" />
+                    <!-- <Border Width="1" Height="28" Margin="4,0" Background="{StaticResource StrokeTranslucentWeakBrush}" /> -->
                     <CheckBox Content="Hide Disabled Collections" IsEnabled="False" />
                     <Border Width="1" Height="28" Margin="4,0" Background="{StaticResource StrokeTranslucentWeakBrush}" />
                     <controls:StandardButton
@@ -106,7 +106,7 @@
                 <!-- right column (tree data grid) -->
                 <TreeDataGrid Grid.Column="1" x:Name="SortOrderTreeDataGrid"
                               AutoDragDropRows="False"
-                              CanUserResizeColumns="True"
+                              CanUserResizeColumns="False"
                               CanUserSortColumns="False"
                               ShowColumnHeaders="True"
                               RowDrop="OnRowDrop">

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderViewDesignViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderViewDesignViewModel.cs
@@ -25,28 +25,17 @@ public class LoadOrderDesignViewModel : AViewModel<ILoadOrderViewModel>, ILoadOr
     public ReactiveCommand<Unit, Unit> InfoAlertCommand { get; } = ReactiveCommand.Create(() => { });
     public string TrophyToolTip { get; } = "Winner Tooltip";
     public ListSortDirection SortDirectionCurrent { get; set; }
+    public ReactiveCommand<Unit, Unit> SwitchSortDirectionCommand { get; }
+    public bool IsAscending { get; set;  } = true;
     public bool IsWinnerTop { get; set; } = true;
     public string EmptyStateMessageTitle { get; } = "Empty State Message Title";
     public string EmptyStateMessageContents { get; } = "Empty State Message Contents";
     public AlertSettingsWrapper AlertSettingsWrapper { get; }
 
-    public LoadOrderDesignViewModel(ISettingsManager settingsManager)
-    {
-        Adapter = new LoadOrderTreeDataGridDesignAdapter();
-
-        this.WhenActivated(d =>
-            {
-                Adapter.Activate();
-                Disposable.Create(() => Adapter.Deactivate())
-                    .DisposeWith(d);
-            }
-        );
-        
-        AlertSettingsWrapper = new AlertSettingsWrapper(settingsManager, "cyberpunk2077 redmod load-order first-loaded-wins");
-    }
-
     public LoadOrderDesignViewModel()
     {
+        SwitchSortDirectionCommand = ReactiveCommand.Create(() => { IsAscending = !IsAscending; });
+        
        Adapter = new LoadOrderTreeDataGridDesignAdapter();
 
        this.WhenActivated(d =>

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderViewModel.cs
@@ -32,6 +32,10 @@ public class LoadOrderViewModel : AViewModel<ILoadOrderViewModel>, ILoadOrderVie
     public ReactiveUI.ReactiveCommand<Unit, Unit> InfoAlertCommand { get; }
     public string TrophyToolTip { get; }
     [Reactive] public ListSortDirection SortDirectionCurrent { get; set; }
+    
+    public ReactiveUI.ReactiveCommand<Unit, Unit> SwitchSortDirectionCommand { get; }
+    
+    [Reactive] public bool IsAscending { get; private set; }
     [Reactive] public bool IsWinnerTop { get; private set; }
     public string EmptyStateMessageTitle { get; }
     public string EmptyStateMessageContents { get; }
@@ -54,6 +58,7 @@ public class LoadOrderViewModel : AViewModel<ILoadOrderViewModel>, ILoadOrderVie
 
         // TODO: load these from settings
         SortDirectionCurrent = itemProviderFactory.SortDirectionDefault;
+        IsAscending = SortDirectionCurrent == ListSortDirection.Ascending;
         InfoAlertIsVisible = true;
 
         IsWinnerTop = SortDirectionCurrent == ListSortDirection.Ascending &&
@@ -76,6 +81,14 @@ public class LoadOrderViewModel : AViewModel<ILoadOrderViewModel>, ILoadOrderVie
 
         InfoAlertCommand = ReactiveCommand.Create(() => { AlertSettingsWrapper.ShowAlert(); });
 
+        SwitchSortDirectionCommand = ReactiveCommand.Create(() =>
+            {
+                SortDirectionCurrent = IsAscending
+                    ? ListSortDirection.Descending 
+                    : ListSortDirection.Ascending;
+            }
+        );
+
         this.WhenActivated(d =>
             {
                 Adapter.Activate();
@@ -91,8 +104,8 @@ public class LoadOrderViewModel : AViewModel<ILoadOrderViewModel>, ILoadOrderVie
                 // Update IsWinnerTop
                 sortDirectionObservable.Subscribe(sortDirection =>
                         {
-                            var isAscending = sortDirection == ListSortDirection.Ascending;
-                            IsWinnerTop = isAscending &&
+                            IsAscending = sortDirection == ListSortDirection.Ascending;
+                            IsWinnerTop = IsAscending &&
                                           itemProviderFactory.IndexOverrideBehavior == IndexOverrideBehavior.SmallerIndexWins;
                         }
                     )

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/TreeDataGridStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/TreeDataGridStyles.axaml
@@ -41,6 +41,82 @@
             </Border>
         </ControlTemplate>
 
+        <!-- this template is solely used for the load order index column which can't use built in sort functionality
+        as it is disabled when drag and drop is enabled. This is the same template as our default 
+        TreeDataGridColumnHeader one with the only change being the addition of a button to switch the sort direction 
+        while mimicking the default header styles -->
+        <ControlTemplate x:Key="LoadOrderIndexTreeDataGridColumnHeaderTemplate"
+                         TargetType="TreeDataGridColumnHeader"
+                         x:DataType="sorting:ILoadOrderViewModel">
+            <Border Name="DataGridBorder"
+                    Background="{TemplateBinding Background}"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    BorderThickness="{TemplateBinding BorderThickness}"
+                    CornerRadius="{TemplateBinding CornerRadius}">
+                <!-- added button so we can fake a column header click-->
+                <Button x:Name="FakeSortButton"
+                        Command="{CompiledBinding SwitchSortDirectionCommand }"
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Stretch">
+                    <DockPanel Name="DataGridDockPanel" VerticalAlignment="Stretch">
+                        <Panel DockPanel.Dock="Right"
+                               TabIndex="2">
+                            <Rectangle Fill="{StaticResource TreeDataGridGridLinesBrush}"
+                                       HorizontalAlignment="Center"
+                                       Width="1"
+                                       Height="24"
+                                       Margin="0,0,0,0" />
+                            <!-- negative margin to bump the vertical line to the right -->
+                            <Thumb Name="PART_Resizer"
+                                   DockPanel.Dock="Right"
+                                   Background="Transparent"
+                                   Cursor="SizeWestEast"
+                                   IsVisible="{TemplateBinding CanUserResize}"
+                                   Width="5">
+                                <Thumb.Template>
+                                    <ControlTemplate>
+                                        <Border Background="{TemplateBinding Background}"
+                                                VerticalAlignment="Stretch" />
+                                    </ControlTemplate>
+                                </Thumb.Template>
+                            </Thumb>
+                        </Panel>
+                        <Border Padding="{TemplateBinding Padding}">
+                            <StackPanel Orientation="Horizontal">
+                                <ContentPresenter Name="PART_ContentPresenter"
+                                                  Content="{TemplateBinding Header}"
+                                                  ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                  TabIndex="0">
+                                    <ContentPresenter.DataTemplates>
+                                        <DataTemplate DataType="x:String">
+                                            <StackPanel Orientation="Horizontal">
+                                                <TextBlock Text="{Binding}" TextTrimming="CharacterEllipsis" />
+                                            </StackPanel>
+                                        </DataTemplate>
+                                    </ContentPresenter.DataTemplates>
+                                </ContentPresenter>
+                                <Border
+                                    Padding="0,0,0,0"
+                                    Background="Transparent"
+                                    Height="20"
+                                    Width="20"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    TabIndex="1">
+                                    <icons:UnifiedIcon Name="SortIcon"
+                                                       Foreground="{TemplateBinding Foreground}"
+                                                       Value="{x:Null}"
+                                                       Classes.IsAscending="{CompiledBinding IsAscending}" />
+                                </Border>
+                            </StackPanel>
+                        </Border>
+                    </DockPanel>
+                </Button>
+            </Border>
+        </ControlTemplate>
+
         <!-- if we have this control theme here, we can override styles properly -->
         <ControlTheme x:Key="TreeDataGridExpandCollapseChevron" TargetType="ToggleButton">
             <Setter Property="Margin" Value="0" />
@@ -405,11 +481,47 @@
         </Style>
 
         <Style Selector="^ TreeDataGridColumnHeader">
-            <!-- First column header -->
+
+            <!-- Index column header -->
+            <!-- TODO: change this selector to always get the index column even if it isn't the first one -->
             <Style Selector="^:nth-child(1)">
                 <!-- reset padding -->
                 <Setter Property="Padding" Value="8,0,0,0" />
+                <Setter Property="Template" Value="{DynamicResource LoadOrderIndexTreeDataGridColumnHeaderTemplate}" />
+
+                <Style Selector="^ icons|UnifiedIcon#SortIcon.IsAscending">
+                    <Setter Property="Value" Value="{x:Static icons:IconValues.ArrowDropDown}" />
+                </Style>
+                <Style Selector="^ icons|UnifiedIcon#SortIcon:not(.IsAscending)">
+                    <Setter Property="Value" Value="{x:Static icons:IconValues.ArrowDropUp}" />
+                </Style>
             </Style>
+
+            <!-- Everything but the index column as we want to disable styles and not look clickable -->
+            <Style Selector="^:not(:nth-child(1))">
+                <!-- reset padding -->
+                <Setter Property="IsEnabled" Value="False" />
+            </Style>
+
+            <Style Selector="^ Button#FakeSortButton">
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="Padding" Value="0" />
+
+                <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter"> 
+                    <Setter Property="Background" 
+                            Value="{StaticResource TreeDataGridHeaderBackgroundPointerOverBrush}" />
+                    <Setter Property="BorderBrush" 
+                            Value="{StaticResource TreeDataGridHeaderBorderBrushPointerOverBrush}" />
+                </Style>
+
+                <Style Selector="^:pressed /template/ ContentPresenter#PART_ContentPresenter">
+                    <Setter Property="Background" 
+                            Value="{StaticResource TreeDataGridHeaderBackgroundPressedBrush}" />
+                    <Setter Property="BorderBrush" 
+                            Value="{StaticResource TreeDataGridHeaderBorderBrushPressedBrush}" />
+                </Style>
+            </Style>
+
         </Style>
 
         <!-- NOTES:

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/TreeDataGridStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/TreeDataGridStyles.axaml
@@ -60,7 +60,8 @@
                         VerticalAlignment="Stretch">
                     <DockPanel Name="DataGridDockPanel" VerticalAlignment="Stretch">
                         <Panel DockPanel.Dock="Right"
-                               TabIndex="2">
+                               TabIndex="2"
+                               IsVisible="False">
                             <Rectangle Fill="{StaticResource TreeDataGridGridLinesBrush}"
                                        HorizontalAlignment="Center"
                                        Width="1"


### PR DESCRIPTION
Part of https://github.com/Nexus-Mods/NexusMods.App/issues/2277

Fake button to cover the header for the first column to use existing sort functions instead of using the combo box.