### PR TITLE
Fix apply preview and exceptions when switching loadouts

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -905,10 +905,22 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
         return replacement.Id > existing.Id;
     }
     
-    /// <inheritdoc />
-    public FileDiffTree LoadoutToDiskDiff(Loadout.ReadOnly loadout, DiskState diskState)
+    /// <summary>
+    /// Returns true if the loadout state doesn't match the last scanned disk state.
+    /// </summary>
+    public bool ShouldSynchronize(Loadout.ReadOnly loadout, DiskState previousDiskState, DiskState lastScannedDiskState)
     {
-        var syncTree = BuildSyncTree(DiskStateToPathPartPair(diskState), DiskStateToPathPartPair(diskState), loadout);
+        var syncTree = BuildSyncTree(DiskStateToPathPartPair(lastScannedDiskState), DiskStateToPathPartPair(previousDiskState), loadout);
+        // Process the sync tree to get the actions populated in the nodes
+        ProcessSyncTree(syncTree);
+        
+        return syncTree.Any(n => n.Value.Actions != Actions.DoNothing);
+    }
+    
+    /// <inheritdoc />
+    public FileDiffTree LoadoutToDiskDiff(Loadout.ReadOnly loadout, DiskState previousDiskState, DiskState lastScannedDiskState)
+    {
+        var syncTree = BuildSyncTree(DiskStateToPathPartPair(lastScannedDiskState), DiskStateToPathPartPair(previousDiskState), loadout);
         // Process the sync tree to get the actions populated in the nodes
         ProcessSyncTree(syncTree);
 
@@ -951,6 +963,22 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
                     ChangeType = FileChangeType.Removed,
                     GamePath = path,
                 };
+            }
+            else if (actions.HasFlag(Actions.IngestFromDisk))
+            {
+                // File is already on disk and will not be changed
+                entry = new DiskDiffEntry
+                {
+                    Hash = node.Disk.Hash,
+                    Size = node.Disk.Size,
+                    ChangeType = FileChangeType.None,
+                    GamePath = path,
+                };
+            }
+            else if (actions.HasFlag(Actions.AddReifiedDelete))
+            {
+                // File is not on disk and will not end up on disk, so don't show it
+                continue;
             }
             else
             {

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ILoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ILoadoutSynchronizer.cs
@@ -56,13 +56,16 @@ public interface ILoadoutSynchronizer
     
     #region High Level Methods
     
+    public bool ShouldSynchronize(Loadout.ReadOnly loadout, DiskState previousState, DiskState lastScannedState);
+    
     /// <summary>
     /// Computes the difference between a loadout and a disk state, assuming the loadout to be the newer state.
     /// </summary>x
     /// <param name="loadout">Newer state, e.g. unapplied loadout</param>
-    /// <param name="diskState">The old state, e.g. last applied DiskState</param>
+    /// <param name="previousState">The old state, e.g. last applied DiskState</param>
+    /// <param name="lastScannedState">The last scanned state, e.g. the last time the game folder was scanned</param>
     /// <returns>A tree of all the files with associated <see cref="FileChangeType"/></returns>
-    FileDiffTree LoadoutToDiskDiff(Loadout.ReadOnly loadout, DiskState diskState);
+    FileDiffTree LoadoutToDiskDiff(Loadout.ReadOnly loadout, DiskState previousState, DiskState lastScannedState);
     
     /// <summary>
     /// Creates a loadout for a game, managing the game if it has not previously

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ILoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ILoadoutSynchronizer.cs
@@ -83,7 +83,7 @@ public interface ILoadoutSynchronizer
     /// Resets a game back to it's initial state, any applied loadouts will be unapplied.
     /// Last synced loadout should be cleared if the game is being reset
     /// </summary>
-    public Task DeactivateCurrentLoadout(GameInstallation installation, bool clearLastSyncedLoadout = true);
+    public Task DeactivateCurrentLoadout(GameInstallation installation);
     
     /// <summary>
     /// Gets the currently active loadout for the game, if any.

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ILoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ILoadoutSynchronizer.cs
@@ -81,8 +81,9 @@ public interface ILoadoutSynchronizer
 
     /// <summary>
     /// Resets a game back to it's initial state, any applied loadouts will be unapplied.
+    /// Last synced loadout should be cleared if the game is being reset
     /// </summary>
-    public Task DeactivateCurrentLoadout(GameInstallation installation);
+    public Task DeactivateCurrentLoadout(GameInstallation installation, bool clearLastSyncedLoadout = true);
     
     /// <summary>
     /// Gets the currently active loadout for the game, if any.

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts/ISynchronizerService.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts/ISynchronizerService.cs
@@ -24,6 +24,11 @@ public interface ISynchronizerService
     public FileDiffTree GetApplyDiffTree(LoadoutId loadout);
 
     /// <summary>
+    /// Computes whether there are changes that need to be synchronized for a given loadout.
+    /// </summary>
+    public bool GetShouldSynchronize(LoadoutId loadoutId);
+
+    /// <summary>
     /// Returns the last applied loadout for a given game installation.
     /// </summary>
     public bool TryGetLastAppliedLoadout(GameInstallation gameInstallation, out Loadout.ReadOnly loadout);

--- a/src/NexusMods.DataModel/Synchronizer/SynchronizerService.cs
+++ b/src/NexusMods.DataModel/Synchronizer/SynchronizerService.cs
@@ -55,8 +55,16 @@ public class SynchronizerService : ISynchronizerService
         var loadout = Loadout.Load(_conn.Db, loadoutId);
         var synchronizer = loadout.InstallationInstance.GetGame().Synchronizer;
         var metaData = GameInstallMetadata.Load(_conn.Db, loadout.InstallationInstance.GameMetadataId);
+
+        if (!metaData.Contains(GameInstallMetadata.LastSyncedLoadoutTransaction) ||
+            !metaData.Contains(GameInstallMetadata.LastScannedDiskStateTransaction))
+        {
+            return true;
+        }
+        
         var previousDiskState   = metaData.DiskStateAsOf(metaData.LastSyncedLoadoutTransaction);
         var lastScannedDiskState = metaData.DiskStateAsOf(metaData.LastScannedDiskStateTransaction);
+        
         return synchronizer.ShouldSynchronize(loadout, previousDiskState, lastScannedDiskState);
     }
     

