### PR TITLE
Add observable tracker page

### DIFF
--- a/src/NexusMods.App.UI/Pages/ObservableInfo/ObservableInfoPage.cs
+++ b/src/NexusMods.App.UI/Pages/ObservableInfo/ObservableInfoPage.cs
@@ -1,0 +1,47 @@
+using JetBrains.Annotations;
+using NexusMods.Abstractions.Serialization.Attributes;
+using NexusMods.App.BuildInfo;
+using NexusMods.App.UI.WorkspaceSystem;
+using NexusMods.Icons;
+using R3;
+
+namespace NexusMods.App.UI.Pages.ObservableInfo;
+
+[JsonName("ObservableInfoPageContext")]
+public record ObservableInfoPageContext : IPageFactoryContext;
+
+[UsedImplicitly]
+public class ObservableInfoPageFactory : APageFactory<IObservableInfoPageViewModel, ObservableInfoPageContext>
+{
+    public static readonly PageFactoryId StaticId = PageFactoryId.From(Guid.Parse("2d0dce70-c5a7-4bea-b985-78007cdd95e6"));
+    public override PageFactoryId Id => StaticId;
+
+    public ObservableInfoPageFactory(IServiceProvider serviceProvider) : base(serviceProvider) { }
+
+    public override IObservableInfoPageViewModel CreateViewModel(ObservableInfoPageContext context)
+    {
+        ObservableTracker.EnableTracking = true;
+        ObservableTracker.EnableStackTrace = true;
+        return new ObservableInfoPageViewModel(WindowManager);
+    }
+
+    public override IEnumerable<PageDiscoveryDetails?> GetDiscoveryDetails(IWorkspaceContext workspaceContext)
+    {
+        if (!CompileConstants.IsDebug) return [];
+
+        return
+        [
+            new PageDiscoveryDetails
+            {
+                Icon = IconValues.Warning,
+                ItemName = "Observable Tracker",
+                SectionName = "Utilities",
+                PageData = new PageData
+                {
+                    FactoryId = StaticId,
+                    Context = new ObservableInfoPageContext(),
+                },
+            },
+        ];
+    }
+}

--- a/src/NexusMods.App.UI/Pages/ObservableInfo/ObservableInfoPageView.axaml
+++ b/src/NexusMods.App.UI/Pages/ObservableInfo/ObservableInfoPageView.axaml
@@ -1,0 +1,31 @@
+<reactive:ReactiveUserControl
+    x:TypeArguments="local:IObservableInfoPageViewModel"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:reactive="http://reactiveui.net"
+    xmlns:local="clr-namespace:NexusMods.App.UI.Pages.ObservableInfo"
+    xmlns:r3="clr-namespace:R3;assembly=R3"
+    mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+    x:Class="NexusMods.App.UI.Pages.ObservableInfo.ObservableInfoPageView">
+
+    <Grid RowDefinitions="Auto, *">
+        <StackPanel Grid.Row="0" Spacing="{StaticResource Spacing-2}" Orientation="Horizontal">
+            <TextBlock x:Name="Count" Classes="BodyLGNormal"/>
+        </StackPanel>
+
+        <ListBox Grid.Row="1" x:Name="States" SelectionMode="Single">
+            <ListBox.ItemTemplate>
+                <DataTemplate x:DataType="r3:TrackingState">
+                    <StackPanel Orientation="Horizontal" Spacing="{StaticResource Spacing-2}">
+                        <TextBlock Classes="BodyMDNormal ForegroundSubdued" Text="{CompiledBinding TrackingId, Mode=OneTime}"/>
+                        <TextBlock Classes="BodyMDNormal ForegroundModerate" Text="{CompiledBinding FormattedType, Mode=OneTime}"/>
+                    </StackPanel>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
+    </Grid>
+
+</reactive:ReactiveUserControl>
+

--- a/src/NexusMods.App.UI/Pages/ObservableInfo/ObservableInfoPageView.axaml.cs
+++ b/src/NexusMods.App.UI/Pages/ObservableInfo/ObservableInfoPageView.axaml.cs
@@ -1,0 +1,22 @@
+using System.Reactive.Disposables;
+using Avalonia.ReactiveUI;
+using ReactiveUI;
+
+namespace NexusMods.App.UI.Pages.ObservableInfo;
+
+public partial class ObservableInfoPageView : ReactiveUserControl<IObservableInfoPageViewModel>
+{
+    public ObservableInfoPageView()
+    {
+        InitializeComponent();
+
+        this.WhenActivated(disposables =>
+        {
+            this.OneWayBind(ViewModel, vm => vm.TrackingStates, view => view.States.ItemsSource)
+                .DisposeWith(disposables);
+
+            this.OneWayBind(ViewModel, vm => vm.TrackingStates.Count, view => view.Count.Text, static i => $"Observable Count: {i}")
+                .DisposeWith(disposables);
+        });
+    }
+}

