### PR TITLE
Tweaks for development banner

### DIFF
--- a/src/NexusMods.App.UI/Controls/DevelopmentBuildBanner/DevelopmentBuildBannerView.axaml
+++ b/src/NexusMods.App.UI/Controls/DevelopmentBuildBanner/DevelopmentBuildBannerView.axaml
@@ -1,6 +1,6 @@
 ﻿<reactiveUi:ReactiveUserControl
     d:DesignHeight="48"
-    d:DesignWidth="800"
+    d:DesignWidth="500"
     mc:Ignorable="d"
     x:Class="NexusMods.App.UI.Controls.DevelopmentBuildBanner.DevelopmentBuildBannerView"
     x:TypeArguments="developmentBuildBanner:IDevelopmentBuildBannerViewModel"
@@ -9,19 +9,39 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:reactiveUi="http://reactiveui.net"
-    xmlns:developmentBuildBanner="clr-namespace:NexusMods.App.UI.Controls.DevelopmentBuildBanner"
-    xmlns:icons="clr-namespace:NexusMods.Icons;assembly=NexusMods.Icons"
-    xmlns:alert="clr-namespace:NexusMods.App.UI.Controls.Alerts">
+    xmlns:developmentBuildBanner="clr-namespace:NexusMods.App.UI.Controls.DevelopmentBuildBanner">
+    
     <Design.DataContext>
         <developmentBuildBanner:DevelopmentBuildBannerViewModel />
     </Design.DataContext>
-    
-    <alert:Alert
-        Title="{Binding Text, RelativeSource={RelativeSource AncestorType={x:Type developmentBuildBanner:DevelopmentBuildBannerView}}}"
-        Severity="Warning"
-        ShowDismiss="False"
-        ShowBody="False"
-        CornerRadius="0"
-        />
-    
+
+    <reactiveUi:ReactiveUserControl.Resources>
+        <LinearGradientBrush x:Key="RainbowBrush" StartPoint="0%,50%" EndPoint="100%,50%">
+            <GradientStop Color="#4ade80" Offset="0" />
+            <GradientStop Color="#2563eb" Offset="1" />
+        </LinearGradientBrush>
+    </reactiveUi:ReactiveUserControl.Resources>
+
+    <Border
+        Padding=" 12, 10"
+        BorderThickness="0,1,0,0"
+        BorderBrush="{StaticResource StrokeTranslucentWeakBrush}"
+        Background="{StaticResource SurfaceBaseBrush}"
+        CornerRadius="0">
+        
+        <StackPanel Orientation="Horizontal" Spacing="8">
+            <TextBlock
+                Text="{Binding AppName, RelativeSource={RelativeSource AncestorType={x:Type developmentBuildBanner:DevelopmentBuildBannerView}}}"
+                Theme="{StaticResource BodyMDBoldTheme}"
+                Foreground="{StaticResource RainbowBrush}"
+                VerticalAlignment="Center"/>
+            <TextBlock
+                Text="{Binding AppVersion, RelativeSource={RelativeSource AncestorType={x:Type developmentBuildBanner:DevelopmentBuildBannerView}}}"
+                Theme="{StaticResource BodyMDBoldTheme}"
+                Foreground="{StaticResource NeutralModerateBrush}"
+                VerticalAlignment="Center" />
+        </StackPanel>
+        
+    </Border>
+
 </reactiveUi:ReactiveUserControl>

--- a/src/NexusMods.App.UI/Controls/DevelopmentBuildBanner/DevelopmentBuildBannerView.axaml
+++ b/src/NexusMods.App.UI/Controls/DevelopmentBuildBanner/DevelopmentBuildBannerView.axaml
@@ -18,7 +18,7 @@
     
     <alert:Alert
         Title="{Binding Text, RelativeSource={RelativeSource AncestorType={x:Type developmentBuildBanner:DevelopmentBuildBannerView}}}"
-        Severity="Error"
+        Severity="Warning"
         ShowDismiss="False"
         ShowBody="False"
         CornerRadius="0"

--- a/src/NexusMods.App.UI/Controls/DevelopmentBuildBanner/DevelopmentBuildBannerView.axaml.cs
+++ b/src/NexusMods.App.UI/Controls/DevelopmentBuildBanner/DevelopmentBuildBannerView.axaml.cs
@@ -28,7 +28,6 @@ public partial class DevelopmentBuildBannerView : ReactiveUserControl<IDevelopme
 
     private static string GetAppVersion()
     {
-        var prefix = CompileConstants.IsDebug ? "Debug build" : ApplicationConstants.Version.ToString();
-        return $"{prefix} - {ApplicationConstants.CommitHash}";
+        return CompileConstants.IsDebug ? $"Debug build - {ApplicationConstants.CommitHash}" : ApplicationConstants.Version.ToString();
     }
 }

