### PR TITLE
Fix the deadlocks by introducing an entity cache

### DIFF
--- a/src/NexusMods.App.UI/EntityCache.cs
+++ b/src/NexusMods.App.UI/EntityCache.cs
@@ -1,0 +1,113 @@
+using System.Reactive.Linq;
+using DynamicData;
+using NexusMods.MnemonicDB.Abstractions;
+
+
+namespace NexusMods.App.UI;
+
+/// <summary>
+/// A in-memory entity cache and observable index for a MnemonicDb entity set
+/// </summary>
+/// <typeparam name="TKey">The type of the unique key for the items (often the model's Entity Id)</typeparam>
+/// <typeparam name="TItem">The type of the entity being stored</typeparam>
+/// <typeparam name="TIndex">The type of the index for the data</typeparam>
+public class EntityCache<TKey, TItem, TIndex> : IDisposable
+    where TKey : notnull
+    where TItem : notnull
+    where TIndex : notnull
+{
+    private record IndexRow(HashSet<IObserver<IChangeSet<TItem, TKey>>> Observers, Dictionary<TKey, TItem> Items);
+    
+    private readonly Dictionary<TIndex, IndexRow> _index = new();
+    private readonly IDisposable _disposable;
+    private readonly Lock _lock = new();
+    private readonly Func<TItem,TIndex> _indexSelector;
+    
+    /// <summary>
+    /// DI Constructor, must provide a factory for the observables, and an index selector
+    /// </summary>
+    /// <param name="connection">MnemonicDB Connection</param>
+    /// <param name="indexSelector">A selector function for index keys. Multiple rows are allowed the same index </param>
+    /// <param name="observableFactory">A factory for all items to observe given a MnemonicDB connection</param>
+    public EntityCache(IConnection connection, Func<TItem, TIndex> indexSelector, Func<IConnection, IObservable<IChangeSet<TItem, TKey>>> observableFactory)
+    {
+        _indexSelector = indexSelector;
+        _disposable = observableFactory(connection)
+            .Subscribe(OnUpdate);
+
+    }
+
+    private void OnUpdate(IChangeSet<TItem, TKey> changes)
+    {
+        lock (_lock)
+        {
+            foreach (var change in changes)
+            {
+                var index = _indexSelector(change.Current);
+                if (!_index.TryGetValue(index, out var row))
+                {
+                    row = new IndexRow(new HashSet<IObserver<IChangeSet<TItem, TKey>>>(), new Dictionary<TKey, TItem>());
+                    _index.Add(index, row);
+                }
+
+                foreach (var observer in row.Observers)
+                {
+                    observer.OnNext(new ChangeSet<TItem, TKey>([change]));
+                    
+                }
+
+                switch (change.Reason)
+                {
+                    case ChangeReason.Add:
+                    case ChangeReason.Update:
+                        row.Items[change.Key] = change.Current;
+                        break;
+                    case ChangeReason.Remove:
+                        row.Items.Remove(change.Key);
+                        break;
+                }
+            }
+            
+        }
+    }
+    
+    /// <summary>
+    /// Get an observable changeset for all the items in a specific index entry. 
+    /// </summary>
+    public IObservable<IChangeSet<TItem, TKey>> Get(TIndex index)
+    {
+        return Observable.Create<IChangeSet<TItem, TKey>>(observer =>
+            {
+                lock (_lock)
+                {
+                    if (!_index.TryGetValue(index, out var row))
+                    {
+                        row = new IndexRow(new HashSet<IObserver<IChangeSet<TItem, TKey>>>(), new Dictionary<TKey, TItem>());
+                        _index.Add(index, row);
+                    }
+
+                    row.Observers.Add(observer);
+                    observer.OnNext(new ChangeSet<TItem, TKey>(row.Items.Select(kvp => new Change<TItem, TKey>(ChangeReason.Add, kvp.Key, kvp.Value))));
+                }
+
+                return () =>
+                {
+                    lock (_lock)
+                    {
+                        if (_index.TryGetValue(index, out var row))
+                        {
+                            row.Observers.Remove(observer);
+                        }
+                    }
+                };
+
+            }
+        );
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        _disposable.Dispose();
+    }
+}

--- a/src/NexusMods.App.UI/Services.cs
+++ b/src/NexusMods.App.UI/Services.cs
@@ -2,6 +2,9 @@ using System.Text.Json.Serialization;
 using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.Diagnostics;
 using NexusMods.Abstractions.EventBus;
+using NexusMods.Abstractions.Library.Models;
+using NexusMods.Abstractions.Loadouts;
+using NexusMods.Abstractions.NexusModsLibrary;
 using NexusMods.Abstractions.Serialization.ExpressionGenerator;
 using NexusMods.Abstractions.Serialization.Json;
 using NexusMods.App.UI.Controls.DataGrid;
@@ -59,6 +62,7 @@ using NexusMods.App.UI.Settings;
 using NexusMods.App.UI.Windows;
 using NexusMods.App.UI.WorkspaceAttachments;
 using NexusMods.App.UI.WorkspaceSystem;
+using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.Paths;
 using ReactiveUI;
 using DownloadGameNameView = NexusMods.App.UI.Controls.DownloadGrid.Columns.DownloadGameName.DownloadGameNameView;
@@ -97,7 +101,7 @@ public static class Services
             .AddTransient(typeof(DataGridViewModelColumn<,>))
             .AddTransient(typeof(DataGridColumnFactory<,,>))
             .AddSingleton<IViewLocator, InjectedViewLocator>()
