### PR TITLE
Add tests for Stardew Valley diagnostic emitters

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Games/AGame.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Games/AGame.cs
@@ -101,7 +101,7 @@ public abstract class AGame : IGame
     /// Returns a game specific version of the game, usually from the primary executable.
     /// Usually used for game specific diagnostics.
     /// </summary>
-    public virtual Version GetLocalVersion(GameInstallMetadata.ReadOnly installation)
+    public virtual Optional<Version> GetLocalVersion(GameInstallMetadata.ReadOnly installation)
     {
         try
         {
@@ -112,7 +112,7 @@ public abstract class AGame : IGame
         }
         catch (Exception)
         {
-            return new Version(0, 0, 0, 0);
+            return Optional<Version>.None;
         }
     }
 

--- a/src/Games/NexusMods.Games.Larian/BaldursGate3/BaldursGate3.cs
+++ b/src/Games/NexusMods.Games.Larian/BaldursGate3/BaldursGate3.cs
@@ -1,3 +1,4 @@
+using DynamicData.Kernel;
 using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.Diagnostics.Emitters;
 using NexusMods.Abstractions.GameLocators;
@@ -46,7 +47,7 @@ public class BaldursGate3 : AGame, ISteamGame, IGogGame
         _fs = provider.GetRequiredService<IFileSystem>();
     }
     
-    public override Version GetLocalVersion(GameInstallMetadata.ReadOnly installation)
+    public override Optional<Version> GetLocalVersion(GameInstallMetadata.ReadOnly installation)
     {
         try
         {
@@ -62,7 +63,7 @@ public class BaldursGate3 : AGame, ISteamGame, IGogGame
         }
         catch (Exception)
         {
-            return new Version(0, 0, 0, 0);
+            return Optional<Version>.None;
         }
     }
 

--- a/src/Games/NexusMods.Games.MountAndBlade2Bannerlord/Bannerlord.cs
+++ b/src/Games/NexusMods.Games.MountAndBlade2Bannerlord/Bannerlord.cs
@@ -1,4 +1,5 @@
 using Bannerlord.ModuleManager;
+using DynamicData.Kernel;
 using FetchBannerlordVersion;
 using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.Diagnostics.Emitters;
@@ -82,7 +83,7 @@ public sealed class Bannerlord : AGame, ISteamGame, IGogGame, IEpicGame, IXboxGa
 
     public override GamePath GetPrimaryFile(GameStore store) => GamePathProvier.PrimaryLauncherFile(store);
 
