### PR TITLE
Fix blue thumbnails

### DIFF
--- a/src/NexusMods.Media/ImageDecoder.cs
+++ b/src/NexusMods.Media/ImageDecoder.cs
@@ -46,7 +46,7 @@ public sealed class ImageDecoder<TResourceIdentifier> : ANestedResourceLoader<TR
                 height: qoiImage.Height,
                 colorType: SKColorType.Rgba8888,
                 alphaType: SKAlphaType.Unpremul,
-                colorspace: SKColorSpace.CreateSrgbLinear()
+                colorspace: SKColorSpace.CreateSrgb()
             );
 
             var skBitmap = new SKBitmap(skImageInfo);

--- a/src/NexusMods.Media/ImageEncoder.cs
+++ b/src/NexusMods.Media/ImageEncoder.cs
@@ -68,13 +68,22 @@ public sealed class ImageEncoder<TResourceIdentifier> : ANestedResourceLoader<TR
         // TODO: check if input is already in the correct layout, then we can skip this transposing step
         var skImageInfo = skBitmap.Info
             .WithAlphaType(SKAlphaType.Unpremul)
-            .WithColorSpace(SKColorSpace.CreateSrgbLinear())
-            .WithColorType(SKColorType.Rgba8888);
+            .WithColorType(SKColorType.Rgba8888)
+            .WithColorSpace(SKColorSpace.CreateSrgb());
 
         using var outputSkBitmap = new SKBitmap(skImageInfo);
-        skBitmap.CopyTo(outputSkBitmap);
 
-        return skBitmap.GetPixelSpan().ToArray();
+        using (var skCanvas = new SKCanvas(outputSkBitmap))
+        using (var skPaint = new SKPaint())
+        {
+            skCanvas.DrawBitmap(
+                bitmap: skBitmap,
+                dest: skImageInfo.Rect,
+                paint: skPaint
+            );
+        }
+
+        return outputSkBitmap.GetPixelSpan().ToArray();
     }
 }
 


### PR DESCRIPTION
There were two issues:

1) The transposing step was completely skipped as we always used the
   pixels of the input bitmap. This is what resulted in the channels
   being swapped, as the input bitmap was BGRA instead of RGBA.
2) The SRGB Linear color space was used even though we encode images
   using the normal SRGB color space. This resulted in colors that were
   noticeably off.