### PR TITLE
Add Delete button to mod contents File Tree view

### DIFF
--- a/src/NexusMods.App.UI/Pages/ItemContentsFileTree/IItemContentsFileTreeViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/ItemContentsFileTree/IItemContentsFileTreeViewModel.cs
@@ -1,8 +1,6 @@
-using System.Reactive;
 using NexusMods.App.UI.Controls.Navigation;
 using NexusMods.App.UI.Controls.Trees;
 using NexusMods.App.UI.WorkspaceSystem;
-using ReactiveUI;
 
 namespace NexusMods.App.UI.Pages.ItemContentsFileTree;
 
@@ -12,7 +10,7 @@ public interface IItemContentsFileTreeViewModel : IPageViewModelInterface
 
     IFileTreeViewModel? FileTreeViewModel { get; }
 
-    ReactiveCommand<NavigationInformation, Unit> OpenEditorCommand { get; }
+    R3.ReactiveCommand<NavigationInformation> OpenEditorCommand { get; }
     
-    ReactiveCommand<Unit, Unit> RemoveCommand { get; }
+    R3.ReactiveCommand<R3.Unit> RemoveCommand { get; }
 }

--- a/src/NexusMods.App.UI/Pages/ItemContentsFileTree/IItemContentsFileTreeViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/ItemContentsFileTree/IItemContentsFileTreeViewModel.cs
@@ -13,4 +13,6 @@ public interface IItemContentsFileTreeViewModel : IPageViewModelInterface
     IFileTreeViewModel? FileTreeViewModel { get; }
 
     ReactiveCommand<NavigationInformation, Unit> OpenEditorCommand { get; }
+    
+    ReactiveCommand<Unit, Unit> RemoveCommand { get; }
 }

--- a/src/NexusMods.App.UI/Pages/ItemContentsFileTree/ItemContentsFileTreeView.axaml
+++ b/src/NexusMods.App.UI/Pages/ItemContentsFileTree/ItemContentsFileTreeView.axaml
@@ -9,6 +9,7 @@
     xmlns:icons="clr-namespace:NexusMods.Icons;assembly=NexusMods.Icons"
     xmlns:reactive="http://reactiveui.net"
     xmlns:itemContentsFileTree="clr-namespace:NexusMods.App.UI.Pages.ItemContentsFileTree"
+    xmlns:controls="clr-namespace:NexusMods.App.UI.Controls"
     mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
     x:Class="NexusMods.App.UI.Pages.ItemContentsFileTree.ItemContentsFileTreeView">
 
@@ -20,6 +21,12 @@
                                               LeftIcon="{x:Static icons:IconValues.FileEdit}"
                                               ShowIcon="Left"
                                               Size="Small"/>
+                
+                <controls:StandardButton x:Name="RemoveButton" 
+                                         Text="Delete"
+                                         LeftIcon="{x:Static icons:IconValues.DeleteForever}"
+                                         ShowIcon="Left"
+                                         Size="Small"/>
             </StackPanel>
         </Border>
 

--- a/src/NexusMods.App.UI/Pages/ItemContentsFileTree/ItemContentsFileTreeView.cs
+++ b/src/NexusMods.App.UI/Pages/ItemContentsFileTree/ItemContentsFileTreeView.cs
@@ -17,6 +17,9 @@ public partial class ItemContentsFileTreeView : ReactiveUserControl<IItemContent
 
             this.BindCommand(ViewModel, vm => vm.OpenEditorCommand, view => view.OpenEditorMenuItem)
                 .DisposeWith(disposables);
+            
+            this.BindCommand(ViewModel, vm => vm.RemoveCommand, view => view.RemoveButton)
+                .DisposeWith(disposables);
         });
     }
 }


### PR DESCRIPTION
- Closes #2324
- Closes #2603 


Since the tree is static it doesn't react to changes, the only way to refresh the view is to recompute the tree from scratch, which resets the expanded states.

Functionality is there, experience isn't great. We need to move the file tree to new TreeDataGrid tech to make it dynamic and fix the performance/memory problems.