--- a/src/NexusMods.App.UI/Pages/ObservableInfo/ObservableInfoPageViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/ObservableInfo/ObservableInfoPageViewModel.cs
@@ -1,0 +1,50 @@
+using NexusMods.App.UI.Windows;
+using NexusMods.App.UI.WorkspaceSystem;
+using ObservableCollections;
+using R3;
+using ReactiveUI;
+
+namespace NexusMods.App.UI.Pages.ObservableInfo;
+
+public interface IObservableInfoPageViewModel : IPageViewModelInterface
+{
+    NotifyCollectionChangedSynchronizedViewList<TrackingState> TrackingStates { get; }
+}
+
+public class ObservableInfoPageViewModel : APageViewModel<IObservableInfoPageViewModel>, IObservableInfoPageViewModel
+{
+    private readonly List<TrackingState> _trackingStatesBuffer = [];
+
+    private readonly ObservableList<TrackingState> _trackingStates = [];
+    public NotifyCollectionChangedSynchronizedViewList<TrackingState> TrackingStates { get; }
+
+    public ObservableInfoPageViewModel(IWindowManager windowManager) : base(windowManager)
+    {
+        TrackingStates = _trackingStates.ToNotifyCollectionChangedSlim();
+
+        this.WhenActivated(disposables =>
+        {
+            Observable
+                .Timer(dueTime: TimeSpan.Zero, period: TimeSpan.FromSeconds(1), timeProvider: TimeProvider.System)
+                .Do(this, static (_, self) =>
+                {
+                    self._trackingStatesBuffer.Clear();
+
+                    ObservableTracker.CheckAndResetDirty();
+                    ObservableTracker.ForEachActiveTask(trackingState =>
+                    {
+                        self._trackingStatesBuffer.Add(trackingState);
+                    });
+
+                    self._trackingStatesBuffer.Sort();
+                })
+                .ObserveOnUIThreadDispatcher()
+                .Subscribe(this, static (_, self) =>
+                {
+                    self._trackingStates.Clear();
+                    self._trackingStates.AddRange(self._trackingStatesBuffer);
+                })
+                .AddTo(disposables);
+        });
+    }
+}

--- a/src/NexusMods.App.UI/Services.cs
+++ b/src/NexusMods.App.UI/Services.cs
@@ -50,6 +50,7 @@ using NexusMods.App.UI.Pages.LibraryPage.Collections;
 using NexusMods.App.UI.Pages.LoadoutPage;
 using NexusMods.App.UI.Pages.MyGames;
 using NexusMods.App.UI.Pages.MyLoadouts;
+using NexusMods.App.UI.Pages.ObservableInfo;
 using NexusMods.App.UI.Pages.Settings;
 using NexusMods.App.UI.Pages.Sorting;
 using NexusMods.App.UI.Pages.TextEdit;
@@ -221,6 +222,9 @@ public static class Services
             .AddView<CollectionLoadoutView, ICollectionLoadoutViewModel>()
             .AddViewModel<CollectionLoadoutViewModel, ICollectionLoadoutViewModel>()
 
+            .AddView<ObservableInfoPageView, IObservableInfoPageViewModel>()
+            .AddViewModel<ObservableInfoPageViewModel, IObservableInfoPageViewModel>()
+
             // workspace system
             .AddSingleton<IWindowManager, WindowManager>()
             .AddWindowDataAttributesModel()
@@ -255,6 +259,7 @@ public static class Services
             .AddSingleton<IPageFactory, CollectionDownloadPageFactory>()
             .AddSingleton<IPageFactory, LoadOrdersWIPPageFactory>()
             .AddSingleton<IPageFactory, CollectionLoadoutPageFactory>()
+            .AddSingleton<IPageFactory, ObservableInfoPageFactory>()
 
             // LeftMenu factories
             .AddSingleton<ILeftMenuFactory, HomeLeftMenuFactory>()

--- a/src/NexusMods.App.UI/TypeFinder.cs
+++ b/src/NexusMods.App.UI/TypeFinder.cs
@@ -9,6 +9,7 @@ using NexusMods.App.UI.Pages.LibraryPage;
 using NexusMods.App.UI.Pages.LoadoutPage;
 using NexusMods.App.UI.Pages.MyGames;
 using NexusMods.App.UI.Pages.MyLoadouts;
+using NexusMods.App.UI.Pages.ObservableInfo;
 using NexusMods.App.UI.Pages.Settings;
 using NexusMods.App.UI.Pages.Sorting;
 using NexusMods.App.UI.Pages.TextEdit;
@@ -45,6 +46,7 @@ internal class TypeFinder : ITypeFinder
         typeof(LoadoutContext),
         typeof(DownloadsContext),
         typeof(CollectionDownloadPageContext),
+        typeof(ObservableInfoPageContext),
 
         // other
         typeof(WindowData),


### PR DESCRIPTION
For devs only. The page taps into the R3 observable tracker system and allows us to visualize all active observables.