### PR TITLE
Fix migration check for existing data models

### DIFF
--- a/src/NexusMods.App/Program.cs
+++ b/src/NexusMods.App/Program.cs
@@ -67,7 +67,7 @@ public class Program
             var dataModelSettings = services.GetRequiredService<ISettingsManager>().Get<DataModelSettings>();
             var fileSystem = services.GetRequiredService<IFileSystem>();
 
-            var modelExists = dataModelSettings.MnemonicDBPath.ToPath(fileSystem).FileExists;
+            var modelExists = dataModelSettings.MnemonicDBPath.ToPath(fileSystem).DirectoryExists();
             
             // This will startup the MnemonicDb connection
             var migration = services.GetRequiredService<MigrationService>();


### PR DESCRIPTION
The tested path is a directory, not a file, which makes the check always return false, even if the DB actually exists.
Let me know if it can be a file as well, in which case the code needs to be updated to check for either.