### PR TITLE
Fix active loadout indicator on Loadout badge

### DIFF
--- a/src/NexusMods.App.UI/Controls/LoadoutBadge/LoadoutBadgeViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/LoadoutBadge/LoadoutBadgeViewModel.cs
@@ -34,8 +34,8 @@ public class LoadoutBadgeViewModel : AViewModel<ILoadoutBadgeViewModel>, ILoadou
                     .OnUI()
                     .Do(applyStatus =>
                         {
-                            IsLoadoutApplied = applyStatus == LoadoutSynchronizerState.Current;
-                            IsLoadoutInProgress = applyStatus == LoadoutSynchronizerState.Pending;
+                            IsLoadoutApplied = applyStatus is LoadoutSynchronizerState.Current or LoadoutSynchronizerState.NeedsSync;
+                            IsLoadoutInProgress = applyStatus is LoadoutSynchronizerState.Pending;
                         }
                     )
                     .SubscribeWithErrorLogging();;


### PR DESCRIPTION
It wasn't showing if the loadout was the last applied one, but had changes to synchronize