### PR TITLE
Loadout and Library fixes

### DIFF
--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/AValueComponent.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/AValueComponent.cs
@@ -48,7 +48,7 @@ public abstract class AValueComponent<T> : ReactiveR3Object, IItemModelComponent
         }
         else
         {
-            Value = valueObservable.ToBindableReactiveProperty(initialValue: initialValue);
+            Value = valueObservable.ObserveOnUIThreadDispatcher().ToBindableReactiveProperty(initialValue: initialValue);
         }
     }
 

--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/CompositeItemModel.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/CompositeItemModel.cs
@@ -153,9 +153,9 @@ public class CompositeItemModel<TKey> : TreeDataGridItemModel<CompositeItemModel
                 if (!optionalValue.HasValue) return;
                 var component = componentFactory(
                     observable
-                        .ObserveOnUIThreadDispatcher()
                         .Where(static optionalValue => optionalValue.HasValue)
-                        .Select(static optionalValue => optionalValue.Value),
+                        .Select(static optionalValue => optionalValue.Value)
+                        .ObserveOnUIThreadDispatcher(),
                     optionalValue.Value
                 );
 

--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridAdapter.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridAdapter.cs
@@ -67,6 +67,7 @@ public abstract class TreeDataGridAdapter<TModel, TKey> : ReactiveR3Object
 
             self.ViewHierarchical
                 .AsObservable()
+                .ObserveOnUIThreadDispatcher()
                 .Do(self, static (viewHierarchical, self) =>
                 {
                     self.Roots.Clear();

--- a/src/NexusMods.App.UI/Extensions/EnumerableExtensions.cs
+++ b/src/NexusMods.App.UI/Extensions/EnumerableExtensions.cs
@@ -32,7 +32,7 @@ public static class EnumerableExtensions
         return new ReadOnlyObservableCollection<T>(source.ToObservableCollection());
     }
 
-    public static Optional<TItem> MaxByOptional<TItem, TValue>(this IEnumerable<TItem> source, Func<TItem, TValue> selector)
+    public static Optional<TItem> OptionalMaxBy<TItem, TValue>(this IEnumerable<TItem> source, Func<TItem, TValue> selector)
         where TItem : notnull
         where TValue : IComparable<TValue>
     {
@@ -60,5 +60,35 @@ public static class EnumerableExtensions
         }
 
         return maxItem;
+    }
+    
+    public static Optional<TItem> OptionalMinBy<TItem, TValue>(this IEnumerable<TItem> source, Func<TItem, TValue> selector)
+        where TItem : notnull
+        where TValue : IComparable<TValue>
+    {
+        var minItem = Optional<TItem>.None;
+        var minValue = Optional<TValue>.None;
+
+        foreach (var item in source)
+        {
+            if (!minItem.HasValue)
+            {
+                minItem = item;
+                minValue = selector(item);
+                continue;
+            }
+
+            var value = selector(item);
+            var result = value.CompareTo(minValue.Value);
+
+            // Smaller than zero: value comes before minValue
+            if (result < 0)
+            {
+                minItem = item;
+                minValue = value;
+            }
+        }
+
+        return minItem;
     }
 }

--- a/src/NexusMods.App.UI/LeftMenu/Loadout/LoadoutLeftMenuViewModel.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Loadout/LoadoutLeftMenuViewModel.cs
@@ -203,12 +203,12 @@ public class LoadoutLeftMenuViewModel : AViewModel<ILoadoutLeftMenuViewModel>, I
 
                 LibraryUserFilters.ObserveFilteredLibraryItems(connection: conn)
                     .RemoveKey()
-                    .OnUI()
                     .WhereReasonsAre(ListChangeReason.Add,
                         ListChangeReason.AddRange,
                         ListChangeReason.Remove,
                         ListChangeReason.RemoveRange
                     )
