### PR TITLE
Allow deleting installed collections and other fixes

### DIFF
--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadView.axaml
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadView.axaml
@@ -31,7 +31,7 @@
             </MenuItem>
             <MenuItem x:Name="MenuItemOpenJsonFile">
                 <MenuItem.Icon>
-                    <icons:UnifiedIcon Value="{x:Static icons:IconValues.FileEdit}" />
+                    <icons:UnifiedIcon Value="{x:Static icons:IconValues.FileDocumentOutline}" />
                 </MenuItem.Icon>
                 <MenuItem.Header>
                     <TextBlock>Open JSON file</TextBlock>

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadView.axaml
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadView.axaml
@@ -31,7 +31,7 @@
             </MenuItem>
             <MenuItem x:Name="MenuItemOpenJsonFile">
                 <MenuItem.Icon>
-                    <icons:UnifiedIcon Value="{x:Static icons:IconValues.LibraryOutline}" />
+                    <icons:UnifiedIcon Value="{x:Static icons:IconValues.FileEdit}" />
                 </MenuItem.Icon>
                 <MenuItem.Header>
                     <TextBlock>Open JSON file</TextBlock>
@@ -88,7 +88,10 @@
                     <controls:StandardButton x:Name="ButtonInstallOptionalItems"
                                              Text="{x:Static resources:Language.CollectionDownloadViewModel_InstallOptional}"
                                              Size="Small" />
-                    <controls:StandardButton Flyout="{StaticResource CollectionMenuFlyout}" Text="..."
+                    <controls:StandardButton Flyout="{StaticResource CollectionMenuFlyout}" 
+                                             ShowLabel="False"
+                                             LeftIcon="{x:Static icons:IconValues.MoreVertical}"
+                                             ShowIcon="Left"
                                              Size="Small" />
                 </panels:FlexPanel>
             </Border>

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadViewModel.cs
@@ -302,11 +302,13 @@ public sealed class CollectionDownloadViewModel : APageViewModel<ICollectionDown
                         }
                         else
                         {
+                            IsInstalled.Value = false;
                             CollectionStatusText = Language.CollectionDownloadViewModel_Ready_to_install;
                         }
                     }
                     else
                     {
+                        IsInstalled.Value = false;
                         CollectionStatusText = string.Format(Language.CollectionDownloadViewModel_Num_required_mods_downloaded, numDownloadedRequiredItems, RequiredDownloadsCount);
                     }
                 }).AddTo(disposables);

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadViewModel.cs
@@ -149,7 +149,7 @@ public sealed class CollectionDownloadViewModel : APageViewModel<ICollectionDown
 
                 var workspaceController = GetWorkspaceController();
                 var behavior = new OpenPageBehavior.ReplaceTab(PanelId, TabId);
-                workspaceController.OpenPage(WorkspaceId, pageData, behavior);
+                workspaceController.OpenPage(WorkspaceId, pageData, behavior, checkOtherPanels: false);
 
                 await collectionDownloader.DeleteCollectionLoadoutGroup(_revision, cancellationToken: CancellationToken.None);
                 await collectionDownloader.DeleteRevision(_revision);

--- a/src/NexusMods.App.UI/Pages/ILoadoutDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/ILoadoutDataProvider.cs
@@ -129,7 +129,7 @@ public static class LoadoutDataProviderHelper
                 .Where(static optional => optional.HasValue)
                 .Select(static optional => optional.Value)
                 .Order(StringComparer.OrdinalIgnoreCase)
