### PR TITLE
Fixed: Token Expiry Date Not using UTC Time

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.NexusWebApi/DTOs/OAuth/JwtTokenReply.cs
+++ b/src/Abstractions/NexusMods.Abstractions.NexusWebApi/DTOs/OAuth/JwtTokenReply.cs
@@ -38,7 +38,8 @@ public class JwtTokenReply
     public string? Scope { get; set; }
 
     /// <summary>
-    /// unix timestamp (seconds resolution) of when the token was created
+    /// unix timestamp (seconds resolution) of when the token was created.
+    /// This timestamp is UTC+0.
     /// </summary>
     [JsonPropertyName("created_at")]
     public long CreatedAt { get; set; }

--- a/src/Networking/NexusMods.Networking.NexusWebApi/Auth/JWTToken.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/Auth/JWTToken.cs
@@ -63,7 +63,7 @@ public partial class JWTToken : IModelDefinition
 
         tx.Add(entityId, AccessToken, reply.AccessToken);
         tx.Add(entityId, RefreshToken, reply.RefreshToken);
-        tx.Add(entityId, ExpiresAt, DateTimeOffset.FromUnixTimeSeconds(reply.CreatedAt).DateTime + TimeSpan.FromSeconds(reply.ExpiresIn));
+        tx.Add(entityId, ExpiresAt, DateTimeOffset.FromUnixTimeSeconds(reply.CreatedAt).UtcDateTime + TimeSpan.FromSeconds(reply.ExpiresIn));
 
         return entityId;
     }

--- a/src/Networking/NexusMods.Networking.NexusWebApi/Auth/JWTToken.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/Auth/JWTToken.cs
@@ -63,7 +63,7 @@ public partial class JWTToken : IModelDefinition
 
         tx.Add(entityId, AccessToken, reply.AccessToken);
         tx.Add(entityId, RefreshToken, reply.RefreshToken);
-        tx.Add(entityId, ExpiresAt, DateTimeOffset.FromUnixTimeSeconds(reply.CreatedAt).UtcDateTime + TimeSpan.FromSeconds(reply.ExpiresIn));
+        tx.Add(entityId, ExpiresAt, DateTimeOffset.FromUnixTimeSeconds(reply.CreatedAt) + TimeSpan.FromSeconds(reply.ExpiresIn));
 
         return entityId;
     }


### PR DESCRIPTION
fixes #2442

I tested this on both Windows and Linux; should be fine.

Normally something like this you'd unit test with a DateTimeProvider, and mock that; however, time for test build is now, not later.