### PR TITLE
Fix error dialog when closing SDV

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Games/RunGameTool.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Games/RunGameTool.cs
@@ -161,7 +161,7 @@ public class RunGameTool<T> : IRunGameTool
         }
         
         if (process.ExitCode != 0)
-            _logger.LogError("While Running {Filename}", program);
+            _logger.LogWarning("Application closed with a non-zero exit code ({ExitCode}): {Application}", process.ExitCode, program);
         return process;
     }
 


### PR DESCRIPTION
Demoted the log message about exit code to a warning since it games often return whatever, e.g. SDV always returns -1.
Showing an error dialog each time you close the game isn't great experience. 