### PR TITLE
Refactor `IFileHashesService` and implementations

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.GameLocators/IGameLocatorResultMetadata.cs
+++ b/src/Abstractions/NexusMods.Abstractions.GameLocators/IGameLocatorResultMetadata.cs
@@ -11,5 +11,5 @@ public interface IGameLocatorResultMetadata
     /// <summary>
     /// Converts this metadata to a format that the game locator and file hash db can use to reference a specific build, version, etc.
     /// </summary>
-    public IEnumerable<string> ToLocatorIds();
+    public IEnumerable<LocatorId> ToLocatorIds();
 }

--- a/src/Abstractions/NexusMods.Abstractions.GameLocators/LocatorId.cs
+++ b/src/Abstractions/NexusMods.Abstractions.GameLocators/LocatorId.cs
@@ -1,0 +1,38 @@
+using JetBrains.Annotations;
+using NexusMods.MnemonicDB.Abstractions;
+using NexusMods.MnemonicDB.Abstractions.Attributes;
+using NexusMods.MnemonicDB.Abstractions.ValueSerializers;
+using TransparentValueObjects;
+
+namespace NexusMods.Abstractions.GameLocators;
+
+/// <summary>
+/// Represents an opaque ID created by locators.
+/// </summary>
+/// <remarks>
+/// The meaning of an ID is dependent on the locator.
+/// </remarks>
+[ValueObject<string>]
+[PublicAPI]
+public readonly partial struct LocatorId : IAugmentWith<JsonAugment, DefaultValueAugment, DefaultEqualityComparerAugment>
+{
+    /// <inheritdoc/>
+    public static LocatorId DefaultValue { get; } = From(string.Empty);
+
+    /// <inheritdoc/>
+    public static IEqualityComparer<string> InnerValueDefaultEqualityComparer { get; } = StringComparer.OrdinalIgnoreCase;
+}
+
+/// <summary>
+/// Attribute for many <see cref="LocatorId"/>.
+/// </summary>
+[PublicAPI]
+public sealed class LocatorIdsAttribute(string ns, string name) : CollectionAttribute<LocatorId, string, Utf8Serializer>(ns, name)
+{
+    /// <inheritdoc/>
+    protected override string ToLowLevel(LocatorId value) => value.Value;
+
+    /// <inheritdoc/>
+    protected override LocatorId FromLowLevel(string value, AttributeResolver resolver) => LocatorId.From(value);
+}
+

--- a/src/Abstractions/NexusMods.Abstractions.GameLocators/LocatorId.cs
+++ b/src/Abstractions/NexusMods.Abstractions.GameLocators/LocatorId.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using JetBrains.Annotations;
 using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.MnemonicDB.Abstractions.Attributes;
@@ -21,6 +22,24 @@ public readonly partial struct LocatorId : IAugmentWith<JsonAugment, DefaultValu
 
     /// <inheritdoc/>
     public static IEqualityComparer<string> InnerValueDefaultEqualityComparer { get; } = StringComparer.OrdinalIgnoreCase;
+}
+
+/// <summary>
+/// Tuple of <see cref="GameStore"/> and multiple <see cref="LocatorId"/>.
+/// </summary>
+[PublicAPI]
+public record struct LocatorIdsWithGameStore(GameStore GameStore, LocatorId[] LocatorIds) : IEnumerable<LocatorId>
+{
+    /// <inheritdoc/>
+    public IEnumerator<LocatorId> GetEnumerator() => LocatorIds.AsEnumerable().GetEnumerator();
+
+    /// <inheritdoc/>
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    /// <summary>
+    /// Implicit conversion.
+    /// </summary>
+    public static implicit operator LocatorIdsWithGameStore((GameStore, LocatorId[]) tuple) => new(tuple.Item1, tuple.Item2);
 }
 
 /// <summary>

--- a/src/Abstractions/NexusMods.Abstractions.GameLocators/Stores/EADesktop/EADesktopLocatorResultMetadata.cs
+++ b/src/Abstractions/NexusMods.Abstractions.GameLocators/Stores/EADesktop/EADesktopLocatorResultMetadata.cs
@@ -14,5 +14,5 @@ public record EADesktopLocatorResultMetadata : IGameLocatorResultMetadata
     public required string SoftwareId { get; init; }
 
     /// <inheritdoc />
-    public IEnumerable<string> ToLocatorIds() => [SoftwareId];
+    public IEnumerable<LocatorId> ToLocatorIds() => [LocatorId.From(SoftwareId)];
 }

--- a/src/Abstractions/NexusMods.Abstractions.GameLocators/Stores/EGS/EpicLocatorResultMetadata.cs
+++ b/src/Abstractions/NexusMods.Abstractions.GameLocators/Stores/EGS/EpicLocatorResultMetadata.cs
@@ -14,5 +14,5 @@ public record EpicLocatorResultMetadata : IGameLocatorResultMetadata
     public required string CatalogItemId { get; init; }
 
     /// <inheritdoc />
-    public IEnumerable<string> ToLocatorIds() => [CatalogItemId];
+    public IEnumerable<LocatorId> ToLocatorIds() => [LocatorId.From(CatalogItemId)];
 }

--- a/src/Abstractions/NexusMods.Abstractions.GameLocators/Stores/GOG/GOGLocatorResultMetadata.cs
+++ b/src/Abstractions/NexusMods.Abstractions.GameLocators/Stores/GOG/GOGLocatorResultMetadata.cs
@@ -19,7 +19,7 @@ public record GOGLocatorResultMetadata : IGameLocatorResultMetadata
     public required string BuildId { get; init; }
     
     /// <inheritdoc />
-    public IEnumerable<string> ToLocatorIds() => [BuildId];
+    public IEnumerable<LocatorId> ToLocatorIds() => [LocatorId.From(BuildId)];
 }
 
 [PublicAPI]

