### PR TITLE
Preperations for collection updates

### DIFF
--- a/src/Networking/NexusMods.Networking.NexusWebApi/GraphQL/CollectionRevisionNumbers.graphql
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/GraphQL/CollectionRevisionNumbers.graphql
@@ -1,0 +1,13 @@
+# Fetches all revision numbers of a collection
+query CollectionRevisionNumbers($slug: String!, $domainName: String!, $viewAdultContent: Boolean!)
+{
+    collection(slug: $slug, domainName: $domainName, viewAdultContent: $viewAdultContent)
+    {
+        id,
+
+        revisions {
+            id,
+            revisionNumber
+        }
+    }
+}

--- a/src/Networking/NexusMods.Networking.NexusWebApi/NexusMods.Networking.NexusWebApi.csproj
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/NexusMods.Networking.NexusWebApi.csproj
@@ -24,13 +24,4 @@
       <ProjectReference Include="..\NexusMods.Networking.HttpDownloader\NexusMods.Networking.HttpDownloader.csproj" />
       <ProjectReference Include="..\NexusMods.Networking.ModUpdates\NexusMods.Networking.ModUpdates.csproj" />
     </ItemGroup>
-    
-    <ItemGroup>
-      <GraphQL Update="GraphQL\GameIdToDomain.graphql">
-        <Generator>MSBuild:GenerateGraphQLCode</Generator>
-      </GraphQL>
-      <GraphQL Update="GraphQL\ModFilesByUid.graphql">
-        <Generator>MSBuild:GenerateGraphQLCode</Generator>
-      </GraphQL>
-    </ItemGroup>
 </Project>

--- a/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsLibrary.Collections.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsLibrary.Collections.cs
@@ -61,11 +61,28 @@ public partial class NexusModsLibrary
     }
 
     /// <summary>
+    /// Deletes a revision and all downloaded entities.
+    /// </summary>
+    public async ValueTask DeleteRevision(CollectionRevisionMetadataId revisionId)
+    {
+        var db = _connection.Db;
+        using var tx = _connection.BeginTransaction();
+
+        var downloadIds = db.Datoms(CollectionDownload.CollectionRevision, revisionId);
+        foreach (var downloadId in downloadIds)
+        {
+            tx.Delete(downloadId.E, recursive: false);
+        }
+
+        tx.Delete(revisionId, recursive: false);
+
+        await tx.Commit();
+    }
+
+    /// <summary>
     /// Deletes a collection, all revisions, and all download entities of all revisions.
     /// </summary>
-    public async ValueTask DeleteCollection(
-        CollectionMetadataId collectionMetadataId,
-        CancellationToken cancellationToken)
+    public async ValueTask DeleteCollection(CollectionMetadataId collectionMetadataId)
     {
         var db = _connection.Db;
         using var tx = _connection.BeginTransaction();

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadDesignViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadDesignViewModel.cs
@@ -54,5 +54,5 @@ public class CollectionDownloadDesignViewModel : APageViewModel<ICollectionDownl
     public ReactiveCommand<Unit> CommandViewOnNexusMods { get; } = new ReactiveCommand();
     public ReactiveCommand<Unit> CommandOpenJsonFile { get; } = new ReactiveCommand();
     public ReactiveCommand<Unit> CommandDeleteAllDownloads { get; } = new ReactiveCommand();
-    public ReactiveCommand<Unit> CommandDeleteCollection { get; } = new ReactiveCommand();
+    public ReactiveCommand<Unit> CommandDeleteCollectionRevision { get; } = new ReactiveCommand();
 }

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadView.axaml
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadView.axaml
@@ -40,10 +40,10 @@
                     </panels:FlexPanel>
                 </MenuItem.Header>
             </MenuItem>
-            <MenuItem x:Name="MenuItemDeleteCollection">
+            <MenuItem x:Name="MenuItemDeleteCollectionRevision">
                 <MenuItem.Header>
                     <panels:FlexPanel>
-                        <TextBlock>Delete Collection</TextBlock>
+                        <TextBlock>Delete collection revision</TextBlock>
                     </panels:FlexPanel>
                 </MenuItem.Header>
             </MenuItem>

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadView.axaml.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadView.axaml.cs
@@ -31,7 +31,7 @@ public partial class CollectionDownloadView : ReactiveUserControl<ICollectionDow
             this.BindCommand(ViewModel, vm => vm.CommandDeleteAllDownloads, view => view.MenuItemDeleteAllDownloads)
                 .DisposeWith(d);
 
