### PR TITLE
Fix Active loadout state bug

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Loadouts/ISynchronizerService.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts/ISynchronizerService.cs
@@ -2,6 +2,7 @@
 using NexusMods.Abstractions.Loadouts.Files.Diff;
 using NexusMods.Abstractions.Loadouts.Exceptions;
 using NexusMods.Abstractions.Loadouts.Ids;
+using R3;
 
 namespace NexusMods.Abstractions.Loadouts;
 

--- a/src/NexusMods.DataModel/Synchronizer/SynchronizerService.cs
+++ b/src/NexusMods.DataModel/Synchronizer/SynchronizerService.cs
@@ -209,7 +209,7 @@ public class SynchronizerService : ISynchronizerService
 
                     return diffFound ? LoadoutSynchronizerState.NeedsSync : LoadoutSynchronizerState.Current;
                 },
-                awaitOperation: AwaitOperation.Sequential
+                awaitOperation: AwaitOperation.Switch
             )
             .Replay(1)
             .RefCount();


### PR DESCRIPTION
- Fixes #2563

Fix incorrect LastApplied states being returned due to long diff operation returning out of order.
Using R3 we can ensure that the async operations are executed sequentially, and longer operations don't override later results.