--- a/src/Abstractions/NexusMods.Abstractions.GameLocators/Stores/Origin/OriginLocatorResultMetadata.cs
+++ b/src/Abstractions/NexusMods.Abstractions.GameLocators/Stores/Origin/OriginLocatorResultMetadata.cs
@@ -14,5 +14,5 @@ public record OriginLocatorResultMetadata : IGameLocatorResultMetadata
     public required string Id { get; init; }
 
     /// <inheritdoc />
-    public IEnumerable<string> ToLocatorIds() => [Id];
+    public IEnumerable<LocatorId> ToLocatorIds() => [LocatorId.From(Id)];
 }

--- a/src/Abstractions/NexusMods.Abstractions.GameLocators/Stores/Steam/SteamLocatorResultMetadata.cs
+++ b/src/Abstractions/NexusMods.Abstractions.GameLocators/Stores/Steam/SteamLocatorResultMetadata.cs
@@ -25,5 +25,5 @@ public record SteamLocatorResultMetadata : IGameLocatorResultMetadata
     public ulong[] ManifestIds { get; set; } = [];
     
     /// <inheritdoc />
-    public IEnumerable<string> ToLocatorIds() => ManifestIds.Select(m => m.ToString());
+    public IEnumerable<LocatorId> ToLocatorIds() => ManifestIds.Select(m => LocatorId.From(m.ToString()));
 }

--- a/src/Abstractions/NexusMods.Abstractions.GameLocators/Stores/Xbox/XboxLocatorResultMetadata.cs
+++ b/src/Abstractions/NexusMods.Abstractions.GameLocators/Stores/Xbox/XboxLocatorResultMetadata.cs
@@ -14,5 +14,5 @@ public record XboxLocatorResultMetadata : IGameLocatorResultMetadata
     public required string Id { get; init; }
 
     /// <inheritdoc />
-    public IEnumerable<string> ToLocatorIds() => [Id];
+    public IEnumerable<LocatorId> ToLocatorIds() => [LocatorId.From(Id)];
 }

--- a/src/Abstractions/NexusMods.Abstractions.GameLocators/VanityVersion.cs
+++ b/src/Abstractions/NexusMods.Abstractions.GameLocators/VanityVersion.cs
@@ -1,0 +1,35 @@
+using JetBrains.Annotations;
+using NexusMods.MnemonicDB.Abstractions;
+using NexusMods.MnemonicDB.Abstractions.Attributes;
+using NexusMods.MnemonicDB.Abstractions.ValueSerializers;
+using TransparentValueObjects;
+
+namespace NexusMods.Abstractions.GameLocators;
+
+/// <summary>
+/// Represents a version that only exists to be displayed to humans. It carries no data
+/// that should be used functions, and effectively has no real value.
+/// </summary>
+[ValueObject<string>]
+[PublicAPI]
+public readonly partial struct VanityVersion : IAugmentWith<JsonAugment, DefaultValueAugment, DefaultEqualityComparerAugment>
+{
+    /// <inheritdoc/>
+    public static VanityVersion DefaultValue { get; } = From("0.0.0");
+
+    /// <inheritdoc/>
+    public static IEqualityComparer<string> InnerValueDefaultEqualityComparer { get; } = StringComparer.OrdinalIgnoreCase;
+}
+
+/// <summary>
+/// Attribute for <see cref="VanityVersion"/>.
+/// </summary>
+[PublicAPI]
+public sealed class VanityVersionAttribute(string ns, string name) : ScalarAttribute<VanityVersion, string, Utf8Serializer>(ns, name)
+{
+    /// <inheritdoc />
+    protected override string ToLowLevel(VanityVersion value) => value.Value;
+
+    /// <inheritdoc />
+    protected override VanityVersion FromLowLevel(string value, AttributeResolver resolver) => VanityVersion.From(value);
+}

--- a/src/Abstractions/NexusMods.Abstractions.Games.FileHashes/IFileHashesService.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Games.FileHashes/IFileHashesService.cs
@@ -1,6 +1,7 @@
 using DynamicData.Kernel;
 using NexusMods.Abstractions.GameLocators;
 using NexusMods.Abstractions.Games.FileHashes.Models;
+using NexusMods.Abstractions.Games.FileHashes.Values;
 using NexusMods.Hashing.xxHash3;
 using NexusMods.MnemonicDB.Abstractions;
 
@@ -19,7 +20,7 @@ public interface IFileHashesService
     /// <summary>
     /// Get all the supported game versions for a given game installation
     /// </summary>
-    public IEnumerable<string> GetGameVersions(GameInstallation installation);
+    public IEnumerable<VanityVersion> GetGameVersions(GameInstallation installation);
     
     /// <summary>
     /// Get the file hashes database, downloading it if necessary
@@ -30,38 +31,37 @@ public interface IFileHashesService
     /// Get the files associated with a specific game. The LocatorIds are opaque ids that come from a game locator.
     /// For steam these will be manifestIDs, for GOG they will be buildIDs, etc.
     /// </summary>
-    public IEnumerable<GameFileRecord> GetGameFiles(GameInstallation installation, IEnumerable<string> locatorIds);
-    
+    public IEnumerable<GameFileRecord> GetGameFiles(GameInstallation installation, IEnumerable<LocatorId> locatorIds);
+
     /// <summary>
-    /// The current file hashes database, will thrown an error if not initialized via GetFileHashesDb first.
+    /// The current file hashes database, will throw an error if not initialized via GetFileHashesDb first.
     /// </summary>
     public IDb Current { get; }
 
     /// <summary>
     /// Try to get the game version for a given game installation and locator IDs
     /// </summary>
-    public bool TryGetGameVersion(GameInstallation installation, IEnumerable<string> locatorIds, out string version);
+    public bool TryGetGameVersion(GameInstallation installation, IEnumerable<LocatorId> locatorIds, out VanityVersion version);
     
     /// <summary>
     /// Get the locator IDs for a specific version of a given game installation
     /// </summary>
