### PR TITLE
Fixes for `DirectDownloadLibraryFile`

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Collections/DirectDownloadLibraryFile.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Collections/DirectDownloadLibraryFile.cs
@@ -7,7 +7,7 @@ namespace NexusMods.Abstractions.Collections;
 /// <summary>
 /// A direct downloaded file from a collection
 /// </summary>
-[Include<LibraryFile>]
+[Include<LocalFile>]
 public partial class DirectDownloadLibraryFile : IModelDefinition
 {
     private const string Namespace = "NexusMods.Collections.DirectDownloadLibraryFile";

--- a/src/Networking/NexusMods.Networking.NexusWebApi/ExternalDownloadJob.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/ExternalDownloadJob.cs
@@ -70,5 +70,7 @@ public record ExternalDownloadJob : HttpDownloadJob
             },
             LogicalFileName = LogicalFileName,
         };
+
+        tx.Add(libraryFile.Id, LibraryItem.Name, LogicalFileName);
     }
 }

--- a/src/Networking/NexusMods.Networking.NexusWebApi/ExternalDownloadJob.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/ExternalDownloadJob.cs
@@ -61,6 +61,14 @@ public record ExternalDownloadJob : HttpDownloadJob
                 throw new InvalidOperationException($"MD5 hash mismatch. Expected: {ExpectedMd5}, Actual: {md5Actual}");
         }
 
-        tx.Add(libraryFile, DirectDownloadLibraryFile.LogicalFileName, LogicalFileName);
+        _ = new DirectDownloadLibraryFile.New(tx, libraryFile.Id)
+        {
+            LocalFile = new LocalFile.New(tx, libraryFile.Id)
+            {
+                LibraryFile = libraryFile,
+                OriginalPath = LogicalFileName,
+            },
+            LogicalFileName = LogicalFileName,
+        };
     }
 }

--- a/src/Networking/NexusMods.Networking.NexusWebApi/ExternalDownloadJob.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/ExternalDownloadJob.cs
@@ -1,4 +1,5 @@
 using System.Security.Cryptography;
+using DynamicData.Kernel;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.Collections;
@@ -27,19 +28,26 @@ public record ExternalDownloadJob : HttpDownloadJob
     public required string LogicalFileName { get; init; }
 
     /// <summary>
+    /// File name from the Content-Disposition header.
+    /// </summary>
+    public required Optional<RelativePath> FileName { get; init; }
+
+    /// <summary>
     /// Create a new download job for the given URL, the job will fail if the downloaded file does not
     /// match the expected MD5 hash.
     /// </summary>
     public static IJobTask<ExternalDownloadJob, AbsolutePath> Create(IServiceProvider provider, Uri uri,
-        Md5HashValue expectedMd5, string logicalFileName)
+        Md5HashValue expectedMd5, string logicalFileName, Optional<RelativePath> fileName = default)
     {
         var monitor = provider.GetRequiredService<IJobMonitor>();
         var tempFileManager = provider.GetRequiredService<TemporaryFileManager>();
+
         var job = new ExternalDownloadJob
         {
             Logger = provider.GetRequiredService<ILogger<ExternalDownloadJob>>(),
             ExpectedMd5 = expectedMd5,
             LogicalFileName = logicalFileName,
+            FileName = fileName,
             DownloadPageUri = uri,
             Destination = tempFileManager.CreateFile(),
             Uri = uri,
@@ -66,11 +74,19 @@ public record ExternalDownloadJob : HttpDownloadJob
             LocalFile = new LocalFile.New(tx, libraryFile.Id)
             {
                 LibraryFile = libraryFile,
-                OriginalPath = LogicalFileName,
+                OriginalPath = FileName.HasValue ? FileName.Value.ToString() : Destination.ToString(),
             },
             LogicalFileName = LogicalFileName,
         };
 
-        tx.Add(libraryFile.Id, LibraryItem.Name, LogicalFileName);
+        if (FileName.HasValue)
+        {
+            libraryFile.FileName = FileName.Value;
+            libraryFile.GetLibraryItem(tx).Name = FileName.Value;
+        }
+        else
+        {
+            libraryFile.GetLibraryItem(tx).Name = LogicalFileName;
+        }
     }
 }

--- a/src/NexusMods.Collections/CollectionDownloader.cs
+++ b/src/NexusMods.Collections/CollectionDownloader.cs
@@ -339,7 +339,7 @@ public class CollectionDownloader
 
         foreach (var datom in datoms)
         {
-            var libraryFile = DirectDownloadLibraryFile.Load(db, datom.E).AsLibraryFile();
+            var libraryFile = DirectDownloadLibraryFile.Load(db, datom.E).AsLocalFile().AsLibraryFile();
             if (libraryFile.IsValid()) return GetStatus(libraryFile.AsLibraryItem(), collectionGroup, db);
         }
 