-                .Aggregate(static (a, b) => $"{a}, {b}")
+                .Aggregate(string.Empty, static (a, b) => $"{a}, {b}")
             );
 
         parentItemModel.Add(LoadoutColumns.Collections.ComponentKey, new StringComponent(

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutDesignViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutDesignViewModel.cs
@@ -1,11 +1,9 @@
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
-using NexusMods.Abstractions.Jobs;
 using NexusMods.Abstractions.NexusWebApi.Types;
 using NexusMods.App.UI.Controls.Navigation;
 using NexusMods.App.UI.Windows;
 using NexusMods.App.UI.WorkspaceSystem;
-using NexusMods.Paths;
 using R3;
 
 namespace NexusMods.App.UI.Pages.LoadoutPage;
@@ -24,7 +22,8 @@ public class CollectionLoadoutDesignViewModel : APageViewModel<ICollectionLoadou
     public Bitmap BackgroundImage { get; } = new(AssetLoader.Open(new Uri("avares://NexusMods.App.UI/Assets/DesignTime/header-background.webp")));
     public ReactiveCommand<Unit> CommandToggle { get; } = new ReactiveCommand();
     public ReactiveCommand<Unit> CommandDeleteCollection { get; } = new ReactiveCommand();
-    public ReactiveCommand<NavigationInformation> CommandViewCollectionDownloadPage { get; } = new();
+    public ReactiveUI.ReactiveCommand<NavigationInformation, System.Reactive.Unit> CommandViewCollectionDownloadPage { get; } 
+        = ReactiveUI.ReactiveCommand.Create<NavigationInformation, System.Reactive.Unit>(_ => System.Reactive.Unit.Default);
     public bool IsLocalCollection { get; } = false;
     public bool IsReadOnly { get; } = true;
 }

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutDesignViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutDesignViewModel.cs
@@ -23,6 +23,8 @@ public class CollectionLoadoutDesignViewModel : APageViewModel<ICollectionLoadou
     public Bitmap TileImage { get; } = new(AssetLoader.Open(new Uri("avares://NexusMods.App.UI/Assets/DesignTime/collection_tile_image.png")));
     public Bitmap BackgroundImage { get; } = new(AssetLoader.Open(new Uri("avares://NexusMods.App.UI/Assets/DesignTime/header-background.webp")));
     public ReactiveCommand<Unit> CommandToggle { get; } = new ReactiveCommand();
+    public ReactiveCommand<Unit> CommandDeleteCollection { get; } = new ReactiveCommand();
+    public ReactiveCommand<NavigationInformation> CommandViewCollectionDownloadPage { get; } = new();
     public bool IsLocalCollection { get; } = false;
     public bool IsReadOnly { get; } = true;
 }

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutView.axaml
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutView.axaml
@@ -7,6 +7,8 @@
     xmlns:reactive="http://reactiveui.net"
     xmlns:loadoutPage="clr-namespace:NexusMods.App.UI.Pages.LoadoutPage"
     xmlns:icons="clr-namespace:NexusMods.Icons;assembly=NexusMods.Icons"
+    xmlns:controls="clr-namespace:NexusMods.App.UI.Controls"
+    xmlns:navigation="clr-namespace:NexusMods.App.UI.Controls.Navigation"
     mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
     x:Class="NexusMods.App.UI.Pages.LoadoutPage.CollectionLoadoutView">
 
@@ -144,12 +146,24 @@
 
                     <!-- toolbar -->
                     <Border x:Name="ToolbarBorder"
-                            Classes="Toolbar">
+                            Padding="8">
+                        <Border.Styles>
+                            <Style Selector="Border.Info">
+                                <Setter Property="Background" Value="{StaticResource BrandInfo950Brush}"/>
+                            </Style>
+        
+                            <Style Selector="Border.Warning">
+                                <Setter Property="Background" Value="{StaticResource BrandWarning950Brush}"/>
+                            </Style>
+                        </Border.Styles>
 
                         <Grid ColumnDefinitions="*,*">
 
                             <!-- left side -->
-                            <StackPanel Grid.Column="0" HorizontalAlignment="Left">
+                            <StackPanel Grid.Column="0" 
+                                        HorizontalAlignment="Left" 
+                                        Orientation="Horizontal" 
+                                        VerticalAlignment="Center">
                                 <StackPanel
                                     x:Name="ToolbarReadOnly"
                                     Orientation="Horizontal"
@@ -181,12 +195,41 @@
                             </StackPanel>
 
                             <!-- right side -->
