### PR TITLE
Prevent infinite while loop

### DIFF
--- a/src/NexusMods.SingleProcess/CliServer.cs
+++ b/src/NexusMods.SingleProcess/CliServer.cs
@@ -80,7 +80,7 @@ public class CliServer : IHostedService, IDisposable
 
     private async Task StartListeningAsync()
     {
-        while (!_cancellationTokenSource.IsCancellationRequested)
+        while (_started && !_cancellationTokenSource.IsCancellationRequested)
         {
             try
             {


### PR DESCRIPTION
Should fix an infinite while loop in the `CliServer` that can happen when it gets disposed.