-    public override Version GetLocalVersion(GameInstallMetadata.ReadOnly installation)
+    public override Optional<Version> GetLocalVersion(GameInstallMetadata.ReadOnly installation)
     {
         // Note(sewer): Bannerlord can use prefixes on versions etc. ,we want to strip them out
         // so we sanitize/parse with `ApplicationVersion`.

--- a/src/Games/NexusMods.Games.StardewValley/Emitters/DependencyDiagnosticEmitter.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/DependencyDiagnosticEmitter.cs
@@ -39,7 +39,7 @@ public class DependencyDiagnosticEmitter : ILoadoutDiagnosticEmitter
 
     public async IAsyncEnumerable<Diagnostic> Diagnose(Loadout.ReadOnly loadout, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        var gameVersion = new SemanticVersion((loadout.InstallationInstance.Game as AGame)!.GetLocalVersion(loadout.Installation));
+        var gameVersion = Helpers.GetGameVersion(loadout);
 
         if (!Helpers.TryGetSMAPI(loadout, out var smapi)) yield break;
         if (!SMAPILoadoutItem.Version.TryGetValue(smapi, out var smapiStrVersion)) yield break;

--- a/src/Games/NexusMods.Games.StardewValley/Emitters/SMAPIGameVersionDiagnosticEmitter.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/SMAPIGameVersionDiagnosticEmitter.cs
@@ -187,14 +187,14 @@ public class SMAPIGameVersionDiagnosticEmitter : ILoadoutDiagnosticEmitter
     /// <summary>
     /// Returns the latest supported SMAPI version for <paramref name="gameVersion"/>.
     /// </summary>
-    private static bool TryGetLastSupportedSMAPIVersion(
+    internal static bool TryGetLastSupportedSMAPIVersion(
         GameToSMAPIMapping gameToSmapiMappings,
         ISemanticVersion gameVersion,
         [NotNullWhen(true)] out ISemanticVersion? supportedSMAPIVersion)
     {
         var found = gameToSmapiMappings
             .OrderByDescending(static kv => kv.Key)
-            .SkipWhile(current => current.Key.CompareTo(gameVersion) >= 0)
+            .SkipWhile(current => current.Key.CompareTo(gameVersion) > 0)
             .TryGetFirst(out var mapping);
 
         if (!found)
@@ -245,7 +245,7 @@ public class SMAPIGameVersionDiagnosticEmitter : ILoadoutDiagnosticEmitter
     private SMAPIToGameMapping? _smapiToGameMappings;
     private GameToSMAPIMapping? _gameToSMAPIMappings;
 
-    private async Task<SMAPIToGameMapping?> FetchSMAPIToGameMappings(CancellationToken cancellationToken)
+    internal async Task<SMAPIToGameMapping?> FetchSMAPIToGameMappings(CancellationToken cancellationToken)
     {
         if (_smapiToGameMappings is not null) return _smapiToGameMappings;
 
@@ -276,7 +276,7 @@ public class SMAPIGameVersionDiagnosticEmitter : ILoadoutDiagnosticEmitter
 
     }
 
-    private async Task<GameToSMAPIMapping?> FetchGameToSMAPIMappings(CancellationToken cancellationToken)
+    internal async Task<GameToSMAPIMapping?> FetchGameToSMAPIMappings(CancellationToken cancellationToken)
     {
         if (_gameToSMAPIMappings is not null) return _gameToSMAPIMappings;
 
@@ -319,7 +319,6 @@ public class SMAPIGameVersionDiagnosticEmitter : ILoadoutDiagnosticEmitter
 
             _logger.LogWarning("Serialization of JSON data at {Uri} failed and returned null", dataUri);
             return null;
-
         }
         catch (Exception e)
         {

--- a/src/Games/NexusMods.Games.StardewValley/Emitters/SMAPIGameVersionDiagnosticEmitter.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/SMAPIGameVersionDiagnosticEmitter.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Http.Json;
 using System.Runtime.CompilerServices;
+using DynamicData.Kernel;
 using JetBrains.Annotations;
 using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.Diagnostics;
@@ -42,7 +43,7 @@ public class SMAPIGameVersionDiagnosticEmitter : ILoadoutDiagnosticEmitter
         var gameToSMAPIMappings = await FetchGameToSMAPIMappings(cancellationToken);
         if (gameToSMAPIMappings is null) yield break;
 
-        var gameVersion = new SemanticVersion((loadout.InstallationInstance.Game as AGame)!.GetLocalVersion(loadout.Installation));
+        var gameVersion = Helpers.GetGameVersion(loadout);
         // var gameVersion = new SemanticVersion("1.6.12");
 
         if (!Helpers.TryGetSMAPI(loadout, out var smapi))

--- a/src/Games/NexusMods.Games.StardewValley/Emitters/SMAPIModDatabaseCompatibilityDiagnosticEmitter.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/SMAPIModDatabaseCompatibilityDiagnosticEmitter.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using DynamicData.Kernel;
 using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.Diagnostics;
 using NexusMods.Abstractions.Diagnostics.Emitters;
@@ -59,7 +60,7 @@ public class SMAPIModDatabaseCompatibilityDiagnosticEmitter : ILoadoutDiagnostic
 
     public async IAsyncEnumerable<Diagnostic> Diagnose(Loadout.ReadOnly loadout, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        var gameVersion = new SemanticVersion((loadout.InstallationInstance.Game as AGame)!.GetLocalVersion(loadout.Installation));
+        var gameVersion = Helpers.GetGameVersion(loadout);
 
         if (!Helpers.TryGetSMAPI(loadout, out var smapi)) yield break;
         if (!SMAPILoadoutItem.Version.TryGetValue(smapi, out var smapiStrVersion)) yield break;

--- a/src/Games/NexusMods.Games.StardewValley/Emitters/VersionDiagnosticEmitter.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/VersionDiagnosticEmitter.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using DynamicData.Kernel;
 using JetBrains.Annotations;
 using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.Diagnostics;
@@ -37,7 +38,7 @@ public class VersionDiagnosticEmitter : ILoadoutDiagnosticEmitter
 
     public async IAsyncEnumerable<Diagnostic> Diagnose(Loadout.ReadOnly loadout, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        var gameVersion = new SemanticVersion((loadout.InstallationInstance.Game as AGame)!.GetLocalVersion(loadout.Installation));
+        var gameVersion = Helpers.GetGameVersion(loadout);
 
         if (!Helpers.TryGetSMAPI(loadout, out var smapi)) yield break;
         if (!SMAPILoadoutItem.Version.TryGetValue(smapi, out var smapiStrVersion)) yield break;

--- a/src/Games/NexusMods.Games.StardewValley/Resources/DiagnosticsTests/DisabledRequiredDependency.txt
+++ b/src/Games/NexusMods.Games.StardewValley/Resources/DiagnosticsTests/DisabledRequiredDependency.txt
@@ -1,4 +1,0 @@
-1. Install SMAPI
-2. Install v1.9.2 of Content Patcher: https://www.nexusmods.com/Core/Libs/Common/Widgets/DownloadPopUp?id=18130&game_id=1303&nmm=1
-3. Install Farm Type Manager: https://www.nexusmods.com/Core/Libs/Common/Widgets/DownloadPopUp?id=117244&game_id=1303
-4. Disable Content Patcher.

--- a/src/Games/NexusMods.Games.StardewValley/Resources/DiagnosticsTests/GameVersionNewerThanMaximumGameVersion.txt
+++ b/src/Games/NexusMods.Games.StardewValley/Resources/DiagnosticsTests/GameVersionNewerThanMaximumGameVersion.txt
@@ -1,2 +1,0 @@
-1. Install Stardew Valley 1.6.14
-2. Install SMAPI 3.18.6 https://www.nexusmods.com/stardewvalley/mods/2400?tab=files&file_id=76802&nmm=1

--- a/src/Games/NexusMods.Games.StardewValley/Resources/DiagnosticsTests/GameVersionOlderThanMinimumGameVersion.txt
+++ b/src/Games/NexusMods.Games.StardewValley/Resources/DiagnosticsTests/GameVersionOlderThanMinimumGameVersion.txt
@@ -1,2 +1,0 @@
-1. Install Stardew Valley 1.6.13 or older.
-2. Install SMAPI 4.1.10 https://www.nexusmods.com/stardewvalley/mods/2400?tab=files&file_id=119630&nmm=1

--- a/src/Games/NexusMods.Games.StardewValley/Resources/DiagnosticsTests/GameVersionOlderThanModMinimumGameVersion.txt
+++ b/src/Games/NexusMods.Games.StardewValley/Resources/DiagnosticsTests/GameVersionOlderThanModMinimumGameVersion.txt
@@ -1,3 +1,0 @@
-1. Install Stardew Valley 1.6.13 or older
-1. Install SMAPI.
-2. Install Generic Mod Config Menu 1.14.1 https://www.nexusmods.com/stardewvalley/mods/5098?tab=files&file_id=117566&nmm=1

--- a/src/Games/NexusMods.Games.StardewValley/Resources/DiagnosticsTests/MissingRequiredDependency.txt
+++ b/src/Games/NexusMods.Games.StardewValley/Resources/DiagnosticsTests/MissingRequiredDependency.txt
@@ -1,2 +1,0 @@
-1. Install SMAPI
-2. Install a mod that requires the Content Patcher, e.g. https://www.nexusmods.com/Core/Libs/Common/Widgets/DownloadPopUp?id=117244&game_id=1303

--- a/src/Games/NexusMods.Games.StardewValley/Resources/DiagnosticsTests/ModCompatabilityAssumeBroken.txt
+++ b/src/Games/NexusMods.Games.StardewValley/Resources/DiagnosticsTests/ModCompatabilityAssumeBroken.txt
@@ -1,1 +1,0 @@
-1. Install https://www.nexusmods.com/stardewvalley/mods/16881

--- a/src/Games/NexusMods.Games.StardewValley/Resources/DiagnosticsTests/ModCompatabilityObsolete.txt
+++ b/src/Games/NexusMods.Games.StardewValley/Resources/DiagnosticsTests/ModCompatabilityObsolete.txt
@@ -1,1 +1,0 @@
-No example has been found.

--- a/src/Games/NexusMods.Games.StardewValley/Resources/DiagnosticsTests/ModOverwritesGameFiles.txt
+++ b/src/Games/NexusMods.Games.StardewValley/Resources/DiagnosticsTests/ModOverwritesGameFiles.txt
@@ -1,2 +1,0 @@
-1. Install https://www.nexusmods.com/stardewvalley/mods/1090?tab=files&file_id=4275&nmm=1
-2. Using the advanced installed, map the "Maps" folder to Game/Content.

--- a/src/Games/NexusMods.Games.StardewValley/Resources/DiagnosticsTests/RequiredDependencyIsOutdated.txt
+++ b/src/Games/NexusMods.Games.StardewValley/Resources/DiagnosticsTests/RequiredDependencyIsOutdated.txt
@@ -1,3 +1,0 @@
-1. Install SMAPI
-2. Install v1.9.2 of Content Patcher: https://www.nexusmods.com/Core/Libs/Common/Widgets/DownloadPopUp?id=18130&game_id=1303&nmm=1
-3. Install Farm Type Manager: https://www.nexusmods.com/Core/Libs/Common/Widgets/DownloadPopUp?id=117244&game_id=1303

--- a/src/Games/NexusMods.Games.StardewValley/Resources/DiagnosticsTests/SMAPIRequiredButDisabled.txt
+++ b/src/Games/NexusMods.Games.StardewValley/Resources/DiagnosticsTests/SMAPIRequiredButDisabled.txt
@@ -1,3 +1,0 @@
-1. Install SMAPI
-2. Install Content Patcher https://www.nexusmods.com/stardewvalley/mods/1915
-3. Disable SMAPI

--- a/src/Games/NexusMods.Games.StardewValley/Resources/DiagnosticsTests/SMAPIRequiredButNotInstalled.txt
+++ b/src/Games/NexusMods.Games.StardewValley/Resources/DiagnosticsTests/SMAPIRequiredButNotInstalled.txt
@@ -1,2 +1,0 @@
-1. Install Content Patcher https://www.nexusmods.com/stardewvalley/mods/1915
-2. Ensure SMAPI is not present in any collections.

--- a/src/Games/NexusMods.Games.StardewValley/Resources/DiagnosticsTests/SMAPIVersionOlderThanMinimumAPIVersion.txt
+++ b/src/Games/NexusMods.Games.StardewValley/Resources/DiagnosticsTests/SMAPIVersionOlderThanMinimumAPIVersion.txt
@@ -1,2 +1,0 @@
-1. Install SMAPI 4.0.8 https://www.nexusmods.com/stardewvalley/mods/2400?tab=files&file_id=94412&nmm=1
-2. Install Content Patcher 2.5.3 https://www.nexusmods.com/stardewvalley/mods/1915?tab=files&file_id=124659&nmm=1

--- a/src/Games/NexusMods.Games.StardewValley/Resources/DiagnosticsTests/SuggestSMAPIVersion.txt
+++ b/src/Games/NexusMods.Games.StardewValley/Resources/DiagnosticsTests/SuggestSMAPIVersion.txt
@@ -1,1 +1,0 @@
-1. Manage Stardew Valley with no mods installed.

--- a/src/Games/NexusMods.Games.StardewValley/StardewValley.cs
+++ b/src/Games/NexusMods.Games.StardewValley/StardewValley.cs
@@ -77,7 +77,7 @@ public class StardewValley : AGame, ISteamGame, IGogGame, IXboxGame
         return Optional<GamePath>.Create(path);
     }
 
-    public override Version GetLocalVersion(GameInstallMetadata.ReadOnly installation)
+    public override Optional<Version> GetLocalVersion(GameInstallMetadata.ReadOnly installation)
     {
         try
         {
@@ -92,7 +92,7 @@ public class StardewValley : AGame, ISteamGame, IGogGame, IXboxGame
         }
         catch (Exception)
         {
-            return new Version(0, 0, 0, 0);
+            return Optional<Version>.None;
         }
     }
 

--- a/src/NexusMods.App.UI/DiagnosticSystem/Services.cs
+++ b/src/NexusMods.App.UI/DiagnosticSystem/Services.cs
@@ -1,0 +1,16 @@
+using Microsoft.Extensions.DependencyInjection;
+using NexusMods.Abstractions.Diagnostics;
+
+namespace NexusMods.App.UI.DiagnosticSystem;
+
+public static class Services
+{
+    public static IServiceCollection AddDiagnosticWriter(this IServiceCollection serviceCollection)
+    {
+        return serviceCollection
+            .AddSingleton<IValueFormatter, LoadoutReferenceFormatter>()
+            .AddSingleton<IValueFormatter, NamedLinkFormatter>()
+            .AddSingleton<IValueFormatter, LoadoutItemGroupFormatter>()
+            .AddSingleton<IDiagnosticWriter, DiagnosticWriter>();
+    }
+}

--- a/src/NexusMods.App.UI/Services.cs
+++ b/src/NexusMods.App.UI/Services.cs
@@ -273,11 +273,8 @@ public static class Services
             .AddSingleton<IWorkspaceAttachmentsFactory, LoadoutAttachmentsFactory>()
 
             // Diagnostics
-            .AddSingleton<IValueFormatter, LoadoutReferenceFormatter>()
-            .AddSingleton<IValueFormatter, NamedLinkFormatter>()
-            .AddSingleton<IValueFormatter, LoadoutItemGroupFormatter>()
-            .AddSingleton<IDiagnosticWriter, DiagnosticWriter>()
-            
+            .AddDiagnosticWriter()
+
             // Overlay Helpers
             .AddHostedService<NexusLoginOverlayService>()
 

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/DependencyDiagnosticEmitterTests.Test_DisabledRequiredDependencyMessageData.verified.txt
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/DependencyDiagnosticEmitterTests.Test_DisabledRequiredDependencyMessageData.verified.txt
@@ -1,0 +1,17 @@
+﻿[Id] NexusMods.Games.StardewValley: 5
+[Title] Disabled Dependency
+[Summary] 'Farm Type Manager' requires 'Content Patcher' but it is disabled
+[Details]
+The mod **Farm Type Manager** requires **Content Patcher** to function, but **Content Patcher** is not enabled.
+
+
+### How to Resolve
+1. Enable **Content Patcher** in "Installed Mods"
+
+### Technical Details
+The `manifest.json` file included with **Farm Type Manager** lists **Content Patcher** as a requirement in order function. 
+
+The issue can arise in these scenarios:
+
+1. **Disabled Mod**: The required mod is disabled in the loadout
+2. **Incorrect Mod ID**: The manifest data for **Farm Type Manager** might be incorrect

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/DependencyDiagnosticEmitterTests.Test_MissingRequiredDependency.verified.txt
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/DependencyDiagnosticEmitterTests.Test_MissingRequiredDependency.verified.txt
@@ -1,0 +1,19 @@
+﻿[Id] NexusMods.Games.StardewValley: 1
+[Title] Missing Dependency
+[Summary] 'Farm Type Manager' requires 'Content Patcher' which is not installed
+[Details]
+The mod **Farm Type Manager** requires **Content Patcher** to function, but **Content Patcher** is not installed.
+
+
+### How to Resolve
+1. Download **Content Patcher** from [Nexus Mods](https://nexusmods.com/stardewvalley/mods/1915?mtm_source=nexusmodsapp&mtm_campaign=diagnostics)
+2. Add **Content Patcher** to the loadout. 
+
+### Technical Details
+The `manifest.json` file included with **Farm Type Manager** lists a mod with the ID `Pathoschild.ContentPatcher` as a requirement or is using it as a framework in order function. 
+
+The issue can arise in these scenarios:
+
+1. **Missing Installation**: The required mod is not installed
+2. **Incorrect Mod ID**: The manifest data for **Farm Type Manager** might be incorrect
+

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/DependencyDiagnosticEmitterTests.Test_RequiredDependencyIsOutdated.verified.txt
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/DependencyDiagnosticEmitterTests.Test_RequiredDependencyIsOutdated.verified.txt
@@ -1,0 +1,13 @@
+﻿[Id] NexusMods.Games.StardewValley: 2
+[Title] Outdated Dependency
+[Summary] 'Farm Type Manager' requires an updated version of 'Content Patcher'
+[Details]
+The mod **Farm Type Manager** requires **Content Patcher** version 2.0.0 or higher to function, but an older version of **Content Patcher** (1.30.4) is installed.
+
+### How to Resolve
+1. Download the latest version of **Content Patcher** (version 2.0.0 or newer) from [Nexus Mods](https://nexusmods.com/stardewvalley/mods/1915?mtm_source=nexusmodsapp&mtm_campaign=diagnostics)
+2. Add the latest version of **Content Patcher** to the loadout
+3. Remove version 1.30.4 of **Content Patcher** from the loadout
+
+### Technical Details
+The `manifest.json` file included with **Farm Type Manager** lists **Content Patcher** as a requirement with a minimum version of 2.0.0. 

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/DependencyDiagnosticEmitterTests.cs
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/DependencyDiagnosticEmitterTests.cs
@@ -42,6 +42,8 @@ public class DependencyDiagnosticEmitterTests : ALoadoutDiagnosticEmitterTest<De
         await InstallModFromNexusMods(loadout, ModId.From(1915), FileId.From(124659));
 
         await ShouldHaveNoDiagnostics(loadout, because: "The required dependency Content Patcher has been installed");
+
+        await VerifyDiagnostic(diagnostic);
     }
 
     [Fact]
@@ -70,6 +72,8 @@ public class DependencyDiagnosticEmitterTests : ALoadoutDiagnosticEmitterTest<De
 
         var dependent = disabledRequiredDependencyMessageData.SMAPIMod.ResolveData(ServiceProvider, Connection);
         dependent.AsLoadoutItem().ParentId.Should().Be(farmTypeManager.LoadoutItemGroupId, because: "Farm Type Manager is the dependent");
+
+        await VerifyDiagnostic(diagnostic);
     }
 
     [Fact]
@@ -97,5 +101,7 @@ public class DependencyDiagnosticEmitterTests : ALoadoutDiagnosticEmitterTest<De
 
         var dependent = requiredDependencyIsOutdatedMessageData.Dependent.ResolveData(ServiceProvider, Connection);
         dependent.AsLoadoutItem().ParentId.Should().Be(farmTypeManager.LoadoutItemGroupId, because: "Farm Type Manager is the dependent");
+
+        await VerifyDiagnostic(diagnostic);
     }
 }

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/DependencyDiagnosticEmitterTests.cs
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/DependencyDiagnosticEmitterTests.cs
@@ -1,0 +1,105 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using NexusMods.Abstractions.Diagnostics;
+using NexusMods.Abstractions.Loadouts;
+using NexusMods.Abstractions.NexusWebApi.Types.V2;
+using NexusMods.Games.StardewValley.Emitters;
+using NexusMods.Games.TestFramework;
+using NexusMods.MnemonicDB.Abstractions.ElementComparers;
+using NexusMods.StandardGameLocators.TestHelpers;
+using Xunit.Abstractions;
+
+namespace NexusMods.Games.StardewValley.Tests;
+
+[Trait("RequiresNetworking", "True")]
+public class DependencyDiagnosticEmitterTests : ALoadoutDiagnosticEmitterTest<DependencyDiagnosticEmitterTests, StardewValley, DependencyDiagnosticEmitter>
+{
+    public DependencyDiagnosticEmitterTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper) { }
+
+    protected override IServiceCollection AddServices(IServiceCollection services)
+    {
+        return base.AddServices(services)
+            .AddStardewValley()
+            .AddUniversalGameLocator<StardewValley>(new Version("1.6.14"));
+    }
+
+    [Fact]
+    public async Task Test_MissingRequiredDependency()
+    {
+        var loadout = await CreateLoadout();
+
+        // SMAPI 4.1.10 (https://www.nexusmods.com/stardewvalley/mods/2400?tab=files)
+        await InstallModFromNexusMods(loadout, ModId.From(2400), FileId.From(119630));
+
+        // Farm Type Manager 1.24.0 (https://www.nexusmods.com/stardewvalley/mods/3231?tab=files)
+        await InstallModFromNexusMods(loadout, ModId.From(3231), FileId.From(117244));
+
+        var diagnostic = await GetSingleDiagnostic(loadout);
+        var missingRequiredDependencyMessageData = diagnostic.Should().BeOfType<Diagnostic<Diagnostics.MissingRequiredDependencyMessageData>>(because: "Content Patcher is required for Farm Type Manager").Which.MessageData;
+        missingRequiredDependencyMessageData.MissingDependencyModId.Should().Be("Pathoschild.ContentPatcher", because: "Farm Type Manager requires Content Patcher");
+
+        // Content Patcher 2.5.3 (https://www.nexusmods.com/stardewvalley/mods/1915?tab=files)
+        await InstallModFromNexusMods(loadout, ModId.From(1915), FileId.From(124659));
+
+        await ShouldHaveNoDiagnostics(loadout, because: "The required dependency Content Patcher has been installed");
+    }
+
+    [Fact]
+    public async Task Test_DisabledRequiredDependencyMessageData()
+    {
+        var loadout = await CreateLoadout();
+
+        // SMAPI 4.1.10 (https://www.nexusmods.com/stardewvalley/mods/2400?tab=files)
+        await InstallModFromNexusMods(loadout, ModId.From(2400), FileId.From(119630));
+
+        // Farm Type Manager 1.24.0 (https://www.nexusmods.com/stardewvalley/mods/3231?tab=files)
+        var farmTypeManager = await InstallModFromNexusMods(loadout, ModId.From(3231), FileId.From(117244));
+
+        // Content Patcher 2.5.3 (https://www.nexusmods.com/stardewvalley/mods/1915?tab=files)
+        var contentPatcher = await InstallModFromNexusMods(loadout, ModId.From(1915), FileId.From(124659));
+
+        await ShouldHaveNoDiagnostics(loadout, because: "All required dependencies are installed and enabled");
+
+        {
+            using var tx = Connection.BeginTransaction();
+            tx.Add(contentPatcher.Id, LoadoutItem.Disabled, Null.Instance);
+            await tx.Commit();
+        }
+
+        var diagnostic = await GetSingleDiagnostic(loadout);
+        var disabledRequiredDependencyMessageData = diagnostic.Should().BeOfType<Diagnostic<Diagnostics.DisabledRequiredDependencyMessageData>>(because: "Content Patcher is disabled and required by Farm Type Manager").Which.MessageData;
+
+        var dependency = disabledRequiredDependencyMessageData.Dependency.ResolveData(ServiceProvider, Connection);
+        dependency.AsLoadoutItem().ParentId.Should().Be(contentPatcher.LoadoutItemGroupId, because: "Content Patcher is the dependency");
+
+        var dependent = disabledRequiredDependencyMessageData.SMAPIMod.ResolveData(ServiceProvider, Connection);
+        dependent.AsLoadoutItem().ParentId.Should().Be(farmTypeManager.LoadoutItemGroupId, because: "Farm Type Manager is the dependent");
+    }
+
+    [Fact]
+    public async Task Test_RequiredDependencyIsOutdated()
+    {
+        var loadout = await CreateLoadout();
+
+        // SMAPI 4.1.10 (https://www.nexusmods.com/stardewvalley/mods/2400?tab=files)
+        await InstallModFromNexusMods(loadout, ModId.From(2400), FileId.From(119630));
+
+        // Farm Type Manager 1.24.0 (https://www.nexusmods.com/stardewvalley/mods/3231?tab=files)
+        var farmTypeManager = await InstallModFromNexusMods(loadout, ModId.From(3231), FileId.From(117244));
+
+        // Content Patcher 1.30.4 (https://www.nexusmods.com/stardewvalley/mods/1915?tab=files)
+        var contentPatcher = await InstallModFromNexusMods(loadout, ModId.From(1915), FileId.From(78987));
+
+        var diagnostic = await GetSingleDiagnostic(loadout);
+        var requiredDependencyIsOutdatedMessageData = diagnostic.Should().BeOfType<Diagnostic<Diagnostics.RequiredDependencyIsOutdatedMessageData>>(because: "Content Patcher is outdated and required by Farm Type Manager").Which.MessageData;
+
+        requiredDependencyIsOutdatedMessageData.CurrentVersion.Should().Be("1.30.4", because: "Content Patcher 1.30.4 was installed");
+        requiredDependencyIsOutdatedMessageData.MinimumVersion.Should().Be("2.0.0", because: "Farm Type Manager 1.24.0 requires at least version 2.0.0 of Content Patcher");
+
+        var dependency = requiredDependencyIsOutdatedMessageData.Dependency.ResolveData(ServiceProvider, Connection);
+        dependency.AsLoadoutItem().ParentId.Should().Be(contentPatcher.LoadoutItemGroupId, because: "Content Patcher is the dependency");
+
+        var dependent = requiredDependencyIsOutdatedMessageData.Dependent.ResolveData(ServiceProvider, Connection);
+        dependent.AsLoadoutItem().ParentId.Should().Be(farmTypeManager.LoadoutItemGroupId, because: "Farm Type Manager is the dependent");
+    }
+}

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/DependencyDiagnosticEmitterTests.cs
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/DependencyDiagnosticEmitterTests.cs
@@ -60,11 +60,7 @@ public class DependencyDiagnosticEmitterTests : ALoadoutDiagnosticEmitterTest<De
 
         await ShouldHaveNoDiagnostics(loadout, because: "All required dependencies are installed and enabled");
 
-        {
-            using var tx = Connection.BeginTransaction();
-            tx.Add(contentPatcher.Id, LoadoutItem.Disabled, Null.Instance);
-            await tx.Commit();
-        }
+        await DisabledMod(contentPatcher);
 
         var diagnostic = await GetSingleDiagnostic(loadout);
         var disabledRequiredDependencyMessageData = diagnostic.Should().BeOfType<Diagnostic<Diagnostics.DisabledRequiredDependencyMessageData>>(because: "Content Patcher is disabled and required by Farm Type Manager").Which.MessageData;

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/MissingSMAPIEmitterTests.Test_SMAPIRequiredButDisabled.verified.txt
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/MissingSMAPIEmitterTests.Test_SMAPIRequiredButDisabled.verified.txt
@@ -1,0 +1,11 @@
+﻿[Id] NexusMods.Games.StardewValley: 4
+[Title] SMAPI is not enabled
+[Summary] Stardew Modding API (SMAPI) is required for 2 mod(s) but it's not enabled
+[Details]
+Stardew Modding API (SMAPI) is the mod loader required to run mods for Stardew Valley. The loadout contains 2 mod(s) that require SMAPI to work, but it is not enabled.
+
+### How to Resolve
+1. Enable SMAPI in "Installed Mods".
+
+### Technical Details
+Stardew Modding API (SMAPI) is required for most types of Stardew Valley mod as it provides core features that allow mod content to be loaded into the game.    

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/MissingSMAPIEmitterTests.Test_SMAPIRequiredButNotInstalled.verified.txt
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/MissingSMAPIEmitterTests.Test_SMAPIRequiredButNotInstalled.verified.txt
@@ -1,0 +1,12 @@
+﻿[Id] NexusMods.Games.StardewValley: 3
+[Title] SMAPI is not installed
+[Summary] Stardew Modding API (SMAPI) is required for 2 mod(s) but is not installed
+[Details]
+Stardew Modding API (SMAPI) is the mod loader required to run mods for Stardew Valley. The loadout contains 2 mod(s) that require SMAPI to work, but it is not installed.
+
+### How to Resolve
+1. Download Stardew Modding API (SMAPI) from [Nexus Mods](https://nexusmods.com/stardewvalley/mods/2400?mtm_source=nexusmodsapp&mtm_campaign=diagnostics)
+2. Add SMAPI to the loadout
+
+### Technical Details
+Stardew Modding API (SMAPI) is required for most types of Stardew Valley mod as it provides core features that allow mod content to be loaded into the game.

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/MissingSMAPIEmitterTests.cs
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/MissingSMAPIEmitterTests.cs
@@ -41,6 +41,8 @@ public class MissingSMAPIEmitterTests : ALoadoutDiagnosticEmitterTest<Dependency
         await InstallModFromNexusMods(loadout, ModId.From(2400), FileId.From(119630));
 
         await ShouldHaveNoDiagnostics(loadout, because: "SMAPI is now installed");
+
+        await VerifyDiagnostic(diagnostic);
     }
 
     [Fact]
@@ -65,5 +67,7 @@ public class MissingSMAPIEmitterTests : ALoadoutDiagnosticEmitterTest<Dependency
         var smapiRequiredButDisabledMessageData = diagnostic.Should().BeOfType<Diagnostic<Diagnostics.SMAPIRequiredButDisabledMessageData>>(because: "SMAPI is required for 2 mods but disabled").Which.MessageData;
 
         smapiRequiredButDisabledMessageData.ModCount.Should().Be(2, because: "the loadout contains 2 SMAPI mods");
+
+        await VerifyDiagnostic(diagnostic);
     }
 }

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/MissingSMAPIEmitterTests.cs
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/MissingSMAPIEmitterTests.cs
@@ -1,0 +1,69 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using NexusMods.Abstractions.Diagnostics;
+using NexusMods.Abstractions.NexusWebApi.Types.V2;
+using NexusMods.Games.StardewValley.Emitters;
+using NexusMods.Games.TestFramework;
+using NexusMods.StandardGameLocators.TestHelpers;
+using Xunit.Abstractions;
+
+namespace NexusMods.Games.StardewValley.Tests;
+
+[Trait("RequiresNetworking", "True")]
+public class MissingSMAPIEmitterTests : ALoadoutDiagnosticEmitterTest<DependencyDiagnosticEmitterTests, StardewValley, MissingSMAPIEmitter>
+{
+    public MissingSMAPIEmitterTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper) { }
+
+    protected override IServiceCollection AddServices(IServiceCollection services)
+    {
+        return base.AddServices(services)
+            .AddStardewValley()
+            .AddUniversalGameLocator<StardewValley>(new Version("1.6.14"));
+    }
+
+    [Fact]
+    public async Task Test_SMAPIRequiredButNotInstalled()
+    {
+        var loadout = await CreateLoadout();
+
+        // Content Patcher 2.5.3 (https://www.nexusmods.com/stardewvalley/mods/1915?tab=files)
+        await InstallModFromNexusMods(loadout, ModId.From(1915), FileId.From(124659));
+
+        // Farm Type Manager 1.24.0 (https://www.nexusmods.com/stardewvalley/mods/3231?tab=files)
+        await InstallModFromNexusMods(loadout, ModId.From(3231), FileId.From(117244));
+
+        var diagnostic = await GetSingleDiagnostic(loadout);
+        var smapiRequiredButNotInstalledMessageData = diagnostic.Should().BeOfType<Diagnostic<Diagnostics.SMAPIRequiredButNotInstalledMessageData>>(because: "SMAPI isn't installed but required by 2 mods").Which.MessageData;
+
+        smapiRequiredButNotInstalledMessageData.ModCount.Should().Be(2, because: "the loadout contains 2 SMAPI mods");
+
+        // SMAPI 4.1.10 (https://www.nexusmods.com/stardewvalley/mods/2400?tab=files)
+        await InstallModFromNexusMods(loadout, ModId.From(2400), FileId.From(119630));
+
+        await ShouldHaveNoDiagnostics(loadout, because: "SMAPI is now installed");
+    }
+
+    [Fact]
+    public async Task Test_SMAPIRequiredButDisabled()
+    {
+        var loadout = await CreateLoadout();
+
+        // Content Patcher 2.5.3 (https://www.nexusmods.com/stardewvalley/mods/1915?tab=files)
+        await InstallModFromNexusMods(loadout, ModId.From(1915), FileId.From(124659));
+
+        // Farm Type Manager 1.24.0 (https://www.nexusmods.com/stardewvalley/mods/3231?tab=files)
+        await InstallModFromNexusMods(loadout, ModId.From(3231), FileId.From(117244));
+
+        // SMAPI 4.1.10 (https://www.nexusmods.com/stardewvalley/mods/2400?tab=files)
+        var smapi = await InstallModFromNexusMods(loadout, ModId.From(2400), FileId.From(119630));
+
+        await ShouldHaveNoDiagnostics(loadout, because: "SMAPI is installed and enabled");
+
+        await DisabledMod(smapi);
+
+        var diagnostic = await GetSingleDiagnostic(loadout);
+        var smapiRequiredButDisabledMessageData = diagnostic.Should().BeOfType<Diagnostic<Diagnostics.SMAPIRequiredButDisabledMessageData>>(because: "SMAPI is required for 2 mods but disabled").Which.MessageData;
+
+        smapiRequiredButDisabledMessageData.ModCount.Should().Be(2, because: "the loadout contains 2 SMAPI mods");
+    }
+}

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/ModOverwritesGameFilesEmitterTests.Test_ModOverwritesGameFiles.verified.txt
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/ModOverwritesGameFilesEmitterTests.Test_ModOverwritesGameFiles.verified.txt
@@ -1,0 +1,16 @@
+﻿[Id] NexusMods.Games.StardewValley: 13
+[Title] Overwritten Game Files
+[Summary] 'TileFile' overwrites game files directly which can cause issues
+[Details]
+The mod **TileFile** appears to be an "XNB mod" which overwrites game files directly rather than using a content patcher. 
+
+### How to Resolve
+1. Check the [SMAPI Wiki](https://stardewvalleywiki.com/Modding:Using_XNB_mods#Alternatives_using_Content_Patcher) for SMAPI or Content Patcher alternatives to **TileFile**
+
+OR
+
+1. Remove **TileFile** from the loadout
+
+
+### Why are XNB mods discouraged?
+XNB mods have a lot of limitations. They often conflict with each other, usually break when the game updates, and in rare cases can even corrupt your saved games. You can learn more about XNB mods on the [SMAPI Wiki](https://stardewvalleywiki.com/Modding:Using_XNB_mods).

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/ModOverwritesGameFilesEmitterTests.cs
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/ModOverwritesGameFilesEmitterTests.cs
@@ -41,6 +41,8 @@ public class ModOverwritesGameFilesEmitterTests : ALoadoutDiagnosticEmitterTest<
 
         modOverwritesGameFilesMessageData.GroupName.Should().Be("TileFile");
         modOverwritesGameFilesMessageData.Group.DataId.Should().Be(mod.LoadoutItemGroupId);
+
+        await VerifyDiagnostic(diagnostic);
     }
 }
 

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/ModOverwritesGameFilesEmitterTests.cs
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/ModOverwritesGameFilesEmitterTests.cs
@@ -1,0 +1,81 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NexusMods.Abstractions.Diagnostics;
+using NexusMods.Abstractions.GameLocators;
+using NexusMods.Abstractions.Library.Installers;
+using NexusMods.Abstractions.Library.Models;
+using NexusMods.Abstractions.Loadouts;
+using NexusMods.Abstractions.NexusWebApi.Types.V2;
+using NexusMods.Games.StardewValley.Emitters;
+using NexusMods.Games.TestFramework;
+using NexusMods.MnemonicDB.Abstractions;
+using NexusMods.StandardGameLocators.TestHelpers;
+using Xunit.Abstractions;
+
+namespace NexusMods.Games.StardewValley.Tests;
+
+[Trait("RequiresNetworking", "True")]
+public class ModOverwritesGameFilesEmitterTests : ALoadoutDiagnosticEmitterTest<ModOverwritesGameFilesEmitterTests, StardewValley, ModOverwritesGameFilesEmitter>
+{
+    public ModOverwritesGameFilesEmitterTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper) { }
+
+    protected override IServiceCollection AddServices(IServiceCollection services)
+    {
+        return base.AddServices(services)
+            .AddStardewValley()
+            .AddUniversalGameLocator<StardewValley>(new Version("1.6.14"))
+            .AddSingleton<DummyInstaller>();
+    }
+
+    [Fact]
+    public async Task Test_ModOverwritesGameFiles()
+    {
+        var loadout = await CreateLoadout();
+
+        // 3D NPC Houses 1.0 https://www.nexusmods.com/stardewvalley/mods/763?tab=files
+        var mod = await InstallModFromNexusMods(loadout, ModId.From(763), FileId.From(2874), installer: ServiceProvider.GetRequiredService<DummyInstaller>());
+
+        var diagnostic = await GetSingleDiagnostic(loadout);
+        var modOverwritesGameFilesMessageData = diagnostic.Should().BeOfType<Diagnostic<Diagnostics.ModOverwritesGameFilesMessageData>>(because: "mod overwrites game files").Which.MessageData;
+
+        modOverwritesGameFilesMessageData.GroupName.Should().Be("TileFile");
+        modOverwritesGameFilesMessageData.Group.DataId.Should().Be(mod.LoadoutItemGroupId);
+    }
+}
+
+file class DummyInstaller : ALibraryArchiveInstaller
+{
+    public DummyInstaller(IServiceProvider serviceProvider, ILogger<DummyInstaller> logger) : base(serviceProvider, logger) { }
+
+    public override ValueTask<InstallerResult> ExecuteAsync(
+        LibraryArchive.ReadOnly libraryArchive,
+        LoadoutItemGroup.New loadoutGroup,
+        ITransaction transaction,
+        Loadout.ReadOnly loadout,
+        CancellationToken cancellationToken)
+    {
+        foreach (var fileEntry in libraryArchive.Children)
+        {
+            var to = new GamePath(LocationId.Game, fileEntry.Path);
+
+            _ = new LoadoutFile.New(transaction, out var entityId)
+            {
+                Hash = fileEntry.AsLibraryFile().Hash,
+                Size = fileEntry.AsLibraryFile().Size,
+                LoadoutItemWithTargetPath = new LoadoutItemWithTargetPath.New(transaction, entityId)
+                {
+                    TargetPath = to.ToGamePathParentTuple(loadout.Id),
+                    LoadoutItem = new LoadoutItem.New(transaction, entityId)
+                    {
+                        Name = fileEntry.AsLibraryFile().FileName,
+                        LoadoutId = loadout,
+                        ParentId = loadoutGroup,
+                    },
+                },
+            };
+        }
+
+        return ValueTask.FromResult<InstallerResult>(new Success());
+    }
+}

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/SMAPIGameVersionDiagnosticEmitterTests.cs
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/SMAPIGameVersionDiagnosticEmitterTests.cs
@@ -1,0 +1,28 @@
+using FluentAssertions;
+using NexusMods.Games.StardewValley.Emitters;
+using NexusMods.Games.TestFramework;
+using StardewModdingAPI.Toolkit;
+
+namespace NexusMods.Games.StardewValley.Tests;
+
+public class SMAPIGameVersionDiagnosticEmitterTests : ALoadoutDiagnosticEmitterTest<StardewValley, SMAPIGameVersionDiagnosticEmitter>
+{
+    public SMAPIGameVersionDiagnosticEmitterTests(IServiceProvider serviceProvider) : base(serviceProvider) { }
+
+    [Theory]
+    [InlineData("1.6.12", "4.1.6")]
+    [InlineData("1.5.6", "3.18.6")]
+    public async Task Test_TryGetLastSupportedSMAPIVersion(string rawGameVersion, string rawExpectedSMAPIVersion)
+    {
+        var gameToSMAPIMappings = await Emitter.FetchGameToSMAPIMappings(CancellationToken.None);
+
+        SMAPIGameVersionDiagnosticEmitter.TryGetLastSupportedSMAPIVersion(
+            gameToSMAPIMappings!,
+            new SemanticVersion(rawGameVersion),
+            out var supportedSMAPIVersion
+        ).Should().BeTrue();
+
+        supportedSMAPIVersion.Should().NotBeNull();
+        supportedSMAPIVersion!.ToString().Should().Be(rawExpectedSMAPIVersion);
+    }
+}

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/SMAPIGameVersionDiagnosticEmitterTests.cs
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/SMAPIGameVersionDiagnosticEmitterTests.cs
@@ -1,13 +1,23 @@
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Games.StardewValley.Emitters;
 using NexusMods.Games.TestFramework;
