### PR TITLE
Support bindings in Alert component

### DIFF
--- a/src/NexusMods.App.UI/Controls/Alerts/Alert.axaml.cs
+++ b/src/NexusMods.App.UI/Controls/Alerts/Alert.axaml.cs
@@ -202,16 +202,15 @@ public class Alert : ContentControl
                     .Subscribe(isDismissed => IsDismissed = isDismissed);
             }
         }
-
-        if (change.Property == IsDismissedProperty)
+        else if (change.Property == IsDismissedProperty)
+        {
             IsVisible = !IsDismissed;
-
-        if (change.Property == TitleProperty)
+        }
+        else if (change.Property == TitleProperty)
         {
             UpdateTitle(change.GetNewValue<string?>());
         }
-
-        if (change.Property == BodyProperty)
+        else if (change.Property == BodyProperty)
         {
             UpdateBody(change.GetNewValue<string?>());
         }
@@ -221,23 +220,23 @@ public class Alert : ContentControl
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
     {
         _bodyTextBorder = e.NameScope.Find<Border>("BodyTextBorder");
-        if(_bodyTextBorder != null)
+        if (_bodyTextBorder != null)
             _bodyTextBorder.IsVisible = ShowBody && !string.IsNullOrWhiteSpace(Body);
 
         _actionsRowBorder = e.NameScope.Find<Border>("ActionsRowBorder");
-        if(_actionsRowBorder != null)
+        if (_actionsRowBorder != null)
             _actionsRowBorder.IsVisible = Content != null && ShowActions;
-        
+
         _dismissButton = e.NameScope.Find<Button>("DismissButton");
-        if(_dismissButton != null)
+        if (_dismissButton != null)
         {
             _dismissButton.IsVisible = ShowDismiss;
         }
-        
+
         _titleText = e.NameScope.Find<TextBlock>("TitleText");
         if (_titleText != null)
             UpdateTitle(Title);
-        
+
         _bodyText = e.NameScope.Find<TextBlock>("BodyText");
         if (_bodyText != null)
             UpdateBody(Body);
@@ -245,10 +244,10 @@ public class Alert : ContentControl
         _icon = e.NameScope.Find<UnifiedIcon>("Icon");
         if (_icon != null)
             UpdateSeverity(Severity);
-        
+
         base.OnApplyTemplate(e);
     }
