### PR TITLE
Open collection JSON file in text editor

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Collections/Json/ModSource.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Collections/Json/ModSource.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using JetBrains.Annotations;
 using NexusMods.Abstractions.Collections.Types;
 using NexusMods.Abstractions.MnemonicDB.Attributes;
 using NexusMods.Abstractions.NexusWebApi.Types.V2;
@@ -6,23 +7,41 @@ using NexusMods.Paths;
 
 namespace NexusMods.Abstractions.Collections.Json;
 
+/// <summary>
+/// Polymorphic source
+/// </summary>
+[UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
 public class ModSource
 {
+    /// <summary>
+    /// Type.
+    /// </summary>
     [JsonPropertyName("type")]
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public required ModSourceType Type { get; init; } 
-    
+
+    /// <summary>
+    /// For <see cref="ModSourceType.NexusMods"/>: Nexus Mods Mod ID.
+    /// </summary>
     [JsonPropertyName("modId")]
     public ModId ModId { get; init; }
-    
+
     /// <summary>
-    /// MD5 hash a direct download
+    /// For <see cref="ModSourceType.NexusMods"/>: Nexus Mods File ID.
+    /// </summary>
+    [JsonPropertyName("fileId")]
+    public FileId FileId { get; init; }
+
+    /// <summary>
+    /// MD5 hash, present in <see cref="ModSourceType.NexusMods"/>,
+    /// <see cref="ModSourceType.Browse"/>, and <see cref="ModSourceType.Direct"/>.
     /// </summary>
     [JsonPropertyName("md5")]
     public Md5HashValue Md5 { get; init; }
-    
+
     /// <summary>
-    /// If this is a direct download, this is the URL to download the mod from
+    /// Present in <see cref="ModSourceType.Browse"/> and <see cref="ModSourceType.Direct"/>,
+    /// url to the download page.
     /// </summary>
     [JsonPropertyName("url")]
     public Uri? Url { get; init; }
@@ -33,12 +52,12 @@ public class ModSource
     [JsonPropertyName("logicalFilename")]
     public string? LogicalFilename { get; init; }
 
-    [JsonPropertyName("fileId")]
-    public FileId FileId { get; init; }
-    
     [JsonPropertyName("fileSize")]
     public Size FileSize { get; init; }
     
     [JsonPropertyName("fileExpression")]
     public RelativePath FileExpression { get; init; } = default;
+
+    [JsonPropertyName("tag")]
+    public string? Tag { get; init; }
 }

--- a/src/Abstractions/NexusMods.Abstractions.Collections/Json/ModSource.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Collections/Json/ModSource.cs
@@ -21,6 +21,13 @@ public class ModSource
     public required ModSourceType Type { get; init; } 
 
     /// <summary>
+    /// Update policy.
+    /// </summary>
+    [JsonPropertyName("updatePolicy")]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public UpdatePolicy UpdatePolicy { get; init; }
+
+    /// <summary>
     /// For <see cref="ModSourceType.NexusMods"/>: Nexus Mods Mod ID.
     /// </summary>
     [JsonPropertyName("modId")]

--- a/src/Abstractions/NexusMods.Abstractions.Collections/Json/ModSourceType.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Collections/Json/ModSourceType.cs
@@ -1,4 +1,7 @@
 // ReSharper disable InconsistentNaming
+
+using System.Text.Json.Serialization;
+
 namespace NexusMods.Abstractions.Collections.Json;
 
 /// <summary>
@@ -6,8 +9,27 @@ namespace NexusMods.Abstractions.Collections.Json;
 /// </summary>
 public enum ModSourceType
 {
-    browse,
-    direct,
-    nexus, 
-    bundle,
+    /// <summary>
+    /// Sourced from Nexus Mods.
+    /// </summary>
+    [JsonStringEnumMemberName("nexus")]
+    NexusMods,
+
+    /// <summary>
+    /// Bundled with the collection archive.
+    /// </summary>
+    [JsonStringEnumMemberName("bundle")]
+    Bundle,
+
+    /// <summary>
+    /// Downloaded externally via an URL.
+    /// </summary>
+    [JsonStringEnumMemberName("Browse")]
+    Browse,
+
+    /// <summary>
+    /// Downloaded externally via an URL.
+    /// </summary>
+    [JsonStringEnumMemberName("Direct")]
+    Direct,
 }

--- a/src/Abstractions/NexusMods.Abstractions.Collections/Json/UpdatePolicy.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Collections/Json/UpdatePolicy.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Serialization;
+using JetBrains.Annotations;
+
+namespace NexusMods.Abstractions.Collections.Json;
+
+/// <summary>
+/// Update policy.
+/// </summary>
+[PublicAPI]
+public enum UpdatePolicy
+{
+    /// <summary>
+    /// Use the exact version.
+    /// </summary>
+    [JsonStringEnumMemberName("exact")]
+    ExactVersionOnly,
+
+    /// <summary>
+    /// Use the current version, if it's still available.
+    /// If the file has been archived or deleted, the newest version of the file should be used.
+    /// </summary>
+    [JsonStringEnumMemberName("prefer")]
+    PreferExact,
+
+    /// <summary>
+    /// Use the latest version.
+    /// </summary>
+    [JsonStringEnumMemberName("latest")]
+    LatestVersion,
+}

--- a/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsLibrary.Collections.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsLibrary.Collections.cs
@@ -114,7 +114,7 @@ public partial class NexusModsLibrary
 
         foreach (var collectionMod in collectionRoot.Mods)
         {
-            if (collectionMod.Source.Type != ModSourceType.nexus) continue;
+            if (collectionMod.Source.Type != ModSourceType.NexusMods) continue;
             var fileId = new UidForFile(fileId: collectionMod.Source.FileId, gameId: gameIds[collectionMod.DomainName]);
             if (res.ContainsKey(fileId)) continue;
 
@@ -169,13 +169,13 @@ public partial class NexusModsLibrary
             var source = collectionMod.Source;
             switch (source.Type)
             {
-                case ModSourceType.nexus:
+                case ModSourceType.NexusMods:
                     HandleNexusModsDownload(db, tx, downloadEntity, collectionMod, gameIds, resolvedEntitiesLookup);
                     break;
-                case ModSourceType.direct or ModSourceType.browse:
+                case ModSourceType.Direct or ModSourceType.Browse:
                     HandleExternalDownload(tx, downloadEntity, collectionMod);
                     break;
-                case ModSourceType.bundle:
+                case ModSourceType.Bundle:
                     HandleBundledFiles(tx, downloadEntity, collectionMod);
                     break;
                 default:

--- a/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsLibrary.Collections.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsLibrary.Collections.cs
@@ -308,15 +308,24 @@ public partial class NexusModsLibrary
         NexusModsCollectionLibraryFile.ReadOnly collectionLibraryFile,
         CancellationToken cancellationToken)
     {
-        if (!collectionLibraryFile.AsLibraryFile().TryGetAsLibraryArchive(out var archive))
-            throw new InvalidOperationException("The source collection is not a library archive");
-
-        var jsonFileEntity = archive.Children.FirstOrDefault(f => f.Path == "collection.json");
+        var jsonFileEntity = GetCollectionJsonFile(collectionLibraryFile);
 
         await using var data = await _fileStore.GetFileStream(jsonFileEntity.AsLibraryFile().Hash, token: cancellationToken);
         var root = await JsonSerializer.DeserializeAsync<CollectionRoot>(data, _jsonSerializerOptions, cancellationToken: cancellationToken);
 
         if (root is null) throw new InvalidOperationException("Unable to deserialize collection JSON file");
         return root;
+    }
+
+    /// <summary>
+    /// Gets the collection JSON file.
+    /// </summary>
+    public LibraryArchiveFileEntry.ReadOnly GetCollectionJsonFile(NexusModsCollectionLibraryFile.ReadOnly collectionLibraryFile)
+    {
+        if (!collectionLibraryFile.AsLibraryFile().TryGetAsLibraryArchive(out var archive))
+            throw new InvalidOperationException("The source collection is not a library archive");
+
+        var jsonFileEntity = archive.Children.FirstOrDefault(f => f.Path == "collection.json");
+        return jsonFileEntity;
     }
 }

--- a/src/NexusMods.App.Cli/Types/IpcHandlers/NxmIpcProtocolHandler.cs
+++ b/src/NexusMods.App.Cli/Types/IpcHandlers/NxmIpcProtocolHandler.cs
@@ -147,10 +147,6 @@ public class NxmIpcProtocolHandler : IIpcProtocolHandler
         var downloadJob = await nexusModsLibrary.CreateDownloadJob(destination, modUrl, cache, cancellationToken: cancel);
 
         var libraryJob = await library.AddDownload(downloadJob);
-        _logger.LogInformation("{Result}", libraryJob);
-
-        // var task = await _downloadService.AddTask(modUrl);
-        // _ = task.StartAsync();
     }
 }
 

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadDesignViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadDesignViewModel.cs
@@ -45,6 +45,7 @@ public class CollectionDownloadDesignViewModel : APageViewModel<ICollectionDownl
 
     public ReactiveCommand<Unit> CommandViewOnNexusMods { get; } = new ReactiveCommand();
     public ReactiveCommand<Unit> CommandViewInLibrary { get; } = new ReactiveCommand();
