### PR TITLE
Show bundled mods in the loadout and collection download page

### DIFF
--- a/src/NexusMods.App.UI/Extensions/EnumerableExtensions.cs
+++ b/src/NexusMods.App.UI/Extensions/EnumerableExtensions.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Runtime.InteropServices;
 using DynamicData.Kernel;
 
 namespace NexusMods.App.UI.Extensions;
@@ -97,5 +98,22 @@ public static class EnumerableExtensions
         }
 
         return minItem;
+    }
+
+    /// <summary>
+    /// Custom aggregation method that doesn't throw if the source is empty but instead returns a default value.
+    /// </summary>
+    public static T SafeAggregate<T>(this IEnumerable<T> source, T defaultValue, Func<T, T, T> func)
+    {
+        using var enumerator = source.GetEnumerator();
+        if (!enumerator.MoveNext()) return defaultValue;
+
+        var result = enumerator.Current;
+        while (enumerator.MoveNext())
+        {
+            result = func(result, enumerator.Current);
+        }
+
+        return result;
     }
 }

--- a/src/NexusMods.App.UI/NexusMods.App.UI.csproj
+++ b/src/NexusMods.App.UI/NexusMods.App.UI.csproj
@@ -590,12 +590,6 @@
         <Compile Update="Pages\LoadoutPage\LoadoutViewModel.cs">
           <DependentUpon>ILoadoutViewModel.cs</DependentUpon>
         </Compile>
-        <Compile Update="Pages\LocalFileDataProvider.cs">
-          <DependentUpon>ILibraryDataProvider.cs</DependentUpon>
-        </Compile>
-        <Compile Update="Pages\NexusModsDataProvider.cs">
-          <DependentUpon>ILibraryDataProvider.cs</DependentUpon>
-        </Compile>
         <Compile Update="Pages\ItemContentsFileTree\ItemContentsFileTreeViewModel.cs">
           <DependentUpon>IItemContentsFileTreeViewModel.cs</DependentUpon>
         </Compile>

--- a/src/NexusMods.App.UI/Pages/BundledDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/BundledDataProvider.cs
@@ -1,0 +1,58 @@
+using System.Reactive.Linq;
+using DynamicData;
+using JetBrains.Annotations;
+using Microsoft.Extensions.DependencyInjection;
+using NexusMods.Abstractions.Collections;
+using NexusMods.App.UI.Controls;
+using NexusMods.MnemonicDB.Abstractions;
+using NexusMods.MnemonicDB.Abstractions.Query;
+
+namespace NexusMods.App.UI.Pages;
+
+[UsedImplicitly]
+public class BundledDataProvider : ILoadoutDataProvider
+{
+    private readonly IConnection _connection;
+
+    public BundledDataProvider(IServiceProvider serviceProvider)
+    {
+        _connection = serviceProvider.GetRequiredService<IConnection>();
+    }
+
+    public IObservable<IChangeSet<CompositeItemModel<EntityId>, EntityId>> ObserveLoadoutItems(LoadoutFilter loadoutFilter)
+    {
+        return _connection.ObserveDatoms(NexusCollectionBundledLoadoutGroup.PrimaryAttribute)
+            .AsEntityIds()
+            .FilterInStaticLoadout(_connection, loadoutFilter)
+            .TransformImmutable(datom => NexusCollectionBundledLoadoutGroup.Load(_connection.Db, datom.E))
+            .Transform(item => ToLoadoutItemModel(item));
+    }
+
+    private CompositeItemModel<EntityId> ToLoadoutItemModel(NexusCollectionBundledLoadoutGroup.ReadOnly item)
+    {
+        var loadoutItem = item.AsNexusCollectionItemLoadoutGroup().AsLoadoutItemGroup().AsLoadoutItem();
+
+        var hasChildrenObservable = Observable.Return(true);
+        var childrenObservable = Observable.Return(
+            new ChangeSet<CompositeItemModel<EntityId>, EntityId>(
+                [
+                    new Change<CompositeItemModel<EntityId>, EntityId>(ChangeReason.Add, item.Id, LoadoutDataProviderHelper.ToChildItemModel(_connection, loadoutItem)),
+                ]
+            ));
+
+        var parentItemModel = new CompositeItemModel<EntityId>(item.Id)
+        {
+            HasChildrenObservable = hasChildrenObservable,
+            ChildrenObservable = childrenObservable,
+        };
+
+        parentItemModel.Add(SharedColumns.Name.StringComponentKey, new StringComponent(value: item.AsNexusCollectionItemLoadoutGroup().AsLoadoutItemGroup().AsLoadoutItem().Name));
+        parentItemModel.Add(SharedColumns.Name.ImageComponentKey, new ImageComponent(value: ImagePipelines.ModPageThumbnailFallback));
+        parentItemModel.Add(SharedColumns.InstalledDate.ComponentKey, new DateComponent(value: item.GetCreatedAt()));
+
+        LoadoutDataProviderHelper.AddCollection(_connection, parentItemModel, loadoutItem);
+        LoadoutDataProviderHelper.AddIsEnabled(_connection, parentItemModel, loadoutItem);
+
+        return parentItemModel;
+    }
+}

--- a/src/NexusMods.App.UI/Pages/CollectionDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDataProvider.cs
@@ -21,6 +21,12 @@ using R3;
 namespace NexusMods.App.UI.Pages;
 using CollectionDownloadEntity = Abstractions.NexusModsLibrary.Models.CollectionDownload;
 
+public enum CollectionDownloadsFilter
+{
+    OnlyRequired,
+    OnlyOptional,
+}
+
 public class CollectionDataProvider
 {
     private readonly IConnection _connection;

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/TreeDataGridCollectionResources.axaml
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/TreeDataGridCollectionResources.axaml
@@ -105,10 +105,6 @@
                     </controls:ComponentTemplate.DataTemplate>
                 </controls:ComponentTemplate>
             </controls:MultiComponentControl.AvailableTemplates>
-
-            <controls:MultiComponentControl.Fallback>
-                <icons:UnifiedIcon Size="20" Foreground="Red" Value="{x:Static icons:IconValues.Error}"/>
-            </controls:MultiComponentControl.Fallback>
         </controls:MultiComponentControl>
     </DataTemplate>
 

--- a/src/NexusMods.App.UI/Pages/NexusModsDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/NexusModsDataProvider.cs
@@ -20,12 +20,6 @@ using NexusMods.Paths;
 
 namespace NexusMods.App.UI.Pages;
 
-public enum CollectionDownloadsFilter
-{
-    OnlyRequired,
-    OnlyOptional,
-}
-
 public class NexusModsDataProvider : ILibraryDataProvider, ILoadoutDataProvider
 {
     private readonly IConnection _connection;

--- a/src/NexusMods.App.UI/Services.cs
+++ b/src/NexusMods.App.UI/Services.cs
@@ -290,6 +290,7 @@ public static class Services
             .AddSingleton<ILoadoutDataProvider, LocalFileDataProvider>()
             .AddSingleton<ILibraryDataProvider, NexusModsDataProvider>()
             .AddSingleton<ILoadoutDataProvider, NexusModsDataProvider>()
+            .AddSingleton<ILoadoutDataProvider, BundledDataProvider>()
             .AddFileSystem()
             .AddImagePipelines();
     }


### PR DESCRIPTION
Resolves #2380 and fixes #2663.

Note that this messes up a lot of counts. The count for the `All (x)` left menu will be wrong since it counts the number of `LibraryLinkedLoadoutItem` entities in the loadout. The collection download page also shows the number of downloads (nexus mods or external) but bundled mods can't be downloaded, so the counts are a mess there too.

This would need a proper design pass later.