-            
+
             .AddViewModel<CollectionCardDesignViewModel, ICollectionCardViewModel>()
 
             .AddViewModel<DevelopmentBuildBannerViewModel, IDevelopmentBuildBannerViewModel>()
@@ -161,13 +165,13 @@ public static class Services
             .AddView<FileTreeNodeView, IFileTreeNodeViewModel>()
             .AddView<ApplyDiffView, IApplyDiffViewModel>()
             .AddView<FileTreeView, IFileTreeViewModel>()
-            
+
             .AddView<MyLoadoutsView, IMyLoadoutsViewModel>()
             .AddViewModel<MyLoadoutsViewModel, IMyLoadoutsViewModel>()
             .AddView<LoadoutCardView, ILoadoutCardViewModel>()
             .AddView<CreateNewLoadoutCardView, ICreateNewLoadoutCardViewModel>()
             .AddViewModel<LoadoutBadgeViewModel, ILoadoutBadgeViewModel>()
-            
+
             .AddView<SettingsView, ISettingsPageViewModel>()
             .AddViewModel<SettingsPageViewModel, ISettingsPageViewModel>()
 
@@ -198,7 +202,7 @@ public static class Services
 
             .AddView<LibraryItemDeleteConfirmationView, ILibraryItemDeleteConfirmationViewModel>()
             .AddViewModel<LibraryItemDeleteConfirmationViewModel, ILibraryItemDeleteConfirmationViewModel>()
-            
+
             .AddView<AlphaWarningView, IAlphaWarningViewModel>()
             .AddViewModel<AlphaWarningViewModel, IAlphaWarningViewModel>()
 
@@ -210,11 +214,11 @@ public static class Services
 
             .AddView<CollectionDownloadView, ICollectionDownloadViewModel>()
             .AddViewModel<CollectionDownloadViewModel, ICollectionDownloadViewModel>()
-            
+
             .AddView<LoadOrderView, ILoadOrderViewModel>()
             .AddViewModel<LoadOrderViewModel, ILoadOrderViewModel>()
-            
-            .AddView<LoadOrdersWIPPageView,ILoadOrdersWIPPageViewModel>()
+
+            .AddView<LoadOrdersWIPPageView, ILoadOrdersWIPPageViewModel>()
             .AddViewModel<LoadOrdersWipPageViewModel, ILoadOrdersWIPPageViewModel>()
 
             .AddView<UpgradeToPremiumView, IUpgradeToPremiumViewModel>()
@@ -291,7 +295,21 @@ public static class Services
             .AddSingleton<ILoadoutDataProvider, BundledDataProvider>()
             .AddSingleton<IEventBus, EventBus>()
             .AddFileSystem()
-            .AddImagePipelines();
+            .AddImagePipelines()
+
+            // TODO: These are going to be deprecated soon, and replaced with a better query system
+            .AddSingleton<EntityCache<EntityId, NexusModsLibraryItem.ReadOnly, NexusModsModPageMetadataId>>(s =>
+                new EntityCache<EntityId, NexusModsLibraryItem.ReadOnly, NexusModsModPageMetadataId>(
+                    s.GetRequiredService<IConnection>(), l => l.ModPageMetadataId.Value, NexusModsLibraryItem.ObserveAll
+                )
+            )
+
+            .AddSingleton<EntityCache<EntityId, LibraryLinkedLoadoutItem.ReadOnly, LibraryLinkedLoadoutItemId>>(s =>
+                new EntityCache<EntityId, LibraryLinkedLoadoutItem.ReadOnly, LibraryLinkedLoadoutItemId>(
+                    s.GetRequiredService<IConnection>(), l => l.LibraryLinkedLoadoutItemId.Value, LibraryLinkedLoadoutItem.ObserveAll
+                )
+            );
+
     }
 
 }


### PR DESCRIPTION
Should actually fix the deadlocks now. One of the main causes of the deadlocks in our code is a circular dependency in the observable chains. MnemonicDB will send out an update, and our observables will loop back around and try to add a watch using the same lock MnemonicDB is holding to make the update. 

In my investigation of the deadlock I was surprised to see that it always occured on the `DateTime` column of the composite item models. Every use of this column is a fairly nested set of observables. For example we may be observing the "installed time" of a mod page. Which means that we have to watch everything in the chain of `mod page -> library item -> loadout item -> create at`, that's 2-3 nested observable aggregates, each with their own call to `ObserveDatoms`. I started debugging down this path by disabling (hardcoding to a set value) the datetime field. Suddenly all our deadlocks went away. 

This code introduces a `EntityCache` which watches all entities of a given type, and stores them in a single cache. In addition the cache indexes them by a secondary expression, and allows for observation of a given value of that expression. For example it's now possible to index all `LibraryLinkedLoadoutItems` by their `LibraryLinkedLoadoutId`, other entities can then call `_cache.Get(libraryItemId)` to watch for any entities that may reference this entity.

Introducing this cache helps with the deadlocks in several ways: 

1) it reduces contention on the MnemonicDB lock
2) it breaks apart the contending uses of the lock into two other areas
3) it caches entities, so that a new observable connecting to a indexed value doesn't need to re-query the DB it can use the existing in-memory items (further reducing the chance of a deadlock)
4) it creates one database `ObserveDatoms` for all entries in a given cache. Meaning we can collapse hundreds of watches on the database down to a single observable.

This code will be replaced in the future as we get a better query system, but for now this is a rather clean way to go about the problem. 