### PR TITLE
Add EnsureNoError to GraphQL calls

### DIFF
--- a/src/Networking/NexusMods.Networking.NexusWebApi/NexusApiClient.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/NexusApiClient.cs
@@ -7,7 +7,7 @@ using NexusMods.Abstractions.NexusWebApi.DTOs.Interfaces;
 using NexusMods.Abstractions.NexusWebApi.DTOs.OAuth;
 using NexusMods.Abstractions.NexusWebApi.Types;
 using NexusMods.Abstractions.NexusWebApi.Types.V2;
-using OperationResultExtension = StrawberryShake.OperationResultExtensions
+using OperationResultExtension = StrawberryShake.OperationResultExtensions;
 namespace NexusMods.Networking.NexusWebApi;
 
 /// <summary>

--- a/src/Networking/NexusMods.Networking.NexusWebApi/NexusApiClient.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/NexusApiClient.cs
@@ -7,7 +7,7 @@ using NexusMods.Abstractions.NexusWebApi.DTOs.Interfaces;
 using NexusMods.Abstractions.NexusWebApi.DTOs.OAuth;
 using NexusMods.Abstractions.NexusWebApi.Types;
 using NexusMods.Abstractions.NexusWebApi.Types.V2;
-
+using OperationResultExtension = StrawberryShake.OperationResultExtensions
 namespace NexusMods.Networking.NexusWebApi;
 
 /// <summary>
@@ -118,6 +118,7 @@ public class NexusApiClient : INexusApiClient
     public async Task<Response<CollectionDownloadLinks>> CollectionDownloadLinksAsync(CollectionSlug slug, RevisionNumber revision, bool viewAdultContent = true, CancellationToken token = default)
     {
         var linksLocation = await _graphQLClient.CollectionDownloadLink.ExecuteAsync(slug.Value, (int)revision.Value, viewAdultContent, token);
+        OperationResultExtension.EnsureNoErrors(linksLocation);
         
         var msg = await _factory.Create(HttpMethod.Get, new Uri($"https://api.nexusmods.com" +linksLocation.Data!.CollectionRevision.DownloadLink));
         return await SendAsync<CollectionDownloadLinks>(msg, token);

--- a/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsLibrary.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsLibrary.cs
@@ -69,6 +69,7 @@ public partial class NexusModsLibrary
         using var tx = _connection.BeginTransaction();
 
         var modInfo = await _gqlClient.ModInfo.ExecuteAsync((int)uid.GameId.Value, (int)modId.Value, cancellationToken);
+        modInfo.EnsureNoErrors();
         EntityId first = default;
         foreach (var node in modInfo.Data!.LegacyMods.Nodes)
             first = node.Resolve(_connection.Db, tx);

--- a/src/Networking/NexusMods.Networking.NexusWebApi/RunUpdateCheck.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/RunUpdateCheck.cs
@@ -81,6 +81,7 @@ public static class RunUpdateCheck
         
         // Update Mod
         var modInfo = await gqlClient.ModInfo.ExecuteAsync((int)uid.GameId.Value, (int)uid.ModId.Value, cancellationToken);
+        modInfo.EnsureNoErrors();
         foreach (var node in modInfo.Data!.LegacyMods.Nodes)
             node.Resolve(db, tx);
         


### PR DESCRIPTION
So that we get more meaningful errors when request fails than null ref exception
- related to #2569 