--- a/src/NexusMods.DataModel/Synchronizer/SynchronizerService.cs
+++ b/src/NexusMods.DataModel/Synchronizer/SynchronizerService.cs
@@ -55,12 +55,6 @@ public class SynchronizerService : ISynchronizerService
         var loadout = Loadout.Load(_conn.Db, loadoutId);
         var synchronizer = loadout.InstallationInstance.GetGame().Synchronizer;
         var metaData = GameInstallMetadata.Load(_conn.Db, loadout.InstallationInstance.GameMetadataId);
-
-        if (!metaData.Contains(GameInstallMetadata.LastSyncedLoadoutTransaction) ||
-            !metaData.Contains(GameInstallMetadata.LastScannedDiskStateTransaction))
-        {
-            return true;
-        }
         
         var previousDiskState   = metaData.DiskStateAsOf(metaData.LastSyncedLoadoutTransaction);
         var lastScannedDiskState = metaData.DiskStateAsOf(metaData.LastScannedDiskStateTransaction);

--- a/tests/Games/NexusMods.Games.TestFramework/AIsolatedGameTest.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/AIsolatedGameTest.cs
@@ -58,6 +58,7 @@ public abstract class AIsolatedGameTest<TTest, TGame> : IAsyncLifetime where TGa
 
     protected readonly NexusApiClient NexusNexusApiClient;
     protected ILoadoutSynchronizer Synchronizer => GameInstallation.GetGame().Synchronizer;
+    protected ISynchronizerService SynchronizerService;
     
     private bool _gameFilesWritten = false;
     private readonly IHost _host;
@@ -101,6 +102,7 @@ public abstract class AIsolatedGameTest<TTest, TGame> : IAsyncLifetime where TGa
         Logger = ServiceProvider.GetRequiredService<ILogger<TTest>>();
         LibraryService = ServiceProvider.GetRequiredService<ILibraryService>();
         NexusModsLibrary = ServiceProvider.GetRequiredService<NexusModsLibrary>();
