### PR TITLE
Cli fixes and escape hatches

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
     <PackageVersion Include="Bannerlord.ModuleManager" Version="6.0.246" />
     <PackageVersion Include="BsDiff" Version="1.1.0" />
     <PackageVersion Include="LinqGen" Version="0.3.1" />
+    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.0.0" />

--- a/src/Networking/NexusMods.Networking.NexusWebApi/NexusApiVerbs.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/NexusApiVerbs.cs
@@ -11,31 +11,33 @@ namespace NexusMods.Networking.NexusWebApi;
 internal static class NexusApiVerbs
 {
     internal static IServiceCollection AddNexusApiVerbs(this IServiceCollection collection) =>
-        collection.AddVerb(() => NexusApiVerify)
+        collection
+            .AddModule("nexus", "Commands for interacting with the Nexus Mods API")
+            .AddVerb(() => NexusApiVerify)
             .AddVerb(() => NexusDownloadLinks);
 
 
-    [Verb("nexus-api-verify", "Verifies the logged in account via the Nexus API")]
+    [Verb("nexus verify", "Verifies the logged in account via the Nexus API")]
     private static async Task<int> NexusApiVerify([Injected] IRenderer renderer,
         [Injected] NexusApiClient nexusApiClient,
         [Injected] IAuthenticatingMessageFactory messageFactory,
         [Injected] CancellationToken token)
     {
         var userInfo = await messageFactory.Verify(nexusApiClient, token);
-        await renderer.Table(new[] { "Name", "Premium" },
-            new[]
-            {
-                new object[]
-                {
-                    userInfo?.Name ?? "<Not logged in>",
+        
+        await renderer.Table(["Name", "Premium"],
+        [
+            [
+                userInfo?.Name ?? "<Not logged in>",
                     userInfo?.IsPremium ?? false,
-                }
-            });
+            ],
+        ]
+        );
 
         return 0;
     }
 
-    [Verb("nexus-download-links", "Generates download links for a given file")]
+    [Verb("nexus download-links", "Generates download links for a given file")]
     private static async Task<int> NexusDownloadLinks([Injected] IRenderer renderer,
         [Option("g", "gameDomain", "Game domain")] string gameDomain,
         [Option("m", "modId", "Mod ID")] ModId modId,

--- a/src/NexusMods.App.Cli/OptionParsers/MatcherParser.cs
+++ b/src/NexusMods.App.Cli/OptionParsers/MatcherParser.cs
@@ -1,0 +1,25 @@
+using Microsoft.Extensions.FileSystemGlobbing;
+using NexusMods.ProxyConsole.Abstractions.VerbDefinitions;
+
+namespace NexusMods.CLI.OptionParsers;
+
+internal class MatcherParser : IOptionParser<Matcher>
+{
+    /// <inheritdoc />
+    public bool TryParse(string toParse, out Matcher value, out string error)
+    {
+        try
+        {
+            value = new Matcher();
+            value.AddInclude(toParse);
+            error = string.Empty;
+            return true;
+        }
+        catch (Exception exception)
+        {
+            value = null!;
+            error = exception.Message;
+            return false;
+        }
+    }
+}

--- a/src/NexusMods.App.Cli/Services.cs
+++ b/src/NexusMods.App.Cli/Services.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileSystemGlobbing;
 using NexusMods.Abstractions.Games;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.CLI.OptionParsers;
@@ -28,6 +29,7 @@ public static class Services
                 .AddOptionParser<Uri>(u => (new Uri(u), null))
                 .AddOptionParser<Version>(v => (Version.Parse(v), null))
                 .AddOptionParser<string>(s => (s, null))
+                .AddOptionParser<Matcher, MatcherParser>()
                 .AddOptionParser<ITool, ToolParser>();
 
         // Protocol Handlers

--- a/src/NexusMods.App/ConsoleHelper.cs
+++ b/src/NexusMods.App/ConsoleHelper.cs
@@ -1,11 +1,13 @@
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 namespace NexusMods.App;
 
 /// <summary>
 /// Helpers for consoles on Windows
 /// </summary>
-public class ConsoleHelper
+[SupportedOSPlatform("windows")]
+public static class ConsoleHelper
 {
     // ReSharper disable once InconsistentNaming
     private const int ATTACH_PARENT_PROCESS = -1;

--- a/src/NexusMods.App/ConsoleHelper.cs
+++ b/src/NexusMods.App/ConsoleHelper.cs
@@ -1,0 +1,30 @@
+using System.Runtime.InteropServices;
+
+namespace NexusMods.App;
+
+/// <summary>
+/// Helpers for consoles on Windows
+/// </summary>
+public class ConsoleHelper
+{
+    // ReSharper disable once InconsistentNaming
+    private const int ATTACH_PARENT_PROCESS = -1;
+    
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool AttachConsole(int dwProcessId);
+    
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool AllocConsole();
+    
+    /// <summary>
+    /// Attempt to attach to the console, if it fails, create a new console window if desired
+    /// </summary>
+    /// <param name="forceNewConsoleIfNoParent">If there is no parent console, should one be created?</param>
+    public static void EnsureConsole(bool forceNewConsoleIfNoParent = false)
+    {
+        if (!AttachConsole(ATTACH_PARENT_PROCESS) && !forceNewConsoleIfNoParent)
+        {
+            AllocConsole();
+        }
+    }
+}

--- a/src/NexusMods.App/NexusMods.App.csproj
+++ b/src/NexusMods.App/NexusMods.App.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <OutputType>WinExe</OutputType>
+        <OutputType>Exe</OutputType>
         <ApplicationIcon>icon.ico</ApplicationIcon>
         <ApplicationManifest>app.manifest</ApplicationManifest>
     </PropertyGroup>

--- a/src/NexusMods.App/Program.cs
+++ b/src/NexusMods.App/Program.cs
@@ -24,6 +24,7 @@ using NLog.Extensions.Logging;
 using NLog.Targets;
 using ReactiveUI;
 using Spectre.Console;
+using Spectre.Console.Advanced;
 
 namespace NexusMods.App;
 
@@ -90,11 +91,12 @@ public class Program
 
         try
         {
+            if (OperatingSystem.IsWindows())
+                ConsoleHelper.EnsureConsole();
+            
             if (startupMode.RunAsMain)
             {
-                LogMessages.StartingProcess(_logger, Environment.ProcessPath, Environment.ProcessId,
-                    args
-                );
+                LogMessages.StartingProcess(_logger, Environment.ProcessPath, Environment.ProcessId, args);
 
                 if (startupMode.ShowUI)
                 {
@@ -180,6 +182,7 @@ public class Program
         if (!startupMode.ExecuteCli)
             return Task.FromResult(0);
         var configurator = provider.GetRequiredService<CommandLineConfigurator>();
+        _logger.LogInformation("Starting with Spectre.Cli");
         return configurator.RunAsync(startupMode.Args, new SpectreRenderer(AnsiConsole.Console), CancellationToken.None);
     }
 

--- a/src/NexusMods.DataModel/CommandLine/Verbs/LoadoutManagementVerbs.cs
+++ b/src/NexusMods.DataModel/CommandLine/Verbs/LoadoutManagementVerbs.cs
@@ -27,18 +27,18 @@ public static class LoadoutManagementVerbs
     /// <returns></returns>
     public static IServiceCollection AddLoadoutManagementVerbs(this IServiceCollection services) =>
         services
+            .AddModule("loadouts", "Commands for managing loadouts as a whole")
+            .AddModule("loadout", "Commands for managing a specific loadout")
+            .AddModule("loadout groups", "Commands for managing the file groups in a loadout")
+            .AddModule("loadout group", "Commands for managing a specific group of files in a loadout")
             .AddVerb(() => Synchronize)
-            .AddVerb(() => ChangeTracking)
-            .AddVerb(() => Ingest)
             .AddVerb(() => InstallMod)
             .AddVerb(() => ListLoadouts)
-            .AddVerb(() => ListModContents)
+            .AddVerb(() => ListGroupContents)
             .AddVerb(() => ListMods)
-            .AddVerb(() => CreateLoadout)
-            .AddVerb(() => RenameLoadout)
-            .AddVerb(() => RemoveLoadout);
+            .AddVerb(() => CreateLoadout);
 
-    [Verb("synchronize", "Synchronize the loadout with the game folders, adding any changes in the game folder to the loadout and applying any new changes in the loadout to the game folder")]
+    [Verb("loadout synchronize", "Synchronize the loadout with the game folders, adding any changes in the game folder to the loadout and applying any new changes in the loadout to the game folder")]
     private static async Task<int> Synchronize([Injected] IRenderer renderer,
         [Option("l", "loadout", "Loadout to apply")] Loadout.ReadOnly loadout,
         [Injected] ISynchronizerService syncService)
@@ -47,41 +47,8 @@ public static class LoadoutManagementVerbs
         return 0;
     }
 
-    [Verb("ingest", "Ingest changes from the game folders into the given loadout")]
-    private static async Task<int> Ingest([Injected] IRenderer renderer,
-        [Option("l", "loadout", "Loadout ingest changes into")] LoadoutId loadout)
-    {
-        throw new NotImplementedException();
-        /*
-        var state = await loadout.Value.Ingest();
-        loadout.Alter("Ingest changes from the game folder", _ => state);
-
-        await renderer.Text($"Ingested game folder changes into {loadout.Value.Name}");
-
-        return 0;
-        */
-    }
-
-    [Verb("change-tracking", "Show changes for the given loadout")]
-    private static async Task<int> ChangeTracking([Injected] IRenderer renderer,
-        [Option("l", "loadout", "Loadout to track changes for")] LoadoutId loadout,
-        [Injected] CancellationToken token)
-    {
-        throw new NotImplementedException();
-        /*
-        using var d = registry.Revisions(loadout.Id)
-            .Subscribe(async id =>
-            {
-                await renderer.Text("Revision {Id} for {LoadoutId}", id, loadout.Id);
-            });
-
-        while (!token.IsCancellationRequested)
-            await Task.Delay(1000, token);
-        return 0;
-        */
-    }
     
-    [Verb("install-mod", "Installs a mod into a loadout")]
+    [Verb("loadout install", "Installs a mod into a loadout")]
     private static async Task<int> InstallMod([Injected] IRenderer renderer,
         [Option("l", "loadout", "loadout to add the mod to")] Loadout.ReadOnly loadout,
         [Option("f", "file", "Mod file to install")] AbsolutePath file,
@@ -98,7 +65,7 @@ public static class LoadoutManagementVerbs
     }
 
 
-    [Verb("list-loadouts", "Lists all the loadouts")]
+    [Verb("loadouts list", "Lists all the loadouts")]
     private static async Task<int> ListLoadouts([Injected] IRenderer renderer,
         [Injected] IConnection conn,
         [Injected] CancellationToken token)
@@ -106,66 +73,62 @@ public static class LoadoutManagementVerbs
         var db = conn.Db;
         var rows = Loadout.All(db)
             .Where(x => x.IsVisible())
-            .Select(list => new object[] { list.Name, list.Installation, list.LoadoutId, list.Items.Count })
+            .Select(list => new object[] { list.Name, list.Installation.Name, list.LoadoutId, list.Items.Count })
             .ToList();
 
-        await renderer.Table(["Name", "Game", "Id", "Mod Count"], rows);
+        await renderer.Table(["Name", "Game", "Id", "Items"], rows);
         return 0;
     }
 
-    [Verb("list-mod-contents", "Lists the contents of a mod")]
-    private static async Task<int> ListModContents([Injected] IRenderer renderer,
+    [Verb("loadout group list", "Lists the contents of a loadout group")]
+    private static async Task<int> ListGroupContents([Injected] IRenderer renderer,
         [Option("l", "loadout", "Loadout to load")] Loadout.ReadOnly loadout,
-        [Option("m", "mod", "Mod to print the contents of")] string modName,
+        [Option("g", "group", "Name of the group to list")] string groupName,
         [Injected] CancellationToken token)
     {
-        var rows = new List<object[]>();
         var mod = loadout.Items
             .OfTypeLoadoutItemGroup()
-            .First(m => m.AsLoadoutItem().Name == modName);
-        foreach (var file in mod.Children)
-        {
-            if (!file.TryGetAsLoadoutItemWithTargetPath(out var withPath))
-                continue;
-            
-            if (withPath.TryGetAsLoadoutFile(out var stored))
-                rows.Add([withPath.TargetPath, stored.Hash]);
-            else
-                rows.Add([file.GetType().ToString(), "<none>"]);
-        }
+            .First(m => m.AsLoadoutItem().Name == groupName);
+        
+        if (!mod.IsValid())
+            return await renderer.InputError("Group {0} not found", groupName);
+        
+        await mod.Children
+            .Select(c =>
+                {
+                    var hasPath = c.TryGetAsLoadoutItemWithTargetPath(out var withPath);
+                    var hasFile = withPath.TryGetAsLoadoutFile(out var withFile);
 
-        await renderer.Table(["Name", "Source"], rows);
+                    if (hasPath && hasFile)
+                        return (withPath.TargetPath.Item2, withPath.TargetPath.Item3, withFile.Hash.ToString());
+
+                    if (hasPath)
+                        return (withPath.TargetPath.Item2, withPath.TargetPath.Item3, "<none>");
+
+                    return default((LocationId, RelativePath, string));
+
+                })
+            .Where(v => v != default((LocationId, RelativePath, string)))
+            .OrderBy(v => v.Item1)
+            .ThenBy(v => v.Item2)
+            .RenderTable(renderer, "Folder", "File", "Hash");
         return 0;
     }
 
-    [Verb("list-mods", "Lists the mods in a loadout")]
+    [Verb("loadout groups list", "Lists the groups in a loadout")]
     private static async Task<int> ListMods([Injected] IRenderer renderer,
         [Option("l", "loadout", "Loadout to load")] Loadout.ReadOnly loadout,
         [Injected] CancellationToken token)
     {
-        var rows = loadout.Items
+        await loadout.Items
             .OfTypeLoadoutItemGroup()
-            .Where(group => !group.Contains(LoadoutItem.Parent))
-            .Select(mod => new object[] { mod.AsLoadoutItem().Name })
-            .ToList();
+            .Select(mod => (mod.AsLoadoutItem().Name, mod.Children.Count))
+            .RenderTable(renderer, "Name", "Items");
 
-        await renderer.Table(["Name"], rows);
         return 0;
     }
 
-    [Verb("rename", "Rename a loadout id to a specific registry name")]
-    private static async Task<int> RenameLoadout([Option("l", "loadout", "Loadout to assign a name")] LoadoutId loadout,
-        [Option("n", "name", "Name to assign the loadout")] string name,
-        [Injected] LoadoutId registry)
-    {
-        throw new NotImplementedException();
-        /*
-        registry.Alter(loadout.LoadoutId, $"Renamed {loadout.DataStoreId} to {name}", _ => loadout);
-        return 0;
-        */
-    }
-
-    [Verb("create-loadout", "Create a Loadout for a given game")]
+    [Verb("loadout create", "Create a Loadout for a given game")]
     private static async Task<int> CreateLoadout([Injected] IRenderer renderer,
         [Option("g", "game", "Game to create a loadout for")] IGame game,
         [Option("v", "version", "Version of the game to manage")] Version version,
@@ -183,17 +146,5 @@ public static class LoadoutManagementVerbs
             await game.Synchronizer.CreateLoadout(install, name);
             return 0;
         });
-    }
-
-    [Verb("remove-loadout", "Remove a loadout by its ID")]
-    private static async Task<int> RemoveLoadout(
-        [Injected] IRenderer renderer,
-        [Injected] IConnection conn,
-        [Option("l", "loadout", "Loadout to delete")] LoadoutId loadoutId,
-        [Injected] CancellationToken token)
-    {
-
-        // TODO: make this call into the new removal logic that uses disk states
-        throw new Exception("Not implemented");
     }
 }

--- a/src/NexusMods.DataModel/NexusMods.DataModel.csproj
+++ b/src/NexusMods.DataModel/NexusMods.DataModel.csproj
@@ -30,6 +30,7 @@
         <PackageReference Include="BitFaster.Caching" />
         <PackageReference Include="DynamicData" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
         <PackageReference Include="Microsoft.Extensions.Logging" />
         <PackageReference Include="Microsoft.Extensions.ObjectPool" />

--- a/src/NexusMods.Library/AddLibraryFileJob.cs
+++ b/src/NexusMods.Library/AddLibraryFileJob.cs
@@ -23,7 +23,9 @@ internal class AddLibraryFileJob : IJobDefinitionWithStart<AddLibraryFileJob, Li
 
     private Extension[] NestedArchiveExtensions { get; } =
     [
-        KnownExtensions._7z, KnownExtensions.Rar, KnownExtensions.Zip, KnownExtensions._7zip
+        KnownExtensions._7z, KnownExtensions.Rar, KnownExtensions.Zip, KnownExtensions._7zip,
+        // Stardew Valley SMAPI nested archive
+        new(".dat"),
     ];
 
     public static IJobTask<AddLibraryFileJob, LibraryFile.New> Create(IServiceProvider provider, ITransaction transaction, AbsolutePath filePath, bool doCommit, bool doBackup)

--- a/src/NexusMods.ProxyConsole.Abstractions/VerbDefinitions/ModuleDefinition.cs
+++ b/src/NexusMods.ProxyConsole.Abstractions/VerbDefinitions/ModuleDefinition.cs
@@ -1,0 +1,6 @@
+namespace NexusMods.ProxyConsole.Abstractions.VerbDefinitions;
+
+/// <summary>
+/// Documentation for a collection of verbs
+/// </summary>
+public record ModuleDefinition(string Name, string Description);

--- a/src/NexusMods.ProxyConsole.Abstractions/VerbDefinitions/OptionAttribute.cs
+++ b/src/NexusMods.ProxyConsole.Abstractions/VerbDefinitions/OptionAttribute.cs
@@ -9,7 +9,7 @@ namespace NexusMods.ProxyConsole.Abstractions.VerbDefinitions;
 /// <param name="longName"></param>
 /// <param name="helpText"></param>
 [AttributeUsage(AttributeTargets.Parameter)]
-public class OptionAttribute(string shortName, string longName, string helpText) : Attribute
+public class OptionAttribute(string shortName, string longName, string helpText, bool isOptional = false) : Attribute
 {
     /// <summary>
     /// The short name of the option. For example `h`
@@ -25,5 +25,9 @@ public class OptionAttribute(string shortName, string longName, string helpText)
     /// The help text for the option.
     /// </summary>
     public string HelpText { get; } = helpText;
-
+    
+    /// <summary>
+    /// True if the option is optional, false otherwise.
+    /// </summary>
+    public bool IsOptional { get; } = isOptional;
 }

--- a/src/NexusMods.ProxyConsole.Abstractions/VerbDefinitions/OptionDefinition.cs
+++ b/src/NexusMods.ProxyConsole.Abstractions/VerbDefinitions/OptionDefinition.cs
@@ -10,4 +10,4 @@ namespace NexusMods.ProxyConsole.Abstractions.VerbDefinitions;
 /// <param name="LongName"></param>
 /// <param name="HelpText"></param>
 /// <param name="IsInjected"></param>
-public record OptionDefinition(Type Type, string ShortName, string LongName, string HelpText, bool IsInjected);
+public record OptionDefinition(Type Type, string ShortName, string LongName, string HelpText, bool IsInjected, bool IsOptional);

--- a/src/NexusMods.ProxyConsole.Abstractions/VerbDefinitions/ServiceExtensions.cs
+++ b/src/NexusMods.ProxyConsole.Abstractions/VerbDefinitions/ServiceExtensions.cs
@@ -75,11 +75,11 @@ public static class ServiceExtensions
 
             if (option is not null)
             {
-                options.Add(new OptionDefinition(param.ParameterType, option.ShortName, option.LongName, option.HelpText, false));
+                options.Add(new OptionDefinition(param.ParameterType, option.ShortName, option.LongName, option.HelpText, false, option.IsOptional));
             }
             else if (injected is not null)
             {
-                options.Add(new OptionDefinition(param.ParameterType, string.Empty, string.Empty, string.Empty, true));
+                options.Add(new OptionDefinition(param.ParameterType, string.Empty, string.Empty, string.Empty, true, false));
             }
         }
 

