### PR TITLE
Fix `GetGameVersion` for Stardew Valley

### DIFF
--- a/src/Games/NexusMods.Games.StardewValley/Emitters/Helpers.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/Helpers.cs
@@ -23,7 +23,18 @@ internal static class Helpers
     public static ISemanticVersion GetGameVersion(Loadout.ReadOnly loadout)
     {
         var game = (loadout.InstallationInstance.Game as AGame)!;
-        var localVersion = game.GetLocalVersion(loadout.Installation).Convert(static version => new SemanticVersion(version));
+
+        // NOTE(erri120): `Major.Minor.Patch` is the only thing the SMAPI API supports
+        // in regard to SemanticVersion. Passing a `System.Version` into the constructor
+        // will create a `SemanticVersion` with only `Major`, `Minor`, and `Patch` fields.
+        // The string parser of `SemanticVersion` accepts more if `allowNonStandard` is enabled,
+        // however the SMAPI API will not return any data if a "non-standard" version is passed
+        // to it for some reason.
+        // See https://github.com/Nexus-Mods/NexusMods.App/pull/2713 for details.
+        var localVersion = game
+            .GetLocalVersion(loadout.Installation)
+            .Convert(static version => new SemanticVersion(version));
+
         if (localVersion.HasValue) return localVersion.Value;
 
         // NOTE(erri120): should only be hit during tests

--- a/src/Games/NexusMods.Games.StardewValley/Emitters/Helpers.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/Helpers.cs
@@ -23,8 +23,11 @@ internal static class Helpers
     public static ISemanticVersion GetGameVersion(Loadout.ReadOnly loadout)
     {
         var game = (loadout.InstallationInstance.Game as AGame)!;
-        var localVersion = game.GetLocalVersion(loadout.Installation).Convert(static v => v.ToString());
-        var rawVersion = localVersion.ValueOr(() => loadout.GameVersion);
+        var localVersion = game.GetLocalVersion(loadout.Installation).Convert(static version => new SemanticVersion(version));
+        if (localVersion.HasValue) return localVersion.Value;
+
+        // NOTE(erri120): should only be hit during tests
+        var rawVersion = loadout.GameVersion;
 
 #if DEBUG
         // NOTE(erri120): dumb hack for tests


### PR DESCRIPTION
The SMAPI API doesn't return any data if the `ISemanticVersion` we're passing on is "non-standard". Although the API type allows any `ISemanticVersion` implementation, it apparently doesn't like anything other than versions created using the `SemanticVersion(Version)` constructor.

This fix changes the behavior of how we create `SemanticVersion` to the old behavior of passing the `System.Version` we get from the Stardew Valley DLL to the `SemanticVersion` constructor.

Fixes #2705.