### PR TITLE
doc and ci fix

### DIFF
--- a/docs/users/SystemRequirements.md
+++ b/docs/users/SystemRequirements.md
@@ -37,11 +37,13 @@ The App requires the following programs to be available on the system `PATH` at 
 - `xdg-settings` (part of [xdg-utils](https://www.freedesktop.org/wiki/Software/xdg-utils/))
 - `update-desktop-database` (part of [desktop-file-utils](https://www.freedesktop.org/wiki/Software/desktop-file-utils/)) to update the MIME cache after creating a desktop entry file for the NXM link handler.
 
+
 In addition, the following libraries are required:
 
 - [FUSE 2](https://github.com/AppImage/AppImageKit/wiki/FUSE) if running the AppImage
 - `glibc` 2.2.5 or newer
 - `glibc++` 3.4 or newer
+- `fontconfig`
 
 ### Linux Packages
 

--- a/src/NexusMods.App/com.nexusmods.app.metainfo.xml
+++ b/src/NexusMods.App/com.nexusmods.app.metainfo.xml
@@ -21,7 +21,7 @@
 
     <url type="homepage">https://github.com/Nexus-Mods/NexusMods.App</url>
     <url type="bugtracker">https://github.com/Nexus-Mods/NexusMods.App/issues</url>
-    <url type="faq">https://nexus-mods.github.io/NexusMods.App/users/FAQ/</url>
+    <url type="faq">https://nexus-mods.github.io/NexusMods.App/users/faq/</url>
     <url type="help">https://nexus-mods.github.io/NexusMods.App/users</url>
     <url type="translate">https://nexus-mods.github.io/NexusMods.App/developers/Contributing/</url>
     <url type="contact">https://discord.gg/ReWTxb93jS</url>


### PR DESCRIPTION
just adding the missing dependency mentioned in #2419 and updating the url for faqs in the app metainfo xml. I *think* that was the source of the CI failure for build appimage in some of the more recent PRs. 