--- a/src/NexusMods.App.UI/Controls/DevelopmentBuildBanner/DevelopmentBuildBannerView.axaml.cs
+++ b/src/NexusMods.App.UI/Controls/DevelopmentBuildBanner/DevelopmentBuildBannerView.axaml.cs
@@ -8,22 +8,32 @@ namespace NexusMods.App.UI.Controls.DevelopmentBuildBanner;
 [UsedImplicitly]
 public partial class DevelopmentBuildBannerView : ReactiveUserControl<IDevelopmentBuildBannerViewModel>
 {
-    private static readonly StyledProperty<string> TextProperty =
-        AvaloniaProperty.Register<DevelopmentBuildBannerView, string>(nameof(Text), "vX.X - DEVELOPMENT USE ONLY");
+    private static readonly StyledProperty<string> AppNameProperty =
+        AvaloniaProperty.Register<DevelopmentBuildBannerView, string>(nameof(AppName), "DEVELOPMENT USE ONLY");
+    
+    private static readonly StyledProperty<string> AppVersionProperty =
+        AvaloniaProperty.Register<DevelopmentBuildBannerView, string>(nameof(AppVersion), "vX.X.X");
 
-    public string Text
+    public string AppName
     {
-        get => GetValue(TextProperty);
-        set => SetValue(TextProperty, value);
+        get => GetValue(AppNameProperty);
+        set => SetValue(AppNameProperty, value);
+    }
+    
+    public string AppVersion
+    {
+        get => GetValue(AppVersionProperty);
+        set => SetValue(AppVersionProperty, value);
     }
 
     public DevelopmentBuildBannerView()
     {
         InitializeComponent();
+        
+        var appName = CompileConstants.IsDebug ? "DEVELOPMENT USE ONLY" : "Stardew Valley Preview";
 
-        var appVersion = GetAppVersion();
-        var prefix = CompileConstants.IsDebug ? "DEVELOPMENT USE ONLY" : "Stardew Valley Beta";
-        Text = $"{prefix} - {appVersion}";
+        AppVersion = GetAppVersion();
+        AppName = $"{appName}:";
     }
 
     private static string GetAppVersion()

--- a/src/NexusMods.App.UI/Controls/DevelopmentBuildBanner/DevelopmentBuildBannerView.axaml.cs
+++ b/src/NexusMods.App.UI/Controls/DevelopmentBuildBanner/DevelopmentBuildBannerView.axaml.cs
@@ -22,12 +22,11 @@ public partial class DevelopmentBuildBannerView : ReactiveUserControl<IDevelopme
         InitializeComponent();
 
         var appVersion = GetAppVersion();
-        Text = $"{appVersion} - DEVELOPMENT USE ONLY";
+        Text = $"{appVersion} - Stardew Valley Preview Build";
     }
 
     private static string GetAppVersion()
     {
-        var prefix = CompileConstants.IsDebug ? "Debug build" : ApplicationConstants.Version.ToString();
-        return $"{prefix} - {ApplicationConstants.CommitHash}";
+        return CompileConstants.IsDebug ? "Debug build" : ApplicationConstants.Version.ToString();
     }
 }

--- a/src/NexusMods.App.UI/Controls/DevelopmentBuildBanner/DevelopmentBuildBannerView.axaml.cs
+++ b/src/NexusMods.App.UI/Controls/DevelopmentBuildBanner/DevelopmentBuildBannerView.axaml.cs
@@ -22,11 +22,13 @@ public partial class DevelopmentBuildBannerView : ReactiveUserControl<IDevelopme
         InitializeComponent();
 
         var appVersion = GetAppVersion();
-        Text = $"{appVersion} - Stardew Valley Preview Build";
+        var prefix = CompileConstants.IsDebug ? "DEVELOPMENT USE ONLY" : "Stardew Valley Beta";
+        Text = $"{prefix} - {appVersion}";
     }
 
     private static string GetAppVersion()
     {
-        return CompileConstants.IsDebug ? "Debug build" : ApplicationConstants.Version.ToString();
+        var prefix = CompileConstants.IsDebug ? "Debug build" : ApplicationConstants.Version.ToString();
+        return $"{prefix} - {ApplicationConstants.CommitHash}";
     }
 }


### PR DESCRIPTION
Text and color changes for bottom development banner

"Debug build" is replaced with version number on a release.

![image](https://github.com/user-attachments/assets/38df6b1b-c84e-4ee9-831d-e6d45ebe6e46)

Closes #2546

