### PR TITLE
Upgrade deps, fix several broken tests on `main`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -105,7 +105,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17">
       <PrivateAssets>all</PrivateAssets>
@@ -128,7 +128,7 @@
     <PackageVersion Include="BitFaster.Caching" Version="2.5.2" />
     <PackageVersion Include="CliWrap" Version="3.6.7" />
     <PackageVersion Include="DynamicData" Version="9.0.4" />
-    <PackageVersion Include="GameFinder" Version="4.3.3" />
+    <PackageVersion Include="GameFinder" Version="4.4.0" />
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="ini-parser-netstandard" Version="2.5.2" />
     <PackageVersion Include="Mutagen.Bethesda.Skyrim" Version="0.44.0" />

--- a/src/Abstractions/NexusMods.Abstractions.Collections/Json/ModSourceType.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Collections/Json/ModSourceType.cs
@@ -24,12 +24,12 @@ public enum ModSourceType
     /// <summary>
     /// Downloaded externally via an URL.
     /// </summary>
-    [JsonStringEnumMemberName("Browse")]
+    [JsonStringEnumMemberName("browse")]
     Browse,
 
     /// <summary>
     /// Downloaded externally via an URL.
     /// </summary>
-    [JsonStringEnumMemberName("Direct")]
+    [JsonStringEnumMemberName("direct")]
     Direct,
 }

--- a/tests/NexusMods.Collections.Tests/CollectionInstallTests.cs
+++ b/tests/NexusMods.Collections.Tests/CollectionInstallTests.cs
@@ -32,6 +32,7 @@ public class CollectionInstallTests(ITestOutputHelper helper) : ACyberpunkIsolat
         var loginManager = ServiceProvider.GetRequiredService<ILoginManager>();
         _ = await loginManager.GetUserInfoAsync();
 
+        loginManager.UserInfo.Should().NotBeNull(because: "this test requires a logged in user");
         loginManager.IsPremium.Should().BeTrue(because: "this test requires premium to automatically download mods");
 
         await using var destination = TemporaryFileManager.CreateFile();

--- a/tests/NexusMods.StandardGameLocators.TestHelpers/Services.cs
+++ b/tests/NexusMods.StandardGameLocators.TestHelpers/Services.cs
@@ -42,7 +42,7 @@ public static class Services
 
         coll.AddSingleton<AHandler<GOGGame, GOGGameId>>(s =>
             new StubbedGameLocator<GOGGame, GOGGameId>(s.GetRequiredService<TemporaryFileManager>(),
-                tfm => new GOGGame(GOGGameId.From(42), "Stubbed Game", tfm.CreateFolder("gog_game").Path),
+                tfm => new GOGGame(GOGGameId.From(42), "Stubbed Game", tfm.CreateFolder("gog_game").Path, "4242"),
                 game => game.Id));
 
         coll.AddSingleton<AHandler<SteamGame, AppId>>(s =>


### PR DESCRIPTION
Updates Game Finder and MS test deps. Also fixes the following broken behavior on `main`

* The ModType used capital letters for the enum of `Browse` and `Direct` meaning that those collections were not parsable. This fixes that behavior. We really need to be running all the unit tests more often. 

* The LoginManager was borked, using a `CachedObject` but not changing `UserInfo` to point to this new cache, so depending on how logins were performed half the login manager wouldn't see the data. Also would have been caught by running the tests. 