-                            <StackPanel Grid.Column="1" HorizontalAlignment="Right">
+                            <StackPanel Grid.Column="1" 
+                                        HorizontalAlignment="Right"
+                                        Orientation="Horizontal"
+                                        VerticalAlignment="Center"
+                                        Spacing="4">
                                 <!-- <controls:StandardButton Size="Small" Text="..." /> -->
                                 <!-- <Line Classes="Separator" /> -->
                                 <ToggleSwitch x:Name="CollectionToggle" Classes="Compact"
                                               OnContent="{x:Null}"
                                               OffContent="{x:Null}"/>
+                                
+                                <!-- Dots menu button -->
+                                <controls:StandardButton LeftIcon="{x:Static icons:IconValues.MoreVertical}"
+                                                         ShowLabel="False"
+                                                         ShowIcon="IconOnly"
+                                                         Size="Medium"
+                                                         ToolTip.Tip="More">
+                                    <controls:StandardButton.Flyout>
+                                        <MenuFlyout>
+                                            <navigation:NavigationMenuItem Header="View collection download page"
+                                                      x:Name="ViewCollectionDownloadMenuItem" >
+                                                <MenuItem.Icon>
+                                                    <icons:UnifiedIcon Size="16" Value="{x:Static icons:IconValues.Downloading}" />
+                                                </MenuItem.Icon>
+                                            </navigation:NavigationMenuItem>
+                                            <MenuItem Header="Remove Collection"
+                                                      x:Name="RemoveCollectionMenuItem"
+                                                      Classes="Critical">
+                                                <MenuItem.Icon>
+                                                    <icons:UnifiedIcon Size="16" Value="{x:Static icons:IconValues.DeleteOutline}" />
+                                                </MenuItem.Icon>
+                                            </MenuItem>
+                                        </MenuFlyout>
+                                    </controls:StandardButton.Flyout>
+                                </controls:StandardButton>
                             </StackPanel>
                         </Grid>
 

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutView.axaml.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutView.axaml.cs
@@ -41,6 +41,10 @@ public partial class CollectionLoadoutView : ReactiveUserControl<ICollectionLoad
                 .AddTo(disposables);
             this.BindCommand(ViewModel, vm => vm.CommandToggle, view => view.CollectionToggle)
                 .AddTo(disposables);
+            this.BindCommand(ViewModel, vm => vm.CommandDeleteCollection, view => view.RemoveCollectionMenuItem)
+                .AddTo(disposables);
+            this.BindCommand(ViewModel, vm => vm.CommandViewCollectionDownloadPage, view => view.ViewCollectionDownloadMenuItem)
+                .AddTo(disposables);
 
             this.OneWayBind(ViewModel, vm => vm.IsLocalCollection, view => view.NexusModsLogo.IsVisible, static b => !b)
                 .AddTo(disposables);

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutViewModel.cs
@@ -13,6 +13,7 @@ using System.Reactive.Linq;
 using NexusMods.Abstractions.Collections;
 using NexusMods.App.UI.Controls.Navigation;
 using NexusMods.App.UI.Pages.CollectionDownload;
+using NexusMods.App.UI.Pages.LibraryPage;
 using NexusMods.MnemonicDB.Abstractions.TxFunctions;
 using R3;
 using ReactiveUI;