+using NexusMods.StandardGameLocators.TestHelpers;
 using StardewModdingAPI.Toolkit;
+using Xunit.Abstractions;
 
 namespace NexusMods.Games.StardewValley.Tests;
 
-public class SMAPIGameVersionDiagnosticEmitterTests : ALoadoutDiagnosticEmitterTest<StardewValley, SMAPIGameVersionDiagnosticEmitter>
+public class SMAPIGameVersionDiagnosticEmitterTests : ALoadoutDiagnosticEmitterTest<SMAPIGameVersionDiagnosticEmitterTests, StardewValley, SMAPIGameVersionDiagnosticEmitter>
 {
-    public SMAPIGameVersionDiagnosticEmitterTests(IServiceProvider serviceProvider) : base(serviceProvider) { }
+    public SMAPIGameVersionDiagnosticEmitterTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper) { }
+
+    protected override IServiceCollection AddServices(IServiceCollection services)
+    {
+        return base.AddServices(services)
+            .AddStardewValley()
+            .AddUniversalGameLocator<StardewValley>(new Version("1.6.4"));
+    }
 
     [Theory]
     [InlineData("1.6.12", "4.1.6")]

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/SMAPIModDatabaseCompatibilityDiagnosticEmitterTests.Test_ModCompatabilityAssumeBroken.verified.txt
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/SMAPIModDatabaseCompatibilityDiagnosticEmitterTests.Test_ModCompatabilityAssumeBroken.verified.txt
@@ -1,0 +1,19 @@
+﻿[Id] NexusMods.Games.StardewValley: 7
+[Title] Broken Mod
+[Summary] 'Persistent Mines' is reported as broken by SMAPI
+[Details]
+The Stardew Modding API (SMAPI) mod compatibility list reports **Persistent Mines** as broken. This information is sourced from a combination of automated and community-submitted reports. 
+
+### How to Resolve
+1. Check for a version of **Persistent Mines** newer than 1.0.1 on [Nexus Mods](https://nexusmods.com/stardewvalley/mods/14985?mtm_source=nexusmodsapp&mtm_campaign=diagnostics)
+
+OR
+
+1. Remove **Persistent Mines** from the loadout
+
+### Technical Details
+The Stardew Modding API (SMAPI) mod compatibility list has given the following information about the broken state of **Persistent Mines**:
+
+> affected by breaking changes in the SpaceCore mod API
+
+You may be able to find further information about this on the [SMAPI website](https://smapi.io/mods).

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/SMAPIModDatabaseCompatibilityDiagnosticEmitterTests.Test_ModCompatabilityObsolete.verified.txt
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/SMAPIModDatabaseCompatibilityDiagnosticEmitterTests.Test_ModCompatabilityObsolete.verified.txt
@@ -1,0 +1,15 @@
+﻿[Id] NexusMods.Games.StardewValley: 6
+[Title] Obsolete Mod
+[Summary] 'Extra Map Layers' is reported as obsolete by SMAPI
+[Details]
+The Stardew Modding API (SMAPI) mod compatibility list reports **Extra Map Layers** as obsolete. This information is sourced from a combination of automated and community-submitted reports. 
+
+### How to Resolve
+1. Remove **Extra Map Layers** from the loadout
+
+### Technical Details
+The Stardew Modding API (SMAPI) mod compatibility list has given the following information about the broken state of **Extra Map Layers**:
+
+> Extra Map Layers is obsolete because extra map layer support was added in Stardew Valley 1.6. You can delete this mod.
+
+You may be able to find further information about this on the [SMAPI website](https://smapi.io/mods).

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/SMAPIModDatabaseCompatibilityDiagnosticEmitterTests.cs
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/SMAPIModDatabaseCompatibilityDiagnosticEmitterTests.cs
@@ -1,0 +1,59 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using NexusMods.Abstractions.Diagnostics;
+using NexusMods.Abstractions.NexusWebApi.Types.V2;
+using NexusMods.Games.StardewValley.Emitters;
+using NexusMods.Games.TestFramework;
+using NexusMods.StandardGameLocators.TestHelpers;
+using Xunit.Abstractions;
+
+namespace NexusMods.Games.StardewValley.Tests;
+
+public class SMAPIModDatabaseCompatibilityDiagnosticEmitterTests : ALoadoutDiagnosticEmitterTest<SMAPIModDatabaseCompatibilityDiagnosticEmitterTests, StardewValley, SMAPIModDatabaseCompatibilityDiagnosticEmitter>
+{
+    public SMAPIModDatabaseCompatibilityDiagnosticEmitterTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper) { }
+
+    protected override IServiceCollection AddServices(IServiceCollection services)
+    {
+        return base.AddServices(services)
+            .AddStardewValley()
+            .AddUniversalGameLocator<StardewValley>(new Version("1.6.14"));
+    }
+
+    [Fact]
+    public async Task Test_ModCompatabilityObsolete()
+    {
+        var loadout = await CreateLoadout();
+
+        // SMAPI 4.1.10 (https://www.nexusmods.com/stardewvalley/mods/2400?tab=files)
+        await InstallModFromNexusMods(loadout, ModId.From(2400), FileId.From(119630));
+
+        // Extra Map Layers 0.3.10 (https://www.nexusmods.com/stardewvalley/mods/9633?tab=files)
+        await InstallModFromNexusMods(loadout, ModId.From(9633), FileId.From(75206));
+
+        var diagnostic = await GetSingleDiagnostic(loadout);
+        var modCompatabilityObsoleteMessageData = diagnostic.Should().BeOfType<Diagnostic<Diagnostics.ModCompatabilityObsoleteMessageData>>(because: "Extra Map Layers is obsolete in 1.6").Which.MessageData;
+
+        modCompatabilityObsoleteMessageData.SMAPIModName.Should().Be("Extra Map Layers");
+        modCompatabilityObsoleteMessageData.ReasonPhrase.Should().Be("extra map layer support was added in Stardew Valley 1.6. You can delete this mod.");
+    }
+
+    [Fact]
+    public async Task Test_ModCompatabilityAssumeBroken()
+    {
+        var loadout = await CreateLoadout();
+
+        // SMAPI 4.1.10 (https://www.nexusmods.com/stardewvalley/mods/2400?tab=files)
+        await InstallModFromNexusMods(loadout, ModId.From(2400), FileId.From(119630));
+
+        // Persistent Mines 1.0.1 (https://www.nexusmods.com/stardewvalley/mods/14985?tab=files)
+        await InstallModFromNexusMods(loadout, ModId.From(14985), FileId.From(64850));
+
+        var diagnostic = await GetSingleDiagnostic(loadout);
+        var modCompatabilityAssumeBrokenMessageData = diagnostic.Should().BeOfType<Diagnostic<Diagnostics.ModCompatabilityAssumeBrokenMessageData>>(because: "").Which.MessageData;
+
+        modCompatabilityAssumeBrokenMessageData.SMAPIModName.Should().Be("Persistent Mines");
+        modCompatabilityAssumeBrokenMessageData.ReasonPhrase.Should().Be("affected by breaking changes in the SpaceCore mod API");
+        modCompatabilityAssumeBrokenMessageData.ModVersion.Should().Be("1.0.1");
+    }
+}

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/SMAPIModDatabaseCompatibilityDiagnosticEmitterTests.cs
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/SMAPIModDatabaseCompatibilityDiagnosticEmitterTests.cs
@@ -36,6 +36,8 @@ public class SMAPIModDatabaseCompatibilityDiagnosticEmitterTests : ALoadoutDiagn
 
         modCompatabilityObsoleteMessageData.SMAPIModName.Should().Be("Extra Map Layers");
         modCompatabilityObsoleteMessageData.ReasonPhrase.Should().Be("extra map layer support was added in Stardew Valley 1.6. You can delete this mod.");
+
+        await VerifyDiagnostic(diagnostic);
     }
 
     [Fact]
@@ -55,5 +57,7 @@ public class SMAPIModDatabaseCompatibilityDiagnosticEmitterTests : ALoadoutDiagn
         modCompatabilityAssumeBrokenMessageData.SMAPIModName.Should().Be("Persistent Mines");
         modCompatabilityAssumeBrokenMessageData.ReasonPhrase.Should().Be("affected by breaking changes in the SpaceCore mod API");
         modCompatabilityAssumeBrokenMessageData.ModVersion.Should().Be("1.0.1");
+
+        await VerifyDiagnostic(diagnostic);
     }
 }