+        SynchronizerService = ServiceProvider.GetRequiredService<ISynchronizerService>();
     }
     
     public async Task<LibraryArchive.ReadOnly> RegisterLocalArchive(AbsolutePath file)

--- a/tests/NexusMods.DataModel.Synchronizer.Tests/GeneralLoadoutManagementTests.SynchronizerIntegrationTests.verified.md
+++ b/tests/NexusMods.DataModel.Synchronizer.Tests/GeneralLoadoutManagementTests.SynchronizerIntegrationTests.verified.md
@@ -102,43 +102,26 @@ After the loadout has been synchronized, the new file should be added to the loa
 
 
 
-## 6 - Loadout Deactivated:
-At this point the loadout is deactivated, and all the files in the current state should match the initial state.
-### Initial State - (1)
-| Path | Hash | Size |
-| --- | --- | --- |
-| {Game, bin/originalGameFile.txt} | 0x673E3C493921A2D5 | 12 B |
-### Current State - (4)
-| Path | Hash | Size |
-| --- | --- | --- |
-| {Game, config.ini} | 0xB4108DF91E677789 | 33 B |
-| {Game, Data/image.dds} | 0x9829BF9CBC5991D2 | 85.484 KB |
-| {Game, README.txt} | 0x284B31336E242FFA | 26 B |
-| {Game, StubbedGame.exe} | 0xAD76A8A9233B7238 | 209 KB |
-### Loadout A - (2)
-| Path | Hash | Size | Disabled | Deleted |
-| --- | --- | --- | --- | --- |
-| {Game, bin/newFileInGameFolderA.txt} | 0x3FB1DBAC894B6380 | 25 B |   |   |
-| {Game, bin/originalGameFile.txt} | 0x673E3C493921A2D5 | 12 B |   |   |
-
-
-
-## 7 - New Loadout (B) Created - No Sync:
+## 6 - New Loadout (B) Created - No Sync:
 A new loadout is created, but it has not been synchronized yet. So again the 'Last Synced State' is not set.
 ### Initial State - (1)
 | Path | Hash | Size |
 | --- | --- | --- |
 | {Game, bin/originalGameFile.txt} | 0x673E3C493921A2D5 | 12 B |
-### Last Synced State - (4)
+### Last Synced State - (6)
 | Path | Hash | Size |
 | --- | --- | --- |
+| {Game, bin/newFileInGameFolderA.txt} | 0x3FB1DBAC894B6380 | 25 B |
+| {Game, bin/originalGameFile.txt} | 0x673E3C493921A2D5 | 12 B |
 | {Game, config.ini} | 0xB4108DF91E677789 | 33 B |
 | {Game, Data/image.dds} | 0x9829BF9CBC5991D2 | 85.484 KB |
 | {Game, README.txt} | 0x284B31336E242FFA | 26 B |
 | {Game, StubbedGame.exe} | 0xAD76A8A9233B7238 | 209 KB |
-### Current State - (4)
+### Current State - (6)
 | Path | Hash | Size |
 | --- | --- | --- |
+| {Game, bin/newFileInGameFolderA.txt} | 0x3FB1DBAC894B6380 | 25 B |
+| {Game, bin/originalGameFile.txt} | 0x673E3C493921A2D5 | 12 B |
 | {Game, config.ini} | 0xB4108DF91E677789 | 33 B |
 | {Game, Data/image.dds} | 0x9829BF9CBC5991D2 | 85.484 KB |
 | {Game, README.txt} | 0x284B31336E242FFA | 26 B |
@@ -154,7 +137,7 @@ A new loadout is created, but it has not been synchronized yet. So again the 'La
 
 
 
-## 8 - New Loadout (B) Synced:
+## 7 - New Loadout (B) Synced:
 After the new loadout has been synchronized, the 'Last Synced State' should match the 'Current State' as the loadout has been applied to the game folder. Note that the contents of this 
 loadout are different from the previous loadout due to the new file only being in the previous loadout.
 ### Initial State - (1)
