### PR TITLE
Allow installing collections with no required mods

### DIFF
--- a/src/NexusMods.Collections/CollectionDownloader.cs
+++ b/src/NexusMods.Collections/CollectionDownloader.cs
@@ -270,8 +270,10 @@ public class CollectionDownloader
     {
         var observables = revision.Downloads
             .Where(download => DownloadMatchesItemType(download, itemType))
-            .Select(download => GetStatusObservable(download, groupObservable).Select(static status => status.IsInstalled(out _)));
+            .Select(download => GetStatusObservable(download, groupObservable).Select(static status => status.IsInstalled(out _)))
+            .ToArray();
 
+        if (observables.Length == 0) return groupObservable.Select(static optional => optional.HasValue);
         return observables.CombineLatest(static list => list.All(static installed => installed));
     }
 

--- a/src/NexusMods.Collections/InstallCollectionJob.cs
+++ b/src/NexusMods.Collections/InstallCollectionJob.cs
@@ -84,13 +84,11 @@ public class InstallCollectionJob : IJobDefinitionWithStart<InstallCollectionJob
             .Where(item => !CollectionDownloader.GetStatus(item, g, Connection.Db).IsInstalled(out _))
             .ToArray();
 
-        if (items.Length == 0) return Group.Value;
-
         var skipCount = Items.Length - items.Length;
         if (skipCount > 0) Logger.LogInformation("Skipping `{Count}` already installed items for `{CollectionName}/{RevisionNumber}`", skipCount, RevisionMetadata.Collection.Name, RevisionMetadata.RevisionNumber);
 
-        var isReady = CollectionDownloader.IsFullyDownloaded(items, db: Connection.Db);
-        if (!isReady) throw new InvalidOperationException("The collection hasn't fully been downloaded!");
+        var isFullyDownloaded = CollectionDownloader.IsFullyDownloaded(items, db: Connection.Db);
+        if (!isFullyDownloaded) throw new InvalidOperationException("The collection hasn't fully been downloaded!");
 
         var root = await NexusModsLibrary.ParseCollectionJsonFile(SourceCollection, context.CancellationToken);
         var modsAndDownloads = GatherDownloads(items, root);


### PR DESCRIPTION
Fixes #2654.

We'd probably want to look at the UI again for this case later as it doesn't really make a lot of sense of you have no required mods. The tab for required mods is always visible and the text will say "All required mods downloaded/installed".