@@ -94,11 +95,26 @@ public class CollectionLoadoutViewModel : APageViewModel<ICollectionLoadoutViewM
         CommandDeleteCollection = new ReactiveCommand(
             executeAsync: async (_, _) =>
             {
+                // Switch away from this page since its collection will be deleted
+                var pageData = new PageData
+                {
+                    FactoryId = LibraryPageFactory.StaticId,
+                    Context = new LibraryPageContext()
+                    {
+                        LoadoutId = pageContext.LoadoutId,
+                    },
+                };
+
+                var workspaceController = GetWorkspaceController();
+                var behavior = new OpenPageBehavior.ReplaceTab(PanelId, TabId);
+                workspaceController.OpenPage(WorkspaceId, pageData, behavior);
+                
+                
                 using var tx = connection.BeginTransaction();
                 
                 // Delete collection loadout group and all installed mods inside it
                 tx.Delete(nexusCollectionGroup.Id, recursive: true);
-
+                
                 await tx.Commit();
             },
             awaitOperation: AwaitOperation.Drop,

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutViewModel.cs
@@ -13,7 +13,6 @@ using System.Reactive.Linq;
 using NexusMods.Abstractions.Collections;
 using NexusMods.App.UI.Controls.Navigation;
 using NexusMods.App.UI.Pages.CollectionDownload;
-using NexusMods.App.UI.Pages.LibraryPage;
 using NexusMods.MnemonicDB.Abstractions.TxFunctions;
 using R3;
 using ReactiveUI;
@@ -98,17 +97,17 @@ public class CollectionLoadoutViewModel : APageViewModel<ICollectionLoadoutViewM
                 // Switch away from this page since its collection will be deleted
                 var pageData = new PageData
                 {
-                    FactoryId = LibraryPageFactory.StaticId,
-                    Context = new LibraryPageContext()
+                    FactoryId = CollectionDownloadPageFactory.StaticId,
+                    Context = new CollectionDownloadPageContext()
                     {
-                        LoadoutId = pageContext.LoadoutId,
+                        TargetLoadout = pageContext.LoadoutId,
+                        CollectionRevisionMetadataId = nexusCollectionGroup.RevisionId,
                     },
                 };
 
                 var workspaceController = GetWorkspaceController();
                 var behavior = new OpenPageBehavior.ReplaceTab(PanelId, TabId);
-                workspaceController.OpenPage(WorkspaceId, pageData, behavior);
-                
+                workspaceController.OpenPage(WorkspaceId, pageData, behavior, checkOtherPanels: false);
                 
                 using var tx = connection.BeginTransaction();
                 
@@ -121,7 +120,8 @@ public class CollectionLoadoutViewModel : APageViewModel<ICollectionLoadoutViewM
             configureAwait: false
         );
 
-        CommandViewCollectionDownloadPage = new ReactiveCommand<NavigationInformation>(
+        CommandViewCollectionDownloadPage = ReactiveUI.ReactiveCommand.Create<NavigationInformation, System.Reactive.Unit>
+        (
             info =>
             {
                 var pageData = new PageData
@@ -137,6 +137,8 @@ public class CollectionLoadoutViewModel : APageViewModel<ICollectionLoadoutViewM
                 var workspaceController = GetWorkspaceController();
                 var behavior = workspaceController.GetOpenPageBehavior(pageData, info);
                 workspaceController.OpenPage(WorkspaceId, pageData, behavior);
+                
+                return System.Reactive.Unit.Default;
             }
         );
 
@@ -192,5 +194,5 @@ public class CollectionLoadoutViewModel : APageViewModel<ICollectionLoadoutViewM
     [Reactive] public bool IsCollectionEnabled { get; private set; }
     public ReactiveCommand<Unit> CommandToggle { get; }
     public ReactiveCommand<Unit> CommandDeleteCollection { get; }
-    public ReactiveCommand<NavigationInformation> CommandViewCollectionDownloadPage { get; }
+    public ReactiveUI.ReactiveCommand<NavigationInformation, System.Reactive.Unit> CommandViewCollectionDownloadPage { get; }
 }

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutViewModel.cs
@@ -94,14 +94,10 @@ public class CollectionLoadoutViewModel : APageViewModel<ICollectionLoadoutViewM
         CommandDeleteCollection = new ReactiveCommand(
             executeAsync: async (_, _) =>
             {
-                var db = connection.Db;
                 using var tx = connection.BeginTransaction();
-
-                var groupDatoms = db.Datoms(NexusCollectionLoadoutGroup.Revision, nexusCollectionGroup.RevisionId);
-                foreach (var datom in groupDatoms)
-                {
-                    tx.Delete(datom.E, recursive: true);
-                }
+                
+                // Delete collection loadout group and all installed mods inside it
+                tx.Delete(nexusCollectionGroup.Id, recursive: true);
 
                 await tx.Commit();
             },

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/ICollectionLoadoutViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/ICollectionLoadoutViewModel.cs
@@ -1,8 +1,9 @@
+using System.Reactive;
 using Avalonia.Media.Imaging;
 using NexusMods.Abstractions.NexusWebApi.Types;
 using NexusMods.App.UI.Controls.Navigation;
 using NexusMods.App.UI.WorkspaceSystem;
-using R3;
+using ReactiveUI;
 
 namespace NexusMods.App.UI.Pages.LoadoutPage;
 
@@ -37,9 +38,9 @@ public interface ICollectionLoadoutViewModel : IPageViewModelInterface
 
     Bitmap? BackgroundImage { get; }
 
-    ReactiveCommand<Unit> CommandToggle { get; }
+    R3.ReactiveCommand<R3.Unit> CommandToggle { get; }
     
-    ReactiveCommand<Unit> CommandDeleteCollection { get; }
+    R3.ReactiveCommand<R3.Unit> CommandDeleteCollection { get; }
     
-    ReactiveCommand<NavigationInformation> CommandViewCollectionDownloadPage { get; }
+    ReactiveCommand<NavigationInformation, Unit> CommandViewCollectionDownloadPage { get; }
 }

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/ICollectionLoadoutViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/ICollectionLoadoutViewModel.cs
@@ -1,5 +1,6 @@
 using Avalonia.Media.Imaging;
 using NexusMods.Abstractions.NexusWebApi.Types;
