### PR TITLE
Fix health checks not refreshing on loaodut changes

### DIFF
--- a/src/Games/NexusMods.Games.StardewValley/Emitters/Helpers.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/Helpers.cs
@@ -2,6 +2,7 @@ using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.Diagnostics.Values;
 using NexusMods.Abstractions.Loadouts;
+using NexusMods.Abstractions.Loadouts.Extensions;
 using NexusMods.Abstractions.Resources;
 using NexusMods.Abstractions.Telemetry;
 using NexusMods.Extensions.BCL;
@@ -20,7 +21,7 @@ internal static class Helpers
         var foundSMAPI = loadout.Items
             .OfTypeLoadoutItemGroup()
             .OfTypeSMAPILoadoutItem()
-            .TryGetFirst(x => !x.AsLoadoutItemGroup().AsLoadoutItem().IsDisabled, out smapi);
+            .TryGetFirst(x => x.AsLoadoutItemGroup().AsLoadoutItem().IsEnabled(), out smapi);
 
         return foundSMAPI;
     }
@@ -35,7 +36,7 @@ internal static class Helpers
         var asyncEnumerable = loadout.Items
             .OfTypeLoadoutItemGroup()
             .OfTypeSMAPIModLoadoutItem()
-            .Where(x => !onlyEnabledMods || !x.AsLoadoutItemGroup().AsLoadoutItem().IsDisabled)
+            .Where(x => !onlyEnabledMods || x.AsLoadoutItemGroup().AsLoadoutItem().IsEnabled())
             .ToAsyncEnumerable()
             .ConfigureAwait(continueOnCapturedContext: false)
             .WithCancellation(cancellationToken);

--- a/src/NexusMods.DataModel/Diagnostics/DiagnosticManager.cs
+++ b/src/NexusMods.DataModel/Diagnostics/DiagnosticManager.cs
@@ -42,7 +42,7 @@ internal sealed class DiagnosticManager : IDiagnosticManager
             var existingObservable = _observableCache.Lookup(loadoutId);
             if (existingObservable.HasValue) return existingObservable.Value;
 
-            var connectableObservable = _connection.ObserveDatoms(loadoutId)
+            var connectableObservable = Loadout.RevisionsWithChildUpdates(_connection, loadoutId)
                 .Throttle(dueTime: TimeSpan.FromMilliseconds(250))
                 .SelectMany(async _ =>
                 {


### PR DESCRIPTION
- fixes #2525 

I thought health checks weren't updating on collection enabled state changes, but they weren't updating at all.
Don't know how that went by for so long. I think it happened because we are no longer updating the Revision attribute on Loadouts when child items were edited or something.

Also fixed enabled state of ancestors not being considered during SDV health checks. 