### PR TITLE
Fix startup issues...

### DIFF
--- a/src/NexusMods.App/Program.cs
+++ b/src/NexusMods.App/Program.cs
@@ -67,7 +67,7 @@ public class Program
             var dataModelSettings = services.GetRequiredService<ISettingsManager>().Get<DataModelSettings>();
             var fileSystem = services.GetRequiredService<IFileSystem>();
 
-            var modelExists = dataModelSettings.MnemonicDBPath.ToPath(fileSystem).FileExists;
+            var modelExists = dataModelSettings.MnemonicDBPath.ToPath(fileSystem).DirectoryExists();
             
             // This will startup the MnemonicDb connection
             var migration = services.GetRequiredService<MigrationService>();


### PR DESCRIPTION
MnemonicDB stores data in a folder not a file 🤦‍♂️. This typeo made the app think we always had a fresh DB causing the "cannot perform a schema init on a database that already has a schema version" error