@@ -186,7 +169,7 @@ loadout are different from the previous loadout due to the new file only being i
 
 
 
-## 9 - New File Added to Game Folder (B):
+## 8 - New File Added to Game Folder (B):
 A new file has been added to the game folder and B loadout has been synchronized. The new file should be added to the B loadout.
 ### Initial State - (1)
 | Path | Hash | Size |
@@ -220,7 +203,7 @@ A new file has been added to the game folder and B loadout has been synchronized
 
 
 
-## 10 - Switch back to Loadout A:
+## 9 - Switch back to Loadout A:
 Now we switch back to the A loadout, and the new file should be removed from the game folder.
 ### Initial State - (1)
 | Path | Hash | Size |
@@ -256,7 +239,7 @@ Now we switch back to the A loadout, and the new file should be removed from the
 
 
 
-## 11 - Loadout A Copied to Loadout C:
+## 10 - Loadout A Copied to Loadout C:
 Loadout A has been copied to Loadout C, and the contents should match.
 ### Initial State - (1)
 | Path | Hash | Size |
@@ -297,7 +280,7 @@ Loadout A has been copied to Loadout C, and the contents should match.
 
 
 
-## 12 - Game Unmanaged:
+## 11 - Game Unmanaged:
 The loadouts have been deleted and the game folder should be back to its initial state.
 ### Initial State - (1)
 | Path | Hash | Size |

--- a/tests/NexusMods.DataModel.Synchronizer.Tests/GeneralLoadoutManagementTests.cs
+++ b/tests/NexusMods.DataModel.Synchronizer.Tests/GeneralLoadoutManagementTests.cs
@@ -88,6 +88,7 @@ public class GeneralLoadoutManagementTests(ITestOutputHelper helper) : ACyberpun
             """, [loadoutA, loadoutB]
         );
         
+        await Synchronizer.DeactivateCurrentLoadout(loadoutA.InstallationInstance);
         await Synchronizer.ActivateLoadout(loadoutA);
         
         LogDiskState(sb, "## 9 - Switch back to Loadout A",

--- a/tests/NexusMods.DataModel.Synchronizer.Tests/GeneralLoadoutManagementTests.cs
+++ b/tests/NexusMods.DataModel.Synchronizer.Tests/GeneralLoadoutManagementTests.cs
@@ -1,10 +1,10 @@
+using System.Reactive;
 using System.Text;
 using FluentAssertions;
 using NexusMods.Abstractions.GameLocators;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Games.TestFramework;
 using NexusMods.MnemonicDB.Abstractions.ElementComparers;
-using NexusMods.MnemonicDB.Abstractions.TxFunctions;
 using NexusMods.Paths;
 using Xunit.Abstractions;
 
@@ -30,6 +30,8 @@ public class GeneralLoadoutManagementTests(ITestOutputHelper helper) : ACyberpun
             The initial state of the game folder should contain the game files as they were created by the game store. No loadout has been created yet.
             """);
         var loadoutA = await CreateLoadout();
+        var loadoutAState = await SynchronizerService.StatusForLoadout(loadoutA);
+        var subADisposable = loadoutAState.SubscribeSafe(new AnonymousObserver<LoadoutSynchronizerState>(_ => { }, onError: exception => sb.AppendLine($"Loadout A State Error: {exception}")));
 
         LogDiskState(sb, "## 2 - Loadout Created (A) - Synced",
             """
@@ -54,17 +56,11 @@ public class GeneralLoadoutManagementTests(ITestOutputHelper helper) : ACyberpun
             After the loadout has been synchronized, the new file should be added to the loadout.
             """, [loadoutA]);
         
-        
-        await Synchronizer.DeactivateCurrentLoadout(GameInstallation);
-        LogDiskState(sb, "## 6 - Loadout Deactivated", 
-            """
-            At this point the loadout is deactivated, and all the files in the current state should match the initial state.
-            """, [loadoutA]);
-        
-        
         var loadoutB = await CreateLoadout();