+                    .OnUI()
                     .SubscribeWithErrorLogging(changeSet => NewDownloadModelCount = Math.Max(0, NewDownloadModelCount + (changeSet.Adds - changeSet.Removes)))
                     .DisposeWith(disposable);
 

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadViewModel.cs
@@ -361,7 +361,7 @@ public sealed class CollectionDownloadViewModel : APageViewModel<ICollectionDown
                 .Subscribe(this, static (newerRevisions, self) =>
                 {
                     self.IsUpdateAvailable.Value = newerRevisions.Length > 0;
-                    self.NewestRevisionNumber.Value = newerRevisions.First();
+                    self.NewestRevisionNumber.Value = newerRevisions.FirstOrOptional(_ => true);
                 }).AddTo(disposables);
 
             R3.Observable.Return(collectionJsonFile)

--- a/src/NexusMods.App.UI/Pages/Downloads/ViewModels/DownloadTaskViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/Downloads/ViewModels/DownloadTaskViewModel.cs
@@ -26,15 +26,15 @@ public class DownloadTaskViewModel : AViewModel<IDownloadTaskViewModel>, IDownlo
         {
 
             _task.WhenAnyValue(t => t.Downloaded)
-                .OnUI()
                 .Select(s => s.Value)
+                .OnUI()
                 .BindTo(this, x => x.DownloadedBytes)
                 .DisposeWith(d);
 
 
             _task.WhenAnyValue(t => t.Bandwidth)
-                .OnUI()
                 .Select(b => b.Value)
+                .OnUI()
                 .BindTo(this, x => x.Throughput)
                 .DisposeWith(d);
             

--- a/src/NexusMods.App.UI/Pages/ILibraryDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/ILibraryDataProvider.cs
@@ -6,6 +6,7 @@ using NexusMods.Abstractions.GameLocators;
 using NexusMods.Abstractions.Library.Models;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.App.UI.Controls;
+using NexusMods.App.UI.Extensions;
 using NexusMods.App.UI.Pages.LibraryPage;
 using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.MnemonicDB.Abstractions.Query;
@@ -58,8 +59,8 @@ public static class LibraryDataProviderHelper
                 if (query.Count == 0) return Optional<DateTimeOffset>.None;
 
                 return query.Items
-                    .Select(static item => item.GetCreatedAt())
-                    .Min();
+                        .Select(static item => item.GetCreatedAt())
+                        .OptionalMinBy(item => item);
             });
 
         itemModel.AddObservable(

--- a/src/NexusMods.App.UI/Pages/ILoadoutDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/ILoadoutDataProvider.cs
@@ -5,6 +5,7 @@ using NexusMods.Abstractions.Library.Models;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Loadouts.Extensions;
 using NexusMods.App.UI.Controls;
+using NexusMods.App.UI.Extensions;
 using NexusMods.App.UI.Pages.LoadoutPage;
 using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.MnemonicDB.Abstractions.DatomIterators;
@@ -87,7 +88,8 @@ public static class LoadoutDataProviderHelper
         var dateObservable = linkedItemsObservable
             .QueryWhenChanged(query => query.Items
                 .Select(static item => item.GetCreatedAt())
-                .Min()
+                .OptionalMinBy(item => item)
+                .ValueOr(DateTimeOffset.MinValue)
             );
 
         parentItemModel.Add(SharedColumns.InstalledDate.ComponentKey, new DateComponent(

--- a/src/NexusMods.App.UI/Pages/LibraryPage/LibraryComponents.cs
+++ b/src/NexusMods.App.UI/Pages/LibraryPage/LibraryComponents.cs
@@ -121,7 +121,6 @@ public static class LibraryComponents
 
             CommandInstall = isInstalled.Value
                 .Select(static isInstalled => !isInstalled)
-                .ObserveOnUIThreadDispatcher()
                 .ToReactiveCommand<Unit>();
 
             ButtonText = isInstalled.Value
@@ -148,7 +147,6 @@ public static class LibraryComponents
             CommandInstall = IsInstalled
                 .AsObservable()
                 .Select(static isInstalled => !isInstalled)
-                .ObserveOnUIThreadDispatcher()
                 .ToReactiveCommand<Unit>();
 
             ButtonText = matches.Value

--- a/src/NexusMods.App.UI/Pages/LibraryPage/LibraryComponents.cs
+++ b/src/NexusMods.App.UI/Pages/LibraryPage/LibraryComponents.cs
@@ -121,6 +121,7 @@ public static class LibraryComponents
 
             CommandInstall = isInstalled.Value
                 .Select(static isInstalled => !isInstalled)
+                .ObserveOnUIThreadDispatcher()
                 .ToReactiveCommand<Unit>();
 
             ButtonText = isInstalled.Value
@@ -147,6 +148,7 @@ public static class LibraryComponents
             CommandInstall = IsInstalled
                 .AsObservable()
                 .Select(static isInstalled => !isInstalled)
+                .ObserveOnUIThreadDispatcher()
                 .ToReactiveCommand<Unit>();
 
             ButtonText = matches.Value

--- a/src/NexusMods.App.UI/Pages/LibraryPage/LibraryViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LibraryPage/LibraryViewModel.cs
@@ -135,21 +135,21 @@ public class LibraryViewModel : APageViewModel<ILibraryViewModel>, ILibraryViewM
             .ObserveCountChanged()
             .Select(count => count > 0);
 
-        InstallSelectedItemsCommand = hasSelection.ToReactiveCommand<Unit>(
+        InstallSelectedItemsCommand = hasSelection.ObserveOnUIThreadDispatcher().ToReactiveCommand<Unit>(
             executeAsync: (_, cancellationToken) => InstallSelectedItems(useAdvancedInstaller: false, cancellationToken),
             awaitOperation: AwaitOperation.Parallel,
             initialCanExecute: false,
             configureAwait: false
         );
 
-        InstallSelectedItemsWithAdvancedInstallerCommand = hasSelection.ToReactiveCommand<Unit>(
+        InstallSelectedItemsWithAdvancedInstallerCommand = hasSelection.ObserveOnUIThreadDispatcher().ToReactiveCommand<Unit>(
             executeAsync: (_, cancellationToken) => InstallSelectedItems(useAdvancedInstaller: true, cancellationToken),
             awaitOperation: AwaitOperation.Parallel,
             initialCanExecute: false,
             configureAwait: false
         );
 
-        RemoveSelectedItemsCommand = hasSelection.ToReactiveCommand<Unit>(
+        RemoveSelectedItemsCommand = hasSelection.ObserveOnUIThreadDispatcher().ToReactiveCommand<Unit>(
             executeAsync: (_, cancellationToken) => RemoveSelectedItems(cancellationToken),
             awaitOperation: AwaitOperation.Parallel,
             initialCanExecute: false,
@@ -161,7 +161,7 @@ public class LibraryViewModel : APageViewModel<ILibraryViewModel>, ILibraryViewM
             .WhereNotNull()
             .Select(x => x.CanOpen);
 
-        OpenFilePickerCommand = canUseFilePicker.ToReactiveCommand<Unit>(
+        OpenFilePickerCommand = canUseFilePicker.ObserveOnUIThreadDispatcher().ToReactiveCommand<Unit>(
             executeAsync: (_, cancellationToken) => AddFilesFromDisk(StorageProvider!, cancellationToken),
             awaitOperation: AwaitOperation.Parallel,
             initialCanExecute: true,

--- a/src/NexusMods.App.UI/Pages/LibraryPage/LibraryViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LibraryPage/LibraryViewModel.cs
@@ -135,21 +135,21 @@ public class LibraryViewModel : APageViewModel<ILibraryViewModel>, ILibraryViewM
             .ObserveCountChanged()
             .Select(count => count > 0);
 
-        InstallSelectedItemsCommand = hasSelection.ObserveOnUIThreadDispatcher().ToReactiveCommand<Unit>(
+        InstallSelectedItemsCommand = hasSelection.ToReactiveCommand<Unit>(
             executeAsync: (_, cancellationToken) => InstallSelectedItems(useAdvancedInstaller: false, cancellationToken),
             awaitOperation: AwaitOperation.Parallel,
             initialCanExecute: false,
             configureAwait: false
         );
 
-        InstallSelectedItemsWithAdvancedInstallerCommand = hasSelection.ObserveOnUIThreadDispatcher().ToReactiveCommand<Unit>(
+        InstallSelectedItemsWithAdvancedInstallerCommand = hasSelection.ToReactiveCommand<Unit>(
             executeAsync: (_, cancellationToken) => InstallSelectedItems(useAdvancedInstaller: true, cancellationToken),
             awaitOperation: AwaitOperation.Parallel,
             initialCanExecute: false,
             configureAwait: false
         );
 
-        RemoveSelectedItemsCommand = hasSelection.ObserveOnUIThreadDispatcher().ToReactiveCommand<Unit>(
+        RemoveSelectedItemsCommand = hasSelection.ToReactiveCommand<Unit>(
             executeAsync: (_, cancellationToken) => RemoveSelectedItems(cancellationToken),
             awaitOperation: AwaitOperation.Parallel,
             initialCanExecute: false,
@@ -161,7 +161,7 @@ public class LibraryViewModel : APageViewModel<ILibraryViewModel>, ILibraryViewM
             .WhereNotNull()
             .Select(x => x.CanOpen);
 
-        OpenFilePickerCommand = canUseFilePicker.ObserveOnUIThreadDispatcher().ToReactiveCommand<Unit>(
+        OpenFilePickerCommand = canUseFilePicker.ToReactiveCommand<Unit>(
             executeAsync: (_, cancellationToken) => AddFilesFromDisk(StorageProvider!, cancellationToken),
             awaitOperation: AwaitOperation.Parallel,
             initialCanExecute: true,

--- a/src/NexusMods.App.UI/Pages/LibraryPage/LibraryViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LibraryPage/LibraryViewModel.cs
@@ -92,12 +92,6 @@ public class LibraryViewModel : APageViewModel<ILibraryViewModel>, ILibraryViewM
         var tileImagePipeline = ImagePipelines.GetCollectionTileImagePipeline(serviceProvider);
         var userAvatarPipeline = ImagePipelines.GetUserAvatarPipeline(serviceProvider);
 
-        var ticker = R3.Observable
-            .Interval(period: TimeSpan.FromSeconds(30), timeProvider: ObservableSystem.DefaultTimeProvider)
-            .ObserveOnUIThreadDispatcher()
-            .Select(_ => TimeProvider.System.GetLocalNow())
-            .Publish(initialValue: TimeProvider.System.GetLocalNow());
-
         var loadoutObservable = LoadoutSubject
             .Where(static id => id.HasValue)
             .Select(static id => id.Value)
@@ -120,9 +114,7 @@ public class LibraryViewModel : APageViewModel<ILibraryViewModel>, ILibraryViewM
 
         TabTitle = Language.LibraryPageTitle;
         TabIcon = IconValues.LibraryOutline;
-
-        ticker.Connect();
-
+        
         _loadout = Loadout.Load(_connection.Db, loadoutId.Value);
         var game = _loadout.InstallationInstance.Game;
 

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutViewModel.cs
@@ -100,7 +100,6 @@ public class LoadoutViewModel : APageViewModel<ILoadoutViewModel>, ILoadoutViewM
 
         ViewFilesCommand = viewModFilesArgumentsSubject
             .Select(viewModFilesArguments => viewModFilesArguments.HasValue)
-            .ObserveOnUIThreadDispatcher()
             .ToReactiveCommand<NavigationInformation>( info =>
                 {
                     var group = viewModFilesArgumentsSubject.Value;
@@ -176,6 +175,7 @@ public class LoadoutViewModel : APageViewModel<ILoadoutViewModel>, ILoadoutViewM
                     if (model is null) return Optional<LoadoutItemGroup.ReadOnly>.None;
                     return LoadoutItemGroupFileTreeViewModel.GetViewModFilesLoadoutItemGroup(GetLoadoutItemIds(model).ToArray(), connection);
                 })
+                .ObserveOnUIThreadDispatcher()
                 .Subscribe(viewModFilesArgumentsSubject.OnNext)
                 .AddTo(disposables);
             

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutViewModel.cs
@@ -100,6 +100,7 @@ public class LoadoutViewModel : APageViewModel<ILoadoutViewModel>, ILoadoutViewM
 
         ViewFilesCommand = viewModFilesArgumentsSubject
             .Select(viewModFilesArguments => viewModFilesArguments.HasValue)
+            .ObserveOnUIThreadDispatcher()
             .ToReactiveCommand<NavigationInformation>( info =>
                 {
                     var group = viewModFilesArgumentsSubject.Value;
@@ -120,7 +121,8 @@ public class LoadoutViewModel : APageViewModel<ILoadoutViewModel>, ILoadoutViewM
                 false
             );
 
-        RemoveItemCommand = hasSelection.ToReactiveCommand<Unit>(async (_, _) =>
+        RemoveItemCommand = hasSelection.ObserveOnUIThreadDispatcher()
+            .ToReactiveCommand<Unit>(async (_, _) =>
             {
                 var ids = Adapter.SelectedModels
                     .SelectMany(static itemModel => GetLoadoutItemIds(itemModel))
@@ -174,7 +176,6 @@ public class LoadoutViewModel : APageViewModel<ILoadoutViewModel>, ILoadoutViewM
                     if (model is null) return Optional<LoadoutItemGroup.ReadOnly>.None;
                     return LoadoutItemGroupFileTreeViewModel.GetViewModFilesLoadoutItemGroup(GetLoadoutItemIds(model).ToArray(), connection);
                 })
-                .ObserveOnUIThreadDispatcher()
                 .Subscribe(viewModFilesArgumentsSubject.OnNext)
                 .AddTo(disposables);
             

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutViewModel.cs
@@ -121,7 +121,7 @@ public class LoadoutViewModel : APageViewModel<ILoadoutViewModel>, ILoadoutViewM
                 false
             );
 
-        RemoveItemCommand = hasSelection.ObserveOnUIThreadDispatcher()
+        RemoveItemCommand = hasSelection
             .ToReactiveCommand<Unit>(async (_, _) =>
             {
                 var ids = Adapter.SelectedModels

--- a/src/NexusMods.App.UI/Pages/MyGames/MyGamesViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/MyGames/MyGamesViewModel.cs
@@ -89,7 +89,6 @@ public class MyGamesViewModel : APageViewModel<IMyGamesViewModel>, IMyGamesViewM
             {
                 gameRegistry.InstalledGames
                     .ToObservableChangeSet()
-                    .OnUI()
                     .Transform(installation =>
                         {
                             var vm = provider.GetRequiredService<IGameWidgetViewModel>();
@@ -141,6 +140,7 @@ public class MyGamesViewModel : APageViewModel<IMyGamesViewModel>, IMyGamesViewM
                             return vm;
                         }
                     )
+                    .OnUI()
                     .Bind(out _installedGames)
                     .SubscribeWithErrorLogging()
                     .DisposeWith(d);

--- a/src/NexusMods.App.UI/Pages/NexusModsDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/NexusModsDataProvider.cs
@@ -244,7 +244,7 @@ public class NexusModsDataProvider : ILibraryDataProvider, ILoadoutDataProvider
         // Downloaded date: most recent downloaded file date
         var downloadedDateObservable = libraryItems
             .TransformImmutable(static item => item.GetCreatedAt())
-            .QueryWhenChanged(query => query.Items.Max());
+            .QueryWhenChanged(query => query.Items.OptionalMaxBy(item => item).ValueOr(DateTimeOffset.MinValue));
 
         parentItemModel.Add(LibraryColumns.DownloadedDate.ComponentKey, new DateComponent(
             initialValue: modPage.GetCreatedAt(),
@@ -263,7 +263,7 @@ public class NexusModsDataProvider : ILibraryDataProvider, ILoadoutDataProvider
             })
             .QueryWhenChanged(static query =>
             {
-                var max = query.Items.MaxByOptional(static tuple => tuple.parsedVersion.ValueOr(new NuGetVersion(0, 0, 0)));
+                var max = query.Items.OptionalMaxBy(static tuple => tuple.parsedVersion.ValueOr(new NuGetVersion(0, 0, 0)));
                 if (!max.HasValue) return string.Empty;
                 return max.Value.rawVersion;
             });


### PR DESCRIPTION
- Depends on #2584 

## Details:
- Fixed Loadout View multi-selection operations not working correctly (same dispose issue we fixed in the library)
- Fixed CanExecute command observables not executing on UI thread
- Rearranged a bunch of OnUI to decrease unnecessary operations happening on UI thread