### PR TITLE
Update to the new MnemonicDB

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,8 +15,8 @@
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.0.0" />
     <PackageVersion Include="Nerdbank.FullDuplexStream" Version="1.1.12" />
     <PackageVersion Include="Nerdbank.Streams" Version="2.11.79" />
-    <PackageVersion Include="NexusMods.MnemonicDB" Version="0.9.97" />
-    <PackageVersion Include="NexusMods.MnemonicDB.Abstractions" Version="0.9.97" />
+    <PackageVersion Include="NexusMods.MnemonicDB" Version="0.9.98" />
+    <PackageVersion Include="NexusMods.MnemonicDB.Abstractions" Version="0.9.98" />
     <PackageVersion Include="NexusMods.Hashing.xxHash3.Paths" Version="3.0.3" />
     <PackageVersion Include="NexusMods.Hashing.xxHash3" Version="3.0.3" />
     <PackageVersion Include="NexusMods.Paths" Version="0.15.0" />
@@ -136,7 +136,7 @@
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="ini-parser-netstandard" Version="2.5.2" />
     <PackageVersion Include="Mutagen.Bethesda.Skyrim" Version="0.44.0" />
-    <PackageVersion Include="NexusMods.MnemonicDB.SourceGenerator" Version="0.9.97" />
+    <PackageVersion Include="NexusMods.MnemonicDB.SourceGenerator" Version="0.9.98" />
     <PackageVersion Include="NLog.Extensions.Logging" Version="5.3.14" />
     <PackageVersion Include="OneOf" Version="3.0.271" />
     <PackageVersion Include="ReactiveUI.Fody" Version="19.5.41" />


### PR DESCRIPTION
Fixes some of the issues with installing collections with lots of mods. Exposes other performance issues with the creation of the `SyncTree` those will need to be fixed in another patch. 

This PR goes into more detail about the changes on the MnemonicDB side: https://github.com/Nexus-Mods/NexusMods.MnemonicDB/pull/117