--- a/tests/Games/NexusMods.Games.TestFramework/AIsolatedGameTest.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/AIsolatedGameTest.cs
@@ -18,6 +18,7 @@ using NexusMods.Abstractions.HttpDownloader;
 using NexusMods.Abstractions.IO;
 using NexusMods.Abstractions.IO.StreamFactories;
 using NexusMods.Abstractions.Library;
+using NexusMods.Abstractions.Library.Installers;
 using NexusMods.Abstractions.Library.Models;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Loadouts.Extensions;
@@ -116,10 +117,10 @@ public abstract class AIsolatedGameTest<TTest, TGame> : IAsyncLifetime where TGa
         return await LibraryService.AddDownload(downloadJob);
     }
 
-    public async Task<LoadoutItemGroup.ReadOnly> InstallModFromNexusMods(Loadout.ReadOnly loadout, ModId modId, FileId fileId)
+    public async Task<LoadoutItemGroup.ReadOnly> InstallModFromNexusMods(LoadoutId loadoutId, ModId modId, FileId fileId, ILibraryItemInstaller? installer = null)
     {
         var libraryFile = await DownloadModFromNexusMods(modId, fileId);
-        return await LibraryService.InstallItem(libraryFile.AsLibraryItem(), loadout);
+        return await LibraryService.InstallItem(libraryFile.AsLibraryItem(), loadoutId, installer: installer);
     }
 
     public async Task<LibraryArchive.ReadOnly> RegisterLocalArchive(AbsolutePath file)

