### PR TITLE
Fix leaking workspaces and some code cleanup

### DIFF
--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
@@ -83,8 +83,7 @@ public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceVie
 
         _panelSource
             .Connect()
-            .Sort(PanelComparer.Instance)
-            .Bind(out _panels)
+            .SortAndBind(out _panels, PanelComparer.Instance)
             .Do(_ => UpdateStates())
             .Do(_ => UpdateResizers())
             .SubscribeWithErrorLogging();

--- a/src/NexusMods.App.UI/WorkspaceSystem/WorkspaceController/IWorkspaceController.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/WorkspaceController/IWorkspaceController.cs
@@ -84,6 +84,12 @@ public interface IWorkspaceController
     /// </summary>
     public IWorkspaceViewModel ChangeOrCreateWorkspaceByContext<TContext>(Func<TContext, bool> predicate, Func<Optional<PageData>> getPageData, Func<TContext> getWorkspaceContext) where TContext : IWorkspaceContext;
 
+
+    /// <summary>
+    /// Unregisters a workspace identified by its ContextId.
+    /// </summary>
+    public void UnregisterWorkspaceByContext<TContext>(Func<TContext, bool> predicate) where TContext : IWorkspaceContext;
+
     /// <summary>
     /// Adds a new panel to a workspace.
     /// </summary>


### PR DESCRIPTION
- Part of #2433 

Going through the Left Menu code I noticed that Left Menus and the entire workspaces were being leaked.
The cleanup code was simply never implemented after we added support for deleting loadouts.

This also has a couple of other changes:
- Fix workspaces not getting deleted when loadouts are removed
- Use SortAndBind when practical rather than Sort to avoid obsolete warning
- Store left menus in dictionary rather than ReadOnlyObservableCollection