### PR TITLE
Layout change for Collection Loadout Page

### DIFF
--- a/src/NexusMods.App.UI/LeftMenu/Loadout/LoadoutLeftMenuViewModel.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Loadout/LoadoutLeftMenuViewModel.cs
@@ -63,7 +63,7 @@ public class LoadoutLeftMenuViewModel : AViewModel<ILoadoutLeftMenuViewModel>, I
         var logger = serviceProvider.GetRequiredService<ILogger<LoadoutLeftMenuViewModel>>();
 
         var collectionItemComparer = new LeftMenuCollectionItemComparer();
-        var collectionDownloader = new CollectionDownloader(serviceProvider);
+        var collectionDownloader = serviceProvider.GetRequiredService<CollectionDownloader>();
         
         // Library
         LeftMenuItemLibrary = new LeftMenuItemWithCountBadgeViewModel(

--- a/src/NexusMods.App.UI/Pages/CollectionDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDataProvider.cs
@@ -38,7 +38,7 @@ public class CollectionDataProvider
     {
         _connection = serviceProvider.GetRequiredService<IConnection>();
         _jobMonitor = serviceProvider.GetRequiredService<IJobMonitor>();
-        _collectionDownloader = new CollectionDownloader(serviceProvider);
+        _collectionDownloader = serviceProvider.GetRequiredService<CollectionDownloader>();
         _thumbnailLoader = ImagePipelines.GetModPageThumbnailPipeline(serviceProvider);
     }
 

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadViewModel.cs
@@ -60,7 +60,7 @@ public sealed class CollectionDownloadViewModel : APageViewModel<ICollectionDown
         var mappingCache = serviceProvider.GetRequiredService<IGameDomainToGameIdMappingCache>();
         var osInterop = serviceProvider.GetRequiredService<IOSInterop>();
         var nexusModsLibrary = serviceProvider.GetRequiredService<NexusModsLibrary>();
-        var collectionDownloader = new CollectionDownloader(serviceProvider);
+        var collectionDownloader = serviceProvider.GetRequiredService<CollectionDownloader>();
         var loginManager = serviceProvider.GetRequiredService<ILoginManager>();
         var overlayController = serviceProvider.GetRequiredService<IOverlayController>();
         var jobMonitor = serviceProvider.GetRequiredService<IJobMonitor>();

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutDesignViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutDesignViewModel.cs
@@ -14,6 +14,7 @@ public class CollectionLoadoutDesignViewModel : APageViewModel<ICollectionLoadou
 
     public LoadoutTreeDataGridAdapter Adapter { get; } = null!;
     public bool IsCollectionEnabled => true;
+    public int InstalledModsCount { get; } = 10;
     public string Name => "Vanilla+ [Quality of Life]";
     public RevisionNumber RevisionNumber { get; } = RevisionNumber.From(6);
     public string AuthorName => "Lowtonotolerance";

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutView.axaml
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutView.axaml
@@ -100,26 +100,27 @@
                                                VerticalAlignment="Center" />
                                 </StackPanel>
 
-                                <StackPanel x:Name="ReadOnlyPillStack" 
+                                <!-- read only pill -->
+                                <StackPanel x:Name="ReadOnlyPillStack"
                                             Orientation="Horizontal"
                                             Spacing="8">
-                                    
+
                                     <Ellipse Fill="{StaticResource NeutralSubduedBrush}" Width="4" Height="4" />
 
-                                <!-- read only pill? -->
-                                <Border Background="{StaticResource BrandInfo900Brush}" 
-                                        CornerRadius="999" 
-                                        Height="18"
-                                        Padding="6,0">
-                                    <StackPanel Orientation="Horizontal" Spacing="2">
-                                        <icons:UnifiedIcon Value="{x:Static icons:IconValues.Lock}" Size="12"
-                                                           Foreground="{StaticResource InfoStrongBrush}" />
-                                        <TextBlock Text="Read only"
-                                                   Theme="{StaticResource BodySMNormalTheme}"
-                                                   Foreground="{StaticResource InfoStrongBrush}"
-                                                   VerticalAlignment="Center" />
-                                    </StackPanel>
-                                </Border>
+                                    <Border Background="{StaticResource BrandInfo900Brush}"
+                                            CornerRadius="999"
+                                            Height="18"
+                                            Padding="6,0"
+                                            ToolTip.Tip="Collections downloaded from Nexus Mods are currently not editable. However, the ability to create local, editable copies will be available soon.">
+                                        <StackPanel Orientation="Horizontal" Spacing="2">
+                                            <icons:UnifiedIcon Value="{x:Static icons:IconValues.Lock}" Size="12"
+                                                               Foreground="{StaticResource InfoStrongBrush}" />
+                                            <TextBlock Text="Read only"
+                                                       Theme="{StaticResource BodySMNormalTheme}"
+                                                       Foreground="{StaticResource InfoStrongBrush}"
+                                                       VerticalAlignment="Center" />
+                                        </StackPanel>
+                                    </Border>
                                 </StackPanel>
 
                                 <Ellipse Fill="{StaticResource NeutralSubduedBrush}" Width="4" Height="4" />
@@ -161,7 +162,8 @@
                                 <Separator Width="1" Margin="0,0" Height="18"
                                            Background="{StaticResource SurfaceTranslucentMidBrush}" />
 
-                                <TextBlock Text="10 MODS"
+                                <TextBlock x:Name="TotalModsTextBlock"
+                                           Text="10 MODS"
                                            Theme="{StaticResource TitleSMSemiTheme}"
                                            VerticalAlignment="Center" />
 
@@ -203,18 +205,18 @@
                 </Grid>
             </Border>
         </Border>
-        
+
         <!-- toolbar -->
         <Border Grid.Row="1" Classes="Toolbar"
                 Padding="24,0"
                 Height="52">
-            <controls:StandardButton
+            <controls:StandardButton x:Name="ViewModFilesButton"
                 Size="Small"
                 Type="Tertiary"
                 Fill="Weak"
                 LeftIcon="{x:Static icons:IconValues.FolderEyeOutline}"
                 ShowIcon="Left"
-                Text="View Mod Files"/>
+                Text="View Mod Files" />
         </Border>
 
         <!-- tree data grid -->

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutView.axaml
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutView.axaml
@@ -9,7 +9,7 @@
     xmlns:icons="clr-namespace:NexusMods.Icons;assembly=NexusMods.Icons"
     xmlns:controls="clr-namespace:NexusMods.App.UI.Controls"
     xmlns:navigation="clr-namespace:NexusMods.App.UI.Controls.Navigation"
-    mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+    mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="450"
     x:Class="NexusMods.App.UI.Pages.LoadoutPage.CollectionLoadoutView">
 
     <Design.DataContext>
@@ -129,8 +129,8 @@
                                                        Foreground="{StaticResource NeutralTranslucentModerateBrush}" />
                                         </StackPanel>
                                         <StackPanel x:Name="NexusModsLogo"
-                                            Orientation="Horizontal"
-                                            Spacing="4">
+                                                    Orientation="Horizontal"
+                                                    Spacing="4">
                                             <icons:UnifiedIcon Size="24"
                                                                Value="{x:Static icons:IconValues.NexusColor}" />
                                             <TextBlock Text="Nexus Mods"
@@ -146,90 +146,110 @@
 
                     <!-- toolbar -->
                     <Border x:Name="ToolbarBorder"
-                            Padding="8">
+                            Padding="24,12" >
+                        
                         <Border.Styles>
                             <Style Selector="Border.Info">
-                                <Setter Property="Background" Value="{StaticResource BrandInfo950Brush}"/>
+                                <Setter Property="Background" Value="{StaticResource BrandInfo950Brush}" />
                             </Style>
-        
+
                             <Style Selector="Border.Warning">
-                                <Setter Property="Background" Value="{StaticResource BrandWarning950Brush}"/>
+                                <Setter Property="Background" Value="{StaticResource BrandWarning950Brush}" />
                             </Style>
                         </Border.Styles>
 
-                        <Grid ColumnDefinitions="*,*">
+                        <Grid ColumnDefinitions="*,Auto" ShowGridLines="False">
 
-                            <!-- left side -->
-                            <StackPanel Grid.Column="0" 
-                                        HorizontalAlignment="Left" 
-                                        Orientation="Horizontal" 
-                                        VerticalAlignment="Center">
+                            <!-- left column (text) -->
+
+                            <!-- dock panel so the last textblock width is calculated properly to text trim -->
+                            <DockPanel Grid.Column="0" x:Name="ToolbarReadOnly">
                                 <StackPanel
-                                    x:Name="ToolbarReadOnly"
                                     Orientation="Horizontal"
-                                    Spacing="4">
+                                    VerticalAlignment="Center"
+                                    Spacing="{StaticResource Spacing-1}">
+                                    
                                     <icons:UnifiedIcon Size="20"
                                                        Value="{x:Static icons:IconValues.Lock}"
                                                        Foreground="{StaticResource NeutralTranslucentStrongBrush}" />
                                     <TextBlock Text="Read only"
                                                Theme="{StaticResource BodyMDBoldTheme}"
-                                               Foreground="{StaticResource NeutralTranslucentStrongBrush}" />
-                                    <TextBlock Text="- Create a local copy of a Nexus Mods collection to make changes"
-                                               Theme="{StaticResource BodyMDNormalTheme}"
-                                               Foreground="{StaticResource NeutralTranslucentModerateBrush}" />
+                                               Foreground="{StaticResource NeutralTranslucentStrongBrush}"
+                                               TextWrapping="NoWrap" />
                                 </StackPanel>
+                                <TextBlock Text="- Create a local copy of a Nexus Mods collection to make changes"
+                                           Theme="{StaticResource BodyMDNormalTheme}"
+                                           Foreground="{StaticResource NeutralTranslucentModerateBrush}"
+                                           TextWrapping="NoWrap"
+                                           TextTrimming="CharacterEllipsis"
+                                           VerticalAlignment="Center"
+                                           Margin="4,0" />
+                            </DockPanel>
+
+                            <!-- dock panel so the last textblock width is calculated properly to text trim -->
+                            <DockPanel Grid.Column="0" x:Name="ToolbarDisabled">
                                 <StackPanel
-                                    x:Name="ToolbarDisabled"
                                     Orientation="Horizontal"
-                                    Spacing="4">
+                                    VerticalAlignment="Center"
+                                    Spacing="{StaticResource Spacing-1}">
                                     <icons:UnifiedIcon Size="20"
                                                        Value="{x:Static icons:IconValues.Info}"
                                                        Foreground="{StaticResource NeutralTranslucentStrongBrush}" />
                                     <TextBlock Text="Collection disabled"
                                                Theme="{StaticResource BodyMDBoldTheme}"
                                                Foreground="{StaticResource NeutralTranslucentStrongBrush}" />
-                                    <TextBlock Text="- Mods will not be loaded"
-                                               Theme="{StaticResource BodyMDNormalTheme}"
-                                               Foreground="{StaticResource NeutralTranslucentModerateBrush}" />
                                 </StackPanel>
-                            </StackPanel>
+                                <TextBlock Text="- Mods will not be loaded"
+                                           Theme="{StaticResource BodyMDNormalTheme}"
+                                           Foreground="{StaticResource NeutralTranslucentModerateBrush}"
+                                           TextWrapping="NoWrap"
+                                           TextTrimming="CharacterEllipsis"
+                                           VerticalAlignment="Center"
+                                           Margin="4,0" />
+                            </DockPanel>
 
-                            <!-- right side -->
-                            <StackPanel Grid.Column="1" 
+                            <!-- right column (actions) -->
+                            <StackPanel Grid.Column="1"
                                         HorizontalAlignment="Right"
                                         Orientation="Horizontal"
                                         VerticalAlignment="Center"
-                                        Spacing="4">
-                                <!-- <controls:StandardButton Size="Small" Text="..." /> -->
-                                <!-- <Line Classes="Separator" /> -->
-                                <ToggleSwitch x:Name="CollectionToggle" Classes="Compact"
-                                              OnContent="{x:Null}"
-                                              OffContent="{x:Null}"/>
+                                        Spacing="{StaticResource Spacing-2}">
+                                
+                                <Separator Width="1" Margin="0,0" Height="28" Background="{StaticResource SurfaceTranslucentMidBrush}"/>
                                 
                                 <!-- Dots menu button -->
                                 <controls:StandardButton LeftIcon="{x:Static icons:IconValues.MoreVertical}"
                                                          ShowLabel="False"
-                                                         ShowIcon="IconOnly"
-                                                         Size="Medium"
+                                                         ShowIcon="Left"
+                                                         Size="Small"
                                                          ToolTip.Tip="More">
+                                    
                                     <controls:StandardButton.Flyout>
                                         <MenuFlyout>
                                             <navigation:NavigationMenuItem Header="View collection download page"
-                                                      x:Name="ViewCollectionDownloadMenuItem" >
+                                                                           x:Name="ViewCollectionDownloadMenuItem">
                                                 <MenuItem.Icon>
-                                                    <icons:UnifiedIcon Size="16" Value="{x:Static icons:IconValues.Downloading}" />
+                                                    <icons:UnifiedIcon Size="16"
+                                                                       Value="{x:Static icons:IconValues.Downloading}" />
                                                 </MenuItem.Icon>
                                             </navigation:NavigationMenuItem>
                                             <MenuItem Header="Remove Collection"
                                                       x:Name="RemoveCollectionMenuItem"
                                                       Classes="Critical">
                                                 <MenuItem.Icon>
-                                                    <icons:UnifiedIcon Size="16" Value="{x:Static icons:IconValues.DeleteOutline}" />
+                                                    <icons:UnifiedIcon Size="16"
+                                                                       Value="{x:Static icons:IconValues.DeleteOutline}" />
                                                 </MenuItem.Icon>
                                             </MenuItem>
                                         </MenuFlyout>
                                     </controls:StandardButton.Flyout>
                                 </controls:StandardButton>
+                                
+                                <ToggleSwitch x:Name="CollectionToggle" Classes="Compact"
+                                              OnContent="{x:Null}"
+                                              OffContent="{x:Null}" />
+
+                                
                             </StackPanel>
                         </Grid>
 
@@ -243,7 +263,7 @@
                       ShowColumnHeaders="True"
                       CanUserResizeColumns="True"
                       CanUserSortColumns="True"
-                      Classes="MainListsStyling"/>
+                      Classes="MainListsStyling" />
     </Grid>
 
 

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutView.axaml
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutView.axaml
@@ -163,7 +163,6 @@
                                            Background="{StaticResource SurfaceTranslucentMidBrush}" />
 
                                 <TextBlock x:Name="TotalModsTextBlock"
-                                           Text="10 MODS"
                                            Theme="{StaticResource TitleSMSemiTheme}"
                                            VerticalAlignment="Center" />
 

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutView.axaml
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutView.axaml
@@ -206,7 +206,8 @@
         </Border>
 
         <!-- toolbar -->
-        <Border Grid.Row="1" Classes="Toolbar"
+        <!-- TODO: wire up View Mod Files button -->
+        <Border Grid.Row="1" IsVisible="False" Classes="Toolbar"
                 Padding="24,0"
                 Height="52">
             <controls:StandardButton x:Name="ViewModFilesButton"

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutView.axaml
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutView.axaml
@@ -17,10 +17,10 @@
     </Design.DataContext>
 
     <!-- header, treedatagrid -->
-    <Grid RowDefinitions="Auto, *">
+    <Grid RowDefinitions="Auto, Auto, *">
 
         <!-- header -->
-        <Border x:Name="HeaderBorderBackground">
+        <Border Grid.Row="0" x:Name="HeaderBorderBackground">
             <Border x:Name="HeaderBorder">
 
                 <Border.Background>
@@ -30,7 +30,7 @@
                     </LinearGradientBrush>
                 </Border.Background>
 
-                <Grid RowDefinitions="Auto,Auto">
+                <Grid RowDefinitions="Auto,Auto,Auto">
 
                     <!-- first row (image and title) -->
                     <Border Grid.Row="0" x:Name="MainContentBorder" Padding="24">
@@ -203,9 +203,22 @@
                 </Grid>
             </Border>
         </Border>
+        
+        <!-- toolbar -->
+        <Border Grid.Row="1" Classes="Toolbar"
+                Padding="24,0"
+                Height="52">
+            <controls:StandardButton
+                Size="Small"
+                Type="Tertiary"
+                Fill="Weak"
+                LeftIcon="{x:Static icons:IconValues.FolderEyeOutline}"
+                ShowIcon="Left"
+                Text="View Mod Files"/>
+        </Border>
 
         <!-- tree data grid -->
-        <TreeDataGrid Grid.Row="1" x:Name="TreeDataGrid"
+        <TreeDataGrid Grid.Row="2" x:Name="TreeDataGrid"
                       ShowColumnHeaders="True"
                       CanUserResizeColumns="True"
                       CanUserSortColumns="True"

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutView.axaml
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutView.axaml
@@ -9,7 +9,7 @@
     xmlns:icons="clr-namespace:NexusMods.Icons;assembly=NexusMods.Icons"
     xmlns:controls="clr-namespace:NexusMods.App.UI.Controls"
     xmlns:navigation="clr-namespace:NexusMods.App.UI.Controls.Navigation"
-    mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="450"
+    mc:Ignorable="d" d:DesignWidth="1000" d:DesignHeight="450"
     x:Class="NexusMods.App.UI.Pages.LoadoutPage.CollectionLoadoutView">
 
     <Design.DataContext>
@@ -30,19 +30,18 @@
                     </LinearGradientBrush>
                 </Border.Background>
 
-                <StackPanel x:Name="Banner" Orientation="Vertical">
+                <Grid RowDefinitions="Auto,Auto">
 
-                    <!-- first header row (image and metadata) -->
-                    <Border x:Name="MainContentBorder" Padding="24">
-                        <Grid x:Name="MainContent" ColumnDefinitions="Auto, *">
+                    <!-- first row (image and title) -->
+                    <Border Grid.Row="0" x:Name="MainContentBorder" Padding="24">
+                        <StackPanel x:Name="MainContent" Orientation="Horizontal" Spacing="12">
 
-                            <!-- left column (image) -->
-                            <Grid>
-
+                            <!-- used to place one over the top of the other -->
+                            <Panel>
                                 <!-- placeholder -->
-                                <Border Grid.Column="0"
-                                        Height="90"
-                                        Width="73"
+                                <Border x:Name="ImagePlaceholderBorder"
+                                        Height="60"
+                                        Width="48"
                                         VerticalAlignment="Top"
                                         ClipToBounds="True"
                                         CornerRadius="{StaticResource Rounded}"
@@ -55,175 +54,128 @@
                                 </Border>
 
                                 <!-- collection image -->
-                                <Border Grid.Column="0" x:Name="CollectionImageBorder"
-                                        Height="90"
-                                        Width="73"
+                                <Border x:Name="CollectionImageBorder"
+                                        Height="60"
+                                        Width="48"
                                         VerticalAlignment="Top"
                                         ClipToBounds="True"
                                         CornerRadius="{StaticResource Rounded}">
                                     <Image x:Name="CollectionImage" />
                                 </Border>
-                            </Grid>
+                            </Panel>
 
-                            <!-- right column (metadata) -->
-
-                            <Grid Grid.Column="1" x:Name="CollectionDetails"
-                                  RowDefinitions="Auto,Auto,Auto"
-                                  Margin="16,0">
-
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" MaxWidth="500" />
-                                </Grid.ColumnDefinitions>
-
-                                <StackPanel Orientation="Horizontal" Spacing="2">
-                                    <icons:UnifiedIcon Size="16"
-                                                       Value="{x:Static icons:IconValues.CollectionsOutline}"
-                                                       Foreground="{StaticResource NeutralTranslucentModerateBrush}" />
-                                    <TextBlock Grid.Row="0" x:Name="Title"
-                                               Text="COLLECTION"
-                                               Theme="{StaticResource TitleXSSemiTheme}"
-                                               Foreground="{StaticResource NeutralTranslucentModerateBrush}" />
-                                </StackPanel>
-
-                                <TextBlock Grid.Row="1" x:Name="CollectionName"
-                                           Theme="{StaticResource HeadingXSSemiTheme}"
-                                           Foreground="{StaticResource NeutralStrongBrush}"
-                                           Margin="0,4,0,4" />
-
-                                <Border Grid.Row="2" IsVisible="False">
-                                    <StackPanel>
-                                        <TextBlock Text="Your Loadout starts with a default, private collection."
-                                                   Theme="{StaticResource BodyMDNormalTheme}"
-                                                   Foreground="{StaticResource NeutralTranslucentModerateBrush}" />
-                                        <TextBlock Text="You can copy it to share."
-                                                   Theme="{StaticResource BodyMDNormalTheme}"
-                                                   Foreground="{StaticResource NeutralTranslucentModerateBrush}" />
-                                    </StackPanel>
-                                </Border>
-
-                                <Border Grid.Row="2" x:Name="TagsPanelBorder"
-                                        BorderBrush="{StaticResource StrokeTranslucentWeakBrush}"
-                                        BorderThickness="0,1,0,0"
-                                        Padding="0,8,0,8">
-
-                                    <StackPanel x:Name="TagsPanel"
-                                                Orientation="Horizontal"
-                                                Spacing="12">
-                                        <TextBlock x:Name="Revision"
-                                                   Theme="{StaticResource BodyMDBoldTheme}"
-                                                   Foreground="{StaticResource NeutralTranslucentModerateBrush}" />
-                                        <StackPanel x:Name="AuthorStackPanel"
-                                                    Orientation="Horizontal"
-                                                    Margin="0,0,0,0"
-                                                    Spacing="4">
-                                            <Border x:Name="AuthorAvatarBorder"
-                                                    Width="24"
-                                                    Height="24">
-                                                <Border.Clip>
-                                                    <EllipseGeometry Rect="0,0,24,24" />
-                                                </Border.Clip>
-                                                <Image x:Name="AuthorAvatar" />
-                                            </Border>
-                                            <TextBlock x:Name="AuthorName"
-                                                       Theme="{StaticResource BodyMDNormalTheme}"
-                                                       Foreground="{StaticResource NeutralTranslucentModerateBrush}" />
-                                        </StackPanel>
-                                        <StackPanel x:Name="NexusModsLogo"
-                                                    Orientation="Horizontal"
-                                                    Spacing="4">
-                                            <icons:UnifiedIcon Size="24"
-                                                               Value="{x:Static icons:IconValues.NexusColor}" />
-                                            <TextBlock Text="Nexus Mods"
-                                                       Theme="{StaticResource BodyMDNormalTheme}"
-                                                       Foreground="{StaticResource PrimaryStrongBrush}" />
-
-                                        </StackPanel>
-                                    </StackPanel>
-                                </Border>
-                            </Grid>
-                        </Grid>
+                            <!-- collection title -->
+                            <TextBlock x:Name="CollectionName"
+                                       Theme="{StaticResource HeadingSMSemiTheme}"
+                                       Foreground="{StaticResource NeutralStrongBrush}"
+                                       Margin="0,4,0,4"
+                                       VerticalAlignment="Center" />
+                        </StackPanel>
                     </Border>
 
-                    <!-- toolbar -->
-                    <Border x:Name="ToolbarBorder"
-                            Padding="24,12" >
-                        
-                        <Border.Styles>
-                            <Style Selector="Border.Info">
-                                <Setter Property="Background" Value="{StaticResource BrandInfo950Brush}" />
-                            </Style>
-
-                            <Style Selector="Border.Warning">
-                                <Setter Property="Background" Value="{StaticResource BrandWarning950Brush}" />
-                            </Style>
-                        </Border.Styles>
+                    <!-- second row (metadata) -->
+                    <Border Grid.Row="1" x:Name="TagsPanelBorder"
+                            Background="{StaticResource StrokeTranslucentWeakBrush}"
+                            Padding="24,0"
+                            Height="42">
 
                         <Grid ColumnDefinitions="*,Auto" ShowGridLines="False">
 
-                            <!-- left column (text) -->
+                            <!-- left column (tags and metadata) -->
+                            <StackPanel x:Name="TagsPanel"
+                                        Grid.Column="0"
+                                        Orientation="Horizontal"
+                                        Spacing="10"
+                                        VerticalAlignment="Center">
 
-                            <!-- dock panel so the last textblock width is calculated properly to text trim -->
-                            <DockPanel Grid.Column="0" x:Name="ToolbarReadOnly">
-                                <StackPanel
-                                    Orientation="Horizontal"
-                                    VerticalAlignment="Center"
-                                    Spacing="{StaticResource Spacing-1}">
+                                <!-- nexus mods logo -->
+                                <StackPanel x:Name="NexusModsLogo"
+                                            Orientation="Horizontal"
+                                            Spacing="4">
+                                    <icons:UnifiedIcon Size="24"
+                                                       Value="{x:Static icons:IconValues.NexusColor}" />
+                                    <TextBlock Text="Nexus Mods"
+                                               Theme="{StaticResource BodySMNormalTheme}"
+                                               Foreground="{StaticResource PrimaryStrongBrush}"
+                                               VerticalAlignment="Center" />
+                                </StackPanel>
+
+                                <StackPanel x:Name="ReadOnlyPillStack" 
+                                            Orientation="Horizontal"
+                                            Spacing="8">
                                     
-                                    <icons:UnifiedIcon Size="20"
-                                                       Value="{x:Static icons:IconValues.Lock}"
-                                                       Foreground="{StaticResource NeutralTranslucentStrongBrush}" />
-                                    <TextBlock Text="Read only"
-                                               Theme="{StaticResource BodyMDBoldTheme}"
-                                               Foreground="{StaticResource NeutralTranslucentStrongBrush}"
-                                               TextWrapping="NoWrap" />
-                                </StackPanel>
-                                <TextBlock Text="- Create a local copy of a Nexus Mods collection to make changes"
-                                           Theme="{StaticResource BodyMDNormalTheme}"
-                                           Foreground="{StaticResource NeutralTranslucentModerateBrush}"
-                                           TextWrapping="NoWrap"
-                                           TextTrimming="CharacterEllipsis"
-                                           VerticalAlignment="Center"
-                                           Margin="4,0" />
-                            </DockPanel>
+                                    <Ellipse Fill="{StaticResource NeutralSubduedBrush}" Width="4" Height="4" />
 
-                            <!-- dock panel so the last textblock width is calculated properly to text trim -->
-                            <DockPanel Grid.Column="0" x:Name="ToolbarDisabled">
-                                <StackPanel
-                                    Orientation="Horizontal"
-                                    VerticalAlignment="Center"
-                                    Spacing="{StaticResource Spacing-1}">
-                                    <icons:UnifiedIcon Size="20"
-                                                       Value="{x:Static icons:IconValues.Info}"
-                                                       Foreground="{StaticResource NeutralTranslucentStrongBrush}" />
-                                    <TextBlock Text="Collection disabled"
-                                               Theme="{StaticResource BodyMDBoldTheme}"
-                                               Foreground="{StaticResource NeutralTranslucentStrongBrush}" />
+                                <!-- read only pill? -->
+                                <Border Background="{StaticResource BrandInfo900Brush}" 
+                                        CornerRadius="999" 
+                                        Height="18"
+                                        Padding="6,0">
+                                    <StackPanel Orientation="Horizontal" Spacing="2">
+                                        <icons:UnifiedIcon Value="{x:Static icons:IconValues.Lock}" Size="12"
+                                                           Foreground="{StaticResource InfoStrongBrush}" />
+                                        <TextBlock Text="Read only"
+                                                   Theme="{StaticResource BodySMNormalTheme}"
+                                                   Foreground="{StaticResource InfoStrongBrush}"
+                                                   VerticalAlignment="Center" />
+                                    </StackPanel>
+                                </Border>
                                 </StackPanel>
-                                <TextBlock Text="- Mods will not be loaded"
-                                           Theme="{StaticResource BodyMDNormalTheme}"
-                                           Foreground="{StaticResource NeutralTranslucentModerateBrush}"
-                                           TextWrapping="NoWrap"
-                                           TextTrimming="CharacterEllipsis"
-                                           VerticalAlignment="Center"
-                                           Margin="4,0" />
-                            </DockPanel>
 
-                            <!-- right column (actions) -->
+                                <Ellipse Fill="{StaticResource NeutralSubduedBrush}" Width="4" Height="4" />
+
+                                <!-- revision -->
+                                <TextBlock x:Name="Revision"
+                                           Theme="{StaticResource BodySMNormalTheme}"
+                                           Foreground="{StaticResource NeutralTranslucentModerateBrush}"
+                                           VerticalAlignment="Center" />
+                                <Ellipse Fill="{StaticResource NeutralSubduedBrush}" Width="4" Height="4" />
+
+                                <!-- author and avatar -->
+                                <StackPanel x:Name="AuthorStackPanel"
+                                            Orientation="Horizontal"
+                                            Margin="0"
+                                            Spacing="6">
+                                    <Border x:Name="AuthorAvatarBorder"
+                                            Width="24"
+                                            Height="24">
+                                        <Border.Clip>
+                                            <EllipseGeometry Rect="0,0,24,24" />
+                                        </Border.Clip>
+                                        <Image x:Name="AuthorAvatar" />
+                                    </Border>
+                                    <TextBlock x:Name="AuthorName"
+                                               Theme="{StaticResource BodySMNormalTheme}"
+                                               Foreground="{StaticResource NeutralTranslucentModerateBrush}"
+                                               VerticalAlignment="Center" />
+                                </StackPanel>
+                            </StackPanel>
+
+                            <!-- right column (controls and actions) -->
                             <StackPanel Grid.Column="1"
                                         HorizontalAlignment="Right"
                                         Orientation="Horizontal"
                                         VerticalAlignment="Center"
-                                        Spacing="{StaticResource Spacing-2}">
-                                
-                                <Separator Width="1" Margin="0,0" Height="28" Background="{StaticResource SurfaceTranslucentMidBrush}"/>
-                                
+                                        Spacing="{StaticResource Spacing-3}">
+
+                                <Separator Width="1" Margin="0,0" Height="18"
+                                           Background="{StaticResource SurfaceTranslucentMidBrush}" />
+
+                                <TextBlock Text="10 MODS"
+                                           Theme="{StaticResource TitleSMSemiTheme}"
+                                           VerticalAlignment="Center" />
+
+                                <ToggleSwitch x:Name="CollectionToggle" Classes="Compact"
+                                              OnContent="{x:Null}"
+                                              OffContent="{x:Null}" />
+
                                 <!-- Dots menu button -->
                                 <controls:StandardButton LeftIcon="{x:Static icons:IconValues.MoreVertical}"
                                                          ShowLabel="False"
                                                          ShowIcon="Left"
                                                          Size="Small"
                                                          ToolTip.Tip="More">
-                                    
+
                                     <controls:StandardButton.Flyout>
                                         <MenuFlyout>
                                             <navigation:NavigationMenuItem Header="View collection download page"
@@ -244,22 +196,16 @@
                                         </MenuFlyout>
                                     </controls:StandardButton.Flyout>
                                 </controls:StandardButton>
-                                
-                                <ToggleSwitch x:Name="CollectionToggle" Classes="Compact"
-                                              OnContent="{x:Null}"
-                                              OffContent="{x:Null}" />
 
-                                
                             </StackPanel>
                         </Grid>
-
                     </Border>
-                </StackPanel>
+                </Grid>
             </Border>
         </Border>
 
         <!-- tree data grid -->
-        <TreeDataGrid Grid.Row="2" x:Name="TreeDataGrid"
+        <TreeDataGrid Grid.Row="1" x:Name="TreeDataGrid"
                       ShowColumnHeaders="True"
                       CanUserResizeColumns="True"
                       CanUserSortColumns="True"

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutView.axaml.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutView.axaml.cs
@@ -48,6 +48,8 @@ public partial class CollectionLoadoutView : ReactiveUserControl<ICollectionLoad
 
             this.OneWayBind(ViewModel, vm => vm.IsLocalCollection, view => view.NexusModsLogo.IsVisible, static b => !b)
                 .AddTo(disposables);
+            this.OneWayBind(ViewModel, vm => vm.IsReadOnly, view => view.ReadOnlyPillStack.IsVisible)
+                .AddTo(disposables);
 
             this.WhenAnyValue(view => view.ViewModel!.IsCollectionEnabled)
                 .WhereNotNull()

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutView.axaml.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutView.axaml.cs
@@ -22,6 +22,8 @@ public partial class CollectionLoadoutView : ReactiveUserControl<ICollectionLoad
                 .AddTo(disposables);
             this.OneWayBind(ViewModel, vm => vm.Name, view => view.CollectionName.Text)
                 .AddTo(disposables);
+            this.OneWayBind(ViewModel, vm => vm.InstalledModsCount, view => view.TotalModsTextBlock.Text, count => $"{count} MODS")
+                .AddTo(disposables);
             this.OneWayBind(ViewModel, vm => vm.TileImage, view => view.CollectionImage.Source)
                 .AddTo(disposables);
             

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutView.axaml.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutView.axaml.cs
@@ -54,18 +54,18 @@ public partial class CollectionLoadoutView : ReactiveUserControl<ICollectionLoad
                 .SubscribeWithErrorLogging(value =>
                     {
                         CollectionToggle.IsChecked = value;
-                        ToolbarReadOnly.IsVisible = value;
-                        ToolbarDisabled.IsVisible = !value;
+                        ReadOnlyPillStack.IsVisible = value;
+                        //ToolbarDisabled.IsVisible = !value;
 
                         if (value)
                         {
-                            ToolbarBorder.Classes.Add("Info");
-                            ToolbarBorder.Classes.Remove("Warning");
+                            //ToolbarBorder.Classes.Add("Info");
+                            //ToolbarBorder.Classes.Remove("Warning");
                         }
                         else
                         {
-                            ToolbarBorder.Classes.Remove("Info");
-                            ToolbarBorder.Classes.Add("Warning");
+                            //ToolbarBorder.Classes.Remove("Info");
+                            //ToolbarBorder.Classes.Add("Warning");
                         }
                     }
                 )

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutView.axaml.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutView.axaml.cs
@@ -54,19 +54,6 @@ public partial class CollectionLoadoutView : ReactiveUserControl<ICollectionLoad
                 .SubscribeWithErrorLogging(value =>
                     {
                         CollectionToggle.IsChecked = value;
-                        ReadOnlyPillStack.IsVisible = value;
-                        //ToolbarDisabled.IsVisible = !value;
-
-                        if (value)
-                        {
-                            //ToolbarBorder.Classes.Add("Info");
-                            //ToolbarBorder.Classes.Remove("Warning");
-                        }
-                        else
-                        {
-                            //ToolbarBorder.Classes.Remove("Info");
-                            //ToolbarBorder.Classes.Add("Warning");
-                        }
                     }
                 )
                 .DisposeWith(disposables);

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutViewModel.cs
@@ -10,9 +10,11 @@ using NexusMods.Icons;
 using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.MnemonicDB.Abstractions.ElementComparers;
 using System.Reactive.Linq;
+using DynamicData;
 using NexusMods.Abstractions.Collections;
 using NexusMods.App.UI.Controls.Navigation;
 using NexusMods.App.UI.Pages.CollectionDownload;
+using NexusMods.MnemonicDB.Abstractions.Query;
 using NexusMods.MnemonicDB.Abstractions.TxFunctions;
 using R3;
 using ReactiveUI;
@@ -145,7 +147,13 @@ public class CollectionLoadoutViewModel : APageViewModel<ICollectionLoadoutViewM
         this.WhenActivated(disposables =>
         {
             Adapter.Activate().AddTo(disposables);
-
+            
+            connection.ObserveDatoms(LoadoutItem.ParentId, pageContext.GroupId)
+                .QueryWhenChanged(datoms => datoms.Count)
+                .OnUI()
+                .Subscribe(count => InstalledModsCount = count)
+                .AddTo(disposables);
+            
             LoadoutItem
                 .Observe(connection, pageContext.GroupId)
                 .Select(static item => !item.IsDisabled)
@@ -192,6 +200,9 @@ public class CollectionLoadoutViewModel : APageViewModel<ICollectionLoadoutViewM
     [Reactive] public Bitmap? TileImage { get; private set; }
 
     [Reactive] public bool IsCollectionEnabled { get; private set; }
+    
+    [Reactive] public int InstalledModsCount { get; private set; }
+    
     public ReactiveCommand<Unit> CommandToggle { get; }
     public ReactiveCommand<Unit> CommandDeleteCollection { get; }
     public ReactiveUI.ReactiveCommand<NavigationInformation, System.Reactive.Unit> CommandViewCollectionDownloadPage { get; }

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/ICollectionLoadoutViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/ICollectionLoadoutViewModel.cs
@@ -25,6 +25,11 @@ public interface ICollectionLoadoutViewModel : IPageViewModelInterface
     /// Gets whether the collection is enabled.
     /// </summary>
     bool IsCollectionEnabled { get; }
+    
+    /// <summary>
+    /// Gets the number of mods installed in the collection, both required and optional.
+    /// </summary>
+    int InstalledModsCount { get; }
 
     string Name { get; }
 

--- a/src/NexusMods.Collections/InstallCollectionDownloadJob.cs
+++ b/src/NexusMods.Collections/InstallCollectionDownloadJob.cs
@@ -59,7 +59,7 @@ public class InstallCollectionDownloadJob : IJobDefinitionWithStart<InstallColle
         if (!optionalCollectionGroup.HasValue) throw new InvalidOperationException("Collection must exist!");
         var collectionGroup = optionalCollectionGroup.Value.AsCollectionGroup();
 
-        var sourceCollection = new CollectionDownloader(serviceProvider).GetLibraryFile(download.CollectionRevision);
+        var sourceCollection = serviceProvider.GetRequiredService<CollectionDownloader>().GetLibraryFile(download.CollectionRevision);
         var nexusModsLibrary = serviceProvider.GetRequiredService<NexusModsLibrary>();
 
         var root = await nexusModsLibrary.ParseCollectionJsonFile(sourceCollection, cancellationToken);

--- a/src/NexusMods.Collections/Services.cs
+++ b/src/NexusMods.Collections/Services.cs
@@ -15,6 +15,7 @@ public static class Services
             .AddNexusCollectionBundledLoadoutGroupModel()
             .AddNexusCollectionItemLoadoutGroupModel()
             .AddNexusCollectionReplicatedLoadoutGroupModel()
-            .AddCollectionVerbs();
+            .AddCollectionVerbs()
+            .AddSingleton<CollectionDownloader>();
     }
 }

--- a/src/NexusMods.Collections/Verbs.cs
+++ b/src/NexusMods.Collections/Verbs.cs
@@ -34,6 +34,7 @@ internal static class Verbs
         [Injected] NexusModsLibrary nexusModsLibrary,
         [Injected] IServiceProvider serviceProvider,
         [Injected] IConnection connection,
+        [Injected] CollectionDownloader collectionDownloader,
         [Injected] CancellationToken token)
     {
         await using var destination = temporaryFileManager.CreateFile();
@@ -46,7 +47,6 @@ internal static class Verbs
 
         var revisionMetadata = await nexusModsLibrary.GetOrAddCollectionRevision(collectionFile, CollectionSlug.From(slug), RevisionNumber.From((ulong)revision), token);
 
-        var collectionDownloader = new CollectionDownloader(serviceProvider);
         await collectionDownloader.DownloadItems(revisionMetadata, itemType: CollectionDownloader.ItemType.Required, db: connection.Db, cancellationToken: token);
 
         var items = CollectionDownloader.GetItems(revisionMetadata, CollectionDownloader.ItemType.Required);

--- a/src/NexusMods.Icons/IconValues.cs
+++ b/src/NexusMods.Icons/IconValues.cs
@@ -261,6 +261,9 @@ public static class IconValues
 
     // https://pictogrammers.com/library/mdi/icon/folder-outline/
     public static readonly IconValue Folder = new ProjektankerIcon("mdi-folder-outline");
+    
+    // https://pictogrammers.com/library/mdi/icon/folder-eye-outline/
+    public static readonly IconValue FolderEyeOutline = new ProjektankerIcon("mdi-folder-eye-outline");
 
     // https://pictogrammers.com/library/mdi/icon/check-underline/
     public static readonly IconValue FolderOpen = new ProjektankerIcon("mdi-folder-open-outline");

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Icons/IconsStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Icons/IconsStyles.axaml
@@ -125,6 +125,7 @@
                     <icons:UnifiedIcon Classes="DotsGrid" />
                     <icons:UnifiedIcon Classes="FormatAlignJustify" />
                     <icons:UnifiedIcon Classes="MoreVertical" />
+                    <icons:UnifiedIcon Classes="FolderEyeOutline" />
                 </WrapPanel>
                 <WrapPanel>
                     <icons:UnifiedIcon Classes="Nexus" />
@@ -662,5 +663,8 @@
     </Style>
     <Style Selector="icons|UnifiedIcon.MoreVertical">
         <Setter Property="Value" Value="{x:Static icons:IconValues.MoreVertical}" />
+    </Style>
+    <Style Selector="icons|UnifiedIcon.FolderEyeOutline">
+        <Setter Property="Value" Value="{x:Static icons:IconValues.FolderEyeOutline}" />
     </Style>
 </Styles>


### PR DESCRIPTION
This is a start on getting the Collection Loadout Page up to date with [Figma](https://www.figma.com/design/5LmVL8YpgDHFSFA76fgCZA/%F0%9F%93%B1-Mod-library?node-id=2290-35931&m=dev) while @Al12rs and @erri120 are working on the functionality.

![image](https://github.com/user-attachments/assets/9bc0b191-85e7-42dc-bbb8-32dc28a1b7da)

Elements that need wiring up:

- Read only pill `StackPanel#ReadOnlyPillStack` needs showing\hiding based on if the collection is read only or not. This StackPanel includes the dot seperator.
- Total mods `TextBlock#TotalModsTextBlock` needs to update based on how many mods are installed (both optional and required)
- 'View mod files' button `StandardButton#ViewModFilesButton` needs to work the same as it does on 'All', shows the file system contents of the mod

Part of #2598