### PR TITLE
Use correct version data for SDV diagnostics

### DIFF
--- a/src/Games/NexusMods.Games.Larian/BaldursGate3/BaldursGate3.cs
+++ b/src/Games/NexusMods.Games.Larian/BaldursGate3/BaldursGate3.cs
@@ -8,6 +8,7 @@ using NexusMods.Abstractions.Games;
 using NexusMods.Abstractions.IO;
 using NexusMods.Abstractions.IO.StreamFactories;
 using NexusMods.Abstractions.Library.Installers;
+using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Loadouts.Synchronizers;
 using NexusMods.Abstractions.NexusWebApi.Types.V2;
 using NexusMods.Games.Generic.Installers;
@@ -22,6 +23,7 @@ public class BaldursGate3 : AGame, ISteamGame, IGogGame
 {
     private readonly IServiceProvider _serviceProvider;
     private readonly IOSInformation _osInformation;
+    private readonly IFileSystem _fs;
     public override string Name => "Baldur's Gate 3";
 
     public IEnumerable<uint> SteamIds => [1086940u];
@@ -41,9 +43,10 @@ public class BaldursGate3 : AGame, ISteamGame, IGogGame
     {
         _serviceProvider = provider;
         _osInformation = provider.GetRequiredService<IOSInformation>();
+        _fs = provider.GetRequiredService<IFileSystem>();
     }
     
-    protected override Version GetVersion(GameLocatorResult locatorResult)
+    public override Version GetLocalVersion(GameInstallMetadata.ReadOnly installation)
     {
         try
         {
@@ -53,7 +56,7 @@ public class BaldursGate3 : AGame, ISteamGame, IGogGame
                 : new GamePath(LocationId.Game, "bin/bg3.exe");
 
             var fvi = executableGamePath
-                .Combine(locatorResult.Path).FileInfo
+                .Combine(_fs.FromUnsanitizedFullPath(installation.Path)).FileInfo
                 .GetFileVersionInfo();
             return fvi.ProductVersion;
         }

--- a/src/Games/NexusMods.Games.MountAndBlade2Bannerlord/Bannerlord.cs
+++ b/src/Games/NexusMods.Games.MountAndBlade2Bannerlord/Bannerlord.cs
@@ -12,6 +12,7 @@ using NexusMods.Abstractions.Games;
 using NexusMods.Abstractions.IO;
 using NexusMods.Abstractions.IO.StreamFactories;
 using NexusMods.Abstractions.Library.Installers;
+using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Loadouts.Synchronizers;
 using NexusMods.Abstractions.NexusWebApi.Types;
 using NexusMods.Abstractions.NexusWebApi.Types.V2;
@@ -36,6 +37,7 @@ public sealed class Bannerlord : AGame, ISteamGame, IGogGame, IEpicGame, IXboxGa
 
     private readonly IServiceProvider _serviceProvider;
     private readonly LauncherManagerFactory _launcherManagerFactory;
+    private readonly IFileSystem _fs;
 
     public override string Name => DisplayName;
     public override GameId GameId => GameIdStatic;
@@ -75,15 +77,16 @@ public sealed class Bannerlord : AGame, ISteamGame, IGogGame, IEpicGame, IXboxGa
     {
         _serviceProvider = serviceProvider;
         _launcherManagerFactory = launcherManagerFactory;
+        _fs = serviceProvider.GetRequiredService<IFileSystem>();
     }
 
     public override GamePath GetPrimaryFile(GameStore store) => GamePathProvier.PrimaryLauncherFile(store);
 
-    protected override Version GetVersion(GameLocatorResult installation)
+    public override Version GetLocalVersion(GameInstallMetadata.ReadOnly installation)
     {
         // Note(sewer): Bannerlord can use prefixes on versions etc. ,we want to strip them out
         // so we sanitize/parse with `ApplicationVersion`.
-        var bannerlordVerStr = Fetcher.GetVersion(installation.Path.ToString(), "TaleWorlds.Library.dll");
+        var bannerlordVerStr = Fetcher.GetVersion(installation.Path, "TaleWorlds.Library.dll");
         var versionStr = ApplicationVersion.TryParse(bannerlordVerStr, out var av) ? $"{av.Major}.{av.Minor}.{av.Revision}.{av.ChangeSet}" : "0.0.0.0";
         return Version.TryParse(versionStr, out var val) ? val : new Version();
     }

--- a/src/Games/NexusMods.Games.StardewValley/Emitters/DependencyDiagnosticEmitter.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/DependencyDiagnosticEmitter.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.Diagnostics;
 using NexusMods.Abstractions.Diagnostics.Emitters;
 using NexusMods.Abstractions.Diagnostics.References;
+using NexusMods.Abstractions.Games;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Loadouts.Extensions;
 using NexusMods.Abstractions.Resources;
@@ -38,7 +39,7 @@ public class DependencyDiagnosticEmitter : ILoadoutDiagnosticEmitter
 
     public async IAsyncEnumerable<Diagnostic> Diagnose(Loadout.ReadOnly loadout, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        var gameVersion = new SemanticVersion(loadout.GameVersion);
+        var gameVersion = new SemanticVersion((loadout.InstallationInstance.Game as AGame)!.GetLocalVersion(loadout.Installation));
 
         if (!Helpers.TryGetSMAPI(loadout, out var smapi)) yield break;
         if (!SMAPILoadoutItem.Version.TryGetValue(smapi, out var smapiStrVersion)) yield break;

--- a/src/Games/NexusMods.Games.StardewValley/Emitters/SMAPIGameVersionDiagnosticEmitter.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/SMAPIGameVersionDiagnosticEmitter.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.Diagnostics;
 using NexusMods.Abstractions.Diagnostics.Emitters;
 using NexusMods.Abstractions.Diagnostics.References;
+using NexusMods.Abstractions.Games;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Games.StardewValley.Models;
 using StardewModdingAPI;
@@ -39,8 +40,7 @@ public class SMAPIGameVersionDiagnosticEmitter : ILoadoutDiagnosticEmitter
         var gameToSMAPIMappings = await FetchGameToSMAPIMappings(cancellationToken);
         if (gameToSMAPIMappings is null) yield break;
 
-        // var gameVersion = SimplifyVersion(new Version("1.5.6.22018"));
-        var gameVersion = new SemanticVersion(loadout.GameVersion);
+        var gameVersion = new SemanticVersion((loadout.InstallationInstance.Game as AGame)!.GetLocalVersion(loadout.Installation));
 
         if (!Helpers.TryGetSMAPI(loadout, out var smapi))
         {

--- a/src/Games/NexusMods.Games.StardewValley/Emitters/SMAPIModDatabaseCompatibilityDiagnosticEmitter.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/SMAPIModDatabaseCompatibilityDiagnosticEmitter.cs
@@ -4,6 +4,7 @@ using NexusMods.Abstractions.Diagnostics;
 using NexusMods.Abstractions.Diagnostics.Emitters;
 using NexusMods.Abstractions.Diagnostics.References;
 using NexusMods.Abstractions.Diagnostics.Values;
+using NexusMods.Abstractions.Games;
 using NexusMods.Abstractions.IO;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Resources;
@@ -58,7 +59,7 @@ public class SMAPIModDatabaseCompatibilityDiagnosticEmitter : ILoadoutDiagnostic
 
     public async IAsyncEnumerable<Diagnostic> Diagnose(Loadout.ReadOnly loadout, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        var gameVersion = new SemanticVersion(loadout.GameVersion);
+        var gameVersion = new SemanticVersion((loadout.InstallationInstance.Game as AGame)!.GetLocalVersion(loadout.Installation));
 
         if (!Helpers.TryGetSMAPI(loadout, out var smapi)) yield break;
         if (!SMAPILoadoutItem.Version.TryGetValue(smapi, out var smapiStrVersion)) yield break;

--- a/src/Games/NexusMods.Games.StardewValley/Emitters/VersionDiagnosticEmitter.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/VersionDiagnosticEmitter.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.Diagnostics;
 using NexusMods.Abstractions.Diagnostics.Emitters;
 using NexusMods.Abstractions.Diagnostics.References;
+using NexusMods.Abstractions.Games;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Resources;
 using NexusMods.Games.StardewValley.Models;
@@ -36,8 +37,7 @@ public class VersionDiagnosticEmitter : ILoadoutDiagnosticEmitter
 
     public async IAsyncEnumerable<Diagnostic> Diagnose(Loadout.ReadOnly loadout, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        var gameVersion = new SemanticVersion(loadout.GameVersion);
-        // var gameVersion = new SemanticVersion("1.5.6");
+        var gameVersion = new SemanticVersion((loadout.InstallationInstance.Game as AGame)!.GetLocalVersion(loadout.Installation));
 
         if (!Helpers.TryGetSMAPI(loadout, out var smapi)) yield break;
         if (!SMAPILoadoutItem.Version.TryGetValue(smapi, out var smapiStrVersion)) yield break;

--- a/src/Games/NexusMods.Games.StardewValley/StardewValley.cs
+++ b/src/Games/NexusMods.Games.StardewValley/StardewValley.cs
@@ -11,6 +11,7 @@ using NexusMods.Abstractions.Games;
 using NexusMods.Abstractions.IO;
 using NexusMods.Abstractions.IO.StreamFactories;
 using NexusMods.Abstractions.Library.Installers;
+using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Loadouts.Synchronizers;
 using NexusMods.Abstractions.NexusWebApi.Types;
 using NexusMods.Abstractions.NexusWebApi.Types.V2;
@@ -27,6 +28,7 @@ public class StardewValley : AGame, ISteamGame, IGogGame, IXboxGame
     public static GameDomain DomainStatic => GameDomain.From("stardewvalley");
     private readonly IOSInformation _osInformation;
     private readonly IServiceProvider _serviceProvider;
+    private readonly IFileSystem _fs;
     public IEnumerable<uint> SteamIds => new[] { 413150u };
     public IEnumerable<long> GogIds => new long[] { 1453375253 };
     public IEnumerable<string> XboxIds => new[] { "ConcernedApe.StardewValleyPC" };
@@ -50,6 +52,7 @@ public class StardewValley : AGame, ISteamGame, IGogGame, IXboxGame
     {
         _osInformation = osInformation;
         _serviceProvider = provider;
+        _fs = provider.GetRequiredService<IFileSystem>();
     }
 
     public override GamePath GetPrimaryFile(GameStore store)
@@ -74,7 +77,7 @@ public class StardewValley : AGame, ISteamGame, IGogGame, IXboxGame
         return Optional<GamePath>.Create(path);
     }
 
-    protected override Version GetVersion(GameLocatorResult installation)
+    public override Version GetLocalVersion(GameInstallMetadata.ReadOnly installation)
     {
         try
         {
@@ -84,7 +87,7 @@ public class StardewValley : AGame, ISteamGame, IGogGame, IXboxGame
                 onOSX: () => "Contents/MacOS/Stardew Valley.dll"
             );
 
-            var fileInfo = installation.Path.Combine(path).FileInfo;
+            var fileInfo = _fs.FromUnsanitizedFullPath(installation.Path).Combine(path).FileInfo;
             return fileInfo.GetFileVersionInfo().FileVersion;
         }
         catch (Exception)


### PR DESCRIPTION
We want to use the same version that SMAPI uses for the diagnostics. 
I reused the existing GetVersion code and just adapted it enough to make it usable.

This is to fix all the exceptions we would otherwise get after any loadout operation for SDV due to diagnostics not having the correct version data.