### PR TITLE
Add instructions tab

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Collections/Json/CollectionInfo.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Collections/Json/CollectionInfo.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using JetBrains.Annotations;
 using NexusMods.Abstractions.GameLocators;
 using NexusMods.Abstractions.NexusWebApi.Types;
 
@@ -19,6 +20,7 @@ public class CollectionInfo
     public string Description { get; init; } = string.Empty;
     
     [JsonPropertyName("installInstructions")]
+    [LanguageInjection("markdown")]
     public string InstallInstructions { get; init; } = string.Empty;
     
     [JsonPropertyName("domainName")]

--- a/src/Abstractions/NexusMods.Abstractions.UI/ReactiveR3Object.cs
+++ b/src/Abstractions/NexusMods.Abstractions.UI/ReactiveR3Object.cs
@@ -9,6 +9,7 @@ namespace NexusMods.Abstractions.UI;
 public interface IReactiveR3Object : ReactiveUI.IReactiveObject, IDisposable
 {
     Observable<bool> Activation { get; }
+    bool IsActivated { get; }
     IDisposable Activate();
     void Deactivate();
 }
@@ -22,6 +23,7 @@ public class ReactiveR3Object : IReactiveR3Object
 {
     private readonly BehaviorSubject<bool> _activation = new(initialValue: false);
     public Observable<bool> Activation => _activation;
+    public bool IsActivated => _activation.Value;
 
     public IDisposable Activate()
     {

--- a/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsLibrary.Collections.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsLibrary.Collections.cs
@@ -322,12 +322,21 @@ public partial class NexusModsLibrary
     /// <summary>
     /// Parses the collection json file.
     /// </summary>
-    public async ValueTask<CollectionRoot> ParseCollectionJsonFile(
+    public ValueTask<CollectionRoot> ParseCollectionJsonFile(
         NexusModsCollectionLibraryFile.ReadOnly collectionLibraryFile,
         CancellationToken cancellationToken)
     {
         var jsonFileEntity = GetCollectionJsonFile(collectionLibraryFile);
+        return ParseCollectionJsonFile(jsonFileEntity, cancellationToken);
+    }
 
+    /// <summary>
+    /// Parses the collection json file.
+    /// </summary>
+    public async ValueTask<CollectionRoot> ParseCollectionJsonFile(
+        LibraryArchiveFileEntry.ReadOnly jsonFileEntity,
+        CancellationToken cancellationToken)
+    {
         await using var data = await _fileStore.GetFileStream(jsonFileEntity.AsLibraryFile().Hash, token: cancellationToken);
         var root = await JsonSerializer.DeserializeAsync<CollectionRoot>(data, _jsonSerializerOptions, cancellationToken: cancellationToken);
 

--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridAdapter.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridAdapter.cs
@@ -44,11 +44,11 @@ public abstract class TreeDataGridAdapter<TModel, TKey> : ReactiveR3Object
                 {
                     var (model, isActivating) = tuple;
 
-                    if (isActivating)
+                    if (isActivating && !model.IsActivated)
                     {
                         self.BeforeModelActivationHook(model);
                         model.Activate();
-                    } else
+                    } else if (!isActivating && model.IsActivated)
                     {
                         self.BeforeModelDeactivationHook(model);
                         model.Deactivate();

--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridViewHelper.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridViewHelper.cs
@@ -1,4 +1,6 @@
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.ReactiveUI;
 using NexusMods.Abstractions.UI;
 using R3;
@@ -34,7 +36,25 @@ public static class TreeDataGridViewHelper
                 removeHandler: handler => treeDataGrid.RowClearing -= handler
             ).Select(static tuple => (tuple.e.Row.Model, false));
 
-            deactivate.Merge(activate)
+            // NOTE(erri120): TreeDataGridRow doesn't invoke RowClearing when it gets detached
+            // from the visual tree. It does invoke RowPrepared when it gets attached with previous
+            // context, so this is likely an oversight. Regardless, it messes with our activation/deactivation
+            // system since now you can have situations where a row will never get deactivated if the entire TreeDataGrid
+            // gets detached from the visual tree.
+            // Example: ContentControl or TabControl that sometimes has a TreeDataGrid and sometimes not
+            var rowDetached = Observable.FromEventHandler<TreeDataGridRowEventArgs>(
+                addHandler: handler => treeDataGrid.RowPrepared += handler,
+                removeHandler: handler => treeDataGrid.RowPrepared -= handler
+            )
+                .Select(static tuple => tuple.e.Row)
+                .SelectMany(static row => Observable.FromEventHandler<VisualTreeAttachmentEventArgs>(
+                    addHandler: handler => row.DetachedFromVisualTree += handler,
+                    removeHandler: handler => row.DetachedFromVisualTree -= handler
+                ))
+                .Select(static tuple => tuple.sender as TreeDataGridRow)
+                .Select(static row => (row?.Model, false));
+
+            deactivate.Merge(rowDetached).Merge(activate)
                 .Where(static tuple => tuple.Model is TItemModel)
                 .Select(static tuple => ((tuple.Model as TItemModel)!, tuple.Item2))
                 .Subscribe((view, getAdapter), static (tuple, state) => state.getAdapter(state.view.ViewModel!).ModelActivationSubject.OnNext(tuple))

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadDesignViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadDesignViewModel.cs
@@ -3,6 +3,7 @@ using Avalonia.Platform;
 using DynamicData.Kernel;
 using NexusMods.Abstractions.Jobs;
 using NexusMods.Abstractions.NexusWebApi.Types;
+using NexusMods.App.UI.Controls.MarkdownRenderer;
 using NexusMods.App.UI.Controls.Navigation;
 using NexusMods.App.UI.Windows;
 using NexusMods.App.UI.WorkspaceSystem;
@@ -37,6 +38,7 @@ public class CollectionDownloadDesignViewModel : APageViewModel<ICollectionDownl
     public Bitmap TileImage { get; } = new(AssetLoader.Open(new Uri("avares://NexusMods.App.UI/Assets/DesignTime/collection_tile_image.png")));
     public Bitmap BackgroundImage { get; } = new(AssetLoader.Open(new Uri("avares://NexusMods.App.UI/Assets/DesignTime/header-background.webp")));
     public string CollectionStatusText { get; } = "0 of 9 mods downloaded";
+    public IMarkdownRendererViewModel? InstructionsRenderer { get; }
 
     public int CountDownloadedOptionalItems { get; } = 0;
     public int CountDownloadedRequiredItems { get; } = 1;

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadView.axaml
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadView.axaml
@@ -190,6 +190,13 @@
                     </StackPanel>
                 </TabItem.Header>
             </TabItem>
+            <TabItem x:Name="Instructions" IsVisible="False">
+                <TabItem.Header>
+                    <TextBlock Text="Additional Instructions"/>
+                </TabItem.Header>
+
+                <reactiveUi:ViewModelViewHost x:Name="InstructionsRendererHost"/>
+            </TabItem>
         </TabControl>
     </DockPanel>
 

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/ICollectionDownloadViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/ICollectionDownloadViewModel.cs
@@ -3,6 +3,7 @@ using DynamicData.Kernel;
 using NexusMods.Abstractions.Jobs;
 using NexusMods.Abstractions.NexusModsLibrary.Models;
 using NexusMods.Abstractions.NexusWebApi.Types;
+using NexusMods.App.UI.Controls.MarkdownRenderer;
 using NexusMods.App.UI.Controls.Navigation;
 using NexusMods.App.UI.WorkspaceSystem;
 using NexusMods.Paths;
@@ -37,6 +38,8 @@ public interface ICollectionDownloadViewModel : IPageViewModelInterface
 
     /// <inheritdoc cref="CollectionRevisionMetadata.IsAdult"/>
     bool IsAdult { get; }
+
+    IMarkdownRendererViewModel? InstructionsRenderer { get; }
 
     /// <summary>
     /// The collection's revision number


### PR DESCRIPTION
Adds the instruction tab to the collections download page without styling. The tab currently only shows collection instructions.

Resolves #2341.

Also fixes a bug when the entire TreeDataGrid gets detached from the visual tree.