### PR TITLE
Fix `ApplyChanges` exceptions in the library/loadout

### DIFF
--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridAdapter.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridAdapter.cs
@@ -7,6 +7,7 @@ using NexusMods.Abstractions.UI.Extensions;
 using NexusMods.App.UI.Extensions;
 using ObservableCollections;
 using R3;
+using System.Reactive.Linq;
 
 namespace NexusMods.App.UI.Controls;
 
@@ -99,8 +100,9 @@ public abstract class TreeDataGridAdapter<TModel, TKey> : ReactiveR3Object
                     return self
                         .GetRootsObservable(viewHierarchical)
                         .OnUI()
+                        .Do(changeSet => self.Roots.ApplyChanges(changeSet))
+                        .DisposeMany()
                         .ToObservable()
-                        .Do(self, static (changeSet, self) => self.Roots.ApplyChanges(changeSet))
                         .Select(viewHierarchical, static (_, viewHierarchical) => viewHierarchical);
                 })
                 .Switch()
@@ -118,7 +120,7 @@ public abstract class TreeDataGridAdapter<TModel, TKey> : ReactiveR3Object
             SingleSelect = false,
         };
 
-        var selectionObservable = Observable.FromEventHandler<TreeSelectionModelSelectionChangedEventArgs<TModel>>(
+        var selectionObservable = R3.Observable.FromEventHandler<TreeSelectionModelSelectionChangedEventArgs<TModel>>(
             addHandler: handler => selection.SelectionChanged += handler,
             removeHandler: handler => selection.SelectionChanged -= handler
         ).Select(tuple => tuple.e);

--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridAdapter.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridAdapter.cs
@@ -99,7 +99,6 @@ public abstract class TreeDataGridAdapter<TModel, TKey> : ReactiveR3Object
                     return self
                         .GetRootsObservable(viewHierarchical)
                         .OnUI()
-                        .DisposeMany()
                         .ToObservable()
                         .Do(self, static (changeSet, self) => self.Roots.ApplyChanges(changeSet))
                         .Select(viewHierarchical, static (_, viewHierarchical) => viewHierarchical);

--- a/src/NexusMods.App.UI/Pages/LibraryPage/NexusModsModPageLibraryItemModel.cs
+++ b/src/NexusMods.App.UI/Pages/LibraryPage/NexusModsModPageLibraryItemModel.cs
@@ -120,7 +120,8 @@ public class NexusModsModPageLibraryItemModel : TreeDataGridItemModel<ILibraryIt
             FormattedInstalledDate,
             InstallItemCommand,
             IsInstalled,
-            InstallButtonText
+            InstallButtonText,
+            linkedLoadoutItemsDisposable
         );
     }
 


### PR DESCRIPTION
- Fixes #2529 

This `DisposeMany` seems to wreak havoc on items that are still in view or similar. I don't know if it is necessary to replace this with a different mechanism for disposing the items, but I think it should happen higher level to avoid items getting disposed before they are fully removed from view and other collections.