--- a/src/NexusMods.ProxyConsole.Abstractions/VerbDefinitions/ServiceExtensions.cs
+++ b/src/NexusMods.ProxyConsole.Abstractions/VerbDefinitions/ServiceExtensions.cs
@@ -1,9 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace NexusMods.ProxyConsole.Abstractions.VerbDefinitions;
@@ -24,6 +20,15 @@ public static class ServiceExtensions
         var methodInfo = (MethodInfo)((ConstantExpression)((MethodCallExpression)((UnaryExpression)fn.Body).Operand).Object!)
             ?.Value!;
         return coll.AddVerb(methodInfo);
+    }
+    
+    /// <summary>
+    /// Add a new module to the CLI, any verbs that are in a given module path must have a corresponding module definition.
+    /// </summary>
+    public static IServiceCollection AddModule(this IServiceCollection coll, string name, string description)
+    {
+        return coll
+            .AddSingleton(new ModuleDefinition(name, description));
     }
 
 

--- a/src/NexusMods.ProxyConsole.Abstractions/VerbDefinitions/VerbAttribute.cs
+++ b/src/NexusMods.ProxyConsole.Abstractions/VerbDefinitions/VerbAttribute.cs
@@ -5,18 +5,27 @@ namespace NexusMods.ProxyConsole.Abstractions.VerbDefinitions;
 /// <summary>
 /// Defines a method that should be exposed as a verb.
 /// </summary>
