### PR TITLE
Better log filters

### DIFF
--- a/src/NexusMods.App.UI/HighPerformanceLogging.cs
+++ b/src/NexusMods.App.UI/HighPerformanceLogging.cs
@@ -6,7 +6,7 @@ internal static partial class HighPerformanceLogging
 {
     [LoggerMessage(
         EventId = 0,
-        Level = LogLevel.Debug,
+        Level = LogLevel.Trace,
         Message = "Finding View for {viewModel}")]
     public static partial void FindingView(
         this ILogger logger,

--- a/src/NexusMods.App/LogMessages.cs
+++ b/src/NexusMods.App/LogMessages.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using NexusMods.App.BuildInfo;
+using NexusMods.App.UI.Pages.CollectionDownload;
 
 namespace NexusMods.App;
 
@@ -47,6 +48,16 @@ internal static partial class LogMessages
         Message = "Encountered an exception published to an object with an unobserved ThrownExceptions property"
     )]
     public static partial void UnobservedReactiveThrownException(
+        ILogger logger,
+        Exception e
+    );
+
+    [LoggerMessage(
+        EventId = 4, EventName = nameof(R3UnhandledException),
+        Level = LogLevel.Error,
+        Message = "Encountered an unhandled exception in R3"
+    )]
+    public static partial void R3UnhandledException(
         ILogger logger,
         Exception e
     );

--- a/src/NexusMods.App/Program.cs
+++ b/src/NexusMods.App/Program.cs
@@ -300,6 +300,7 @@ public class Program
 
         loggingBuilder.AddFilter("Microsoft", LogLevel.Warning);
         loggingBuilder.AddFilter("System", LogLevel.Warning);
+        loggingBuilder.AddFilter("Avalonia.ReactiveUI", LogLevel.Warning);
 
         loggingBuilder.ClearProviders();
         loggingBuilder.SetMinimumLevel(settings.MinimumLevel);

--- a/src/NexusMods.App/Startup.cs
+++ b/src/NexusMods.App/Startup.cs
@@ -10,6 +10,7 @@ using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 using Projektanker.Icons.Avalonia;
 using Projektanker.Icons.Avalonia.MaterialDesign;
+using R3;
 using ReactiveUI;
 using Splat;
 
@@ -108,6 +109,12 @@ public class Startup
 
         Locator.CurrentMutable.UnregisterCurrent(typeof(IViewLocator));
         Locator.CurrentMutable.Register(serviceProvider.GetRequiredService<InjectedViewLocator>, typeof(IViewLocator));
+
+        var logger = serviceProvider.GetRequiredService<ILogger<Startup>>();
+        ObservableSystem.RegisterUnhandledExceptionHandler(exception =>
+        {
+            LogMessages.R3UnhandledException(logger, exception);
+        });
 
         return app;
     }


### PR DESCRIPTION
- Changes `Finding View for {viewModel}` from `Debug` to `Trace`
- Adds filter for `Avalonia.ReactiveUI` and a min level of `Warning`
- Logs unhandled exceptions in R3