### PR TITLE
Fixes steam game indexing, better performance, etc

### DIFF
--- a/src/NexusMods.App/Startup.cs
+++ b/src/NexusMods.App/Startup.cs
@@ -102,7 +102,7 @@ public class Startup
             .LogToTrace()
             .UseR3()
             .UseReactiveUI()
-            .With(new SkiaOptions { UseOpacitySaveLayer = true });
+            .With(new SkiaOptions { UseOpacitySaveLayer = false });
         
             // NOTE(insomnious): Opacity doesn't work on SVGs without this SkiaOptions set. It's needed for when we want to disable\fade SVG icons.
             // See https://github.com/AvaloniaUI/Avalonia/pull/9964 for more details.


### PR DESCRIPTION
I went to index steam files for Cyberpunk and ended up finding a bunch of small issues. So this does the following:

* Fixes the game hashes db builder so it no longer silently failswhen the version definitions are invalid (like referencing a manifest we've never seen. Now it ignores those versions and logs info about them.
* When critical errors happen we now return -1 so that gihub actions won't continue after a failed run
* Added support for `SteamCache` endpoints and defaults to those
* When we get a failure from a Steam server we mark the server as failed and try the next
* Added support for prefetching in the chunked stream reader. Some steam servers have very bursty responses, this evens it out a bit. 
* Added some parallelism to the steam indexing code
* Added support for logging into Steam via credentials stored in environment variables, useful for github actions 