+    public ReactiveCommand<Unit> CommandOpenJsonFile { get; } = new ReactiveCommand();
     public ReactiveCommand<Unit> CommandDeleteAllDownloads { get; } = new ReactiveCommand();
     public ReactiveCommand<Unit> CommandDeleteCollection { get; } = new ReactiveCommand();
 }

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadView.axaml
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadView.axaml
@@ -31,6 +31,13 @@
                     </panels:FlexPanel>
                 </MenuItem.Header>
             </MenuItem>
+            <MenuItem x:Name="MenuItemOpenJsonFile">
+                <MenuItem.Header>
+                    <panels:FlexPanel>
+                        <TextBlock>Open JSON file</TextBlock>
+                    </panels:FlexPanel>
+                </MenuItem.Header>
+            </MenuItem>
             <MenuItem x:Name="MenuItemDeleteAllDownloads">
                 <MenuItem.Header>
                     <panels:FlexPanel>

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadView.axaml.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadView.axaml.cs
@@ -27,6 +27,9 @@ public partial class CollectionDownloadView : ReactiveUserControl<ICollectionDow
             this.BindCommand(ViewModel, vm => vm.CommandViewInLibrary, view => view.MenuItemViewInLibrary)
                 .DisposeWith(d);
 
+            this.BindCommand(ViewModel, vm => vm.CommandOpenJsonFile, view => view.MenuItemOpenJsonFile)
+                .DisposeWith(d);
+
             this.BindCommand(ViewModel, vm => vm.CommandDeleteAllDownloads, view => view.MenuItemDeleteAllDownloads)
                 .DisposeWith(d);
 

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadViewModel.cs
@@ -16,6 +16,7 @@ using NexusMods.App.UI.Controls;
 using NexusMods.App.UI.Extensions;
 using NexusMods.App.UI.Pages.LibraryPage;
 using NexusMods.App.UI.Pages.LibraryPage.Collections;
