### PR TITLE
Fix open panel with no tabs

### DIFF
--- a/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelViewModel.cs
@@ -256,7 +256,7 @@ public class PanelViewModel : AViewModel<IPanelViewModel>, IPanelViewModel
             }
         });
 
-        if (data.Tabs.Length == 0)
+        if (_tabsList.Count == 0)
         {
             AddDefaultTab();
         }

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
@@ -541,14 +541,12 @@ public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceVie
             if (data.Panels.Length == 0)
             {
                 _logger.LogWarning("Workspace gets loaded with no panels!");
-                var addPanelBehavior = new AddPanelBehavior(new AddPanelBehavior.WithDefaultTab());
 
                 AddPanel(
-                    WorkspaceGridState.From(new[]
-                    {
+                    newWorkspaceState: WorkspaceGridState.From([
                         new PanelGridState(PanelId.DefaultValue, MathUtils.One),
-                    }, isHorizontal: IsHorizontal),
-                    addPanelBehavior
+                    ], isHorizontal: IsHorizontal),
+                    behavior: new AddPanelBehavior(new AddPanelBehavior.WithDefaultTab())
                 );
 
                 return;

--- a/src/NexusMods.App.UI/WorkspaceSystem/WorkspaceController/WorkspaceController.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/WorkspaceController/WorkspaceController.cs
@@ -15,7 +15,6 @@ using NexusMods.App.UI.WorkspaceAttachments;
 using NexusMods.Extensions.BCL;
 using NexusMods.Telemetry;
 using ReactiveUI;
-using ReactiveUI.Fody.Helpers;
 
 namespace NexusMods.App.UI.WorkspaceSystem;
 
@@ -116,6 +115,12 @@ internal sealed class WorkspaceController : ReactiveObject, IWorkspaceController
             if (isActiveWorkspace) activeWorkspace = vm;
         }
 
+        if (_workspaces.Count == 0)
+        {
+            _logger.LogInformation("Restored zero workspaces, creating default workspace");
+            CreateWorkspace(context: new HomeContext(), pageData: Optional<PageData>.None);
+        }
+
         ChangeActiveWorkspace(activeWorkspace?.Id ?? _workspaces.Keys.First());
     }
 
@@ -151,21 +156,7 @@ internal sealed class WorkspaceController : ReactiveObject, IWorkspaceController
 
         return vm;
     }
-    
 
-    private void AddDefaultPanel(WorkspaceViewModel vm)
-    {
-        var addPanelBehavior = new AddPanelBehavior(new AddPanelBehavior.WithDefaultTab());
-
-        vm.AddPanel(
-            WorkspaceGridState.From(new[]
-            {
-                new PanelGridState(PanelId.DefaultValue, MathUtils.One),
-            }, isHorizontal: vm.IsHorizontal),
-            addPanelBehavior
-        );
-    }
-    
     public void UnregisterWorkspaceByContext<TContext>(Func<TContext, bool> predicate)
         where TContext : IWorkspaceContext
     {


### PR DESCRIPTION
Fixes #2632.

Changing `if (data.Tabs.Length == 0)` to `if (_tabsList.Count == 0)`. Before we'd check if the data has no tabs, now we check if we created no tabs.

Also cleans up some code for restoring data, I'll probably do another pass on this at a later point.