-/// <param name="name"></param>
-/// <param name="description"></param>
 [AttributeUsage(AttributeTargets.Method)]
-public class VerbAttribute(string name, string description) : Attribute
+public class VerbAttribute : Attribute
 {
+    /// <summary>
+    /// Defines a method that should be exposed as a verb.
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="description"></param>
+    public VerbAttribute(string name, string description)
+    {
+        Name = name;
+        Description = description;
+    }
+    
     /// <summary>
     /// The name of the verb.
     /// </summary>
-    public string Name { get; } = name;
+    public string Name { get; }
 
     /// <summary>
     /// Help text for the verb.
     /// </summary>
-    public string Description { get; } = description;
+    public string Description { get; }
 }

--- a/src/NexusMods.ProxyConsole.Abstractions/VerbDefinitions/VerbDefinition.cs
+++ b/src/NexusMods.ProxyConsole.Abstractions/VerbDefinitions/VerbDefinition.cs
@@ -5,8 +5,8 @@ namespace NexusMods.ProxyConsole.Abstractions.VerbDefinitions;
 /// <summary>
 /// A definition of a verb, used as an abstraction layer between the CLI handler code and the verb code.
 /// </summary>
-/// <param name="Name"></param>
-/// <param name="Description"></param>
-/// <param name="Info"></param>
-/// <param name="Options"></param>
+/// <param name="Name">The name of the verb, prefixed by the module path it is in</param>
+/// <param name="Description">A description of the verb</param>
+/// <param name="Info">The method to invoke to run the verb</param>
+/// <param name="Options">Option definitions for the method's parameters</param>
 public record VerbDefinition(string Name, string Description, MethodInfo Info, OptionDefinition[] Options);

