### PR TITLE
Fix incorrect style selector on Actions column

### DIFF
--- a/src/Themes/NexusMods.Themes.NexusFluentDark/NexusMods.Themes.NexusFluentDark.csproj
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/NexusMods.Themes.NexusFluentDark.csproj
@@ -46,7 +46,6 @@
       <AdditionalFiles Include="Styles\Controls\RadioButton\RadioButtonStyles.axaml" />
       <AdditionalFiles Include="Styles\Controls\TextBlock\TextBlockStyles.axaml" />
       <AdditionalFiles Include="Styles\Controls\TextBox\TextBoxStyles.axaml" />
-      <AdditionalFiles Include="Styles\Controls\TreeDataGrid\TreeDataGridStyles.axaml" />
       <AdditionalFiles Include="Styles\Controls\Window\DialogStyles.axaml" />
       <AdditionalFiles Include="Styles\UserControls\LaunchButton\LaunchButtonStyles.axaml" />
       <AdditionalFiles Include="Styles\UserControls\LoadoutBadge\LoadoutBadgeStyles.axaml" />

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/TreeDataGridCollectionDownloadStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/TreeDataGridCollectionDownloadStyles.axaml
@@ -23,13 +23,12 @@
 
             <!-- all of our cells will be a type of this -->
             <Style Selector="^ TreeDataGridTemplateCell">
-                <!-- <Setter Property="Background" Value="Blue" /> -->
-                
+
                 <!-- collections download -> actions cell -->
                 <Style Selector="^.CollectionColumns_Actions">
                     <Setter Property="HorizontalAlignment" Value="Right" />
 
-                    <Style Selector="^ StackPanel#DownloadingStack">
+                    <Style Selector="^ StackPanel#DownloadedStack">
                         <Setter Property="Spacing" Value="{StaticResource Spacing-1}" />
 
                         <Style Selector="^ > spinner|Spinner">
@@ -37,7 +36,7 @@
                             <Setter Property="Height" Value="16" />
                             <Setter Property="Foreground" Value="{StaticResource NeutralStrongBrush}" />
                         </Style>
-                        
+
                         <Style Selector="^ > icons|UnifiedIcon">
                             <Setter Property="Size" Value="16" />
                             <Setter Property="Foreground" Value="{StaticResource NeutralModerateBrush}" />

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/TreeDataGridCollectionDownloadStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/TreeDataGridCollectionDownloadStyles.axaml
@@ -1,6 +1,7 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:spinner="clr-namespace:NexusMods.App.UI.Controls.Spinner;assembly=NexusMods.App.UI">
+        xmlns:spinner="clr-namespace:NexusMods.App.UI.Controls.Spinner;assembly=NexusMods.App.UI"
+        xmlns:icons="clr-namespace:NexusMods.Icons;assembly=NexusMods.Icons">
 
     <Style Selector="TreeDataGrid#DownloadsTree">
 
@@ -23,7 +24,7 @@
             <!-- all of our cells will be a type of this -->
             <Style Selector="^ TreeDataGridTemplateCell">
                 <!-- <Setter Property="Background" Value="Blue" /> -->
-
+                
                 <!-- collections download -> actions cell -->
                 <Style Selector="^.CollectionColumns_Actions">
                     <Setter Property="HorizontalAlignment" Value="Right" />
@@ -35,6 +36,11 @@
                             <Setter Property="Width" Value="16" />
                             <Setter Property="Height" Value="16" />
                             <Setter Property="Foreground" Value="{StaticResource NeutralStrongBrush}" />
+                        </Style>
+                        
+                        <Style Selector="^ > icons|UnifiedIcon">
+                            <Setter Property="Size" Value="16" />
+                            <Setter Property="Foreground" Value="{StaticResource NeutralModerateBrush}" />
                         </Style>
 
                         <Style Selector="^ > TextBlock">


### PR DESCRIPTION
Fixes this:

![image](https://github.com/user-attachments/assets/cc8d1fb7-ab0d-4412-ad2d-f20e03e7b56e)

Also cleans up an orphaned file from previous treedatagrid styles refactor