-    public bool TryGetLocatorIdsForVersion(GameInstallation gameInstallation, string version, out string[] commonIds);
+    public bool TryGetLocatorIdsForVersion(GameInstallation gameInstallation, VanityVersion version, out LocatorId[] commonIds);
     
     /// <summary>
     /// Suggest a game version based on the files in a game installation
     /// </summary>
-    public string SuggestGameVersion(GameInstallation gameInstallation, IEnumerable<(GamePath Path, Hash Hash)> files);
+    public VanityVersion SuggestGameVersion(GameInstallation gameInstallation, IEnumerable<(GamePath Path, Hash Hash)> files);
 
     /// <summary>
     /// Return the locator IDs for a specific version definition given a game installation
     /// </summary>
-    public string[] GetLocatorIdsForVersionDefinition(GameInstallation gameInstallation, VersionDefinition.ReadOnly versionDefinition);
+    public LocatorId[] GetLocatorIdsForVersionDefinition(GameInstallation gameInstallation, VersionDefinition.ReadOnly versionDefinition);
 
     /// <summary>
     /// Suggest a version definition for a given game installation
     /// </summary>
     public Optional<VersionData> SuggestVersionDefinitions(GameInstallation gameInstallation, IEnumerable<(GamePath Path, Hash Hash)> files);
-
 }
 
