### PR TITLE
Increases HTTP client timeouts

### DIFF
--- a/src/Networking/NexusMods.Networking.HttpDownloader/HttpDownloadJob.cs
+++ b/src/Networking/NexusMods.Networking.HttpDownloader/HttpDownloadJob.cs
@@ -261,7 +261,7 @@ public record HttpDownloadJob : IJobDefinitionWithStart<HttpDownloadJob, Absolut
         {
             InnerHandler = new SocketsHttpHandler
             {
-                ConnectTimeout = TimeSpan.FromSeconds(10),
+                ConnectTimeout = TimeSpan.FromSeconds(30),
                 KeepAlivePingPolicy = HttpKeepAlivePingPolicy.WithActiveRequests,
                 KeepAlivePingDelay = TimeSpan.FromSeconds(5),
                 KeepAlivePingTimeout = TimeSpan.FromSeconds(20),
@@ -270,7 +270,7 @@ public record HttpDownloadJob : IJobDefinitionWithStart<HttpDownloadJob, Absolut
 
         var client = new HttpClient(handler)
         {
-            Timeout = TimeSpan.FromSeconds(5),
+            Timeout = TimeSpan.FromSeconds(20),
             DefaultRequestVersion = HttpVersion.Version11,
             DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher,
         };

--- a/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsDownloadJob.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsDownloadJob.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.Downloads;
 using NexusMods.Abstractions.Jobs;
 using NexusMods.Abstractions.Library.Models;
@@ -12,26 +13,40 @@ namespace NexusMods.Networking.NexusWebApi;
 
 public class NexusModsDownloadJob : IDownloadJob, IJobDefinitionWithStart<NexusModsDownloadJob, AbsolutePath>
 {
+    public required ILogger Logger { private get; init; }
     public required IJobTask<HttpDownloadJob, AbsolutePath> HttpDownloadJob { get; init; }
     public required NexusModsFileMetadata.ReadOnly FileMetadata { get; init; }
 
     /// <inheritdoc/>
     public AbsolutePath Destination => HttpDownloadJob.Job.Destination;
-    
-    public static IJobTask<NexusModsDownloadJob, AbsolutePath> Create(IServiceProvider provider, IJobTask<HttpDownloadJob, AbsolutePath> httpDownloadJob, NexusModsFileMetadata.ReadOnly fileMetadata)
+
+    public static IJobTask<NexusModsDownloadJob, AbsolutePath> Create(
+        IServiceProvider provider,
+        IJobTask<HttpDownloadJob, AbsolutePath> httpDownloadJob,
+        NexusModsFileMetadata.ReadOnly fileMetadata)
     {
         var monitor = provider.GetRequiredService<IJobMonitor>();
         var job = new NexusModsDownloadJob
         {
+            Logger = provider.GetRequiredService<ILogger<NexusModsDownloadJob>>(),
             HttpDownloadJob = httpDownloadJob,
             FileMetadata = fileMetadata,
         };
+
         return monitor.Begin<NexusModsDownloadJob, AbsolutePath>(job);
     }
-    
+
     public async ValueTask<AbsolutePath> StartAsync(IJobContext<NexusModsDownloadJob> context)
     {
-        return await HttpDownloadJob;
+        try
+        {
+            return await HttpDownloadJob;
+        }
+        catch (Exception e)
+        {
+            Logger.LogError(e, "Exception while downloading `{Url}`", FileMetadata.GetUri());
+            throw;
+        }
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
Resolves #2568.

At some point we want to put these values into settings...

It should be noted that the Polly Retry policy doesn't retry when `TaskCanceledException` is thrown from the HTTP client.