-            this.BindCommand(ViewModel, vm => vm.CommandDeleteCollection, view => view.MenuItemDeleteCollection)
+            this.BindCommand(ViewModel, vm => vm.CommandDeleteCollectionRevision, view => view.MenuItemDeleteCollectionRevision)
                 .DisposeWith(d);
 
             this.OneWayBind(ViewModel, vm => vm.CollectionStatusText, view => view.TextCollectionStatus.Text)

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadViewModel.cs
@@ -117,7 +117,7 @@ public sealed class CollectionDownloadViewModel : APageViewModel<ICollectionDown
             configureAwait: false
         );
 
-        CommandDeleteCollection = new ReactiveCommand(
+        CommandDeleteCollectionRevision = new ReactiveCommand(
             executeAsync: async (_, _) =>
             {
                 var pageData = new PageData
@@ -134,7 +134,7 @@ public sealed class CollectionDownloadViewModel : APageViewModel<ICollectionDown
                 workspaceController.OpenPage(WorkspaceId, pageData, behavior);
 
                 await collectionDownloader.DeleteCollectionLoadoutGroup(_revision, cancellationToken: CancellationToken.None);
-                await nexusModsLibrary.DeleteCollection(_collection, cancellationToken: CancellationToken.None);
+                await nexusModsLibrary.DeleteRevision(_revision);
             },
             awaitOperation: AwaitOperation.Drop,
             configureAwait: false,
@@ -371,7 +371,7 @@ public sealed class CollectionDownloadViewModel : APageViewModel<ICollectionDown
     public ReactiveCommand<Unit> CommandViewOnNexusMods { get; }
     public ReactiveCommand<Unit> CommandOpenJsonFile { get; }
     public ReactiveCommand<Unit> CommandDeleteAllDownloads { get; }
-    public ReactiveCommand<Unit> CommandDeleteCollection { get; }
+    public ReactiveCommand<Unit> CommandDeleteCollectionRevision { get; }
 }
 
 public record DownloadMessage(DownloadableItem Item);

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/ICollectionDownloadViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/ICollectionDownloadViewModel.cs
@@ -102,5 +102,5 @@ public interface ICollectionDownloadViewModel : IPageViewModelInterface
     ReactiveCommand<Unit> CommandViewOnNexusMods { get; }
     ReactiveCommand<Unit> CommandOpenJsonFile { get; }
     ReactiveCommand<Unit> CommandDeleteAllDownloads { get; }
-    ReactiveCommand<Unit> CommandDeleteCollection { get; }
+    ReactiveCommand<Unit> CommandDeleteCollectionRevision { get; }
 }

--- a/src/NexusMods.App.UI/Pages/LibraryPage/LibraryViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LibraryPage/LibraryViewModel.cs
@@ -200,20 +200,16 @@ public class LibraryViewModel : APageViewModel<ILibraryViewModel>, ILibraryViewM
                 configureAwait: false
             ).AddTo(disposables);
 
-            CollectionMetadata.ObserveAll(_connection)
-                .FilterImmutable(collection =>
-                {
-                    if (!CollectionMetadata.GameId.TryGetValue(collection, out var collectionGameId)) return true;
-                    return collectionGameId == game.GameId;
-                })
+            CollectionRevisionMetadata.ObserveAll(_connection)
+                .FilterImmutable(revision => revision.Collection.GameId == game.GameId)
                 .OnUI()
-                .Transform(ICollectionCardViewModel (coll) => new CollectionCardViewModel(
+                .Transform(ICollectionCardViewModel (revision) => new CollectionCardViewModel(
                     tileImagePipeline: tileImagePipeline,
                     userAvatarPipeline: userAvatarPipeline,
                     windowManager: WindowManager,
                     workspaceId: WorkspaceId,
                     connection: _connection,
-                    revision: coll.Revisions.First().RevisionId,
+                    revision: revision.RevisionId,
                     targetLoadout: _loadout)
                 )
                 .Bind(out _collections)


### PR DESCRIPTION
- can delete individual revisions
- can fetch all or newer revision numbers
- library displays revisions instead of first revision of collections

Part of #391.