-public record struct VersionData(string[] LocatorIds, string VersionName);
+public record struct VersionData(LocatorId[] LocatorIds, VanityVersion VersionName);

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -299,7 +299,7 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
 
     public IEnumerable<LoadoutSourceItem> GetNormalGameState(IDb referenceDb, Loadout.ReadOnly loadout)
     {
-        foreach (var item in _fileHashService.GetGameFiles(loadout.InstallationInstance, loadout.LocatorIds.ToArray()))
+        foreach (var item in _fileHashService.GetGameFiles((loadout.InstallationInstance.Store, loadout.LocatorIds.ToArray())))
         {
             yield return new LoadoutSourceItem
             {
@@ -496,7 +496,7 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
         var diskState = loadout.Installation.DiskStateEntries
             .Select(part => ((GamePath)part.Path, part.Hash));
         
-        var suggestedVersionDefinition = _fileHashService.SuggestVersionDefinitions(loadout.InstallationInstance, diskState);
+        var suggestedVersionDefinition = _fileHashService.SuggestVersionData(loadout.InstallationInstance, diskState);
         if (!suggestedVersionDefinition.HasValue)
             return loadout;
         
@@ -511,7 +511,7 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
 
         // Make a lookup set of the new files
         var versionFiles = _fileHashService
-            .GetGameFiles(loadout.InstallationInstance, newLocatorIds)
+            .GetGameFiles((loadout.InstallationInstance.Store, newLocatorIds))
             .Select(file => file.Path)
             .ToHashSet();
 
@@ -533,7 +533,7 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
         
         
         // Update the version and locator ids
-        tx.Add(loadout, Loadout.GameVersion, suggestedVersionDefinition.Value.VersionName);
+        tx.Add(loadout, Loadout.GameVersion, suggestedVersionDefinition.Value.VanityVersion);
         foreach (var id in loadout.LocatorIds) 
             tx.Retract(loadout, Loadout.LocatorIds, id);
         foreach (var id in newLocatorIds)
@@ -1282,13 +1282,13 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
 
                 using var tx = Connection.BeginTransaction();
 
-                List<LocatorId> locatorMetadata = [];
+                List<LocatorId> locatorIds = [];
                 if (installation.LocatorResultMetadata != null)
                 {
-                    locatorMetadata.AddRange(installation.LocatorResultMetadata.ToLocatorIds());
+                    locatorIds.AddRange(installation.LocatorResultMetadata.ToLocatorIds());
                 }
 
-                if (!_fileHashService.TryGetGameVersion(installation, locatorMetadata, out var version))
+                if (!_fileHashService.TryGetVanityVersion((installation.Store, locatorIds.ToArray()), out var version))
                     _logger.LogWarning("Unable to find game version for {Game}", installation.GameMetadataId);
 
                 var loadout = new Loadout.New(tx)
@@ -1298,7 +1298,7 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
                     InstallationId = installation.GameMetadataId,
                     Revision = 0,
                     LoadoutKind = LoadoutKind.Default,
-                    LocatorIds = locatorMetadata,
+                    LocatorIds = locatorIds,
                     GameVersion = version,
                 };
                 
@@ -1531,14 +1531,12 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
         // Execute the garbage collector
         _garbageCollectorRunner.RunWithMode(gcRunMode);
     }
-    
-    
-    /// <inheritdoc />
-    public async Task ResetToOriginalGameState(GameInstallation installation, LocatorId[] commonIds)
+
+    public async Task ResetToOriginalGameState(GameInstallation installation, LocatorId[] locatorIds)
     {
-        var gameState = _fileHashService.GetGameFiles(installation, commonIds);
+        var gameState = _fileHashService.GetGameFiles((installation.Store, locatorIds));
         var metaData = await ReindexState(installation, Connection);
-        
+
         List<PathPartPair> diskState = [];
 
         foreach (var diskFile in metaData.DiskStateEntries)

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -9,6 +9,7 @@ using NexusMods.Abstractions.Collections;
 using NexusMods.Abstractions.GameLocators;
 using NexusMods.Abstractions.Games.FileHashes;
 using NexusMods.Abstractions.Games.FileHashes.Models;
+using NexusMods.Abstractions.Games.FileHashes.Values;
 using NexusMods.Abstractions.GC;
 using NexusMods.Abstractions.Hashes;
 using NexusMods.Abstractions.IO;
@@ -501,9 +502,9 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
         
         var newLocatorIds = suggestedVersionDefinition.Value.LocatorIds;
 
-        var locatorAdditions = loadout.LocatorIds.Except(newLocatorIds, StringComparer.OrdinalIgnoreCase).Count();
-        var locatorRemovals = newLocatorIds.Except(loadout.LocatorIds, StringComparer.OrdinalIgnoreCase).Count();
-        
+        var locatorAdditions = loadout.LocatorIds.Except(newLocatorIds).Count();
+        var locatorRemovals = newLocatorIds.Except(loadout.LocatorIds).Count();
+
         // No reason to change the loadout if the version is the same
         if (locatorRemovals == 0 && locatorAdditions == 0)
             return loadout;
@@ -1281,7 +1282,7 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
 
                 using var tx = Connection.BeginTransaction();
 
-                List<string> locatorMetadata = [];
+                List<LocatorId> locatorMetadata = [];
                 if (installation.LocatorResultMetadata != null)
                 {
                     locatorMetadata.AddRange(installation.LocatorResultMetadata.ToLocatorIds());
@@ -1343,7 +1344,7 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
         
         // Synchronize the last applied loadout, so we don't lose any changes
         await Synchronize(Loadout.Load(Connection.Db, metadata.LastSyncedLoadout));
-        
+
         var commonIds = installation.LocatorResultMetadata?.ToLocatorIds().ToArray() ?? [];
         await ResetToOriginalGameState(installation, commonIds);
     }
@@ -1533,7 +1534,7 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
     
     
     /// <inheritdoc />
-    public async Task ResetToOriginalGameState(GameInstallation installation, string[] commonIds)
+    public async Task ResetToOriginalGameState(GameInstallation installation, LocatorId[] commonIds)
     {
         var gameState = _fileHashService.GetGameFiles(installation, commonIds);
         var metaData = await ReindexState(installation, Connection);

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts/Models/Loadout.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts/Models/Loadout.cs
@@ -31,13 +31,13 @@ public partial class Loadout : IModelDefinition
     /// <summary>
     /// The locator ids for the game this loadout is tied to, for gog this will be the build ids, for example. 
     /// </summary>
-    public static readonly StringsAttribute LocatorIds = new(Namespace, nameof(LocatorIds));
-    
+    public static readonly LocatorIdsAttribute LocatorIds = new(Namespace, nameof(LocatorIds));
+
     /// <summary>
     /// The game version that this loadout is tied to, based on the LocatorIds.
     /// </summary>
-    public static readonly StringAttribute GameVersion = new(Namespace, nameof(GameVersion));
-    
+    public static readonly VanityVersionAttribute GameVersion = new(Namespace, nameof(GameVersion));
+
     /// <summary>
     /// Unique installation of the game this loadout is tied to.
     /// </summary>

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts/NexusMods.Abstractions.Loadouts.csproj
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts/NexusMods.Abstractions.Loadouts.csproj
@@ -5,7 +5,6 @@
 
     <ItemGroup>
       <ProjectReference Include="..\NexusMods.Abstractions.GameLocators\NexusMods.Abstractions.GameLocators.csproj" />
-      <ProjectReference Include="..\NexusMods.Abstractions.Games.FileHashes\NexusMods.Abstractions.Games.FileHashes.csproj" />
       <ProjectReference Include="..\NexusMods.Abstractions.IO\NexusMods.Abstractions.IO.csproj" />
       <ProjectReference Include="..\NexusMods.Abstractions.Jobs\NexusMods.Abstractions.Jobs.csproj" />
       <ProjectReference Include="..\NexusMods.Abstractions.Library.Models\NexusMods.Abstractions.Library.Models.csproj" />

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts/NexusMods.Abstractions.Loadouts.csproj
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts/NexusMods.Abstractions.Loadouts.csproj
@@ -5,6 +5,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\NexusMods.Abstractions.GameLocators\NexusMods.Abstractions.GameLocators.csproj" />
+      <ProjectReference Include="..\NexusMods.Abstractions.Games.FileHashes\NexusMods.Abstractions.Games.FileHashes.csproj" />
       <ProjectReference Include="..\NexusMods.Abstractions.IO\NexusMods.Abstractions.IO.csproj" />
       <ProjectReference Include="..\NexusMods.Abstractions.Jobs\NexusMods.Abstractions.Jobs.csproj" />
       <ProjectReference Include="..\NexusMods.Abstractions.Library.Models\NexusMods.Abstractions.Library.Models.csproj" />

--- a/src/Games/NexusMods.Games.StardewValley/Emitters/Helpers.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/Helpers.cs
@@ -38,7 +38,8 @@ internal static class Helpers
         if (localVersion.HasValue) return localVersion.Value;
 
         // NOTE(erri120): should only be hit during tests
-        var rawVersion = loadout.GameVersion;
+        var vanityVersion = loadout.GameVersion;
+        var rawVersion = vanityVersion.Value;
 
 #if DEBUG
         // NOTE(erri120): dumb hack for tests

--- a/src/Games/NexusMods.Games.StardewValley/Installers/SMAPIInstaller.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Installers/SMAPIInstaller.cs
@@ -160,10 +160,9 @@ public class SMAPIInstaller : ALibraryArchiveInstaller
         // https://github.com/Pathoschild/SMAPI/blob/9763bc7484e29cbc9e7f37c61121d794e6720e75/src/SMAPI.Installer/InteractiveInstaller.cs#L419-L425
         var srcPath = new GamePath(LocationId.Game, "Stardew Valley.deps.json");
         await _fileHashesService.GetFileHashesDb();
-        var foundRecord = _fileHashesService.GetGameFiles(loadout.InstallationInstance, loadout.LocatorIds)
+        var foundRecord = _fileHashesService.GetGameFiles((loadout.InstallationInstance.Store, loadout.LocatorIds.ToArray()))
             .Where(f => f.Path == srcPath)
             .TryGetFirst(out var gameFileRecord);
-        
 
         if (!foundRecord)
         {

--- a/src/NexusMods.App.UI/Controls/GameWidget/GameWidgetViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/GameWidget/GameWidgetViewModel.cs
@@ -42,15 +42,14 @@ public class GameWidgetViewModel : AViewModel<IGameWidgetViewModel>, IGameWidget
                     .DisposeWith(disposables);
 
                 this.WhenAnyValue(vm => vm.Installation)
-                    .SelectMany(async inst =>
-                        {
-                            await fileHashesService.GetFileHashesDb();
-                            var ids = inst.LocatorResultMetadata?.ToLocatorIds() ?? [];
-                            if (!fileHashesService.TryGetGameVersion(inst, ids, out var version))
-                                return $"Version: Unknown";
-                            return $"Version: {version}";
-                        }
-                    )
+                    .SelectMany(async installation =>
+                    {
+                        await fileHashesService.GetFileHashesDb();
+                        var locatorIds = installation.LocatorResultMetadata?.ToLocatorIds().ToArray() ?? [];
+                        if (!fileHashesService.TryGetVanityVersion((installation.Store, locatorIds), out var vanityVersion))
+                            return "Version: Unknown";
+                        return $"Version: {vanityVersion.Value}";
+                    })
                     .BindToVM(this, vm => vm.Version)
                     .DisposeWith(disposables);
 

--- a/src/NexusMods.DataModel.SchemaVersions/Migrations/_0004_RemoveGameFiles.cs
+++ b/src/NexusMods.DataModel.SchemaVersions/Migrations/_0004_RemoveGameFiles.cs
@@ -55,12 +55,13 @@ internal class _0004_RemoveGameFiles : ITransactionalMigration
                 .OfTypeLoadoutFile()
                 .Select(file => ((GamePath)file.AsLoadoutItemWithTargetPath().TargetPath, file.Hash));
 
-            var suggestedVersion = _fileHashesService.SuggestGameVersion(loadout.InstallationInstance, files);
-            if (!_fileHashesService.TryGetLocatorIdsForVersion(loadout.InstallationInstance, suggestedVersion, out var locatorIds))
-                throw new Exception("Could not find locatorIds for version, this should never happen");
-            
-            tx.Add(loadout, Loadout.GameVersion, suggestedVersion);
-            foreach (var locatorId in locatorIds) 
+            var suggestVersionDefinitions = _fileHashesService.SuggestVersionData(loadout.InstallationInstance, files);
+            if (!suggestVersionDefinitions.HasValue) throw new Exception("Could not find locatorIds for version, this should never happen");
+
+            var (locatorIds, vanityVersion) = suggestVersionDefinitions.Value;
+
+            tx.Add(loadout, Loadout.GameVersion, vanityVersion);
+            foreach (var locatorId in locatorIds)
                 tx.Add(loadout, Loadout.LocatorIds, locatorId);
 
             foreach (var group in gameFilesGroups)

--- a/src/NexusMods.DataModel/CommandLine/Verbs/LoadoutManagementVerbs.cs
+++ b/src/NexusMods.DataModel/CommandLine/Verbs/LoadoutManagementVerbs.cs
@@ -52,7 +52,7 @@ public static class LoadoutManagementVerbs
         [Option("v", "version", "Version to set")] string version,
         [Injected] IFileHashesService hasherService)
     {
-        if (!hasherService.TryGetLocatorIdsForVersion(loadout.InstallationInstance, VanityVersion.From(version), out var newCommonIds))
+        if (!hasherService.TryGetLocatorIdsForVanityVersion(loadout.InstallationInstance.Store, VanityVersion.From(version), out var newCommonIds))
         {
             await renderer.Error("Version {0} not found", version);
             return -1;
@@ -60,7 +60,7 @@ public static class LoadoutManagementVerbs
         
         // Get the actual version from the ids, so that we can sanitize the version string, and collapse multiple
         // versions into a single version string
-        if (!hasherService.TryGetGameVersion(loadout.InstallationInstance, newCommonIds, out var actualVersion))
+        if (!hasherService.TryGetVanityVersion((loadout.InstallationInstance.Store, newCommonIds), out var actualVersion))
         {
             await renderer.Error("Version {0} not found", version);
             return -1;

--- a/src/NexusMods.DataModel/CommandLine/Verbs/LoadoutManagementVerbs.cs
+++ b/src/NexusMods.DataModel/CommandLine/Verbs/LoadoutManagementVerbs.cs
@@ -52,7 +52,7 @@ public static class LoadoutManagementVerbs
         [Option("v", "version", "Version to set")] string version,
         [Injected] IFileHashesService hasherService)
     {
-        if (!hasherService.TryGetLocatorIdsForVersion(loadout.InstallationInstance, version, out var newCommonIds))
+        if (!hasherService.TryGetLocatorIdsForVersion(loadout.InstallationInstance, VanityVersion.From(version), out var newCommonIds))
         {
             await renderer.Error("Version {0} not found", version);
             return -1;

--- a/src/NexusMods.Games.FileHashes/FileHashesService.cs
+++ b/src/NexusMods.Games.FileHashes/FileHashesService.cs
@@ -1,16 +1,14 @@
 using System.IO.Compression;
 using System.Text.Json;
-using DynamicData;
 using DynamicData.Kernel;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.GameLocators;
-using NexusMods.Abstractions.Games;
 using NexusMods.Abstractions.Games.FileHashes;
 using NexusMods.Abstractions.Games.FileHashes.Models;
-using NexusMods.Abstractions.Games.FileHashes.Values;
 using NexusMods.Abstractions.GOG.Values;
 using NexusMods.Abstractions.Jobs;
+using NexusMods.Abstractions.NexusWebApi.Types.V2;
 using NexusMods.Abstractions.Settings;
 using NexusMods.Abstractions.Steam.Values;
 using NexusMods.Extensions.BCL;
@@ -24,7 +22,7 @@ using NexusMods.Paths;
 
 namespace NexusMods.Games.FileHashes;
 
-public class FileHashesService : IFileHashesService, IDisposable
+internal sealed class FileHashesService : IFileHashesService, IDisposable
 {
     private readonly ScopedAsyncLock _lock = new();
     private readonly FileHashesServiceSettings _settings;
@@ -87,15 +85,11 @@ public class FileHashesService : IFileHashesService, IDisposable
             {
                 Path = path,
             };
+
             var store = new DatomStore(_provider.GetRequiredService<ILogger<DatomStore>>(), settings, backend);
-            var connection = new Connection(_provider.GetRequiredService<ILogger<Connection>>(), store, _provider,
-                []
-            , readOnlyMode: true);
+            var connection = new Connection(_provider.GetRequiredService<ILogger<Connection>>(), store, _provider, [], readOnlyMode: true);
+            var connectedDb = new ConnectedDb(connection.Db, connection, store, backend, timestamp, path);
 
-
-            var connectedDb = new ConnectedDb(connection.Db, connection, store,
-                backend, timestamp, path
-            );
             _databases[path] = connectedDb;
             return connectedDb;
         }
@@ -113,17 +107,17 @@ public class FileHashesService : IFileHashesService, IDisposable
             .EnumerateDirectories(recursive: false)
             .Where(d => !d.FileName.EndsWith("_tmp"))
             .Select(d =>
-                {
-                    // Format is "{guid}_{timestamp}"
-                    var parts = d.FileName.Split('_');
-                    if (parts.Length != 2 || !ulong.TryParse(parts[1], out var timestamp))
-                        return default((DateTimeOffset, AbsolutePath));
-                    return (DateTimeOffset.FromUnixTimeSeconds((long)timestamp), d);
-                })
+            {
+                // Format is "{guid}_{timestamp}"
+                var parts = d.FileName.Split('_');
+                if (parts.Length != 2 || !ulong.TryParse(parts[1], out var timestamp))
+                    return default((DateTimeOffset, AbsolutePath));
+                return (DateTimeOffset.FromUnixTimeSeconds((long)timestamp), d);
+            })
             .Where(v => v != default((DateTimeOffset, AbsolutePath)))
             .OrderByDescending(v => v.Item1);
     }
-    
+
     private async Task<Manifest> GetRelease(AbsolutePath storagePath)
     {
         await using var stream = await _httpClient.GetStreamAsync(_settings.GithubManifestUrl);
@@ -140,18 +134,17 @@ public class FileHashesService : IFileHashesService, IDisposable
     }
 
     /// <inheritdoc />
-    public IEnumerable<VanityVersion> GetGameVersions(GameInstallation installation)
+    public IEnumerable<VanityVersion> GetKnownVanityVersions(GameId gameId)
     {
-        return VersionDefinition.All(Current)
-            .Where(v => v.GameId == installation.Game.GameId)
+        return GetVersionDefinitions(gameId)
             .Select(v => VanityVersion.From(v.Name))
             .ToList();
     }
 
-    public IEnumerable<VersionDefinition.ReadOnly> GetVersionDefinitions(GameInstallation installation)
+    private List<VersionDefinition.ReadOnly> GetVersionDefinitions(GameId gameId)
     {
         return VersionDefinition.All(Current)
-            .Where(v => v.GameId == installation.Game.GameId)
+            .Where(v => v.GameId == gameId)
             .ToList();
     }
 
@@ -192,7 +185,6 @@ public class FileHashesService : IFileHashesService, IDisposable
             await stream.CopyToAsync(fileStream);
         }
 
-
         var tempDir = _settings.HashDatabaseLocation.ToPath(_fileSystem) / $"{guid}_{release.CreatedAt.ToUnixTimeSeconds()}_tmp";
         {
             // extract it 
@@ -232,9 +224,13 @@ public class FileHashesService : IFileHashesService, IDisposable
 
         return Current;
     }
-    public IEnumerable<GameFileRecord> GetGameFiles(GameInstallation installation, IEnumerable<LocatorId> locatorIds)
+
+    /// <inheritdoc/>
+    public IEnumerable<GameFileRecord> GetGameFiles(LocatorIdsWithGameStore locatorIdsWithGameStore)
     {
-        if (installation.Store == GameStore.GOG)
+        var (gameStore, locatorIds) = locatorIdsWithGameStore;
+
+        if (gameStore == GameStore.GOG)
         {
             foreach (var id in locatorIds)
             {
@@ -258,7 +254,7 @@ public class FileHashesService : IFileHashesService, IDisposable
                 }
             }
         }
-        else if (installation.Store == GameStore.Steam)
+        else if (gameStore == GameStore.Steam)
         {
             foreach (var id in locatorIds)
             {
@@ -284,7 +280,7 @@ public class FileHashesService : IFileHashesService, IDisposable
         }
         else
         {
-            throw new NotImplementedException("No way to get game files for: " + installation.Store);
+            throw new NotSupportedException("No way to get game files for: " + gameStore);
         }
     }
 
@@ -292,9 +288,9 @@ public class FileHashesService : IFileHashesService, IDisposable
     public IDb Current => _currentDb?.Db ?? throw new InvalidOperationException("No database connected");
 
     /// <inheritdoc />
-    public bool TryGetGameVersion(GameInstallation installation, IEnumerable<LocatorId> locatorMetadata, out VanityVersion version)
+    public bool TryGetVanityVersion(LocatorIdsWithGameStore locatorIdsWithGameStore, out VanityVersion version)
     {
-        if (TryGetGameVersionDefinition(installation, locatorMetadata, out var versionDefinition))
+        if (TryGetGameVersionDefinition(locatorIdsWithGameStore, out var versionDefinition))
         {
             version = VanityVersion.From(versionDefinition.Name);
             return true;
@@ -304,14 +300,18 @@ public class FileHashesService : IFileHashesService, IDisposable
         return false;
     }
 
-    private bool TryGetGameVersionDefinition(GameInstallation installation, IEnumerable<LocatorId> locatorMetadata, out VersionDefinition.ReadOnly versionDefinition)
+    private bool TryGetGameVersionDefinition(
+        LocatorIdsWithGameStore locatorIdsWithGameStore,
+        out VersionDefinition.ReadOnly versionDefinition)
     {
+        var (gameStore, locatorIds) = locatorIdsWithGameStore;
+
         versionDefinition = default(VersionDefinition.ReadOnly);
-        if (installation.Store == GameStore.GOG)
+        if (gameStore == GameStore.GOG)
         {
             List<GogBuild.ReadOnly> gogBuilds = [];
 
-            foreach (var gogId in locatorMetadata)
+            foreach (var gogId in locatorIds)
             {
                 if (!ulong.TryParse(gogId.Value, out var parsedId))
                 {
@@ -319,49 +319,47 @@ public class FileHashesService : IFileHashesService, IDisposable
                     return false;
                 }
 
-                var gogBuild = GogBuild.FindByBuildId(Current, BuildId.From(parsedId))
-                    .FirstOrDefault();
-                gogBuilds.Add(gogBuild);
+                var hasBuild = GogBuild.FindByBuildId(Current, BuildId.From(parsedId)).TryGetFirst(out var gogBuild);
+                if (hasBuild) gogBuilds.Add(gogBuild);
             }
 
             if (gogBuilds.Count == 0)
             {
-                _logger.LogDebug("No GOG builds found for locator metadata");
+                _logger.LogDebug("No GOG builds found");
                 return false;
             }
 
-            var wasFound = VersionDefinition.All(_currentDb!.Db)
+            var hasVersionDefinition = VersionDefinition.All(_currentDb!.Db)
                 .Select(version =>
-                    {
-                        var matchingIdCount = gogBuilds.Count(g => version.GogBuildsIds.Contains(g));
-                        return (matchingIdCount, version);
-                    })
+                {
+                    var matchingIdCount = gogBuilds.Count(g => version.GogBuildsIds.Contains(g));
+                    return (matchingIdCount, version);
+                })
                 .Where(row => row.matchingIdCount > 0)
                 .OrderByDescending(row => row.matchingIdCount)
                 .Select(t => t.version)
                 .TryGetFirst(out versionDefinition);
 
-            if (!wasFound)
+            if (!hasVersionDefinition)
             {
-                _logger.LogDebug("No version found for locator metadata");
+                _logger.LogDebug("No matching version definition found");
                 return false;
             }
         }
-        else if (installation.Store == GameStore.Steam)
+        else if (gameStore == GameStore.Steam)
         {
             List<SteamManifest.ReadOnly> steamManifests = [];
             
-            foreach (var steamId in locatorMetadata)
+            foreach (var steamId in locatorIds)
             {
                 if (!ulong.TryParse(steamId.Value, out var parsedId))
                 {
-                    _logger.LogDebug("Steam locator {0} metadata is not a valid ulong", steamId);
+                    _logger.LogDebug("Steam locator {Raw} metadata is not a valid ulong", steamId);
                     return false;
                 }
 
-                var steamManifest = SteamManifest.FindByManifestId(Current, ManifestId.From(parsedId))
-                    .FirstOrDefault();
-                steamManifests.Add(steamManifest);
+                var hasManifest = SteamManifest.FindByManifestId(Current, ManifestId.From(parsedId)).TryGetFirst(out var steamManifest);
+                if (hasManifest) steamManifests.Add(steamManifest);
             }
 
             if (steamManifests.Count == 0)
@@ -389,7 +387,7 @@ public class FileHashesService : IFileHashesService, IDisposable
         }
         else
         {
-            _logger.LogDebug("No way to get game version for: {Store}", installation.Store);
+            _logger.LogDebug("No way to get game version for: {Store}", gameStore);
             return false;
         }
 
@@ -397,9 +395,9 @@ public class FileHashesService : IFileHashesService, IDisposable
     }
 
     /// <inheritdoc />
-    public bool TryGetLocatorIdsForVersion(GameInstallation gameInstallation, VanityVersion version, out LocatorId[] commonIds)
+    public bool TryGetLocatorIdsForVanityVersion(GameStore gameStore, VanityVersion version, out LocatorId[] commonIds)
     {
-        if (gameInstallation.Store == GameStore.GOG)
+        if (gameStore == GameStore.GOG)
         {
             if (!VersionDefinition.FindByName(Current, version.Value).TryGetFirst(out var versionDef))
             {
@@ -407,10 +405,10 @@ public class FileHashesService : IFileHashesService, IDisposable
                 return false;
             }
 
-            commonIds = GetLocatorIdsForVersionDefinition(gameInstallation, versionDef);
+            commonIds = GetLocatorIdsForVersionDefinition(gameStore, versionDef);
             return true;
         }
-        else if (gameInstallation.Store == GameStore.Steam)
+        else if (gameStore == GameStore.Steam)
         {
             if (!VersionDefinition.FindByName(Current, version.Value).TryGetFirst(out var versionDef))
             {
@@ -418,79 +416,53 @@ public class FileHashesService : IFileHashesService, IDisposable
                 return false;
             }
 
-            commonIds = GetLocatorIdsForVersionDefinition(gameInstallation, versionDef);
+            commonIds = GetLocatorIdsForVersionDefinition(gameStore, versionDef);
             return true;
         }
         else
         {
-            throw new NotImplementedException("No way to get common IDs for: " + gameInstallation.Store);
+            throw new NotSupportedException("No way to get common IDs for: " + gameStore);
         }
     }
 
-    public LocatorId[] GetLocatorIdsForVersionDefinition(GameInstallation gameInstallation, VersionDefinition.ReadOnly versionDefinition)
+    public LocatorId[] GetLocatorIdsForVersionDefinition(GameStore gameStore, VersionDefinition.ReadOnly versionDefinition)
     {
-        if (gameInstallation.Store == GameStore.GOG)
+        if (gameStore == GameStore.GOG)
         {
             return versionDefinition.GogBuilds.Select(build => LocatorId.From(build.BuildId.ToString())).ToArray();
         }
 
-        if (gameInstallation.Store == GameStore.Steam)
+        if (gameStore == GameStore.Steam)
         {
             return versionDefinition.SteamManifests.Select(manifest => LocatorId.From(manifest.ManifestId.ToString())).ToArray();
         }
 
-        throw new NotImplementedException("No way to get common IDs for: " + gameInstallation.Store);
-    }
-
-
-    /// <inheritdoc />
-    public VanityVersion SuggestGameVersion(GameInstallation gameInstallation, IEnumerable<(GamePath Path, Hash Hash)> files)
-    {
-        var filesSet = files.ToHashSet();
-
-        List<(VanityVersion VanityVersion, int Matches)> versionMatches = [];
-        foreach (var vanityVersion in GetGameVersions(gameInstallation))
-        {
-            if (!TryGetLocatorIdsForVersion(gameInstallation, vanityVersion, out var commonIds))
-                continue;
-
-            var matchingCount = GetGameFiles(gameInstallation, commonIds)
-                .Count(file => filesSet.Contains((file.Path, file.Hash)));
-
-            versionMatches.Add((vanityVersion, matchingCount));
-        }
-
-        var hasVersion = versionMatches
-            .OrderByDescending(t => t.Matches)
-            .Select(t => t.VanityVersion)
-            .TryGetFirst(out var result);
-
-        if (hasVersion) return result;
-        return VanityVersion.DefaultValue;
+        throw new NotSupportedException("No way to get common IDs for: " + gameStore);
     }
 
     /// <inheritdoc />
-    public Optional<VersionData> SuggestVersionDefinitions(GameInstallation gameInstallation, IEnumerable<(GamePath Path, Hash Hash)> files)
+    public Optional<VersionData> SuggestVersionData(GameInstallation gameInstallation, IEnumerable<(GamePath Path, Hash Hash)> files)
     {
         var filesSet = files.ToHashSet();
-        
+
         List<(VersionData VersionData, int Matches)> versionMatches = [];
-        foreach (var versionDefinition in GetVersionDefinitions(gameInstallation))
+        foreach (var versionDefinition in GetVersionDefinitions(gameInstallation.Game.GameId))
         {
-            var commonIds = GetLocatorIdsForVersionDefinition(gameInstallation, versionDefinition);
+            var locatorIds = GetLocatorIdsForVersionDefinition(gameInstallation.Store, versionDefinition);
 
-            var matchingCount = GetGameFiles(gameInstallation, commonIds)
+            var matchingCount = GetGameFiles((gameInstallation.Store, locatorIds))
                 .Count(file => filesSet.Contains((file.Path, file.Hash)));
 
-            versionMatches.Add((new VersionData(commonIds, VanityVersion.From(versionDefinition.Name)), matchingCount));
+            versionMatches.Add((new VersionData(locatorIds, VanityVersion.From(versionDefinition.Name)), matchingCount));
         }
-        
+
         return versionMatches
             .OrderByDescending(t => t.Matches)
             .Select(t => t.VersionData)
-            .FirstOrOptional(item => true);
+            .FirstOrOptional(_ => true);
     }
 
+    /// <inheritdoc/>
     public void Dispose()
     {
         foreach (var connection in _databases.Values)

--- a/src/NexusMods.StandardGameLocators/ManuallyAddedGame.cs
+++ b/src/NexusMods.StandardGameLocators/ManuallyAddedGame.cs
@@ -32,6 +32,6 @@ public partial class ManuallyAddedGame : IModelDefinition
     public partial struct ReadOnly : IGameLocatorResultMetadata
     {
         /// <inheritdoc />
-        public IEnumerable<string> ToLocatorIds() => ["NONE"];
+        public IEnumerable<LocatorId> ToLocatorIds() => [LocatorId.From("NONE")];
     }
 }

--- a/src/NexusMods.StandardGameLocators/Unknown/UnknownLocatorResultMetadata.cs
+++ b/src/NexusMods.StandardGameLocators/Unknown/UnknownLocatorResultMetadata.cs
@@ -9,5 +9,5 @@ namespace NexusMods.StandardGameLocators.Unknown;
 [PublicAPI]
 public record UnknownLocatorResultMetadata : IGameLocatorResultMetadata
 {
-    public IEnumerable<string> ToLocatorIds() => ["StubbedGameState.zip"];
+    public IEnumerable<LocatorId> ToLocatorIds() => [LocatorId.From("StubbedGameState.zip")];
 }

--- a/tests/NexusMods.DataModel.Synchronizer.Tests/SynchronizerUnitTests.cs
+++ b/tests/NexusMods.DataModel.Synchronizer.Tests/SynchronizerUnitTests.cs
@@ -59,6 +59,6 @@ public class SynchronizerUnitTests(ITestOutputHelper testOutputHelper) : ACyberp
     public async Task LoadoutsContainLocatorMetadata()
     {
         var loadout = await CreateLoadout();
-        loadout.LocatorIds.Should().BeEquivalentTo(["StubbedGameState.zip"]);
+        loadout.LocatorIds.Should().BeEquivalentTo([LocatorId.From("StubbedGameState.zip")]);
     }
 }

--- a/tests/NexusMods.DataModel.Tests/LoadoutObservableTests.cs
+++ b/tests/NexusMods.DataModel.Tests/LoadoutObservableTests.cs
@@ -29,10 +29,9 @@ public class LoadoutObservableTests(IServiceProvider provider) : AGameTest<Cyber
             InstallationId = GameInstallation.GameMetadataId,
             LoadoutKind = LoadoutKind.Default,
             Revision = 0,
-            GameVersion = "Unknown",
+            GameVersion = VanityVersion.From("Unknown"),
         };
-        
-        
+
         var group = new LoadoutItemGroup.New(tx, out var groupId)
         {
             IsGroup = true,


### PR DESCRIPTION
Cleanup PR. Functionality shouldn't be affected.

- Adds two new value types: `VanityVersion` and `LocatorId`
- Removes and updates many methods from `IFileHashesService`
- Refactors the implementations of `IFileHashesService`