### PR TITLE
Respect health check settings in the summaries and side menu

### DIFF
--- a/src/NexusMods.App.UI/LeftMenu/Loadout/LoadoutLeftMenuViewModel.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Loadout/LoadoutLeftMenuViewModel.cs
@@ -11,6 +11,7 @@ using NexusMods.Abstractions.Collections;
 using NexusMods.Abstractions.Diagnostics;
 using NexusMods.Abstractions.Jobs;
 using NexusMods.Abstractions.Loadouts;
+using NexusMods.Abstractions.Settings;
 using NexusMods.Abstractions.UI;
 using NexusMods.App.UI.Controls;
 using NexusMods.App.UI.Controls.Navigation;
@@ -57,6 +58,7 @@ public class LoadoutLeftMenuViewModel : AViewModel<ILoadoutLeftMenuViewModel>, I
         WorkspaceId = workspaceId;
 
         var diagnosticManager = serviceProvider.GetRequiredService<IDiagnosticManager>();
+        var settingsManager = serviceProvider.GetRequiredService<ISettingsManager>();
         var conn = serviceProvider.GetRequiredService<IConnection>();
         var monitor = serviceProvider.GetRequiredService<IJobMonitor>();
         var overlayController = serviceProvider.GetRequiredService<IOverlayController>();
@@ -163,6 +165,7 @@ public class LoadoutLeftMenuViewModel : AViewModel<ILoadoutLeftMenuViewModel>, I
         // Health Check
         LeftMenuItemHealthCheck = new HealthCheckLeftMenuItemViewModel(
             workspaceController,
+            settingsManager,
             WorkspaceId,
             new PageData
             {

--- a/src/NexusMods.App.UI/Pages/Diagnostics/List/DiagnosticListViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/Diagnostics/List/DiagnosticListViewModel.cs
@@ -111,16 +111,19 @@ internal class DiagnosticListViewModel : APageViewModel<IDiagnosticListViewModel
             // diagnostic counts
             severityCountObservable
                 .Select(dict => dict.GetValueOrDefault(DiagnosticSeverity.Suggestion, defaultValue: 0))
+                .Select(num => Settings.MinimumSeverity > DiagnosticSeverity.Suggestion ? 0 : num)
                 .BindToVM(this, vm => vm.NumSuggestions)
                 .DisposeWith(disposable);
 
             severityCountObservable
                 .Select(dict => dict.GetValueOrDefault(DiagnosticSeverity.Warning, defaultValue: 0))
+                .Select(num => Settings.MinimumSeverity > DiagnosticSeverity.Warning ? 0 : num)
                 .BindToVM(this, vm => vm.NumWarnings)
                 .DisposeWith(disposable);
 
             severityCountObservable
                 .Select(dict => dict.GetValueOrDefault(DiagnosticSeverity.Critical, defaultValue: 0))
+                .Select(num => Settings.MinimumSeverity > DiagnosticSeverity.Critical ? 0 : num)
                 .BindToVM(this, vm => vm.NumCritical)
                 .DisposeWith(disposable);
 


### PR DESCRIPTION
Fixes #2720, also only displays the icons in the left menu when the diagnostics are not filtered by the severity settings. 