--- a/src/NexusMods.Collections/CollectionDownloader.cs
+++ b/src/NexusMods.Collections/CollectionDownloader.cs
@@ -85,7 +85,14 @@ public class CollectionDownloader
         return revision;
     }
 
-    private async ValueTask<bool> CanDirectDownload(CollectionDownloadExternal.ReadOnly download, CancellationToken cancellationToken)
+    record DirectDownloadResult(bool CanDownload, Optional<RelativePath> FileName = default)
+    {
+        public static readonly DirectDownloadResult Unable = new(CanDownload: false);
+    };
+
+    private async ValueTask<DirectDownloadResult> CanDirectDownload(
+        CollectionDownloadExternal.ReadOnly download,
+        CancellationToken cancellationToken)
     {
         _logger.LogDebug("Testing if `{Uri}` can be downloaded directly", download.Uri);
 
@@ -93,34 +100,37 @@ public class CollectionDownloader
         {
             using var request = new HttpRequestMessage(HttpMethod.Head, download.Uri);
             using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken: cancellationToken);
-            if (!response.IsSuccessStatusCode) return false;
+            if (!response.IsSuccessStatusCode) return DirectDownloadResult.Unable;
 
             var contentType = response.Content.Headers.ContentType?.MediaType;
             if (contentType is null || !contentType.StartsWith("application/"))
             {
                 _logger.LogInformation("Download at `{Uri}` can't be downloaded automatically because Content-Type `{ContentType}` doesn't indicate a binary download", download.Uri, contentType);
-                return false;
+                return DirectDownloadResult.Unable;
             }
 
             if (!response.Content.Headers.ContentLength.HasValue)
             {
                 _logger.LogInformation("Download at `{Uri}` can't be downloaded automatically because the response doesn't have a Content-Length", download.Uri);
-                return false;
+                return DirectDownloadResult.Unable;
             }
 
             var size = Size.FromLong(response.Content.Headers.ContentLength.Value);
             if (size != download.Size)
             {
                 _logger.LogWarning("Download at `{Uri}` can't be downloaded automatically because the Content-Length `{ContentLength}` doesn't match the expected size `{ExpectedSize}`", download.Uri, size, download.Size);
-                return false;
+                return DirectDownloadResult.Unable;
             }
 
-            return true;
+            var contentDispositionFileName = response.Content.Headers.ContentDisposition?.FileName;
+            var fileName = contentDispositionFileName is null ? Optional<RelativePath>.None : RelativePath.FromUnsanitizedInput(contentDispositionFileName);
+
+            return new DirectDownloadResult(CanDownload: true, FileName: fileName);
         }
         catch (Exception e)
         {
             _logger.LogError(e, "Exception while checking if `{Uri}` can be downloaded directly", download.Uri);
-            return false;
+            return DirectDownloadResult.Unable;
         }
     }
 
