### PR TITLE
Don't show the console on windows

### DIFF
--- a/src/NexusMods.App/ConsoleHelper.cs
+++ b/src/NexusMods.App/ConsoleHelper.cs
@@ -24,7 +24,7 @@ public static class ConsoleHelper
     /// <param name="forceNewConsoleIfNoParent">If there is no parent console, should one be created?</param>
     public static void EnsureConsole(bool forceNewConsoleIfNoParent = false)
     {
-        if (!AttachConsole(ATTACH_PARENT_PROCESS) && !forceNewConsoleIfNoParent)
+        if (!AttachConsole(ATTACH_PARENT_PROCESS) && forceNewConsoleIfNoParent)
         {
             AllocConsole();
         }

--- a/src/NexusMods.App/NexusMods.App.csproj
+++ b/src/NexusMods.App/NexusMods.App.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <OutputType>Exe</OutputType>
+        <!-- Target WinExe so that a console isn't automatically created on Windows -->
+        <OutputType>WinExe</OutputType>
         <ApplicationIcon>icon.ico</ApplicationIcon>
         <ApplicationManifest>app.manifest</ApplicationManifest>
     </PropertyGroup>

--- a/src/NexusMods.App/Program.cs
+++ b/src/NexusMods.App/Program.cs
@@ -35,6 +35,10 @@ public class Program
     [STAThread]
     public static int Main(string[] args)
     {
+        // This code will not work properly if it comes after anything that uses the console. So we need to do this first.
+        if (OperatingSystem.IsWindows())
+            ConsoleHelper.EnsureConsole();
+        
         MainThreadData.SetMainThread();
 
         TelemetrySettings telemetrySettings;
@@ -106,9 +110,6 @@ public class Program
 
         try
         {
-            if (OperatingSystem.IsWindows())
-                ConsoleHelper.EnsureConsole();
-            
             if (startupMode.RunAsMain)
             {
                 LogMessages.StartingProcess(_logger, Environment.ProcessPath, Environment.ProcessId, args);


### PR DESCRIPTION
fixes: [#2493](https://github.com/Nexus-Mods/NexusMods.App/issues/2493)

This will continue to be an issue in the future due to the utter jank way Windows handles CLI commands and compilation modes. But this work for now. 

Known issue: When you invoke a CLI command from the app, you instantly get a new prompt then the info from the app pops up afterwards. This is confusing and annoying but not required for our beta release. At least now the console doesn't pop up when you run the UI, and yet you can still use the CLI.