### PR TITLE
Event Bus and reacting to downloads

### DIFF
--- a/NexusMods.App.sln
+++ b/NexusMods.App.sln
@@ -296,6 +296,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NexusMods.Abstractions.Game
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NexusMods.Games.FileHashes", "src\NexusMods.Games.FileHashes\NexusMods.Games.FileHashes.csproj", "{71D8CF63-A287-45AB-B251-676A54576C1D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NexusMods.Abstractions.EventBus", "src\Abstractions\NexusMods.Abstractions.EventBus\NexusMods.Abstractions.EventBus.csproj", "{653CF228-7CD2-4C1B-8B4F-1332B66A33A2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -782,6 +784,10 @@ Global
 		{71D8CF63-A287-45AB-B251-676A54576C1D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{71D8CF63-A287-45AB-B251-676A54576C1D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{71D8CF63-A287-45AB-B251-676A54576C1D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{653CF228-7CD2-4C1B-8B4F-1332B66A33A2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{653CF228-7CD2-4C1B-8B4F-1332B66A33A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{653CF228-7CD2-4C1B-8B4F-1332B66A33A2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{653CF228-7CD2-4C1B-8B4F-1332B66A33A2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -920,6 +926,7 @@ Global
 		{9DE1C2AC-927A-4BC6-B2A1-7016902F8BAE} = {0CB73565-1207-4A56-A79F-6A8E9BBD795C}
 		{E2DB1DF4-9934-4119-BA90-196FDDB0904A} = {0CB73565-1207-4A56-A79F-6A8E9BBD795C}
 		{71D8CF63-A287-45AB-B251-676A54576C1D} = {70D38D24-79AE-4600-8E83-17F3C11BA81F}
+		{653CF228-7CD2-4C1B-8B4F-1332B66A33A2} = {0CB73565-1207-4A56-A79F-6A8E9BBD795C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9F9F8352-34DD-42C0-8564-EE9AF34A3501}

--- a/src/Abstractions/NexusMods.Abstractions.EventBus/IEventBus.cs
+++ b/src/Abstractions/NexusMods.Abstractions.EventBus/IEventBus.cs
@@ -1,0 +1,34 @@
+using DynamicData.Kernel;
+using JetBrains.Annotations;
+using R3;
+
+namespace NexusMods.Abstractions.EventBus;
+
+/// <summary>
+/// Represents an event bus for sending messages and requests.
+/// </summary>
+[PublicAPI]
+public interface IEventBus
+{
+    /// <summary>
+    /// Sends a message.
+    /// </summary>
+    void Send<T>(T message) where T : IEventBusMessage;
+
+    /// <summary>
+    /// Sends a request as a message and returns task that completes when a handler responds with a result.
+    /// </summary>
+    Task<Optional<TResult>> SendAndReceive<TRequest, TResult>(TRequest request, CancellationToken cancellationToken)
+        where TRequest : IEventBusRequest<TResult>
+        where TResult : notnull;
+
+    /// <summary>
+    /// Observes incoming messages of type <typeparamref name="T"/>.
+    /// </summary>
+    Observable<T> ObserveMessages<T>() where T : IEventBusMessage;
+
+    /// <summary>
+    /// Observes all incoming messages.
+    /// </summary>
+    Observable<IEventBusMessage> ObserveAllMessages();
+}

--- a/src/Abstractions/NexusMods.Abstractions.EventBus/IEventBusMessage.cs
+++ b/src/Abstractions/NexusMods.Abstractions.EventBus/IEventBusMessage.cs
@@ -1,0 +1,9 @@
+using JetBrains.Annotations;
+
+namespace NexusMods.Abstractions.EventBus;
+
+/// <summary>
+/// Represents a message.
+/// </summary>
+[PublicAPI]
+public interface IEventBusMessage;

--- a/src/Abstractions/NexusMods.Abstractions.EventBus/IEventBusRequest.cs
+++ b/src/Abstractions/NexusMods.Abstractions.EventBus/IEventBusRequest.cs
@@ -1,0 +1,10 @@
+using JetBrains.Annotations;
+
+namespace NexusMods.Abstractions.EventBus;
+
+/// <summary>
+/// Represents a request.
+/// </summary>
+[PublicAPI]
+public interface IEventBusRequest<TResult> : IEventBusMessage
+    where TResult : notnull;

--- a/src/Abstractions/NexusMods.Abstractions.EventBus/IEventBusRequestHandler.cs
+++ b/src/Abstractions/NexusMods.Abstractions.EventBus/IEventBusRequestHandler.cs
@@ -1,0 +1,17 @@
+using JetBrains.Annotations;
+
+namespace NexusMods.Abstractions.EventBus;
+
+/// <summary>
+/// Handles requests by responding with a result.
+/// </summary>
+[PublicAPI]
+public interface IEventBusRequestHandler<in TRequest, TResult>
+    where TRequest : IEventBusRequest<TResult>
+    where TResult : notnull
+{
+    /// <summary>
+    /// Handles the request.
+    /// </summary>
+    Task<TResult> Handle(TRequest request, CancellationToken cancellationToken);
+}

--- a/src/Abstractions/NexusMods.Abstractions.EventBus/NexusMods.Abstractions.EventBus.csproj
+++ b/src/Abstractions/NexusMods.Abstractions.EventBus/NexusMods.Abstractions.EventBus.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+    <!-- NuGet Package Shared Details -->
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('NuGet.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+    <ItemGroup>
+        <PackageReference Include="DynamicData"/>
+        <PackageReference Include="R3"/>
+    </ItemGroup>
+
+</Project>

--- a/src/NexusMods.App.Cli/CliMessages.cs
+++ b/src/NexusMods.App.Cli/CliMessages.cs
@@ -1,8 +1,9 @@
+using NexusMods.Abstractions.EventBus;
 using NexusMods.Abstractions.NexusModsLibrary.Models;
 
-namespace NexusMods.App.UI;
+namespace NexusMods.CLI;
 
-public static class UiMessages
+public static class CliMessages
 {
     public record AddedCollection(CollectionRevisionMetadata.ReadOnly Revision) : IEventBusMessage;
 

--- a/src/NexusMods.App.Cli/NexusMods.App.Cli.csproj
+++ b/src/NexusMods.App.Cli/NexusMods.App.Cli.csproj
@@ -7,13 +7,13 @@
 
     <ItemGroup>
         <ProjectReference Include="..\Abstractions\NexusMods.Abstractions.Cli\NexusMods.Abstractions.Cli.csproj" />
+        <ProjectReference Include="..\Abstractions\NexusMods.Abstractions.EventBus\NexusMods.Abstractions.EventBus.csproj" />
         <ProjectReference Include="..\Abstractions\NexusMods.Abstractions.Games\NexusMods.Abstractions.Games.csproj" />
         <ProjectReference Include="..\Abstractions\NexusMods.Abstractions.GOG\NexusMods.Abstractions.GOG.csproj" />
         <ProjectReference Include="..\Abstractions\NexusMods.Abstractions.HttpDownloader\NexusMods.Abstractions.HttpDownloader.csproj" />
         <ProjectReference Include="..\Networking\NexusMods.Networking.Downloaders\NexusMods.Networking.Downloaders.csproj" />
         <ProjectReference Include="..\Networking\NexusMods.Networking.HttpDownloader\NexusMods.Networking.HttpDownloader.csproj" />
         <ProjectReference Include="..\Networking\NexusMods.Networking.NexusWebApi\NexusMods.Networking.NexusWebApi.csproj" />
-        <ProjectReference Include="..\NexusMods.App.UI\NexusMods.App.UI.csproj" />
         <ProjectReference Include="..\NexusMods.Collections\NexusMods.Collections.csproj" />
         <ProjectReference Include="..\NexusMods.ProxyConsole.Abstractions\NexusMods.ProxyConsole.Abstractions.csproj" />
     </ItemGroup>

--- a/src/NexusMods.App.Cli/NexusMods.App.Cli.csproj
+++ b/src/NexusMods.App.Cli/NexusMods.App.Cli.csproj
@@ -13,6 +13,7 @@
         <ProjectReference Include="..\Networking\NexusMods.Networking.Downloaders\NexusMods.Networking.Downloaders.csproj" />
         <ProjectReference Include="..\Networking\NexusMods.Networking.HttpDownloader\NexusMods.Networking.HttpDownloader.csproj" />
         <ProjectReference Include="..\Networking\NexusMods.Networking.NexusWebApi\NexusMods.Networking.NexusWebApi.csproj" />
+        <ProjectReference Include="..\NexusMods.App.UI\NexusMods.App.UI.csproj" />
         <ProjectReference Include="..\NexusMods.Collections\NexusMods.Collections.csproj" />
         <ProjectReference Include="..\NexusMods.ProxyConsole.Abstractions\NexusMods.ProxyConsole.Abstractions.csproj" />
     </ItemGroup>

--- a/src/NexusMods.App.Cli/Types/IpcHandlers/NxmIpcProtocolHandler.cs
+++ b/src/NexusMods.App.Cli/Types/IpcHandlers/NxmIpcProtocolHandler.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using NexusMods.Abstractions.EventBus;
 using NexusMods.Abstractions.GameLocators;
 using NexusMods.Abstractions.GOG;
 using NexusMods.Abstractions.Library;
@@ -7,7 +8,6 @@ using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.NexusModsLibrary;
 using NexusMods.Abstractions.NexusWebApi;
 using NexusMods.Abstractions.NexusWebApi.Types;
-using NexusMods.App.UI;
 using NexusMods.Extensions.BCL;
 using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.MnemonicDB.Abstractions.IndexSegments;
@@ -153,7 +153,7 @@ public class NxmIpcProtocolHandler : IIpcProtocolHandler
         }
 
         var collectionRevision = await nexusModsLibrary.GetOrAddCollectionRevision(collectionFile, collectionUrl.Collection.Slug, collectionUrl.Revision, CancellationToken.None);
-        _eventBus.Send(new UiMessages.AddedCollection(collectionRevision));
+        _eventBus.Send(new CliMessages.AddedCollection(collectionRevision));
     }
 
     private async Task HandleModUrl(CancellationToken cancel, NXMModUrl modUrl)
@@ -170,7 +170,7 @@ public class NxmIpcProtocolHandler : IIpcProtocolHandler
         var library = _serviceProvider.GetRequiredService<ILibraryService>();
         var temporaryFileManager = _serviceProvider.GetRequiredService<TemporaryFileManager>();
 
-        _eventBus.Send(new UiMessages.AddedDownload());
+        _eventBus.Send(new CliMessages.AddedDownload());
 
         await using var destination = temporaryFileManager.CreateFile();
         var downloadJob = await nexusModsLibrary.CreateDownloadJob(destination, modUrl, cancellationToken: cancel);

--- a/src/NexusMods.App.Cli/Types/IpcHandlers/NxmIpcProtocolHandler.cs
+++ b/src/NexusMods.App.Cli/Types/IpcHandlers/NxmIpcProtocolHandler.cs
@@ -1,23 +1,18 @@
-using System.Reactive.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.GameLocators;
-using NexusMods.Abstractions.Games;
 using NexusMods.Abstractions.GOG;
-using NexusMods.Abstractions.GOG.DTOs;
 using NexusMods.Abstractions.Library;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.NexusModsLibrary;
 using NexusMods.Abstractions.NexusWebApi;
 using NexusMods.Abstractions.NexusWebApi.Types;
-using NexusMods.Collections;
+using NexusMods.App.UI;
 using NexusMods.Extensions.BCL;
 using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.MnemonicDB.Abstractions.IndexSegments;
-using NexusMods.Networking.HttpDownloader;
 using NexusMods.Networking.NexusWebApi;
 using NexusMods.Networking.NexusWebApi.Auth;
-using NexusMods.Networking.NexusWebApi.V1Interop;
 using NexusMods.Paths;
 
 namespace NexusMods.CLI.Types.IpcHandlers;
@@ -38,6 +33,7 @@ public class NxmIpcProtocolHandler : IIpcProtocolHandler
 
     private readonly IServiceProvider _serviceProvider;
     private readonly IClient _client;
+    private readonly IEventBus _eventBus;
 
     /// <summary>
     /// constructor
@@ -51,6 +47,7 @@ public class NxmIpcProtocolHandler : IIpcProtocolHandler
         ILoginManager loginManager)
     {
         _serviceProvider = serviceProvider;
+        _eventBus = serviceProvider.GetRequiredService<IEventBus>();
 
         _logger = logger;
         _oauth = oauth;
@@ -156,7 +153,7 @@ public class NxmIpcProtocolHandler : IIpcProtocolHandler
         }
 
         var collectionRevision = await nexusModsLibrary.GetOrAddCollectionRevision(collectionFile, collectionUrl.Collection.Slug, collectionUrl.Revision, CancellationToken.None);
-        // var installJob = await InstallCollectionJob.Create(_serviceProvider, loadout, collectionFile);
+        _eventBus.Send(new UiMessages.AddedCollection(collectionRevision));
     }
 
     private async Task HandleModUrl(CancellationToken cancel, NXMModUrl modUrl)

--- a/src/NexusMods.App.Cli/Types/IpcHandlers/NxmIpcProtocolHandler.cs
+++ b/src/NexusMods.App.Cli/Types/IpcHandlers/NxmIpcProtocolHandler.cs
@@ -170,6 +170,8 @@ public class NxmIpcProtocolHandler : IIpcProtocolHandler
         var library = _serviceProvider.GetRequiredService<ILibraryService>();
         var temporaryFileManager = _serviceProvider.GetRequiredService<TemporaryFileManager>();
 
+        _eventBus.Send(new UiMessages.AddedDownload());
+
         await using var destination = temporaryFileManager.CreateFile();
         var downloadJob = await nexusModsLibrary.CreateDownloadJob(destination, modUrl, cancellationToken: cancel);
 

--- a/src/NexusMods.App.UI/EventBus.cs
+++ b/src/NexusMods.App.UI/EventBus.cs
@@ -1,0 +1,135 @@
+using System.Diagnostics.CodeAnalysis;
+using DynamicData.Kernel;
+using JetBrains.Annotations;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using R3;
+
+namespace NexusMods.App.UI;
+
+[PublicAPI]
+public interface IEventBusMessage;
+
+[PublicAPI]
+public interface IEventBusRequest<TResult> : IEventBusMessage
+    where TResult : notnull;
+
+[PublicAPI]
+public interface IEventBusRequestHandler<in TRequest, TResult>
+    where TRequest : IEventBusRequest<TResult>
+    where TResult : notnull
+{
+    Task<TResult> Handle(TRequest request, CancellationToken cancellationToken);
+}
+
+[PublicAPI]
+public interface IEventBus
+{
+    /// <summary>
+    /// Sends a message.
+    /// </summary>
+    void Send<T>(T message) where T : IEventBusMessage;
+
+    /// <summary>
+    /// Sends a request as a message and returns task that completes when a handler responds with a result.
+    /// </summary>
+    Task<Optional<TResult>> SendAndReceive<TRequest, TResult>(TRequest request, CancellationToken cancellationToken)
+        where TRequest : IEventBusRequest<TResult>
+        where TResult : notnull;
+
+    /// <summary>
+    /// Observes incoming messages of type <typeparamref name="T"/>.
+    /// </summary>
+    Observable<T> ObserveMessages<T>() where T : IEventBusMessage;
+
+    /// <summary>
+    /// Observes all incoming messages.
+    /// </summary>
+    Observable<IEventBusMessage> ObserveAllMessages();
+}
+
+public sealed class EventBus : IEventBus, IDisposable
+{
+    private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(10);
+
+    private static IEventBus? _instance;
+    public static IEventBus Instance
+    {
+        get => _instance ?? throw new InvalidOperationException("Event Bus hasn't been registered yet");
+        private set
+        {
+            if (_instance is not null) throw new InvalidOperationException("Event Bus has already been registered");
+            _instance = value;
+        }
+    }
+
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger _logger;
+    private readonly Subject<IEventBusMessage> _messages = new();
+
+    public EventBus(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+        _logger = serviceProvider.GetRequiredService<ILogger<EventBus>>();
+
+        Instance = this;
+    }
+
+    [SuppressMessage("ReSharper", "HeapView.PossibleBoxingAllocation")]
+    public void Send<T>(T message) where T : IEventBusMessage
+    {
+        _logger.LogDebug("Received message of type `{Type}`: `{Message}`", typeof(T), message.ToString());
+        _messages.OnNext(message);
+    }
+
+    public Task<Optional<TResult>> SendAndReceive<TRequest, TResult>(TRequest request, CancellationToken cancellationToken)
+        where TRequest : IEventBusRequest<TResult>
+        where TResult : notnull
+    {
+        Send(request);
+
+        var requestHandler = _serviceProvider.GetService<IEventBusRequestHandler<TRequest, TResult>>();
+        if (requestHandler is null)
+        {
+            _logger.LogError("Found no request handler for request of type `{RequestType}` with result type `{ResultType}`: `{StringRepresentation}`", typeof(TRequest), typeof(TResult), request.ToString());
+            return Task.FromResult(Optional<TResult>.None);
+        }
+
+        var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(delay: DefaultTimeout);
+
+        return Inner();
+
+        async Task<Optional<TResult>> Inner()
+        {
+            try
+            {
+                return await requestHandler.Handle(request, cts.Token);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "Exception running request handler for request of type `{RequestType}` with result type `{ResultType}`: `{StringRepresentation}`", typeof(TRequest), typeof(TResult), request.ToString());
+                return Optional<TResult>.None;
+            }
+        }
+    }
+
+    public Observable<T> ObserveMessages<T>() where T : IEventBusMessage
+    {
+        return _messages.OfType<IEventBusMessage, T>();
+    }
+
+    public Observable<IEventBusMessage> ObserveAllMessages()
+    {
+        return _messages;
+    }
+
+    private bool _isDisposed;
+    public void Dispose()
+    {
+        if (_isDisposed) return;
+
+        _messages.Dispose();
+        _isDisposed = true;
+    }
+}

--- a/src/NexusMods.App.UI/EventBus.cs
+++ b/src/NexusMods.App.UI/EventBus.cs
@@ -1,52 +1,11 @@
 using System.Diagnostics.CodeAnalysis;
 using DynamicData.Kernel;
-using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using NexusMods.Abstractions.EventBus;
 using R3;
 
 namespace NexusMods.App.UI;
-
-[PublicAPI]
-public interface IEventBusMessage;
-
-[PublicAPI]
-public interface IEventBusRequest<TResult> : IEventBusMessage
-    where TResult : notnull;
-
-[PublicAPI]
-public interface IEventBusRequestHandler<in TRequest, TResult>
-    where TRequest : IEventBusRequest<TResult>
-    where TResult : notnull
-{
-    Task<TResult> Handle(TRequest request, CancellationToken cancellationToken);
-}
-
-[PublicAPI]
-public interface IEventBus
-{
-    /// <summary>
-    /// Sends a message.
-    /// </summary>
-    void Send<T>(T message) where T : IEventBusMessage;
-
-    /// <summary>
-    /// Sends a request as a message and returns task that completes when a handler responds with a result.
-    /// </summary>
-    Task<Optional<TResult>> SendAndReceive<TRequest, TResult>(TRequest request, CancellationToken cancellationToken)
-        where TRequest : IEventBusRequest<TResult>
-        where TResult : notnull;
-
-    /// <summary>
-    /// Observes incoming messages of type <typeparamref name="T"/>.
-    /// </summary>
-    Observable<T> ObserveMessages<T>() where T : IEventBusMessage;
-
-    /// <summary>
-    /// Observes all incoming messages.
-    /// </summary>
-    Observable<IEventBusMessage> ObserveAllMessages();
-}
 
 public sealed class EventBus : IEventBus, IDisposable
 {

--- a/src/NexusMods.App.UI/NexusMods.App.UI.csproj
+++ b/src/NexusMods.App.UI/NexusMods.App.UI.csproj
@@ -86,6 +86,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\Abstractions\NexusMods.Abstractions.EventBus\NexusMods.Abstractions.EventBus.csproj" />
         <ProjectReference Include="..\Abstractions\NexusMods.Abstractions.Logging\NexusMods.Abstractions.Logging.csproj" />
         <ProjectReference Include="..\Abstractions\NexusMods.Abstractions.NexusModsLibrary\NexusMods.Abstractions.NexusModsLibrary.csproj" />
         <ProjectReference Include="..\Abstractions\NexusMods.Abstractions.Resources.Caching\NexusMods.Abstractions.Resources.Caching.csproj" />
@@ -100,6 +101,7 @@
         <ProjectReference Include="..\Networking\NexusMods.Networking.Downloaders\NexusMods.Networking.Downloaders.csproj" />
         <ProjectReference Include="..\Networking\NexusMods.Networking.NexusWebApi\NexusMods.Networking.NexusWebApi.csproj" />
         <ProjectReference Include="..\NexusMods.App.BuildInfo\NexusMods.App.BuildInfo.csproj" />
+        <ProjectReference Include="..\NexusMods.App.Cli\NexusMods.App.Cli.csproj" />
         <ProjectReference Include="..\NexusMods.Collections\NexusMods.Collections.csproj" />
         <ProjectReference Include="..\NexusMods.Icons\NexusMods.Icons.csproj" />
         <ProjectReference Include="..\NexusMods.Media\NexusMods.Media.csproj" />

--- a/src/NexusMods.App.UI/Services.cs
+++ b/src/NexusMods.App.UI/Services.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.Diagnostics;
+using NexusMods.Abstractions.EventBus;
 using NexusMods.Abstractions.Serialization.ExpressionGenerator;
 using NexusMods.Abstractions.Serialization.Json;
 using NexusMods.App.UI.Controls.DataGrid;

--- a/src/NexusMods.App.UI/Services.cs
+++ b/src/NexusMods.App.UI/Services.cs
@@ -291,6 +291,7 @@ public static class Services
             .AddSingleton<ILibraryDataProvider, NexusModsDataProvider>()
             .AddSingleton<ILoadoutDataProvider, NexusModsDataProvider>()
             .AddSingleton<ILoadoutDataProvider, BundledDataProvider>()
+            .AddSingleton<IEventBus, EventBus>()
             .AddFileSystem()
             .AddImagePipelines();
     }

--- a/src/NexusMods.App.UI/Settings/BehaviorSettings.cs
+++ b/src/NexusMods.App.UI/Settings/BehaviorSettings.cs
@@ -1,0 +1,20 @@
+using NexusMods.Abstractions.Settings;
+
+namespace NexusMods.App.UI.Settings;
+
+public record BehaviorSettings : ISettings
+{
+    public bool BringWindowToFront { get; set; } = true;
+
+    public static ISettingsBuilder Configure(ISettingsBuilder settingsBuilder)
+    {
+        return settingsBuilder.AddToUI<BehaviorSettings>(builder => builder
+            .AddPropertyToUI(x => x.BringWindowToFront, propertyBuilder => propertyBuilder
+                .AddToSection(Sections.General)
+                .WithDisplayName("Bring app window to front")
+                .WithDescription("When enabled, operations like adding a collection will bring the app window to the foreground")
+                .UseBooleanContainer()
+            )
+        );
+    }
+}

--- a/src/NexusMods.App.UI/Settings/ServiceExtensions.cs
+++ b/src/NexusMods.App.UI/Settings/ServiceExtensions.cs
@@ -12,6 +12,7 @@ public static class ServiceExtensions
             .AddSettings<TextEditorSettings>()
             .AddSettings<AlphaSettings>()
             .AddSettings<LoginSettings>()
-            .AddSettings<AlertSettings>();
+            .AddSettings<AlertSettings>()
+            .AddSettings<BehaviorSettings>();
     }
 }

--- a/src/NexusMods.App.UI/UiMessages.cs
+++ b/src/NexusMods.App.UI/UiMessages.cs
@@ -5,4 +5,6 @@ namespace NexusMods.App.UI;
 public static class UiMessages
 {
     public record AddedCollection(CollectionRevisionMetadata.ReadOnly Revision) : IEventBusMessage;
+
+    public record AddedDownload() : IEventBusMessage;
 }

--- a/src/NexusMods.App.UI/UiMessages.cs
+++ b/src/NexusMods.App.UI/UiMessages.cs
@@ -1,0 +1,8 @@
+using NexusMods.Abstractions.NexusModsLibrary.Models;
+
+namespace NexusMods.App.UI;
+
+public static class UiMessages
+{
+    public record AddedCollection(CollectionRevisionMetadata.ReadOnly Revision) : IEventBusMessage;
+}

--- a/src/NexusMods.App.UI/Windows/IWorkspaceWindow.cs
+++ b/src/NexusMods.App.UI/Windows/IWorkspaceWindow.cs
@@ -27,5 +27,5 @@ public interface IWorkspaceWindow
     /// <summary>
     ///     This command is used to bring the window to front.
     /// </summary>
-    ReactiveCommand<Unit, Unit> BringWindowToFront { get; }
+    ReactiveCommand<Unit, bool> BringWindowToFront { get; }
 }

--- a/src/NexusMods.App.UI/Windows/MainWindow.axaml.cs
+++ b/src/NexusMods.App.UI/Windows/MainWindow.axaml.cs
@@ -50,6 +50,7 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
 
             this.WhenAnyObservable(view => view.ViewModel!.BringWindowToFront)
                 .OnUI()
+                .Where(static shouldBringToFront => shouldBringToFront)
                 .Subscribe(_ => {
                     if (WindowState == WindowState.Minimized)
                         WindowState = WindowState.Normal;

--- a/src/NexusMods.App.UI/Windows/MainWindowViewModel.cs
+++ b/src/NexusMods.App.UI/Windows/MainWindowViewModel.cs
@@ -1,6 +1,7 @@
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using Microsoft.Extensions.DependencyInjection;
+using NexusMods.Abstractions.EventBus;
 using NexusMods.Abstractions.Logging;
 using NexusMods.Abstractions.NexusWebApi;
 using NexusMods.Abstractions.Settings;
@@ -19,6 +20,7 @@ using NexusMods.App.UI.Overlays.Updater;
 using NexusMods.App.UI.Pages.CollectionDownload;
 using NexusMods.App.UI.Settings;
 using NexusMods.App.UI.WorkspaceSystem;
+using NexusMods.CLI;
 using R3;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
@@ -106,7 +108,7 @@ public class MainWindowViewModel : AViewModel<IMainWindowViewModel>, IMainWindow
                 .DisposeWith(d);
 
             eventBus
-                .ObserveMessages<UiMessages.AddedCollection>()
+                .ObserveMessages<CliMessages.AddedCollection>()
                 .ObserveOnUIThreadDispatcher()
                 .Subscribe(this, static (message, self) =>
                 {
@@ -131,7 +133,7 @@ public class MainWindowViewModel : AViewModel<IMainWindowViewModel>, IMainWindow
                 .DisposeWith(d);
 
             eventBus
-                .ObserveMessages<UiMessages.AddedDownload>()
+                .ObserveMessages<CliMessages.AddedDownload>()
                 .ObserveOnUIThreadDispatcher()
                 .Subscribe(this, static (message, self) =>
                 {

--- a/src/NexusMods.App.UI/Windows/MainWindowViewModel.cs
+++ b/src/NexusMods.App.UI/Windows/MainWindowViewModel.cs
@@ -130,6 +130,15 @@ public class MainWindowViewModel : AViewModel<IMainWindowViewModel>, IMainWindow
                 })
                 .DisposeWith(d);
 
+            eventBus
+                .ObserveMessages<UiMessages.AddedDownload>()
+                .ObserveOnUIThreadDispatcher()
+                .Subscribe(this, static (message, self) =>
+                {
+                    using var _ = self.BringWindowToFront.Execute(System.Reactive.Unit.Default).Subscribe();
+                })
+                .DisposeWith(d);
+
             R3.Disposable.Create(this, vm =>
             {
                 vm._windowManager.UnregisterWindow(vm);

--- a/src/NexusMods.App.UI/Windows/MainWindowViewModel.cs
+++ b/src/NexusMods.App.UI/Windows/MainWindowViewModel.cs
@@ -1,9 +1,9 @@
-using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.Logging;
 using NexusMods.Abstractions.NexusWebApi;
+using NexusMods.Abstractions.Settings;
 using NexusMods.Abstractions.UI;
 using NexusMods.App.UI.Controls.DevelopmentBuildBanner;
 using NexusMods.App.UI.Controls.Spine;
@@ -16,9 +16,14 @@ using NexusMods.App.UI.Overlays.Generic.MessageBox.Ok;
 using NexusMods.App.UI.Overlays.Login;
 using NexusMods.App.UI.Overlays.MetricsOptIn;
 using NexusMods.App.UI.Overlays.Updater;
+using NexusMods.App.UI.Pages.CollectionDownload;
+using NexusMods.App.UI.Settings;
 using NexusMods.App.UI.WorkspaceSystem;
+using R3;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
+using Disposable = System.Reactive.Disposables.Disposable;
+using ReactiveCommand = ReactiveUI.ReactiveCommand;
 
 namespace NexusMods.App.UI.Windows;
 
@@ -26,13 +31,15 @@ public class MainWindowViewModel : AViewModel<IMainWindowViewModel>, IMainWindow
 {
     private readonly IWindowManager _windowManager;
     
-    public ReactiveCommand<Unit, Unit> BringWindowToFront { get; } = ReactiveCommand.Create(() => { });
+    public ReactiveUI.ReactiveCommand<System.Reactive.Unit, bool> BringWindowToFront { get; }
 
     public MainWindowViewModel(
         IServiceProvider serviceProvider,
         IWindowManager windowManager,
         IOverlayController overlayController,
-        ILoginManager loginManager)
+        ILoginManager loginManager,
+        IEventBus eventBus,
+        ISettingsManager settingsManager)
     {
         // NOTE(erri120): can't use DI for VMs that require an active Window because
         // those VMs would be instantiated before this constructor gets called.
@@ -50,7 +57,9 @@ public class MainWindowViewModel : AViewModel<IMainWindowViewModel>, IMainWindow
 
         Spine = serviceProvider.GetRequiredService<ISpineViewModel>();
         DevelopmentBuildBanner = serviceProvider.GetRequiredService<IDevelopmentBuildBannerViewModel>();
-        
+
+        BringWindowToFront = ReactiveCommand.Create(() => settingsManager.Get<BehaviorSettings>().BringWindowToFront);
+
         this.WhenActivated(d =>
         {
             ConnectErrors(serviceProvider)
@@ -74,7 +83,7 @@ public class MainWindowViewModel : AViewModel<IMainWindowViewModel>, IMainWindow
             loginManager.IsLoggedInObservable
                 .DistinctUntilChanged()
                 .Where(isSignedIn => isSignedIn)
-                .Select(_ => Unit.Default)
+                .Select(_ => System.Reactive.Unit.Default)
                 .InvokeReactiveCommand(BringWindowToFront)
                 .DisposeWith(d);
             
@@ -96,7 +105,32 @@ public class MainWindowViewModel : AViewModel<IMainWindowViewModel>, IMainWindow
                 .BindTo(this, vm => vm.CurrentOverlay)
                 .DisposeWith(d);
 
-            Disposable.Create(this, vm =>
+            eventBus
+                .ObserveMessages<UiMessages.AddedCollection>()
+                .ObserveOnUIThreadDispatcher()
+                .Subscribe(this, static (message, self) =>
+                {
+                    var workspaceController = self.WorkspaceController;
+                    if (workspaceController.ActiveWorkspace.Context is not LoadoutContext loadoutContext) return;
+
+                    var pageData = new PageData
+                    {
+                        FactoryId = CollectionDownloadPageFactory.StaticId,
+                        Context = new CollectionDownloadPageContext
+                        {
+                            TargetLoadout = loadoutContext.LoadoutId,
+                            CollectionRevisionMetadataId = message.Revision,
+                        },
+                    };
+
+                    var behavior = workspaceController.GetDefaultOpenPageBehavior(pageData, NavigationInput.Default);
+                    workspaceController.OpenPage(workspaceController.ActiveWorkspaceId, pageData, behavior);
+
+                    using var _ = self.BringWindowToFront.Execute(System.Reactive.Unit.Default).Subscribe();
+                })
+                .DisposeWith(d);
+
+            R3.Disposable.Create(this, vm =>
             {
                 vm._windowManager.UnregisterWindow(vm);
             }).DisposeWith(d);
@@ -152,7 +186,6 @@ public class MainWindowViewModel : AViewModel<IMainWindowViewModel>, IMainWindow
 
     /// <inheritdoc/>
     public IWorkspaceController WorkspaceController { get; }
-
 
     [Reactive] public ISpineViewModel Spine { get; set; }
 


### PR DESCRIPTION
- Implements a simple event bus (Resolves #1537)
- Opens the collection download page when a collection gets added and brings the app window to the front (resolves #2548)
- Brings the app window to the front when a download is added (resolves #2689)
- Adds a setting for users to toggle the behavior of bringing the app window to the front