@@ -129,10 +139,18 @@ public class CollectionDownloader
     /// </summary>
     public async ValueTask Download(CollectionDownloadExternal.ReadOnly download, bool onlyDirectDownloads, CancellationToken cancellationToken)
     {
-        if (await CanDirectDownload(download, cancellationToken))
+        var result = await CanDirectDownload(download, cancellationToken);
+        if (result.CanDownload)
         {
             _logger.LogInformation("Downloading external file at `{Uri}` directly", download.Uri);
-            var job = ExternalDownloadJob.Create(_serviceProvider, download.Uri, download.Md5, download.AsCollectionDownload().Name);
+            var job = ExternalDownloadJob.Create(
+                _serviceProvider,
+                download.Uri,
+                download.Md5,
+                logicalFileName: download.AsCollectionDownload().Name,
+                fileName: result.FileName
+            );
+
             await _libraryService.AddDownload(job);
         }
         else

--- a/src/NexusMods.DataModel.SchemaVersions/Migrations/_0006_DirectDownload.cs
+++ b/src/NexusMods.DataModel.SchemaVersions/Migrations/_0006_DirectDownload.cs
@@ -1,0 +1,29 @@
+using NexusMods.Abstractions.Collections;
+using NexusMods.Abstractions.Library.Models;
+using NexusMods.MnemonicDB.Abstractions;
+
+namespace NexusMods.DataModel.SchemaVersions.Migrations;
+
+/// <summary>
+/// Turns all DirectDownloadLibraryFile entities into LocalFile entities by adding the LocalFile.OriginalPath attribute.
+/// </summary>
+internal class _0006_DirectDownload : ITransactionalMigration
+{
+    public static (MigrationId Id, string Name) IdAndName { get; } = MigrationId.ParseNameAndId(nameof(_0006_DirectDownload));
+
+    private DirectDownloadLibraryFile.ReadOnly[] _entitiesToUpdate = [];
+
+    public Task Prepare(IDb db)
+    {
+        _entitiesToUpdate = DirectDownloadLibraryFile.All(db).Where(entity => !LocalFile.OriginalPath.IsIn(entity)).ToArray();
+        return Task.CompletedTask;
+    }
+
+    public void Migrate(ITransaction tx, IDb db)
+    {
+        foreach (var entity in _entitiesToUpdate)
+        {
+            tx.Add(entity.Id, LocalFile.OriginalPath, entity.LogicalFileName);
+        }
+    }
+}

--- a/src/NexusMods.DataModel.SchemaVersions/Migrations/_0006_DirectDownload.cs
+++ b/src/NexusMods.DataModel.SchemaVersions/Migrations/_0006_DirectDownload.cs
@@ -6,6 +6,7 @@ namespace NexusMods.DataModel.SchemaVersions.Migrations;
 
 /// <summary>
 /// Turns all DirectDownloadLibraryFile entities into LocalFile entities by adding the LocalFile.OriginalPath attribute.
+/// Also updates the LibraryItem.Name attribute to use the provided LogicalFileName instead of the temporary file name.
 /// </summary>
 internal class _0006_DirectDownload : ITransactionalMigration
 {
@@ -24,6 +25,7 @@ internal class _0006_DirectDownload : ITransactionalMigration
         foreach (var entity in _entitiesToUpdate)
         {
             tx.Add(entity.Id, LocalFile.OriginalPath, entity.LogicalFileName);
+            tx.Add(entity.Id, LibraryItem.Name, entity.LogicalFileName);
         }
     }
 }

--- a/src/NexusMods.DataModel.SchemaVersions/Services.cs
+++ b/src/NexusMods.DataModel.SchemaVersions/Services.cs
@@ -17,7 +17,8 @@ public static class Services
             .AddMigration<_0002_NexusCollectionItem>()
             .AddMigration<_0003_FixDuplicates>()
             .AddMigration<_0004_RemoveGameFiles>()
-            .AddMigration<_0005_MD5Hashes>();
+            .AddMigration<_0005_MD5Hashes>()
+            .AddMigration<_0006_DirectDownload>();
     }
 
     /// <summary>

