### PR TITLE
Bump Avalonia versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,7 @@
   <ItemGroup>
     <PackageVersion Include="Avalonia.AvaloniaEdit" Version="11.1.0" />
     <PackageVersion Include="Avalonia.Labs.Panels" Version="11.2.0" />
-    <PackageVersion Include="Avalonia.Skia" Version="11.2.2" />
+    <PackageVersion Include="Avalonia.Skia" Version="11.2.3" />
     <PackageVersion Include="AvaloniaEdit.TextMate" Version="11.1.0" />
     <PackageVersion Include="Jitbit.FastCache" Version="1.1.0" />
     <PackageVersion Include="K4os.Compression.LZ4" Version="1.3.8" />
@@ -65,14 +65,14 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
     <PackageVersion Include="NetEscapades.EnumGenerators" Version="1.0.0-beta07" PrivateAssets="all" ExcludeAssets="compile;runtime" />
-    <PackageVersion Include="Avalonia" Version="11.2.2" />
-    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.2.2" />
-    <PackageVersion Include="Avalonia.Controls.TreeDataGrid" Version="11.1.0" />
-    <PackageVersion Include="Avalonia.Desktop" Version="11.2.2" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.2.2" />
-    <PackageVersion Include="Avalonia.Headless" Version="11.2.2" />
-    <PackageVersion Include="Avalonia.ReactiveUI" Version="11.2.2" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.2.2" />
+    <PackageVersion Include="Avalonia" Version="11.2.3" />
+    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.2.3" />
+    <PackageVersion Include="Avalonia.Controls.TreeDataGrid" Version="11.1.1" />
+    <PackageVersion Include="Avalonia.Desktop" Version="11.2.3" />
+    <PackageVersion Include="Avalonia.Diagnostics" Version="11.2.3" />
+    <PackageVersion Include="Avalonia.Headless" Version="11.2.3" />
+    <PackageVersion Include="Avalonia.ReactiveUI" Version="11.2.3" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.2.3" />
     <PackageVersion Include="Projektanker.Icons.Avalonia.MaterialDesign" Version="9.4.1" />
     <PackageVersion Include="Avalonia.Svg.Skia" Version="11.2.0.2" />
     <PackageVersion Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.0-rc2" />


### PR DESCRIPTION
Tested changes locally.

TreeDataGrid actually seems faster, but still has the bug of the columns collapsing when using star size for the first column.
