### PR TITLE
Silence the event sender errors, but log them with a debug message

### DIFF
--- a/src/NexusMods.Telemetry/EventSender.cs
+++ b/src/NexusMods.Telemetry/EventSender.cs
@@ -32,10 +32,11 @@ internal class EventSender : IEventSender
     private readonly ILoginManager _loginManager;
     private readonly HttpClient _httpClient;
     private readonly ArrayBufferWriter<byte> _writer;
+    private readonly ILogger<EventSender>? _logger;
 
     private static readonly byte[] EncodedUserAgent = CreateUserAgent();
 
-    public EventSender(ILogger<EventSender> logger, ILoginManager loginManager, HttpClient httpClient)
+    public EventSender(ILogger<EventSender>? logger, ILoginManager loginManager, HttpClient httpClient)
     {
         _logger = logger;
         _loginManager = loginManager;
@@ -48,7 +49,6 @@ internal class EventSender : IEventSender
 
     private ulong _lastGeneratedId;
     private ulong _highestSeenId;
-    private readonly ILogger<EventSender> _logger;
 
     /// <summary>
     /// Inserts the event into the queue.
@@ -217,7 +217,7 @@ internal class EventSender : IEventSender
         catch (Exception ex)
         {
             // NOTE (halgari): Yes, this will add more bloat to the log, but only in testing where DEBUG logging is enabled.
-            _logger.LogDebug(ex, "Error occured while sending events");
+            _logger?.LogDebug(ex, "Error occured while sending events");
         }
     }
 

--- a/src/NexusMods.Telemetry/EventSender.cs
+++ b/src/NexusMods.Telemetry/EventSender.cs
@@ -9,6 +9,7 @@ using System.Text;
 using Cysharp.Text;
 using DynamicData.Kernel;
 using JetBrains.Annotations;
+using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.NexusWebApi;
 using NexusMods.Abstractions.NexusWebApi.Types;
 using NexusMods.Paths;
@@ -34,8 +35,9 @@ internal class EventSender : IEventSender
 
     private static readonly byte[] EncodedUserAgent = CreateUserAgent();
 
-    public EventSender(ILoginManager loginManager, HttpClient httpClient)
+    public EventSender(ILogger<EventSender> logger, ILoginManager loginManager, HttpClient httpClient)
     {
+        _logger = logger;
         _loginManager = loginManager;
         _httpClient = httpClient;
         _writer = new ArrayBufferWriter<byte>();
@@ -46,6 +48,7 @@ internal class EventSender : IEventSender
 
     private ulong _lastGeneratedId;
     private ulong _highestSeenId;
+    private readonly ILogger<EventSender> _logger;
 
     /// <summary>
     /// Inserts the event into the queue.
@@ -200,14 +203,22 @@ internal class EventSender : IEventSender
         }
     }
 
-    private static async ValueTask SendEvents(ReadOnlyMemory<byte> data, HttpClient httpClient, CancellationToken cancellationToken)
+    private async ValueTask SendEvents(ReadOnlyMemory<byte> data, HttpClient httpClient, CancellationToken cancellationToken)
     {
         using var request = new HttpRequestMessage(HttpMethod.Post, Constants.MatomoTrackingEndpoint);
         request.Content = new ReadOnlyMemoryContent(data);
         request.Content.Headers.ContentType = new MediaTypeHeaderValue(MediaTypeNames.Application.Json);
 
-        var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
+        try
+        {
+            var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+        }
+        catch (Exception ex)
+        {
+            // NOTE (halgari): Yes, this will add more bloat to the log, but only in testing where DEBUG logging is enabled.
+            _logger.LogDebug(ex, "Error occured while sending events");
+        }
     }
 
     /// <summary>

--- a/tests/NexusMods.Telemetry.Tests/EventSenderTests.cs
+++ b/tests/NexusMods.Telemetry.Tests/EventSenderTests.cs
@@ -46,7 +46,7 @@ public class EventSenderTests
                 ExpectJson($$"""{ "requests": ["?idsite=7&rec=1&apiv=1&ua={{expectedUserAgent}}&send_image=0&ca=1&uid=1337&e_c=Game&e_a=Add+Game&e_n=Mount+%26+Blade&h=0&m=0&s=0","?idsite=7&rec=1&apiv=1&ua={{expectedUserAgent}}&send_image=0&ca=1&uid=1337&e_c=Loadout&e_a=Create+Loadout&e_n=Mount+%26+Blade&h=0&m=0&s=1"] }""", res);
             });
 
-        var sender = new EventSender(loginManager, new HttpClient(messageHandler));
+        var sender = new EventSender(null, loginManager, new HttpClient(messageHandler));
 
         var timeProvider = new FakeTimeProvider();
         sender.AddEvent(definition: Events.Game.AddGame, metadata: new EventMetadata(name: "Mount & Blade", timeProvider: timeProvider));


### PR DESCRIPTION
Fixes: #2615

Fixes for other network related errors will come in future PRs. This logs a debug message on failed sends for telemetry events, for testing purposes, being a "debug" level it won't show up in most users logs. 