--- a/tests/NexusMods.DataModel.SchemaVersions.Tests/LegacyDatabaseSupportTests.TestDatabase_name=Issue-2608.rocksdb.zip.verified.txt
+++ b/tests/NexusMods.DataModel.SchemaVersions.Tests/LegacyDatabaseSupportTests.TestDatabase_name=Issue-2608.rocksdb.zip.verified.txt
@@ -1,7 +1,7 @@
 ﻿{
   Name: Issue-2608.rocksdb.zip,
   OldId: 1,
-  NewId: 5,
+  NewId: 6,
   Loadouts: 1,
   LoadoutItemGroups: 1,
   Collections: 1,

--- a/tests/NexusMods.DataModel.SchemaVersions.Tests/LegacyDatabaseSupportTests.TestDatabase_name=Migration-5.rocksdb.zip.verified.txt
+++ b/tests/NexusMods.DataModel.SchemaVersions.Tests/LegacyDatabaseSupportTests.TestDatabase_name=Migration-5.rocksdb.zip.verified.txt
@@ -1,7 +1,7 @@
 ﻿{
   Name: Migration-5.rocksdb.zip,
   OldId: 4,
-  NewId: 5,
+  NewId: 6,
   Loadouts: 1,
   LoadoutItemGroups: 2,
   Collections: 1,

--- a/tests/NexusMods.DataModel.SchemaVersions.Tests/LegacyDatabaseSupportTests.TestDatabase_name=Migration-6.rocksdb.zip.verified.txt
+++ b/tests/NexusMods.DataModel.SchemaVersions.Tests/LegacyDatabaseSupportTests.TestDatabase_name=Migration-6.rocksdb.zip.verified.txt
@@ -1,0 +1,9 @@
+﻿{
+  Name: Migration-6.rocksdb.zip,
+  OldId: 5,
+  NewId: 6,
+  Loadouts: 1,
+  LoadoutItemGroups: 2,
+  Collections: 1,
+  Created: 2025-02-17 12:05:49
+}

--- a/tests/NexusMods.DataModel.SchemaVersions.Tests/LegacyDatabaseSupportTests.TestDatabase_name=SDV.2_5_2025.rocksdb.zip.verified.txt
+++ b/tests/NexusMods.DataModel.SchemaVersions.Tests/LegacyDatabaseSupportTests.TestDatabase_name=SDV.2_5_2025.rocksdb.zip.verified.txt
@@ -1,6 +1,6 @@
 ﻿{
   Name: SDV.2_5_2025.rocksdb.zip,
-  NewId: 5,
+  NewId: 6,
   Loadouts: 1,
   LoadoutItemGroups: 11,
   Files: 338,

--- a/tests/NexusMods.DataModel.SchemaVersions.Tests/LegacyDatabaseSupportTests.TestDatabase_name=SDV.4_11_2024.rocksdb.zip.verified.txt
+++ b/tests/NexusMods.DataModel.SchemaVersions.Tests/LegacyDatabaseSupportTests.TestDatabase_name=SDV.4_11_2024.rocksdb.zip.verified.txt
@@ -1,6 +1,6 @@
 ﻿{
   Name: SDV.4_11_2024.rocksdb.zip,
-  NewId: 5,
+  NewId: 6,
   LoadoutItemGroups: 200,
   Files: 12932,
   Created: 2024-11-04 17:45:27

--- a/tests/NexusMods.DataModel.SchemaVersions.Tests/MigrationSpecificTests/TestsFor_0006_DirectDownload.cs
+++ b/tests/NexusMods.DataModel.SchemaVersions.Tests/MigrationSpecificTests/TestsFor_0006_DirectDownload.cs
@@ -1,0 +1,22 @@
+using FluentAssertions;
+using NexusMods.Abstractions.Collections;
+using Xunit.Abstractions;
+
+namespace NexusMods.DataModel.SchemaVersions.Tests.MigrationSpecificTests;
+
+public class TestsFor_0006_DirectDownload(ITestOutputHelper helper) : ALegacyDatabaseTest(helper)
+{
+    [Fact]
+    public async Task Test()
+    {
+        await using var tempConnection = await ConnectionFor("Migration-6.rocksdb.zip");
+
+        var db = tempConnection.Connection.Db;
+
+        var entities = DirectDownloadLibraryFile.All(db);
+        foreach (var entity in entities)
+        {
+            entity.AsLocalFile().IsValid().Should().BeTrue("DirectDownloadLibraryFile should also be a LocalFile after migration 6");
+        }
+    }
+}

--- a/tests/NexusMods.DataModel.SchemaVersions.Tests/Resources/Databases/Descriptions.md
+++ b/tests/NexusMods.DataModel.SchemaVersions.Tests/Resources/Databases/Descriptions.md
@@ -19,4 +19,5 @@ Finally, update the `Descriptions.md` file with the new data.
 | 2024-11-04 | `SDV.4_11_2024.rocksdb.zip` | A snapshot of SDV managed and with the "Stardew Valley VERY Expanded" collection installed.                          |
 | 2025-02-05 | `SDV.2_5_2025.rocksdb.zip`  | A snapshot of SDV from 0.7.2 with a few mods installed, no collections, before removing game files from the loadout. |
 | 2025-02-06 | `Issue-2608.rocksdb.zip`    | A snapshot for testing Issue [#2608](https://github.com/Nexus-Mods/NexusMods.App/issues/2608)                        |
-| 2025-02-13 | `Migration-5.rocksdb.zip` | For testing migration 5                                                                                              |
+| 2025-02-13 | `Migration-5.rocksdb.zip`   | For testing migration 5                                                                                              |
+| 2025-02-17 | `Migration-6.rocksdb.zip`   | For testing migration 6                                                                                              |

--- a/tests/NexusMods.DataModel.SchemaVersions.Tests/Resources/Databases/Migration-6.rocksdb.zip
+++ b/tests/NexusMods.DataModel.SchemaVersions.Tests/Resources/Databases/Migration-6.rocksdb.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2b3fd3707fd7775cdf80744946b24a4606f34dd90be4d124f7d5a84382fc232
+size 2167489


### PR DESCRIPTION
Fixes #2638.

- `DirectDownloadLibraryFile` entities now show up in the library
- `DirectDownloadLibraryFile` entities now have proper names