### PR TITLE
Re-added placeholder for mod thumbnails

### DIFF
--- a/src/NexusMods.App.UI/Pages/TreeDataGridSharedResources.axaml
+++ b/src/NexusMods.App.UI/Pages/TreeDataGridSharedResources.axaml
@@ -16,14 +16,12 @@
                                                 ComponentKey="{x:Static controls:SharedColumns+Name.ImageComponentKey}">
                         <controls:ComponentTemplate.DataTemplate>
                             <DataTemplate DataType="{x:Type controls:ImageComponent}">
-                                <Border x:Name="LibraryItemThumbnailBorder">
                                     <Panel>
                                         <!-- The below image is drawn after the icon and covers the icon if a thumbnail is present. --> 
                                         <!-- If no thumbnail, then the below Image is null\transparent and so the icon is seen -->
                                         <icons:UnifiedIcon Value="{x:Static icons:IconValues.Nexus}" />
                                         <Image Source="{CompiledBinding Value.Value}" />
                                     </Panel>
-                                </Border>
                             </DataTemplate>
                         </controls:ComponentTemplate.DataTemplate>
                     </controls:ComponentTemplate>

--- a/src/NexusMods.App.UI/Pages/TreeDataGridSharedResources.axaml
+++ b/src/NexusMods.App.UI/Pages/TreeDataGridSharedResources.axaml
@@ -16,7 +16,14 @@
                                                 ComponentKey="{x:Static controls:SharedColumns+Name.ImageComponentKey}">
                         <controls:ComponentTemplate.DataTemplate>
                             <DataTemplate DataType="{x:Type controls:ImageComponent}">
-                                <Image Source="{CompiledBinding Value.Value}" />
+                                <Border x:Name="LibraryItemThumbnailBorder">
+                                    <Panel>
+                                        <!-- The below image is drawn after the icon and covers the icon if a thumbnail is present. --> 
+                                        <!-- If no thumbnail, then the below Image is null\transparent and so the icon is seen -->
+                                        <icons:UnifiedIcon Value="{x:Static icons:IconValues.Nexus}" />
+                                        <Image Source="{CompiledBinding Value.Value}" />
+                                    </Panel>
+                                </Border>
                             </DataTemplate>
                         </controls:ComponentTemplate.DataTemplate>
                     </controls:ComponentTemplate>

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/SharedStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/SharedStyles.axaml
@@ -10,7 +10,7 @@
         </Style>
 
         <!-- thumbnail -->
-        <Style Selector="^ Border.SharedColumn_Name_ImageComponent Border#LibraryItemThumbnailBorder">
+        <Style Selector="^ Border.SharedColumn_Name_ImageComponent">
             <Setter Property="Background" Value="{StaticResource SurfaceTranslucentMidBrush}" />
             <Setter Property="BorderThickness" Value="0" />
             <Setter Property="CornerRadius" Value="{StaticResource Rounded}" />

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/SharedStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/SharedStyles.axaml
@@ -1,6 +1,7 @@
 <Styles xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:icons="clr-namespace:NexusMods.Icons;assembly=NexusMods.Icons">
+    
     <!-- name column -->
     <Style Selector="TreeDataGridTemplateCell.SharedColumn_Name /template/ ContentPresenter#PART_ContentPresenter">
 
@@ -9,9 +10,23 @@
         </Style>
 
         <!-- thumbnail -->
-        <Style Selector="^ Border.SharedColumn_Name_ImageComponent Image">
-            <Setter Property="Width" Value="45"/>
-            <Setter Property="Height" Value="28"/>
+        <Style Selector="^ Border.SharedColumn_Name_ImageComponent Border#LibraryItemThumbnailBorder">
+            <Setter Property="Background" Value="{StaticResource SurfaceTranslucentMidBrush}" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="CornerRadius" Value="{StaticResource Rounded}" />
+            <Setter Property="Width" Value="45" />
+            <Setter Property="Height" Value="28" />
+            <!-- easy way to get the rounded corner to mask the image below -->
+            <Setter Property="ClipToBounds" Value="True" />
+                        
+            <Style Selector="^ > Panel > icons|UnifiedIcon">
+                <Setter Property="Foreground" Value="{StaticResource NeutralSubduedBrush}" />
+                <Setter Property="Size" Value="16" />
+            </Style>
+                        
+            <Style Selector="^ > Panel > Image">
+                <Setter Property="Stretch" Value="UniformToFill" />
+            </Style>
         </Style>
 
         <!-- name -->


### PR DESCRIPTION
Added placeholder elements back to TreeDataGrid thumbnails so something is shown when an image is null or transparent and not just empty space. 

![image](https://github.com/user-attachments/assets/776cecc6-7b34-4298-8d03-bedf095e4e55)
