### PR TITLE
Show and add newest revision to the app

### DIFF
--- a/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsLibrary.Collections.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsLibrary.Collections.cs
@@ -105,50 +105,6 @@ public partial class NexusModsLibrary
         return revisionNumbers;
     }
 
-    /// <summary>
-    /// Deletes a revision and all downloaded entities.
-    /// </summary>
-    public async ValueTask DeleteRevision(CollectionRevisionMetadataId revisionId)
-    {
-        var db = _connection.Db;
-        using var tx = _connection.BeginTransaction();
-
-        var downloadIds = db.Datoms(CollectionDownload.CollectionRevision, revisionId);
-        foreach (var downloadId in downloadIds)
-        {
-            tx.Delete(downloadId.E, recursive: false);
-        }
-
-        tx.Delete(revisionId, recursive: false);
-
-        await tx.Commit();
-    }
-
-    /// <summary>
-    /// Deletes a collection, all revisions, and all download entities of all revisions.
-    /// </summary>
-    public async ValueTask DeleteCollection(CollectionMetadataId collectionMetadataId)
-    {
-        var db = _connection.Db;
-        using var tx = _connection.BeginTransaction();
-
-        var revisionIds = db.Datoms(CollectionRevisionMetadata.CollectionId, collectionMetadataId);
-        foreach (var revisionId in revisionIds)
-        {
-            var downloadIds = db.Datoms(CollectionDownload.CollectionRevision, revisionId.E);
-            foreach (var downloadId in downloadIds)
-            {
-                tx.Delete(downloadId.E, recursive: false);
-            }
-
-            tx.Delete(revisionId.E, recursive: false);
-        }
-
-        tx.Delete(collectionMetadataId, recursive: false);
-
-        await tx.Commit();
-    }
-
     private static ResolvedEntitiesLookup ResolveModFiles(
         IDb db,
         ITransaction tx,

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadDesignViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadDesignViewModel.cs
@@ -1,5 +1,6 @@
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
+using DynamicData.Kernel;
 using NexusMods.Abstractions.Jobs;
 using NexusMods.Abstractions.NexusWebApi.Types;
 using NexusMods.App.UI.Controls.Navigation;
@@ -44,12 +45,15 @@ public class CollectionDownloadDesignViewModel : APageViewModel<ICollectionDownl
     public BindableReactiveProperty<bool> IsInstalled { get; } = new(value: false);
     public BindableReactiveProperty<bool> IsDownloading { get; } = new();
     public BindableReactiveProperty<bool> IsInstalling { get; } = new();
+    public BindableReactiveProperty<bool> IsUpdateAvailable { get; } = new();
+    public BindableReactiveProperty<Optional<RevisionNumber>> NewestRevisionNumber { get; } = new();
 
     public ReactiveCommand<NavigationInformation> CommandViewCollection { get; } = new();
     public ReactiveCommand<Unit> CommandDownloadOptionalItems { get; } = new ReactiveCommand();
     public ReactiveCommand<Unit> CommandDownloadRequiredItems { get; } = new ReactiveCommand();
     public ReactiveCommand<Unit> CommandInstallOptionalItems { get; } = new ReactiveCommand();
     public ReactiveCommand<Unit> CommandInstallRequiredItems { get; } = new ReactiveCommand();
+    public ReactiveCommand<Unit> CommandUpdateCollection { get; } = new ReactiveCommand();
 
     public ReactiveCommand<Unit> CommandViewOnNexusMods { get; } = new ReactiveCommand();
     public ReactiveCommand<Unit> CommandOpenJsonFile { get; } = new ReactiveCommand();

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadView.axaml
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadView.axaml
@@ -58,6 +58,8 @@
                     <controls:StandardButton x:Name="ButtonInstallRequiredItems" Text="Install Collection" />
                     <navigation:NavigationControl x:Name="ButtonViewCollection" Text="View Installed Collection"/>
 
+                    <controls:StandardButton IsVisible="False" x:Name="ButtonUpdateCollection" Text="Install Update"/>
+
                     <controls:StandardButton x:Name="ButtonDownloadOptionalItems" Text="Download all optional mods" />
                     <controls:StandardButton x:Name="ButtonInstallOptionalItems" Text="Install downloaded optional mods" />
                     <controls:StandardButton Flyout="{StaticResource CollectionMenuFlyout}" Text="..." />
@@ -92,7 +94,11 @@
                                 <TextBlock Grid.Row="1" x:Name="Heading" />
                                 <Border Grid.Row="2" x:Name="TagsPanelBorder">
                                     <StackPanel x:Name="TagsPanel">
-                                        <TextBlock x:Name="Revision" />
+                                        <StackPanel x:Name="RevisionsPanel">
+                                            <TextBlock x:Name="Revision" />
+                                            <icons:UnifiedIcon IsVisible="False" x:Name="ArrowRight"/>
+                                            <TextBlock IsVisible="False" x:Name="NewestRevision"/>
+                                        </StackPanel>
                                         <StackPanel x:Name="AuthorStackPanel">
                                             <Border x:Name="AuthorAvatarBorder">
                                                 <Image x:Name="AuthorAvatar" />

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadView.axaml.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadView.axaml.cs
@@ -50,6 +50,9 @@ public partial class CollectionDownloadView : ReactiveUserControl<ICollectionDow
             this.BindCommand(ViewModel, vm => vm.CommandInstallOptionalItems, view => view.ButtonInstallOptionalItems)
                 .DisposeWith(d);
 
+            this.BindCommand(ViewModel, vm => vm.CommandUpdateCollection, view => view.ButtonUpdateCollection)
+                .DisposeWith(d);
+
             this.OneWayBind(ViewModel, vm => vm.TreeDataGridAdapter.Source.Value, view => view.DownloadsTree.Source)
                 .DisposeWith(d);
 
@@ -105,6 +108,20 @@ public partial class CollectionDownloadView : ReactiveUserControl<ICollectionDow
 
             this.OneWayBind(ViewModel, vm => vm.RevisionNumber, view => view.Revision.Text, revision => $"Revision {revision}")
                 .DisposeWith(d);
+
+            this.WhenAnyValue(
+                    view => view.ViewModel!.IsUpdateAvailable.Value,
+                    view => view.ViewModel!.NewestRevisionNumber.Value)
+                .Subscribe(tuple =>
+                {
+                    var (isUpdateAvailable, optional) = tuple;
+
+                    ButtonUpdateCollection.IsVisible = isUpdateAvailable;
+                    ArrowRight.IsVisible = isUpdateAvailable;
+                    NewestRevision.IsVisible = isUpdateAvailable;
+
+                    if (optional.HasValue) NewestRevision.Text = $"Revision {optional.Value}";
+                }).DisposeWith(d);
 
             this.WhenAnyValue(view => view.TabControl.SelectedItem)
                 .Select(selectedItem =>

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/ICollectionDownloadViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/ICollectionDownloadViewModel.cs
@@ -1,4 +1,5 @@
 using Avalonia.Media.Imaging;
+using DynamicData.Kernel;
 using NexusMods.Abstractions.Jobs;
 using NexusMods.Abstractions.NexusModsLibrary.Models;
 using NexusMods.Abstractions.NexusWebApi.Types;
@@ -91,6 +92,8 @@ public interface ICollectionDownloadViewModel : IPageViewModelInterface
     BindableReactiveProperty<bool> IsInstalled { get; }
     BindableReactiveProperty<bool> IsInstalling { get; }
     BindableReactiveProperty<bool> IsDownloading { get; }
+    BindableReactiveProperty<bool> IsUpdateAvailable { get; }
+    BindableReactiveProperty<Optional<RevisionNumber>> NewestRevisionNumber { get; }
 
     ReactiveCommand<NavigationInformation> CommandViewCollection { get; }
     ReactiveCommand<Unit> CommandDownloadRequiredItems { get; }
@@ -98,6 +101,8 @@ public interface ICollectionDownloadViewModel : IPageViewModelInterface
 
     ReactiveCommand<Unit> CommandDownloadOptionalItems { get; }
     ReactiveCommand<Unit> CommandInstallOptionalItems { get; }
+
+    ReactiveCommand<Unit> CommandUpdateCollection { get; }
 
     ReactiveCommand<Unit> CommandViewOnNexusMods { get; }
     ReactiveCommand<Unit> CommandOpenJsonFile { get; }

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/UserControls/CollectionDownloadPage/CollectionDownloadPageStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/UserControls/CollectionDownloadPage/CollectionDownloadPageStyles.axaml
@@ -87,11 +87,28 @@
                                             <Setter Property="Orientation" Value="Horizontal" />
                                             <Setter Property="Spacing" Value="{StaticResource Spacing-3}" />
 
-                                            <Style Selector="^ TextBlock#Revision">
-                                                <Setter Property="Theme" Value="{StaticResource BodyMDBoldTheme}" />
-                                                <Setter Property="Foreground"
-                                                        Value="{StaticResource NeutralTranslucentModerateBrush}" />
+                                            <Style Selector="^ StackPanel#RevisionsPanel">
+                                                <Setter Property="Orientation" Value="Horizontal"/>
+                                                <Setter Property="Spacing" Value="{StaticResource Spacing-2}"/>
+
+                                                <Style Selector="^ TextBlock#Revision">
+                                                    <Setter Property="Theme" Value="{StaticResource BodyMDBoldTheme}" />
+                                                    <Setter Property="Foreground"
+                                                            Value="{StaticResource NeutralTranslucentModerateBrush}" />
+                                                </Style>
+
+                                                <Style Selector="^ icons|UnifiedIcon#ArrowRight">
+                                                    <Setter Property="Size" Value="18"/>
+                                                    <Setter Property="Foreground" Value="{StaticResource InfoStrongBrush}"/>
+                                                    <Setter Property="Value" Value="{x:Static icons:IconValues.ArrowForward}"/>
+                                                </Style>
+
+                                                <Style Selector="^ TextBlock#NewestRevision">
+                                                    <Setter Property="Theme" Value="{StaticResource BodyMDBoldTheme}"/>
+                                                    <Setter Property="Foreground" Value="{StaticResource InfoStrongBrush}"/>
+                                                </Style>
                                             </Style>
+
 
                                             <Style Selector="^ StackPanel#AuthorStackPanel">
                                                 <Setter Property="Orientation" Value="Horizontal" />


### PR DESCRIPTION
Part of #391.

Fetches all revisions for a collection and shows the newest revision in the UI. Also adds a "Install Update" button that adds the newest revision to the app and navigates to the collection download page for that revision.

Nothing yet for dealing with the old revision.