+using NexusMods.App.UI.Pages.TextEdit;
 using NexusMods.App.UI.Resources;
 using NexusMods.App.UI.Windows;
 using NexusMods.App.UI.WorkspaceSystem;
@@ -61,6 +62,9 @@ public sealed class CollectionDownloadViewModel : APageViewModel<ICollectionDown
         _revision = revisionMetadata;
         _collection = revisionMetadata.Collection;
 
+        var libraryFile = collectionDownloader.GetLibraryFile(revisionMetadata);
+        var collectionJsonFile = nexusModsLibrary.GetCollectionJsonFile(libraryFile);
+
         TabTitle = _collection.Name;
         TabIcon = IconValues.Collections;
 
@@ -99,6 +103,7 @@ public sealed class CollectionDownloadViewModel : APageViewModel<ICollectionDown
             executeAsync: async (_, _) => { await InstallCollectionJob.Create(
                 serviceProvider,
                 targetLoadout,
+                source: libraryFile,
                 revisionMetadata,
                 items: collectionDownloader.GetItems(revisionMetadata, CollectionDownloader.ItemType.Required),
                 group: Optional<NexusCollectionLoadoutGroup.ReadOnly>.None
@@ -148,6 +153,25 @@ public sealed class CollectionDownloadViewModel : APageViewModel<ICollectionDown
         );
 
         CommandViewInLibrary = new ReactiveCommand(canExecuteSource: R3.Observable.Return(false), initialCanExecute: false);
+
+        CommandOpenJsonFile = new ReactiveCommand(
+            execute: _ =>
+            {
+                var pageData = new PageData
+                {
+                    FactoryId = TextEditorPageFactory.StaticId,
+                    Context = new TextEditorPageContext
+                    {
+                        FileId = collectionJsonFile.AsLibraryFile().LibraryFileId,
+                        FilePath = collectionJsonFile.AsLibraryFile().FileName,
+                    },
+                };
+
+                var workspaceController = GetWorkspaceController();
+                var behavior = new OpenPageBehavior.NewTab(PanelId);
+                workspaceController.OpenPage(WorkspaceId, pageData, behavior);
+            }
+        );
 
         this.WhenActivated(disposables =>
         {
@@ -264,6 +288,7 @@ public sealed class CollectionDownloadViewModel : APageViewModel<ICollectionDown
 
     public ReactiveCommand<Unit> CommandViewOnNexusMods { get; }
     public ReactiveCommand<Unit> CommandViewInLibrary { get; }
+    public ReactiveCommand<Unit> CommandOpenJsonFile { get; }
     public ReactiveCommand<Unit> CommandDeleteAllDownloads { get; }
     public ReactiveCommand<Unit> CommandDeleteCollection { get; }
 }

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadViewModel.cs
@@ -71,18 +71,8 @@ public sealed class CollectionDownloadViewModel : APageViewModel<ICollectionDown
         TreeDataGridAdapter = new CollectionDownloadTreeDataGridAdapter(nexusModsDataProvider, revisionMetadata);
         TreeDataGridAdapter.ViewHierarchical.Value = false;
 
-        var requiredDownloadCount = 0;
-        var optionalDownloadCount = 0;
-        foreach (var file in _revision.Downloads)
-        {
-            var isOptional = file.IsOptional;
-
-            requiredDownloadCount += isOptional ? 0 : 1;
-            optionalDownloadCount += isOptional ? 1 : 0;
-        }
-
-        RequiredDownloadsCount = requiredDownloadCount;
-        OptionalDownloadsCount = optionalDownloadCount;
+        RequiredDownloadsCount = collectionDownloader.CountItems(_revision, CollectionDownloader.ItemType.Required);
+        OptionalDownloadsCount = collectionDownloader.CountItems(_revision, CollectionDownloader.ItemType.Optional);
 
         CommandDownloadRequiredItems = _canDownloadRequiredItems.ToReactiveCommand<Unit>(
             executeAsync: (_, cancellationToken) => collectionDownloader.DownloadItems(_revision, itemType: CollectionDownloader.ItemType.Required, db: connection.Db, cancellationToken: cancellationToken),

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/ICollectionDownloadViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/ICollectionDownloadViewModel.cs
@@ -93,6 +93,7 @@ public interface ICollectionDownloadViewModel : IPageViewModelInterface
 
     ReactiveCommand<Unit> CommandViewOnNexusMods { get; }
     ReactiveCommand<Unit> CommandViewInLibrary { get; }
+    ReactiveCommand<Unit> CommandOpenJsonFile { get; }
     ReactiveCommand<Unit> CommandDeleteAllDownloads { get; }
     ReactiveCommand<Unit> CommandDeleteCollection { get; }
 }

--- a/src/NexusMods.App.UI/Pages/ItemContentsFileTree/ItemContentsFileTreeViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/ItemContentsFileTree/ItemContentsFileTreeViewModel.cs
@@ -53,8 +53,8 @@ public class ItemContentsFileTreeViewModel : APageViewModel<IItemContentsFileTre
                 FactoryId = TextEditorPageFactory.StaticId,
                 Context = new TextEditorPageContext
                 {
-                    LoadoutFileId = loadoutFile,
-                    FilePath = loadoutFile.AsLoadoutItemWithTargetPath().TargetPath,
+                    FileId = loadoutFile.LoadoutFileId,
+                    FilePath = loadoutFile.AsLoadoutItemWithTargetPath().TargetPath.Item3,
                 },
             };
 

--- a/src/NexusMods.App.UI/Pages/TextEdit/TextEditorPage.cs
+++ b/src/NexusMods.App.UI/Pages/TextEdit/TextEditorPage.cs
@@ -1,18 +1,21 @@
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.GameLocators;
+using NexusMods.Abstractions.Library.Models;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Loadouts.Files;
 using NexusMods.Abstractions.Serialization.Attributes;
 using NexusMods.App.UI.WorkspaceSystem;
+using NexusMods.Paths;
+using OneOf;
 
 namespace NexusMods.App.UI.Pages.TextEdit;
 
 [JsonName("TextEditorPageContext")]
 public record TextEditorPageContext : IPageFactoryContext
 {
-    public required LoadoutFileId LoadoutFileId { get; init; }
-    public required GamePath FilePath { get; init; }
+    public required OneOf<LoadoutFileId, LibraryFileId> FileId { get; init; }
+    public required RelativePath FilePath { get; init; }
 }
 
 [UsedImplicitly]

--- a/src/NexusMods.Collections/CollectionDownloader.cs
+++ b/src/NexusMods.Collections/CollectionDownloader.cs
@@ -259,6 +259,16 @@ public class CollectionDownloader
     }
 
     /// <summary>