--- a/src/NexusMods.SingleProcess/CommandLineConfigurator.cs
+++ b/src/NexusMods.SingleProcess/CommandLineConfigurator.cs
@@ -105,6 +105,9 @@ public class CommandLineConfigurator
                 {
                     var option = (Option)_makeOptionMethod.MakeGenericMethod(optionDefinition.Type)
                         .Invoke(this, [optionDefinition])!;
+
+                    option.IsRequired = !optionDefinition.IsOptional;
+                    
                     command.AddOption(option);
                     getters.Add(ctx => ctx.ParseResult.GetValueForOption(option));
                 }

--- a/src/NexusMods.SingleProcess/CommandLineConfigurator.cs
+++ b/src/NexusMods.SingleProcess/CommandLineConfigurator.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
@@ -30,12 +31,12 @@ public class CommandLineConfigurator
     /// </summary>
     /// <param name="provider"></param>
     /// <param name="verbDefinitions"></param>
-    public CommandLineConfigurator(IServiceProvider provider, IEnumerable<VerbDefinition> verbDefinitions)
+    public CommandLineConfigurator(IServiceProvider provider, IEnumerable<VerbDefinition> verbDefinitions, IEnumerable<ModuleDefinition> moduleDefinitions)
     {
         _logger = provider.GetRequiredService<ILogger<CommandLineConfigurator>>();
 
         _makeOptionMethod = GetType().GetMethod(nameof(MakeOption), BindingFlags.Instance | BindingFlags.NonPublic)!;
-        (_rootCommand, _injectedTypes) = MakeRootCommand(verbDefinitions);
+        (_rootCommand, _injectedTypes) = MakeRootCommand(verbDefinitions, moduleDefinitions);
         _provider = provider;
     }
 
