### PR TITLE
Temporarily resolve conflicts by newest installed wins

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -680,18 +680,24 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
     {
         return files.MaxBy(GetPriority);
 
-        int GetPriority(LoadoutItemWithTargetPath.ReadOnly item)
+        // Placeholder for a more advanced selection algorithm
+        long GetPriority(LoadoutItemWithTargetPath.ReadOnly item)
         {
             foreach (var parent in item.AsLoadoutItem().GetThisAndParents())
             {
                 if (!parent.TryGetAsLoadoutItemGroup(out var group))
                     continue;
-
+                
+                // GameFiles always lose
                 if (group.TryGetAsLoadoutGameFilesGroup(out var gameFilesGroup))
                     return 0;
+                
+                // return a placeholder priority based on creation time of the LoadoutGroup.
+                // This allows for some degree of control and predictability in the selection process
+                return group.GetCreatedAt().ToUnixTimeSeconds();
             }
-
-            return 50;
+    
+            return int.MaxValue;
         }
     }
 

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -692,8 +692,8 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
                 if (group.TryGetAsLoadoutGameFilesGroup(out var gameFilesGroup))
                     return 0;
                 
-                // return a placeholder priority based on creation time of the LoadoutGroup.
-                // This allows for some degree of control and predictability in the selection process
+                // Return a placeholder priority based on creation time of the LoadoutGroup, newest wins.
+                // This allows for some degree of control and predictability in the selection process.
                 return group.GetCreatedAt().ToUnixTimeSeconds();
             }
     

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using DynamicData.Kernel;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
@@ -692,12 +693,18 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
                 if (group.TryGetAsLoadoutGameFilesGroup(out var gameFilesGroup))
                     return 0;
                 
+                // Overrides should always win
+                if (group.TryGetAsLoadoutOverridesGroup(out var overridesGroup))
+                    return long.MaxValue;
+                
                 // Return a placeholder priority based on creation time of the LoadoutGroup, newest wins.
                 // This allows for some degree of control and predictability in the selection process.
                 return group.GetCreatedAt().ToUnixTimeSeconds();
             }
-    
-            return int.MaxValue;
+            
+            // Should not happen
+            Debug.Assert(false, "LoadoutItem is not part of a LoadoutItemGroup");
+            return 0;
         }
     }
 


### PR DESCRIPTION
This allows for some control and predictability of the app while we don't have a proper conflict resolution system.