+    /// Counts the items.
+    /// </summary>
+    public int CountItems(CollectionRevisionMetadata.ReadOnly revisionMetadata, ItemType itemType)
+    {
+        return revisionMetadata.Downloads
+            .Where(download => DownloadMatchesItemType(download, itemType))
+            .Count(download => download.IsCollectionDownloadNexusMods() || download.IsCollectionDownloadExternal());
+    }
+
+    /// <summary>
     /// Returns whether the item matches the given item type.
     /// </summary>
     private static bool DownloadMatchesItemType(CollectionDownload.ReadOnly download, ItemType itemType)

--- a/src/NexusMods.Collections/CollectionDownloader.cs
+++ b/src/NexusMods.Collections/CollectionDownloader.cs
@@ -13,6 +13,7 @@ using NexusMods.Abstractions.NexusModsLibrary.Models;
 using NexusMods.Abstractions.NexusWebApi;
 using NexusMods.CrossPlatform.Process;
 using NexusMods.MnemonicDB.Abstractions;
+using NexusMods.MnemonicDB.Abstractions.IndexSegments;
 using NexusMods.MnemonicDB.Abstractions.Query;
 using NexusMods.MnemonicDB.Abstractions.TxFunctions;
 using NexusMods.Networking.NexusWebApi;