@@ -44,14 +45,52 @@ public class CommandLineConfigurator
     /// </summary>
     /// <param name="verbDefinitions"></param>
     /// <returns></returns>
-    private (RootCommand, Type[]) MakeRootCommand(IEnumerable<VerbDefinition> verbDefinitions)
+    private (RootCommand, Type[]) MakeRootCommand(IEnumerable<VerbDefinition> verbDefinitions, IEnumerable<ModuleDefinition> moduleDefinitions)
     {
         var rootCommand = new RootCommand();
         var injectedTypes = new HashSet<Type>();
 
-        foreach (var verbDefinition in verbDefinitions)
+        var modules = new Dictionary<string, Command>();
+
+        // Create the modules first so we can tie verbs to them
+        foreach (var module in moduleDefinitions.OrderBy(v => v.Name.Length).ThenBy(v => v.Name.Last()))
         {
-            var command = new Command(verbDefinition.Name, verbDefinition.Description);
+            if (modules.ContainsKey(module.Name))
+                throw new InvalidOperationException($"Module {module.Name} already exists can't define it again");
+            
+            var nameParts = module.Name.Split(" ", StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+            var localName = nameParts[^1];
+            var command = new Command(localName, module.Description);
+            modules.Add(module.Name, command);
+
+            if (nameParts.Length > 1)
+            {
+                var parentName = string.Join(" ", nameParts[..^1]);
+                if (!modules.TryGetValue(parentName, out var parent))
+                    throw new InvalidOperationException($"Parent module {module.Name} does not exist");
+                
+                parent.AddCommand(command);
+            }
+            else
+            {
+                rootCommand.AddCommand(command);
+            }
+            
+        }
+
+        foreach (var verbDefinition in verbDefinitions.OrderBy(v => v.Name.Last()))
+        {
+            Command parentCommand = rootCommand;
+            var nameParts = verbDefinition.Name.Split(" ", StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+            if (nameParts.Length > 1)
+            {
+                var moduleName = string.Join(" ", nameParts[..^1]);
+                if (!modules.TryGetValue(moduleName, out var moduleCommand))
+                    throw new InvalidOperationException($"Module {moduleName} does not exist");
+                parentCommand = moduleCommand;
+            }
+
+            var command = new Command(nameParts[^1], verbDefinition.Description);
             var getters = new List<Func<InvocationContext, object?>>();
 
             foreach (var optionDefinition in verbDefinition.Options)
@@ -65,14 +104,14 @@ public class CommandLineConfigurator
                 else
                 {
                     var option = (Option)_makeOptionMethod.MakeGenericMethod(optionDefinition.Type)
-                        .Invoke(this, new[] { optionDefinition })!;
+                        .Invoke(this, [optionDefinition])!;
                     command.AddOption(option);
                     getters.Add(ctx => ctx.ParseResult.GetValueForOption(option));
                 }
             }
-            command.Handler = new CommandHandler(getters, verbDefinition.Info);
+            command.Handler = new CommandHandler(_provider, getters, verbDefinition.Info);
 
-            rootCommand.AddCommand(command);
+            parentCommand.AddCommand(command);
         }
         return (rootCommand, injectedTypes.ToArray());
     }

--- a/tests/NexusMods.CLI.Tests/VerbTests/AVerbTest.cs
+++ b/tests/NexusMods.CLI.Tests/VerbTests/AVerbTest.cs
@@ -34,7 +34,8 @@ public class AVerbTest(IServiceProvider provider)
     {
         var renderer = new LoggingRenderer();
         var configurator = provider.GetRequiredService<CommandLineConfigurator>();
-        var result = await configurator.RunAsync(args, renderer, CancellationToken.None);
+        var withSplitName = args[0].Split(' ').Concat(args[1..]).ToArray();
+        var result = await configurator.RunAsync(withSplitName, renderer, CancellationToken.None);
         if (result != 0)
         {
             var errorLog = renderer.Logs.OfType<Text>().Select(t => t.Template).Aggregate((acc, itm) => acc + itm);

--- a/tests/NexusMods.CLI.Tests/VerbTests/ModManagementVerbs.cs
+++ b/tests/NexusMods.CLI.Tests/VerbTests/ModManagementVerbs.cs
@@ -14,25 +14,25 @@ public class ModManagementVerbs(StubbedGame stubbedGame, IServiceProvider provid
         
         var install = await CreateInstall();
 
-        var log = await Run("create-loadout", "-g", $"{uint.MaxValue}", "-v",
+        var log = await Run("loadout create", "-g", $"{uint.MaxValue}", "-v",
             install.Version.ToString(), "-n", listName);
 
-        log = await Run("list-loadouts");
+        log = await Run("loadouts list");
 
-        log.LastTableColumns.Should().BeEquivalentTo("Name", "Game", "Id", "Mod Count");
+        log.LastTableColumns.Should().BeEquivalentTo("Name", "Game", "Id", "Items");
         log.TableCellsWith(0, listName).Should().NotBeEmpty();
 
-        log = await Run("list-mods", "-l", listName);
+        log = await Run("loadout groups list", "-l", listName);
         log.LastTable.Rows.Length.Should().Be(2);
 
-        log = await Run("install-mod", "-l", listName, "-f", Data7ZipLZMA2.ToString(), "-n", Data7ZipLZMA2.GetFileNameWithoutExtension());
+        log = await Run("loadout install", "-l", listName, "-f", Data7ZipLZMA2.ToString(), "-n", Data7ZipLZMA2.GetFileNameWithoutExtension());
 
-        log = await Run("list-mods", "-l", listName);
-        log.LastTable.Rows.Length.Should().Be(2);
+        log = await Run("loadout groups list", "-l", listName);
+        log.LastTable.Rows.Length.Should().Be(3);
 
-        log = await Run("list-mod-contents", "-l", listName, "-m", Data7ZipLZMA2.FileName);
+        log = await Run("loadout group list", "-l", listName, "-g", Data7ZipLZMA2.FileName);
         log.LastTable.Rows.Length.Should().Be(3);
         
-        log = await Run("synchronize", "-l", listName);
+        log = await Run("loadout synchronize", "-l", listName);
     }
 }


### PR DESCRIPTION
This PR does the following

* Fixes consoles on Windows
  * When compiling with WinExe the console isn't connected
  * When compiling with Exe we always get a console, even when running in UI mode
  * This is a windows issue. Fixed by compiling with WinExe mode and doing some P/Invoke magic to attach any existing consoles
* Changes up the Proxy Console code a bit so we can create paths of modules for verbs instead of prefixing verbs. For example instead of `nexus-login` we can have `nexus login`, `nexus verify` etc. This is opt-in and we can convert verbs over as time goes on. 
* Modules (verb prefixes) can have doc strings so we can do `nexus --help` to find out what console commands are available in that module
* Verb options can now be optional
* Verb options that are not optional are now *always* required
* Reorganized/Cleaned up the loadout management verbs
* Added some new render helpers, so we can do code like `(IEnumerable<(string, int)>).RenderTable(renderer, "Name", "Count");` making a lot of the render code easier to read
* Added some exception catching to the verb dispatch code
* Added a way to delete files based on a file glob from specific mods via the CLI. So now we have an escape hatch for files that get stuck in `Overrides`.