--- a/tests/Games/NexusMods.Games.TestFramework/ALoadoutDiagnosticEmitterTest.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/ALoadoutDiagnosticEmitterTest.cs
@@ -1,20 +1,22 @@
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.Diagnostics;
 using NexusMods.Abstractions.Diagnostics.Emitters;
 using NexusMods.Abstractions.Games;
 using NexusMods.Abstractions.Loadouts;
+using Xunit.Abstractions;
 
 namespace NexusMods.Games.TestFramework;
 
-public class ALoadoutDiagnosticEmitterTest<TGame, TEmitter> : AGameTest<TGame>
+public class ALoadoutDiagnosticEmitterTest<TTest, TGame, TEmitter> : AIsolatedGameTest<TTest, TGame>
     where TGame : AGame
     where TEmitter : ILoadoutDiagnosticEmitter
 {
     protected readonly TEmitter Emitter;
 
-    protected ALoadoutDiagnosticEmitterTest(IServiceProvider serviceProvider) : base(serviceProvider)
+    protected ALoadoutDiagnosticEmitterTest(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
     {
-        Emitter = serviceProvider.FindImplementationInContainer<TEmitter, ILoadoutDiagnosticEmitter>();
+        Emitter = ServiceProvider.FindImplementationInContainer<TEmitter, ILoadoutDiagnosticEmitter>();
     }
 
     protected async ValueTask<Diagnostic[]> GetAllDiagnostics(Loadout.ReadOnly loadout)
@@ -27,5 +29,11 @@ public class ALoadoutDiagnosticEmitterTest<TGame, TEmitter> : AGameTest<TGame>
         var diagnostics = await GetAllDiagnostics(loadout);
         diagnostics.Should().ContainSingle();
         return diagnostics.First();
+    }
+
+    protected async ValueTask ShouldHaveNoDiagnostics(Loadout.ReadOnly loadout)
+    {
+        var diagnostics = await Emitter.Diagnose(loadout, CancellationToken.None).ToArrayAsync();
+        diagnostics.Should().BeEmpty();
     }
 }

