### PR TITLE
Updated states for loadout items

### DIFF
--- a/src/NexusMods.App.UI/Pages/ILoadoutDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/ILoadoutDataProvider.cs
@@ -74,6 +74,12 @@ public static class LoadoutDataProviderHelper
         if (loadoutItem.Parent.TryGetAsCollectionGroup(out var collectionGroup))
         {
             itemModel.Add(LoadoutColumns.Collections.ComponentKey, new StringComponent(value: collectionGroup.AsLoadoutItemGroup().AsLoadoutItem().Name));
+            var isParentCollectionDisabledObservable = LoadoutItem.Observe(connection, collectionGroup.Id).Select(static item => item.IsDisabled).ToObservable();
+            itemModel.AddObservable(
+                key: LoadoutColumns.IsEnabled.ParentCollectionDisabledComponentKey,
+                shouldAddObservable: isParentCollectionDisabledObservable,
+                componentFactory: () => new LoadoutComponents.ParentCollectionDisabled()
+            );
         }
 
         var isEnabledObservable = LoadoutItem.Observe(connection, loadoutItem.Id).Select(static item => (bool?)!item.IsDisabled);

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutComponents.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutComponents.cs
@@ -14,6 +14,11 @@ namespace NexusMods.App.UI.Pages.LoadoutPage;
 
 public static class LoadoutComponents
 {
+    public sealed class ParentCollectionDisabled : ReactiveR3Object, IItemModelComponent<ParentCollectionDisabled>, IComparable<ParentCollectionDisabled>
+    {
+        public int CompareTo(ParentCollectionDisabled? other) => 0;
+    }
+
     public sealed class IsEnabled : ReactiveR3Object, IItemModelComponent<IsEnabled>, IComparable<IsEnabled>
     {
         public ReactiveCommand<Unit> CommandToggle { get; } = new();
@@ -126,7 +131,7 @@ public static class LoadoutColumns
 
         public const string ColumnTemplateResourceKey = nameof(LoadoutColumns) + "_" + nameof(IsEnabled);
         public static readonly ComponentKey IsEnabledComponentKey = ComponentKey.From(ColumnTemplateResourceKey + "_" + nameof(LoadoutComponents.IsEnabled));
-        // public static readonly ComponentKey LockedComponentKey = ComponentKey.From(ColumnTemplateResourceKey + "_" + nameof(LoadoutComponents.Locked));
+        public static readonly ComponentKey ParentCollectionDisabledComponentKey = ComponentKey.From(ColumnTemplateResourceKey + "_" + nameof(LoadoutComponents.ParentCollectionDisabled));
         public static string GetColumnHeader() => "Enabled";
         public static string GetColumnTemplateResourceKey() => ColumnTemplateResourceKey;
     }

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutComponents.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutComponents.cs
@@ -96,6 +96,22 @@ public static class LoadoutComponents
 public static class LoadoutColumns
 {
     [UsedImplicitly]
+    public sealed class Collections : ICompositeColumnDefinition<Collections>
+    {
+        public static int Compare<TKey>(CompositeItemModel<TKey> a, CompositeItemModel<TKey> b) where TKey : notnull
+        {
+            var aValue = a.GetOptional<StringComponent>(key: ComponentKey);
+            var bValue = a.GetOptional<StringComponent>(key: ComponentKey);
+            return aValue.Compare(bValue);
+        }
+
+        public const string ColumnTemplateResourceKey = nameof(LoadoutColumns) + "_" + nameof(Collections);
+        public static readonly ComponentKey ComponentKey = ComponentKey.From(ColumnTemplateResourceKey + "_" + nameof(StringComponent));
+        public static string GetColumnHeader() => "Collections";
+        public static string GetColumnTemplateResourceKey() => ColumnTemplateResourceKey;
+    }
+
+    [UsedImplicitly]
     public sealed class IsEnabled : ICompositeColumnDefinition<IsEnabled>
     {
         public static int Compare<TKey>(CompositeItemModel<TKey> a, CompositeItemModel<TKey> b) where TKey : notnull

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutViewModel.cs
@@ -288,6 +288,7 @@ public class LoadoutTreeDataGridAdapter :
         [
             viewHierarchical ? ITreeDataGridItemModel<CompositeItemModel<EntityId>, EntityId>.CreateExpanderColumn(nameColumn) : nameColumn,
             ColumnCreator.Create<EntityId, SharedColumns.InstalledDate>(),
+            ColumnCreator.Create<EntityId, LoadoutColumns.Collections>(),
             ColumnCreator.Create<EntityId, LoadoutColumns.IsEnabled>(),
         ];
     }

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/TreeDataGridLoadoutResources.axaml
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/TreeDataGridLoadoutResources.axaml
@@ -5,6 +5,27 @@
                     xmlns:local="clr-namespace:NexusMods.App.UI.Pages.LoadoutPage"
                     xmlns:icons="clr-namespace:NexusMods.Icons;assembly=NexusMods.Icons">
 
+    <!-- Collections -->
+    <DataTemplate x:Key="{x:Static local:LoadoutColumns+Collections.ColumnTemplateResourceKey}">
+        <DataTemplate.DataType>
+            <x:Type TypeName="controls:CompositeItemModel" x:TypeArguments="abstractions:EntityId" />
+        </DataTemplate.DataType>
+
+        <controls:ComponentControl x:TypeArguments="abstractions:EntityId" Content="{CompiledBinding}">
+            <controls:ComponentControl.ComponentTemplate>
+                <controls:ComponentTemplate x:TypeArguments="controls:StringComponent"
+                                            ComponentKey="{x:Static local:LoadoutColumns+Collections.ComponentKey}">
+                    <controls:ComponentTemplate.DataTemplate>
+                        <DataTemplate DataType="{x:Type controls:StringComponent}">
+                            <TextBlock Text="{CompiledBinding Value.Value}" TextTrimming="CharacterEllipsis"/>
+                        </DataTemplate>
+                    </controls:ComponentTemplate.DataTemplate>
+                </controls:ComponentTemplate>
+            </controls:ComponentControl.ComponentTemplate>
+        </controls:ComponentControl>
+    </DataTemplate>
+
+    <!-- Enabled -->
     <DataTemplate x:Key="{x:Static local:LoadoutColumns+IsEnabled.ColumnTemplateResourceKey}">
         <DataTemplate.DataType>
             <x:Type TypeName="controls:CompositeItemModel" x:TypeArguments="abstractions:EntityId" />

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/TreeDataGridLoadoutResources.axaml
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/TreeDataGridLoadoutResources.axaml
@@ -33,32 +33,27 @@
 
         <controls:MultiComponentControl x:TypeArguments="abstractions:EntityId" Content="{CompiledBinding}">
             <controls:MultiComponentControl.AvailableTemplates>
-                <!-- Locked (eg: required mods of collections) -->
-                <controls:ComponentTemplate x:TypeArguments="local:LoadoutComponents+Locked"
-                                            ComponentKey="{x:Static local:LoadoutColumns+IsEnabled.LockedComponentKey}">
-                    <controls:ComponentTemplate.DataTemplate>
-                        <DataTemplate DataType="{x:Type local:LoadoutComponents+Locked}">
-                            <icons:UnifiedIcon Value="{x:Static icons:IconValues.Lock}"
-                                               Size="20" />
-                        </DataTemplate>
-                    </controls:ComponentTemplate.DataTemplate>
-                </controls:ComponentTemplate>
 
                 <controls:ComponentTemplate x:TypeArguments="local:LoadoutComponents+IsEnabled"
                                             ComponentKey="{x:Static local:LoadoutColumns+IsEnabled.IsEnabledComponentKey}">
                     <controls:ComponentTemplate.DataTemplate>
                         <DataTemplate DataType="{x:Type local:LoadoutComponents+IsEnabled}">
-                            <ToggleSwitch Classes="Compact"
-                                          HorizontalAlignment="Center"
-                                          Command="{CompiledBinding CommandToggle}"
-                                          IsChecked="{CompiledBinding Value.Value, Mode=OneWay}">
-                                <ToggleSwitch.OnContent>
-                                    <ContentControl />
-                                </ToggleSwitch.OnContent>
-                                <ToggleSwitch.OffContent>
-                                    <ContentControl />
-                                </ToggleSwitch.OffContent>
-                            </ToggleSwitch>
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                                <icons:UnifiedIcon Value="{x:Static icons:IconValues.Lock}" Size="20" IsVisible="{CompiledBinding IsLocked.Value}"/>
+
+                                <ToggleSwitch Classes="Compact"
+                                              HorizontalAlignment="Center"
+                                              Command="{CompiledBinding CommandToggle}"
+                                              IsChecked="{CompiledBinding Value.Value, Mode=OneWay}"
+                                              IsEnabled="{CompiledBinding !IsLocked.Value}">
+                                    <ToggleSwitch.OnContent>
+                                        <ContentControl />
+                                    </ToggleSwitch.OnContent>
+                                    <ToggleSwitch.OffContent>
+                                        <ContentControl />
+                                    </ToggleSwitch.OffContent>
+                                </ToggleSwitch>
+                            </StackPanel>
                         </DataTemplate>
                     </controls:ComponentTemplate.DataTemplate>
                 </controls:ComponentTemplate>

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/TreeDataGridLoadoutResources.axaml
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/TreeDataGridLoadoutResources.axaml
@@ -33,13 +33,33 @@
 
         <controls:MultiComponentControl x:TypeArguments="abstractions:EntityId" Content="{CompiledBinding}">
             <controls:MultiComponentControl.AvailableTemplates>
+                <!-- parent collection disabled -->
+                <controls:ComponentTemplate x:TypeArguments="local:LoadoutComponents+ParentCollectionDisabled"
+                                            ComponentKey="{x:Static local:LoadoutColumns+IsEnabled.ParentCollectionDisabledComponentKey}">
+                    <controls:ComponentTemplate.DataTemplate>
+                        <DataTemplate DataType="{x:Type local:LoadoutComponents+ParentCollectionDisabled}">
+                            <StackPanel Orientation="Horizontal">
+                                <icons:UnifiedIcon Value="{x:Static icons:IconValues.Collections}" Size="20"/>
+                                <ToggleSwitch Classes="Compact" HorizontalAlignment="Center" IsEnabled="false" IsChecked="False">
+                                    <ToggleSwitch.OnContent>
+                                        <ContentControl />
+                                    </ToggleSwitch.OnContent>
+                                    <ToggleSwitch.OffContent>
+                                        <ContentControl />
+                                    </ToggleSwitch.OffContent>
+                                </ToggleSwitch>
+                            </StackPanel>
+                        </DataTemplate>
+                    </controls:ComponentTemplate.DataTemplate>
+                </controls:ComponentTemplate>
 
+                <!-- normal toggle -->
                 <controls:ComponentTemplate x:TypeArguments="local:LoadoutComponents+IsEnabled"
                                             ComponentKey="{x:Static local:LoadoutColumns+IsEnabled.IsEnabledComponentKey}">
                     <controls:ComponentTemplate.DataTemplate>
                         <DataTemplate DataType="{x:Type local:LoadoutComponents+IsEnabled}">
                             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                                <icons:UnifiedIcon Value="{x:Static icons:IconValues.Lock}" Size="20" IsVisible="{CompiledBinding IsLocked.Value}"/>
+                                <icons:UnifiedIcon Value="{x:Static icons:IconValues.Lock}" Size="18" IsVisible="{CompiledBinding IsLocked.Value}"/>
 
                                 <ToggleSwitch Classes="Compact"
                                               HorizontalAlignment="Center"

--- a/src/NexusMods.App.UI/Pages/LocalFileDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/LocalFileDataProvider.cs
@@ -108,6 +108,7 @@ internal class LocalFileDataProvider : ILibraryDataProvider, ILoadoutDataProvide
         parentItemModel.Add(SharedColumns.Name.ImageComponentKey, new ImageComponent(value: ImagePipelines.ModPageThumbnailFallback));
 
         LoadoutDataProviderHelper.AddDateComponent(parentItemModel, localFile.GetCreatedAt(), linkedItemsObservable);
+        LoadoutDataProviderHelper.AddCollections(parentItemModel, linkedItemsObservable);
         LoadoutDataProviderHelper.AddIsEnabled(_connection, parentItemModel, linkedItemsObservable);
 
         return parentItemModel;

--- a/src/NexusMods.App.UI/Pages/NexusModsDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/NexusModsDataProvider.cs
@@ -260,6 +260,7 @@ public class NexusModsDataProvider : ILibraryDataProvider, ILoadoutDataProvider
                 parentItemModel.Add(SharedColumns.Name.ImageComponentKey, ImageComponent.FromPipeline(_thumbnailLoader, modPage.Id, initialValue: ImagePipelines.ModPageThumbnailFallback));
 
                 LoadoutDataProviderHelper.AddDateComponent(parentItemModel, modPage.GetCreatedAt(), linkedItemsObservable);
+                LoadoutDataProviderHelper.AddCollections(parentItemModel, linkedItemsObservable);
                 LoadoutDataProviderHelper.AddIsEnabled(_connection, parentItemModel, linkedItemsObservable);
 
                 return parentItemModel;


### PR DESCRIPTION
Part of #2598.

- Adds the "Collections"-column for loadout items
- Adds the `IsLocked` state to `LoadoutComponents.IsEnabled`
- Adds a new component for the disabled state of the parent collection

I'll do the more difficult state stuff in another PR.