### PR TITLE
Use StringComponent for Left Menu Item ToolTips

### DIFF
--- a/src/NexusMods.App.UI/LeftMenu/Items/ILeftMenuItemViewModel.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Items/ILeftMenuItemViewModel.cs
@@ -13,6 +13,8 @@ public interface ILeftMenuItemViewModel : IViewModelInterface
     
     public IconValue Icon { get; set; }
     
+    public string ToolTipText { get; }
+    
     public ReactiveCommand<NavigationInformation, Unit> NavigateCommand { get; }
     
     public bool IsActive { get; }

--- a/src/NexusMods.App.UI/LeftMenu/Items/LeftMenuItemDesignViewModel.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Items/LeftMenuItemDesignViewModel.cs
@@ -13,6 +13,8 @@ public class LeftMenuItemDesignViewModel : AViewModel<ILeftMenuItemViewModel>, I
 {
     public StringComponent Text { get; init; } = new("Design Item");
     [Reactive] public IconValue Icon { get; set; } = IconValues.Settings;
+    public string ToolTipText { get; } = "This is design time ToolTip";
+
     public ReactiveCommand<NavigationInformation, Unit> NavigateCommand { get; } = 
         ReactiveCommand.Create<NavigationInformation>((info) => { });
     public bool IsActive { get; } = false;

--- a/src/NexusMods.App.UI/LeftMenu/Items/LeftMenuItemView.axaml.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Items/LeftMenuItemView.axaml.cs
@@ -1,5 +1,4 @@
 using System.Reactive.Disposables;
-using System.Reactive.Linq;
 using Avalonia.Controls;
 using Avalonia.ReactiveUI;
 using ReactiveUI;
@@ -16,10 +15,9 @@ public partial class LeftMenuItemView : ReactiveUserControl<ILeftMenuItemViewMod
             {
                 this.OneWayBind(ViewModel, vm => vm.Text.Value.Value, view => view.LabelTextBlock.Text)
                     .DisposeWith(d);
-
-                this.WhenAnyValue(view => view.ViewModel)
-                    .Where(vm => vm is CollectionLeftMenuItemViewModel)
-                    .Subscribe(vm => { ToolTip.SetTip(this, vm?.Text.Value.Value); })
+                
+                this.WhenAnyValue(view => view.ViewModel!.ToolTipText)
+                    .Subscribe(text => ToolTip.SetTip(this, text))
                     .DisposeWith(d);
 
                 this.OneWayBind(ViewModel, vm => vm.Icon, view => view.LeftIcon.Value)

--- a/src/NexusMods.App.UI/LeftMenu/Items/LeftMenuItemViewModel.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Items/LeftMenuItemViewModel.cs
@@ -1,6 +1,7 @@
 using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
+using Avalonia.Controls;
 using DynamicData;
 using DynamicData.Binding;
 using NexusMods.Abstractions.UI;
@@ -17,9 +18,12 @@ public class LeftMenuItemViewModel : AViewModel<ILeftMenuItemViewModel>, ILeftMe
 {
     public StringComponent Text { get; init; } = new("");
     [Reactive] public IconValue Icon { get; set; } = new();
+    [Reactive] public string ToolTipText { get; private set; }
     [Reactive] public bool IsActive { get; private set; }
     [Reactive] public bool IsSelected { get; private set; }
     public ReactiveCommand<NavigationInformation, Unit> NavigateCommand { get; }
+
+    public StringComponent? ToolTip { get; init; }
 
     public LeftMenuItemViewModel(
         IWorkspaceController workspaceController,
@@ -29,6 +33,7 @@ public class LeftMenuItemViewModel : AViewModel<ILeftMenuItemViewModel>, ILeftMe
     {
         IsActive = false;
         IsSelected = false;
+        ToolTipText = string.Empty;
 
         NavigateCommand = ReactiveCommand.Create<NavigationInformation>((info) =>
             {
@@ -36,7 +41,7 @@ public class LeftMenuItemViewModel : AViewModel<ILeftMenuItemViewModel>, ILeftMe
                 workspaceController.OpenPage(workspaceId, pageData, behavior);
             }
         );
-        
+
         var workspaceIsActiveObservable = workspaceController
             .WhenAnyValue(controller => controller.ActiveWorkspace)
             .Where(workspace => workspace.Id == workspaceId);
@@ -62,14 +67,14 @@ public class LeftMenuItemViewModel : AViewModel<ILeftMenuItemViewModel>, ILeftMe
                     .DistinctUntilChanged()
             )
             .Switch();
-        
+
         var workspaceHasSinglePanelObservable = workspaceIsActiveObservable
             .Select(workspace => workspace.WhenAnyValue(w => w.Panels.Count))
             .Switch()
             .Select(panelCount => panelCount == 1)
             .DistinctUntilChanged()
             .Prepend(workspaceController.ActiveWorkspace.Panels.Count == 1);
-        
+
         // Should be 'Selected' only if there are multiple panels and the page is open and selected in the selected panel 
         var isSelectedObservable = workspaceIsActiveObservable
             .Select(workspace => workspace.WhenAnyValue(w => w.SelectedTab.Contents))
@@ -90,9 +95,16 @@ public class LeftMenuItemViewModel : AViewModel<ILeftMenuItemViewModel>, ILeftMe
 
         this.WhenActivated(d =>
             {
+                ToolTip?.Activate()
+                    .DisposeWith(d);
                 Text.Activate()
                     .DisposeWith(d);
-                
+
+                // Set the ToolTipText to the value of the ToolTip component if it is not null, otherwise set it to the value of the Text component
+                (ToolTip ?? Text).Value.WhenAnyValue(item => item.Value)
+                    .Subscribe(value => ToolTipText = value)
+                    .DisposeWith(d);
+
                 isActiveObservable.Subscribe(isActive => IsActive = isActive)
                     .DisposeWith(d);
 

--- a/src/NexusMods.App.UI/LeftMenu/Loadout/LoadoutLeftMenuView.axaml
+++ b/src/NexusMods.App.UI/LeftMenu/Loadout/LoadoutLeftMenuView.axaml
@@ -14,16 +14,14 @@
 
     <Grid RowDefinitions="*, Auto" Margin="12,0,12,12">
         <StackPanel Grid.Row="0" Orientation="Vertical">
-            <items:LeftMenuItemView x:Name="LibraryItem"
-                                    ToolTip.Tip="{x:Static resources:Language.LibraryPageTitleToolTip}" />
+            <items:LeftMenuItemView x:Name="LibraryItem" />
             
             <StackPanel>
                 <Separator />
                 <TextBlock Text="{x:Static resources:Language.LeftMenu_Label_Installed_Mods}"/>
             </StackPanel>
             
-            <items:LeftMenuItemView x:Name="LoadoutItem"
-                                    ToolTip.Tip="{x:Static resources:Language.LoadoutView_Title_Installed_Mods_ToolTip}" />
+            <items:LeftMenuItemView x:Name="LoadoutItem" />
 
             <ItemsControl x:Name="MenuItemsControl">
                 <ItemsControl.ItemsPanel>
@@ -38,8 +36,7 @@
                 <TextBlock Text="{x:Static resources:Language.LeftMenu_Label_Utilities}"/>
             </StackPanel>
             
-            <items:LeftMenuItemView x:Name="HealthCheckItem" 
-                                    ToolTip.Tip="{x:Static resources:Language.LoadoutLeftMenuViewModel_Diagnostics_ToolTip}" />
+            <items:LeftMenuItemView x:Name="HealthCheckItem" />
         </StackPanel>
 
         <reactiveUi:ViewModelViewHost Grid.Row="1" x:Name="ApplyControlViewHost" />

--- a/src/NexusMods.App.UI/LeftMenu/Loadout/LoadoutLeftMenuViewModel.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Loadout/LoadoutLeftMenuViewModel.cs
@@ -76,6 +76,7 @@ public class LoadoutLeftMenuViewModel : AViewModel<ILoadoutLeftMenuViewModel>, I
         {
             Text = new StringComponent(Language.LibraryPageTitle),
             Icon = IconValues.LibraryOutline,
+            ToolTip = new StringComponent(Language.LibraryPageTitleToolTip),
             CountObservable = this.WhenAnyValue(vm => vm.NewDownloadModelCount),
         };
         
@@ -109,6 +110,7 @@ public class LoadoutLeftMenuViewModel : AViewModel<ILoadoutLeftMenuViewModel>, I
         {
             Text = new StringComponent(Language.LoadoutView_Title_Installed_Mods_Default, loadoutLabelObservable),
             Icon = IconValues.Mods,
+            ToolTip = new StringComponent(Language.LoadoutView_Title_Installed_Mods_ToolTip),
         };
 
         // Collections
@@ -165,6 +167,7 @@ public class LoadoutLeftMenuViewModel : AViewModel<ILoadoutLeftMenuViewModel>, I
         {
             Text = new StringComponent(Language.LoadoutLeftMenuViewModel_LoadoutLeftMenuViewModel_Diagnostics),
             Icon = IconValues.Cardiology,
+            ToolTip = new StringComponent(Language.LoadoutLeftMenuViewModel_Diagnostics_ToolTip),
         };
         
         // Apply Control


### PR DESCRIPTION
Should be final PR for Left Menu rework:
- Closes #2433 

Reorganized the ToolTips to use an optional StringComponent and fallback on Text if not set.