-    
+
     /// <inheritdoc/>
     protected override void OnUnloaded(RoutedEventArgs e)
     {
@@ -262,7 +261,7 @@ public class Alert : ContentControl
     /// <param name="newTitle">The new title text</param>
     private void UpdateTitle(string? newTitle)
     {
-        if(_titleText != null)
+        if (_titleText != null)
             _titleText.Text = newTitle;
     }
 
@@ -273,18 +272,18 @@ public class Alert : ContentControl
     private void UpdateBody(string? newBody)
     {
         if (_bodyText == null || _bodyTextBorder == null) return;
-        
+
         _bodyText.Text = newBody;
         _bodyTextBorder.IsVisible = ShowBody && !string.IsNullOrWhiteSpace(newBody);
     }
-    
+
     /// <summary>
     /// Updates the visual severity icon of the <see cref="Alert"/>.
     /// </summary>
     /// <param name="newSeverity">The new severity option</param>
     private void UpdateSeverity(SeverityOptions? newSeverity)
     {
-        if(_icon != null)
+        if (_icon != null)
             _icon.Value = newSeverity switch
             {
                 SeverityOptions.Info => IconValues.Info,

--- a/src/NexusMods.App.UI/Controls/Alerts/Alert.axaml.cs
+++ b/src/NexusMods.App.UI/Controls/Alerts/Alert.axaml.cs
@@ -186,8 +186,11 @@ public class Alert : ContentControl
 
     private readonly SerialDisposable _serialDisposable = new();
 
+    /// <inheritdoc/>
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
+        base.OnPropertyChanged(change);
+
         if (change.Property == AlertSettingsProperty)
         {
             _serialDisposable.Disposable = null;
@@ -201,52 +204,96 @@ public class Alert : ContentControl
         }
 
         if (change.Property == IsDismissedProperty)
-        {
             IsVisible = !IsDismissed;
+
+        if (change.Property == TitleProperty)
+        {
+            var value = change.GetNewValue<string?>();
+            UpdateTitle(value);
         }
 
-        base.OnPropertyChanged(change);
+        if (change.Property == BodyProperty)
+        {
+            var value = change.GetNewValue<string?>();
+            UpdateBody(value);
+        }
     }
 
+    /// <inheritdoc/>
+    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+    {
+        _bodyTextBorder = e.NameScope.Find<Border>("BodyTextBorder");
+        if(_bodyTextBorder != null)
+            _bodyTextBorder.IsVisible = ShowBody && !string.IsNullOrWhiteSpace(Body);
+
+        _actionsRowBorder = e.NameScope.Find<Border>("ActionsRowBorder");
+        if(_actionsRowBorder != null)
+            _actionsRowBorder.IsVisible = Content != null && ShowActions;
+        
+        _dismissButton = e.NameScope.Find<Button>("DismissButton");
+        if(_dismissButton != null)
+        {
+            _dismissButton.IsVisible = ShowDismiss;
+        }
+        
+        _titleText = e.NameScope.Find<TextBlock>("TitleText");
+        if (_titleText != null)
+            UpdateTitle(Title);
+        
+        _bodyText = e.NameScope.Find<TextBlock>("BodyText");
+        if (_bodyText != null)
+            UpdateBody(Title);
+
+        _icon = e.NameScope.Find<UnifiedIcon>("Icon");
+        if (_icon != null)
+            UpdateSeverity(Severity);
+        
+        base.OnApplyTemplate(e);
+    }
+    
+    /// <inheritdoc/>
     protected override void OnUnloaded(RoutedEventArgs e)
     {
         _serialDisposable.Disposable = null;
         base.OnUnloaded(e);
     }
 
-
-    /// <inheritdoc/>
-    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+    /// <summary>
+    /// Updates the visual title text of the <see cref="Alert"/>.
+    /// </summary>
+    /// <param name="newTitle">The new title text</param>
+    private void UpdateTitle(string? newTitle)
     {
-        base.OnApplyTemplate(e);
+        if(_titleText != null)
+            _titleText.Text = newTitle;
+    }
 
-        _icon = e.NameScope.Find<UnifiedIcon>("Icon");
-        _dismissButton = e.NameScope.Find<Button>("DismissButton");
-        _titleText = e.NameScope.Find<TextBlock>("TitleText");
-        _bodyText = e.NameScope.Find<TextBlock>("BodyText");
-        _bodyTextBorder = e.NameScope.Find<Border>("BodyTextBorder");
-        _actionsRowBorder = e.NameScope.Find<Border>("ActionsRowBorder");
-
-        if (_icon == null || _dismissButton == null || _titleText == null || _bodyText == null || _bodyTextBorder == null || _actionsRowBorder == null)
-            return;
-
-        // turn off elements based on properties
-        _dismissButton.IsVisible = ShowDismiss;
-        _bodyTextBorder.IsVisible = ShowBody && !string.IsNullOrWhiteSpace(Body);
-        _actionsRowBorder.IsVisible = Content != null && ShowActions;
-
-        // set the text
-        _titleText.Text = Title;
-        _bodyText.Text = Body;
-
-        // set icon based on severity
-        _icon.Value = Severity switch
-        {
-            SeverityOptions.Info => IconValues.Info,
-            SeverityOptions.Success => IconValues.CheckCircleOutline,
-            SeverityOptions.Warning => IconValues.WarningAmber,
-            SeverityOptions.Error => IconValues.Warning,
-            _ => IconValues.Info,
-        };
+    /// <summary>
+    /// Updates the visual body text of the <see cref="Alert"/>.
+    /// </summary>
+    /// <param name="newBody">The new body text</param>
+    private void UpdateBody(string? newBody)
+    {
+        if (_bodyText == null || _bodyTextBorder == null) return;
+        
+        _bodyText.Text = newBody;
+        _bodyTextBorder.IsVisible = ShowBody && !string.IsNullOrWhiteSpace(newBody);
+    }
+    
+    /// <summary>
+    /// Updates the visual severity icon of the <see cref="Alert"/>.
+    /// </summary>
+    /// <param name="newSeverity">The new severity option</param>
+    private void UpdateSeverity(SeverityOptions? newSeverity)
+    {
+        if(_icon != null)
+            _icon.Value = newSeverity switch
+            {
+                SeverityOptions.Info => IconValues.Info,
+                SeverityOptions.Success => IconValues.CheckCircleOutline,
+                SeverityOptions.Warning => IconValues.WarningAmber,
+                SeverityOptions.Error => IconValues.Warning,
+                _ => IconValues.Info,
+            };
     }
 }

--- a/src/NexusMods.App.UI/Controls/Alerts/Alert.axaml.cs
+++ b/src/NexusMods.App.UI/Controls/Alerts/Alert.axaml.cs
@@ -208,14 +208,12 @@ public class Alert : ContentControl
 
         if (change.Property == TitleProperty)
         {
-            var value = change.GetNewValue<string?>();
-            UpdateTitle(value);
+            UpdateTitle(change.GetNewValue<string?>());
         }
 
         if (change.Property == BodyProperty)
         {
-            var value = change.GetNewValue<string?>();
-            UpdateBody(value);
+            UpdateBody(change.GetNewValue<string?>());
         }
     }
 
@@ -242,7 +240,7 @@ public class Alert : ContentControl
         
         _bodyText = e.NameScope.Find<TextBlock>("BodyText");
         if (_bodyText != null)
-            UpdateBody(Title);
+            UpdateBody(Body);
 
         _icon = e.NameScope.Find<UnifiedIcon>("Icon");
         if (_icon != null)


### PR DESCRIPTION
Fixes https://github.com/Nexus-Mods/NexusMods.App/issues/2326

Better matches an Avalonia native control and provides ability to now bind Body and Text properties

`UpdateSeverity()` is there for completeness to update visuals and in case we need to use it elsewhere in the control. 

Basic premise is that both changing the property and when the template updates, both update the actual TextBlock where the text is displayed