### PR TITLE
Fix thumbnail exception and monitor job exceptions

### DIFF
--- a/src/NexusMods.App.UI/Pages/LibraryPage/NexusModsModPageLibraryItemModel.cs
+++ b/src/NexusMods.App.UI/Pages/LibraryPage/NexusModsModPageLibraryItemModel.cs
@@ -51,6 +51,10 @@ public class NexusModsModPageLibraryItemModel : TreeDataGridItemModel<ILibraryIt
             .Where(item => item.IsValid())
             .SelectMany(async item =>
             {
+                // Skip mods without thumbnails
+                if (!item.ModPageMetadata.Contains(NexusModsModPageMetadata.ThumbnailUri))
+                    return item;
+                
                 // Note(sewer): Update the thumbnail of the header to be the thumbnail of the first child item.
                 // By definition, all the sub items belong to this page, so the thumbnail of the child item
                 // is the thumbnail of this page.

--- a/src/NexusMods.Jobs/JobContext.cs
+++ b/src/NexusMods.Jobs/JobContext.cs
@@ -96,6 +96,21 @@ public sealed class JobContext<TJobDefinition, TJobResult> : IJobWithResult<TJob
     {
         return _tcs.Task;
     }
+    
+    /// <summary>
+    /// Try to get the exception that caused the job to fail.
+    /// </summary>
+    public bool TryGetException(out Exception? exception)
+    {
+        if (_tcs.Task.IsFaulted)
+        {
+            exception = _tcs.Task.Exception;
+            return true;
+        }
+
+        exception = null;
+        return false;
+    }
 
     public TJobResult Result => _result.HasValue ? _result.Value : throw new InvalidOperationException();
     

--- a/src/NexusMods.Jobs/NexusMods.Jobs.csproj
+++ b/src/NexusMods.Jobs/NexusMods.Jobs.csproj
@@ -3,6 +3,7 @@
         <ProjectReference Include="..\Abstractions\NexusMods.Abstractions.Jobs\NexusMods.Abstractions.Jobs.csproj" />
     </ItemGroup>
     <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
       <PackageReference Include="ObservableCollections.R3" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
A recent issue in QA would have been much easier to debug if we had exceptions on jobs. We'd click a button to install a collection, the job would error, but the Job monitor would throw an exception, so it looked like the button did nothing. This PR surfaces those errors by logging such exceptions. 

Secondly we check files in the library before trying to download or display the icons. This fixes some exception spamming caused by manually added mods. 