--- a/tests/Games/NexusMods.Games.TestFramework/ALoadoutDiagnosticEmitterTest.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/ALoadoutDiagnosticEmitterTest.cs
@@ -19,21 +19,24 @@ public class ALoadoutDiagnosticEmitterTest<TTest, TGame, TEmitter> : AIsolatedGa
         Emitter = ServiceProvider.FindImplementationInContainer<TEmitter, ILoadoutDiagnosticEmitter>();
     }
 
-    protected async ValueTask<Diagnostic[]> GetAllDiagnostics(Loadout.ReadOnly loadout)
+    protected async ValueTask<Diagnostic[]> GetAllDiagnostics(LoadoutId loadoutId)
     {
+        var loadout = Loadout.Load(Connection.Db, loadoutId);
         return await Emitter.Diagnose(loadout, CancellationToken.None).ToArrayAsync();
     }
 
-    protected async ValueTask<Diagnostic> GetSingleDiagnostic(Loadout.ReadOnly loadout)
+    protected async ValueTask<Diagnostic> GetSingleDiagnostic(LoadoutId loadoutId)
     {
+        var loadout = Loadout.Load(Connection.Db, loadoutId);
         var diagnostics = await GetAllDiagnostics(loadout);
         diagnostics.Should().ContainSingle();
         return diagnostics.First();
     }
 