+        var loadoutBState = await SynchronizerService.StatusForLoadout(loadoutB);
+        var subBDisposable = loadoutBState.SubscribeSafe(new AnonymousObserver<LoadoutSynchronizerState>(_ => { }, onError: exception => sb.AppendLine($"Loadout B State Error: {exception}")));
 
-        LogDiskState(sb, "## 7 - New Loadout (B) Created - No Sync",
+        LogDiskState(sb, "## 6 - New Loadout (B) Created - No Sync",
             """
             A new loadout is created, but it has not been synchronized yet. So again the 'Last Synced State' is not set.
             """, [loadoutA, loadoutB]
@@ -72,7 +68,7 @@ public class GeneralLoadoutManagementTests(ITestOutputHelper helper) : ACyberpun
         
         loadoutB = await Synchronizer.Synchronize(loadoutB);
         
-        LogDiskState(sb, "## 8 - New Loadout (B) Synced",
+        LogDiskState(sb, "## 7 - New Loadout (B) Synced",
             """
             After the new loadout has been synchronized, the 'Last Synced State' should match the 'Current State' as the loadout has been applied to the game folder. Note that the contents of this 
             loadout are different from the previous loadout due to the new file only being in the previous loadout.
@@ -86,17 +82,15 @@ public class GeneralLoadoutManagementTests(ITestOutputHelper helper) : ACyberpun
         
         loadoutB = await Synchronizer.Synchronize(loadoutB);
         
-        LogDiskState(sb, "## 9 - New File Added to Game Folder (B)",
+        LogDiskState(sb, "## 8 - New File Added to Game Folder (B)",
             """
             A new file has been added to the game folder and B loadout has been synchronized. The new file should be added to the B loadout.
             """, [loadoutA, loadoutB]
         );
         
-
-        await Synchronizer.DeactivateCurrentLoadout(GameInstallation);
         await Synchronizer.ActivateLoadout(loadoutA);
         
-        LogDiskState(sb, "## 10 - Switch back to Loadout A",
+        LogDiskState(sb, "## 9 - Switch back to Loadout A",
             """
             Now we switch back to the A loadout, and the new file should be removed from the game folder.
             """, [loadoutA, loadoutB]
@@ -104,15 +98,19 @@ public class GeneralLoadoutManagementTests(ITestOutputHelper helper) : ACyberpun
         
         var loadoutC = await Synchronizer.CopyLoadout(loadoutA);
         
-        LogDiskState(sb, "## 11 - Loadout A Copied to Loadout C",
+        LogDiskState(sb, "## 10 - Loadout A Copied to Loadout C",
             """
             Loadout A has been copied to Loadout C, and the contents should match.
             """, [loadoutA, loadoutB, loadoutC]
         );
         
+        // Cleanup state subscriptions
+        subADisposable.Dispose();
+        subBDisposable.Dispose();
+        
         await Synchronizer.UnManage(GameInstallation);
         
-        LogDiskState(sb, "## 12 - Game Unmanaged",
+        LogDiskState(sb, "## 11 - Game Unmanaged",
             """
             The loadouts have been deleted and the game folder should be back to its initial state.
             """,

--- a/tests/NexusMods.StandardGameLocators.TestHelpers/StubbedFileHasherService.cs
+++ b/tests/NexusMods.StandardGameLocators.TestHelpers/StubbedFileHasherService.cs
@@ -115,6 +115,8 @@ public class StubbedFileHasherService : IFileHashesService
 
     public async ValueTask<IDb> GetFileHashesDb()
     {
+        if (_current is not null)
+            return _current;
         await SetupDb();
         return _current!;
     }


### PR DESCRIPTION
Preview view was showing wrong data, now it should show all the changes that will happen to the last analyzed disk state if the loadout is applied. 

This means that if something is on disk but not in the loadout it will appear as a normal entry in the preview, since it will not change. The preview will only show how the game folder will be affected by Apply, not how the loadout will be affected by apply.

I added a different method to determine whether Synchronize should be needed, since the previous one was ignoring a number of cases that still required a synchronize.

Also fixed exceptions that would happen due to missing LastAppliedLoadout data after switching lodouts. 