### PR TITLE
Fix SDV installer flaky test 

### DIFF
--- a/tests/Games/NexusMods.Games.StardewValley.Tests/StardewValleyInstallersTests.CanInstallMod_filename=Portraits_for_Vendors.zip.verified.txt
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/StardewValleyInstallersTests.CanInstallMod_filename=Portraits_for_Vendors.zip.verified.txt
@@ -4,42 +4,63 @@ TDIT - Dialogue Box for Mariner:
   {Game} Mods/Portraits for Vendors/OldMarinerDialogue/manifest.json.bak - 368 B - 0xE28C1B1A0864C036 - Stored: True
   {Game} Mods/Portraits for Vendors/OldMarinerDialogue/OldMarinerDialogue.dll - 12.5 KB - 0x33678179FEB8FE6B - Stored: True
 TDIT - Portraits for Vendors:
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/blank.json - 2 B - 0x1349CDE127705C16 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/blank.png - 227 B - 0xF38349531DF2D07B - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/Bookseller_Default.png - 3.051 KB - 0x5F976973C44C2197 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/Bookseller.json - 464 B - 0x0250CF7CA6366EF3 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/Casino_Bouncer.png - 2.966 KB - 0x105E899C07973828 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/Casino_Bouncer.png - 2.92 KB - 0x744F802E2C63A5F9 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/SCC/Casino_Bouncer.png - 4.347 KB - 0x1172264846B2BE4A - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/Casino_Default.png - 2.188 KB - 0xCE09551F9A1E5EC3 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/Casino_Green.png - 4.322 KB - 0xD6E4277BD7980B89 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/Casino_Green.png - 7.039 KB - 0x624E5C1A0336F051 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/Casino.json - 1.111 KB - 0x89E9FB1D7FE91D02 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/content.json - 12.338 KB - 0x4BEBBCCB7A855311 - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Credits.xlsx - 14.252 KB - 0x655556F7083043CD - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/Crow_Default.png - 5.682 KB - 0x1F77A71BC4CAEA73 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/blank.json - 2 B - 0x1349CDE127705C16 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/Bookseller.json - 464 B - 0x0250CF7CA6366EF3 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/Casino.json - 1.111 KB - 0x89E9FB1D7FE91D02 - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/Crow.json - 1.119 KB - 0x6BAB79C3F65876E5 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/DecorBoat.json - 615 B - 0xD02B94776805089B - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/DesertTrader.json - 1.055 KB - 0x525DFF28AC2BA5E6 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/EggShop.json - 246 B - 0x3181C617A2A4BDF1 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/HatMouse.json - 917 B - 0xDDB4654216489351 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/HDPortraits.json - 32.604 KB - 0xD766DD25BAC75598 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/IslandTrader.json - 580 B - 0xCA296F8DCAF36414 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/JojaCashier.json - 8.577 KB - 0x56A6A7DD396B15E1 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/MagicBoat.json - 767 B - 0xF5CE7967AA285C86 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/MovieConcessionCC.json - 3.515 KB - 0xA670441B51424B6B - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/MovieConcessionJoja.json - 1.063 KB - 0x651A166B7411A117 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/MovieTicketCC.json - 1.041 KB - 0xDD5E74D4BD578CD2 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/MovieTicketJoja.json - 261 B - 0x16BDB948AB305266 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/OldMariner.json - 986 B - 0x0F13C28336982570 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/PierreFestival.json - 2.567 KB - 0xDB57D9FF2A9884EF - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/Raccoon.json - 485 B - 0x0970B736889AF909 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/StarToken.json - 453 B - 0xA8C6A701A14D50E5 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/Traveler.json - 1 KB - 0x80CB2D83B1D6534A - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/VolcanoDwarf.json - 919 B - 0x2EB06D3C568B5237 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/blank.png - 227 B - 0xF38349531DF2D07B - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/Casino_Bouncer.png - 2.966 KB - 0x105E899C07973828 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/Casino_Green.png - 4.322 KB - 0xD6E4277BD7980B89 - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/CrowFrame.png - 5.776 KB - 0xC9BCCD535651A342 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/i18n/de.json - 11.472 KB - 0xE80F6EC23412E01C - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/DesertTrader_RacerGuy.png - 3.694 KB - 0x7D71067294C2D522 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/DesertTrader_Scholar.png - 541 B - 0xC8BEF22120A1838A - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/IslandTrader_Green.png - 4.221 KB - 0x1E235FC168BD0773 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/IslandTrader_Red.png - 4.224 KB - 0x0DAA454711B9822E - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/JojaCashier_Daena.png - 4.993 KB - 0x37899566647BCDB7 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/JojaCashier_Jessie.png - 10.468 KB - 0x3E9D414498DBDC36 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/JojaCashier_Naufal.png - 5.207 KB - 0x5890F4B77877928A - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/JojaCashier_Sign.png - 4.079 KB - 0x20942C2DE3402579 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/MovieConcessionCC_Daena.png - 2.726 KB - 0x1DFAF5DD44D40A14 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/MovieConcessionCC_Naufal.png - 1.17 KB - 0x5248DBB2EA6E46DF - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/MovieConcessionJoja_Daena.png - 2.898 KB - 0x3D97FC919E6380F8 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/MovieConcessionJoja_Naufal.png - 1.22 KB - 0x6A37561546B6CDEC - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/TDIT_Daena.png - 3.379 KB - 0xB63A2E8141A71B68 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/TDIT_DaenaPortrait.png - 6.441 KB - 0x4F252D804672586C - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/TDIT_Naufal.png - 6.317 KB - 0x0BE77069C7822F29 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/Bookseller_Default.png - 3.051 KB - 0x5F976973C44C2197 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/Casino_Bouncer.png - 2.92 KB - 0x744F802E2C63A5F9 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/Casino_Default.png - 2.188 KB - 0xCE09551F9A1E5EC3 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/Casino_Green.png - 7.039 KB - 0x624E5C1A0336F051 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/Crow_Default.png - 5.682 KB - 0x1F77A71BC4CAEA73 - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/DecorBoat_Cat.png - 4.572 KB - 0x9694525826CDCDAC - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/DecorBoat_CatNoHat.png - 4.277 KB - 0xB6A970E008A3326D - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/DecorBoat_CatNoHatWithPipe.png - 4.613 KB - 0x6DAD6222C03A40F4 - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/DecorBoat_CatWithPipe.png - 4.869 KB - 0x76BCB24BD2C493FD - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/DecorBoat_Default.png - 2.714 KB - 0x5020910A27B30591 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/DecorBoat.json - 615 B - 0xD02B94776805089B - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/i18n/default.json - 11.51 KB - 0x79E39E03BE020C0D - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/DesertTrader_Default.png - 5.461 KB - 0x26FE759E109942A7 - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/DesertTrader_Hippie.png - 4.961 KB - 0x73357EB98E889657 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/DesertTrader_RacerGuy.png - 3.694 KB - 0x7D71067294C2D522 - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/DesertTrader_RacerGuy.png - 5.526 KB - 0x6AAA9489958D5FE7 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/DesertTrader_Scholar.png - 541 B - 0xC8BEF22120A1838A - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/DesertTrader_Scholar.png - 5.38 KB - 0x5DA92FDE97CC84C3 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/DesertTrader.json - 1.055 KB - 0x525DFF28AC2BA5E6 - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/EggShop_Default.png - 759 B - 0xAEEE106B8FE20233 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/EggShop.json - 246 B - 0x3181C617A2A4BDF1 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/i18n/en-GB.json - 11.481 KB - 0xEE1521CC81FFD10F - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/i18n/es.json - 5.887 KB - 0xEC4EB50107571C83 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/i18n/fr.json - 7.91 KB - 0xB43E75FEC55465CF - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/HatMouse_Beanie.png - 2.269 KB - 0x5F18B63380F6F838 - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/HatMouse_Bow.png - 5.118 KB - 0xBDEBCF3D4038B868 - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/HatMouse_Default.png - 1.939 KB - 0x17C0CB61097B1FBC - Stored: True
@@ -55,70 +76,49 @@ TDIT - Portraits for Vendors:
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/HatMouse_Sailor.png - 3.762 KB - 0x45AA0BE188EC6684 - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/HatMouse_Strawhat.png - 2.14 KB - 0x25E24B21C97EF337 - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/HatMouse_Wizard.png - 6.375 KB - 0x233C4FD295D57418 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/HatMouse.json - 917 B - 0xDDB4654216489351 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/HDPortraits.json - 32.604 KB - 0xD766DD25BAC75598 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/i18n/id.json - 11.505 KB - 0x231B611FB098A96D - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/HD/VolcanoDwarf_Default.png - 27.476 KB - 0x296F2A8E6675E17F - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/IslandTrader_Default.png - 2.49 KB - 0xD486B8E60ECA87B0 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/IslandTrader_Green.png - 4.221 KB - 0x1E235FC168BD0773 - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/IslandTrader_Green.png - 4.119 KB - 0x05145E964A8EC73D - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/IslandTrader_Red.png - 4.224 KB - 0x0DAA454711B9822E - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/IslandTrader_Red.png - 4.175 KB - 0x009F12BDE539F8BC - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/IslandTrader.json - 580 B - 0xCA296F8DCAF36414 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/i18n/ja.json - 14.375 KB - 0x73EB9C7427C3F739 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/JojaCashier_Daena.png - 4.993 KB - 0x37899566647BCDB7 - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/JojaCashier_Daena.png - 6.563 KB - 0xA383E356CC22D5FF - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/JojaCashier_Default.png - 2.459 KB - 0xA1AD3D67B42932D8 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/JojaCashier_Jessie.png - 10.468 KB - 0x3E9D414498DBDC36 - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/JojaCashier_Jessie.png - 5.669 KB - 0xCDA39CDBF7F605C7 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/JojaCashier_Naufal.png - 5.207 KB - 0x5890F4B77877928A - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/JojaCashier_Naufal.png - 5.537 KB - 0xE35CC04C2D5F231E - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/JojaCashier_Sign.png - 4.079 KB - 0x20942C2DE3402579 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/JojaCashier.json - 8.577 KB - 0x56A6A7DD396B15E1 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/i18n/ko.json - 13.277 KB - 0xB7A9B208C7590215 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/LavenderSkelly/VolcanoDwarf_Default.png - 736 B - 0xF618B4E18D77E2C3 - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/MagicBoat_Default.png - 2.313 KB - 0x7DA82A0E09E38E63 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/MagicBoat.json - 767 B - 0xF5CE7967AA285C86 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/manifest.json - 1.001 KB - 0x2922DC76A3AE5CFE - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/MovieConcessionCC_Daena.png - 2.726 KB - 0x1DFAF5DD44D40A14 - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/MovieConcessionCC_Daena.png - 5.36 KB - 0x49C9DE2863C8B186 - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/MovieConcessionCC_Default.png - 2.753 KB - 0x70F1F4C82D5A464A - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/MovieConcessionCC_Juliet.png - 3.084 KB - 0x5A829E42E68524C1 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/SCC/MovieConcessionCC_Juliet.png - 5.845 KB - 0xB59C97474EB0DADB - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/MovieConcessionCC_Kevin.png - 3.138 KB - 0x969762F635E608B5 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/MovieConcessionCC_Naufal.png - 1.17 KB - 0x5248DBB2EA6E46DF - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/MovieConcessionCC_Naufal.png - 5.773 KB - 0xFEF8162197DF9795 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/MovieConcessionCC.json - 3.515 KB - 0xA670441B51424B6B - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/MovieConcessionJoja_Daena.png - 2.898 KB - 0x3D97FC919E6380F8 - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/MovieConcessionJoja_Daena.png - 5.289 KB - 0x0A5EB93D5C532A94 - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/MovieConcessionJoja_Default.png - 2.696 KB - 0x6FDF5F09C84DE323 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/MovieConcessionJoja_Naufal.png - 1.22 KB - 0x6A37561546B6CDEC - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/MovieConcessionJoja_Naufal.png - 5.475 KB - 0x83AB8310ECD39A96 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/MovieConcessionJoja.json - 1.063 KB - 0x651A166B7411A117 - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/MovieTicketCC_Default.png - 5.146 KB - 0xC839FC0A3034EA72 - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/MovieTicketCC_Naufal.png - 5.491 KB - 0x928A4586E431C9C8 - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/MovieTicketCC_Shift.png - 2.441 KB - 0xD0CDC7ECDF2EB56C - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/MovieTicketCC.json - 1.041 KB - 0xDD5E74D4BD578CD2 - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/MovieTicketJoja_Default.png - 5.028 KB - 0x84C8FD528AD203DB - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/MovieTicketJoja_Naufal.png - 5.396 KB - 0xE27B02056F702337 - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/MovieTicketJoja_Shift.png - 2.418 KB - 0x93C876D4356A9E9E - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/MovieTicketJoja.json - 261 B - 0x16BDB948AB305266 - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/OldMariner_Default.png - 2.457 KB - 0xF9390C6F00B39ABD - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/OldMariner_Mermaid.png - 2.935 KB - 0xAC8644B525A1EDA3 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/OldMariner.json - 986 B - 0x0F13C28336982570 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/PierreFestival.json - 2.567 KB - 0xDB57D9FF2A9884EF - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/i18n/pl.json - 5.393 KB - 0x6AC6FCF11CC68703 - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/Raccoon_Default.png - 4.38 KB - 0x06B19FBEEBB982DC - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/Raccoon.json - 485 B - 0x0970B736889AF909 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/i18n/ru.json - 11.009 KB - 0x2CDA1B7E36B26F53 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/SCC/Casino_Bouncer.png - 4.347 KB - 0x1172264846B2BE4A - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/SCC/MovieConcessionCC_Juliet.png - 5.845 KB - 0xB59C97474EB0DADB - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/StarToken_Default.png - 5.637 KB - 0x2A2014A8DABF30EF - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/StarToken.json - 453 B - 0xA8C6A701A14D50E5 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/TDIT_Daena.png - 3.379 KB - 0xB63A2E8141A71B68 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/TDIT_DaenaPortrait.png - 6.441 KB - 0x4F252D804672586C - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/LooseSprites/TDIT_Naufal.png - 6.317 KB - 0x0BE77069C7822F29 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/Traveler_Default.png - 3.23 KB - 0x81849CBDE30075D2 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/Traveler.json - 1 KB - 0x80CB2D83B1D6534A - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/TravelerDesert_Default.png - 3.324 KB - 0xF126752F6C7C1971 - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/TravelerIce_Default.png - 2.947 KB - 0xD722DB2B494AB111 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/Traveler_Default.png - 3.23 KB - 0x81849CBDE30075D2 - Stored: True
   {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/VolcanoDwarf_Default.png - 2.11 KB - 0x714275BBA5AE8F73 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/HD/VolcanoDwarf_Default.png - 27.476 KB - 0x296F2A8E6675E17F - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Portraits/LavenderSkelly/VolcanoDwarf_Default.png - 736 B - 0xF618B4E18D77E2C3 - Stored: True
-  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/assets/Data/VolcanoDwarf.json - 919 B - 0x2EB06D3C568B5237 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/content.json - 12.338 KB - 0x4BEBBCCB7A855311 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/i18n/de.json - 11.472 KB - 0xE80F6EC23412E01C - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/i18n/default.json - 11.51 KB - 0x79E39E03BE020C0D - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/i18n/en-GB.json - 11.481 KB - 0xEE1521CC81FFD10F - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/i18n/es.json - 5.887 KB - 0xEC4EB50107571C83 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/i18n/fr.json - 7.91 KB - 0xB43E75FEC55465CF - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/i18n/id.json - 11.505 KB - 0x231B611FB098A96D - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/i18n/ja.json - 14.375 KB - 0x73EB9C7427C3F739 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/i18n/ko.json - 13.277 KB - 0xB7A9B208C7590215 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/i18n/pl.json - 5.393 KB - 0x6AC6FCF11CC68703 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/i18n/ru.json - 11.009 KB - 0x2CDA1B7E36B26F53 - Stored: True
+  {Game} Mods/Portraits for Vendors/[CP] Portraits for Vendors/manifest.json - 1.001 KB - 0x2922DC76A3AE5CFE - Stored: True


### PR DESCRIPTION
- Fixes #2532 

by ensuring the sorting of items is consistent
Before it was sorting just by file name, now it is sorting by the entire relative path.
There were files with the same filename, but inside different folders that could end up in different positions