-    protected async ValueTask ShouldHaveNoDiagnostics(Loadout.ReadOnly loadout)
+    protected async ValueTask ShouldHaveNoDiagnostics(LoadoutId loadoutId, string because = "")
     {
+        var loadout = Loadout.Load(Connection.Db, loadoutId);
         var diagnostics = await Emitter.Diagnose(loadout, CancellationToken.None).ToArrayAsync();
-        diagnostics.Should().BeEmpty();
+        diagnostics.Should().BeEmpty(because: because);
     }
 }

--- a/tests/Games/NexusMods.Games.TestFramework/ALoadoutDiagnosticEmitterTest.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/ALoadoutDiagnosticEmitterTest.cs
@@ -4,6 +4,8 @@ using NexusMods.Abstractions.Diagnostics;
 using NexusMods.Abstractions.Diagnostics.Emitters;
 using NexusMods.Abstractions.Games;
 using NexusMods.Abstractions.Loadouts;
+using NexusMods.MnemonicDB.Abstractions;
+using NexusMods.MnemonicDB.Abstractions.ElementComparers;
 using Xunit.Abstractions;
 
 namespace NexusMods.Games.TestFramework;
@@ -38,5 +40,19 @@ public class ALoadoutDiagnosticEmitterTest<TTest, TGame, TEmitter> : AIsolatedGa
         var loadout = Loadout.Load(Connection.Db, loadoutId);
         var diagnostics = await Emitter.Diagnose(loadout, CancellationToken.None).ToArrayAsync();
         diagnostics.Should().BeEmpty(because: because);