+using NexusMods.App.UI.Controls.Navigation;
 using NexusMods.App.UI.WorkspaceSystem;
 using R3;
 
@@ -37,4 +38,8 @@ public interface ICollectionLoadoutViewModel : IPageViewModelInterface
     Bitmap? BackgroundImage { get; }
 
     ReactiveCommand<Unit> CommandToggle { get; }
+    
+    ReactiveCommand<Unit> CommandDeleteCollection { get; }
+    
+    ReactiveCommand<NavigationInformation> CommandViewCollectionDownloadPage { get; }
 }

--- a/src/NexusMods.Icons/IconValues.cs
+++ b/src/NexusMods.Icons/IconValues.cs
@@ -368,6 +368,10 @@ public static class IconValues
 
     // https://pictogrammers.com/library/mdi/icon/swap-vertical"/
     public static readonly IconValue Swap = new ProjektankerIcon("mdi-swap-vertical");
+    
+    // https://pictogrammers.com/library/mdi/icon/dots-vertical/
+    public static readonly IconValue MoreVertical = new ProjektankerIcon("mdi-dots-vertical");
+    
 
 #endregion
     

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Icons/IconsStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Icons/IconsStyles.axaml
@@ -124,6 +124,7 @@
                     <icons:UnifiedIcon Classes="FormatListCheckbox" />
                     <icons:UnifiedIcon Classes="DotsGrid" />
                     <icons:UnifiedIcon Classes="FormatAlignJustify" />
+                    <icons:UnifiedIcon Classes="MoreVertical" />
                 </WrapPanel>
                 <WrapPanel>
                     <icons:UnifiedIcon Classes="Nexus" />
@@ -658,5 +659,8 @@
     </Style>
     <Style Selector="icons|UnifiedIcon.PanelAllFull">
         <Setter Property="Value" Value="{x:Static icons:IconValues.PanelAllFull}" />
+    </Style>
+    <Style Selector="icons|UnifiedIcon.MoreVertical">
+        <Setter Property="Value" Value="{x:Static icons:IconValues.MoreVertical}" />
     </Style>
 </Styles>


### PR DESCRIPTION
- Closes  #2561 
- Closes #2560 
- Fixed Collection `IsInstalled` status not updating when collection is removed
- Fixed `EnumerableEmpty` exception on Aggregate function for Collection column during deletion
- Fixed CollectionDownload page not switching to library page on deletion if Library page was already open in other panel 