@@ -375,5 +376,17 @@ public class CollectionDownloader
 
         Array.Resize(ref res, newSize: i);
         return res;
+    }
+
+    public NexusModsCollectionLibraryFile.ReadOnly GetLibraryFile(CollectionRevisionMetadata.ReadOnly revisionMetadata)
+    {
+        var datoms = _connection.Db.Datoms(
+            (NexusModsCollectionLibraryFile.CollectionSlug, revisionMetadata.Collection.Slug),
+            (NexusModsCollectionLibraryFile.CollectionRevisionNumber, revisionMetadata.RevisionNumber)
+        );
+
+        if (datoms.Count == 0) throw new Exception($"Unable to find collection file for revision `{revisionMetadata.Collection.Slug}` (`{revisionMetadata.RevisionNumber}`)");
+        var source = NexusModsCollectionLibraryFile.Load(_connection.Db, datoms[0]);
+        return source;
     }
 }

--- a/src/NexusMods.Collections/InstallCollectionJob.cs
+++ b/src/NexusMods.Collections/InstallCollectionJob.cs
@@ -66,43 +66,6 @@ public class InstallCollectionJob : IJobDefinitionWithStart<InstallCollectionJob
     }
 
     /// <summary>
-    /// Factory.
-    /// </summary>
-    public static IJobTask<InstallCollectionJob, NexusCollectionLoadoutGroup.ReadOnly> Create(
-        IServiceProvider provider,
-        LoadoutId target,
-        CollectionRevisionMetadata.ReadOnly revisionMetadata,
-        CollectionDownload.ReadOnly[] items,
-        Optional<NexusCollectionLoadoutGroup.ReadOnly> group)
-    {
-        var connection = provider.GetRequiredService<IConnection>();
-        var datoms = connection.Db.Datoms(
-            (NexusModsCollectionLibraryFile.CollectionSlug, revisionMetadata.Collection.Slug),
-            (NexusModsCollectionLibraryFile.CollectionRevisionNumber, revisionMetadata.RevisionNumber)
-        );
-
-        if (datoms.Count == 0) throw new Exception($"Unable to find collection file for revision `{revisionMetadata.Collection.Slug}` (`{revisionMetadata.RevisionNumber}`)");
-        var source = NexusModsCollectionLibraryFile.Load(connection.Db, datoms[0]);
-
-        var monitor = provider.GetRequiredService<IJobMonitor>();
-        var job = new InstallCollectionJob
-        {
-            Items = items,
-            Group = group,
-            TargetLoadout = target,
-            SourceCollection = source,
-            RevisionMetadata = revisionMetadata,
-            ServiceProvider = provider,
-            FileStore = provider.GetRequiredService<IFileStore>(),
-            Connection = connection,
-            LibraryService = provider.GetRequiredService<ILibraryService>(),
-            NexusModsLibrary = provider.GetRequiredService<NexusModsLibrary>(),
-        };
-
-        return monitor.Begin<InstallCollectionJob, NexusCollectionLoadoutGroup.ReadOnly>(job);
-    }
-
-    /// <summary>
     /// Installs the collection.
     /// </summary>
     public async ValueTask<NexusCollectionLoadoutGroup.ReadOnly> StartAsync(IJobContext<InstallCollectionJob> context)


### PR DESCRIPTION
Adds a menu item to open the collection JSON file in a text editor (read-only). Allows us to better debug collection issues.

Part of #2254.

Also documents and adds some more JSON properties.