+    }
+
+    protected async ValueTask EnableMod(EntityId entityId)
+    {
+        using var tx = Connection.BeginTransaction();
+        tx.Retract(entityId, LoadoutItem.Disabled, Null.Instance);
+        await tx.Commit();
+    }
+
+    protected async ValueTask DisabledMod(EntityId entityId)
+    {
+        using var tx = Connection.BeginTransaction();
+        tx.Add(entityId, LoadoutItem.Disabled, Null.Instance);
+        await tx.Commit();
     }
 }

--- a/tests/Games/NexusMods.Games.TestFramework/NexusMods.Games.TestFramework.csproj
+++ b/tests/Games/NexusMods.Games.TestFramework/NexusMods.Games.TestFramework.csproj
@@ -6,6 +6,7 @@
         <ProjectReference Include="..\..\..\src\Games\NexusMods.Games.RedEngine\NexusMods.Games.RedEngine.csproj" />
         <ProjectReference Include="..\..\..\src\Networking\NexusMods.Networking.HttpDownloader\NexusMods.Networking.HttpDownloader.csproj" />
         <ProjectReference Include="..\..\..\src\Networking\NexusMods.Networking.NexusWebApi\NexusMods.Networking.NexusWebApi.csproj" />
+        <ProjectReference Include="..\..\..\src\NexusMods.App.UI\NexusMods.App.UI.csproj" />
         <ProjectReference Include="..\..\..\src\NexusMods.Collections\NexusMods.Collections.csproj" />
         <ProjectReference Include="..\..\..\src\NexusMods.DataModel\NexusMods.DataModel.csproj" />
         <ProjectReference Include="..\..\..\src\NexusMods.Games.FileHashes\NexusMods.Games.FileHashes.csproj" />


### PR DESCRIPTION
This doesn't have tests for the emitters that work on game versions due to how annoying it is to set up game versions in tests.