### PR TITLE
Styling workaround for Success Rating

### DIFF
--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadView.axaml
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadView.axaml
@@ -14,7 +14,7 @@
     xmlns:resources="clr-namespace:NexusMods.App.UI.Resources"
     mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="800"
     x:Class="NexusMods.App.UI.Pages.CollectionDownload.CollectionDownloadView">
-    
+
     <Design.DataContext>
         <collectionDownload:CollectionDownloadDesignViewModel />
     </Design.DataContext>
@@ -80,7 +80,7 @@
                     <controls:StandardButton x:Name="ButtonInstallOptionalItems"
                                              Text="{x:Static resources:Language.CollectionDownloadViewModel_InstallOptional}"
                                              Size="Small" />
-                    <controls:StandardButton Flyout="{StaticResource CollectionMenuFlyout}" 
+                    <controls:StandardButton Flyout="{StaticResource CollectionMenuFlyout}"
                                              ShowLabel="False"
                                              LeftIcon="{x:Static icons:IconValues.MoreVertical}"
                                              ShowIcon="Left"

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadView.axaml.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadView.axaml.cs
@@ -112,19 +112,19 @@ public partial class CollectionDownloadView : ReactiveUserControl<ICollectionDow
                 .Subscribe(tuple =>
                 {
                     var (isUpdateAvailable, optional) = tuple;
-
+            
                     ButtonUpdateCollection.IsVisible = isUpdateAvailable;
                     ArrowRight.IsVisible = isUpdateAvailable;
                     NewestRevision.IsVisible = isUpdateAvailable;
-
+            
                     if (optional.HasValue) NewestRevision.Text = $"Revision {optional.Value}";
                 }).DisposeWith(d);
-
+            
             this.WhenAnyValue(view => view.TabControl.SelectedItem)
                 .Subscribe(selectedItem =>
                 {
                     CollectionDownloadsFilter filter;
-
+            
                     if (ReferenceEquals(selectedItem, RequiredTab))
                     {
                         filter = CollectionDownloadsFilter.OnlyRequired;
@@ -135,7 +135,7 @@ public partial class CollectionDownloadView : ReactiveUserControl<ICollectionDow
                     {
                         return;
                     }
-
+            
                     ViewModel!.TreeDataGridAdapter.Filter.Value = filter;
                 }).DisposeWith(d);
 
@@ -159,7 +159,7 @@ public partial class CollectionDownloadView : ReactiveUserControl<ICollectionDow
                     ButtonDownloadOptionalItems.IsVisible = filter == CollectionDownloadsFilter.OnlyOptional && !hasDownloadedAllOptionalItems;
                     ButtonInstallOptionalItems.IsVisible = filter == CollectionDownloadsFilter.OnlyOptional && hasDownloadedAllOptionalItems && !hasInstalledAllOptionals;
                 }).DisposeWith(d);
-
+            
             this.WhenAnyValue(
                     view => view.ViewModel!.OptionalDownloadsCount,
                     view => view.ViewModel!.InstructionsRenderer,
@@ -168,7 +168,7 @@ public partial class CollectionDownloadView : ReactiveUserControl<ICollectionDow
                 {
                     if (hasSingleTab) TabControl.Classes.Add("SingleTab");
                     else TabControl.Classes.Remove("SingleTab");
-
+            
                     if (hasSingleTab) TabControl.SelectedItem = RequiredTab;
                 }).DisposeWith(d);
 
@@ -179,10 +179,16 @@ public partial class CollectionDownloadView : ReactiveUserControl<ICollectionDow
                     {
                         >= 0.75 => "HighRating",
                         >= 0.5 => "MidRating",
-                        _ => "LowRating",
+                        >= 0.01 => "LowRating",
+                        _ => "NoRating",
                     };
                 })
-                .Subscribe(className => OverallRatingPanel.Classes.Add(className))
+                .Subscribe(className =>
+                    {
+                        OverallRatingPanel.Classes.Add(className);
+                        OverallRating.Text = className == "NoRating" ? "--" : ViewModel!.OverallRating.Value.ToString("P2");
+                    }
+                )
                 .DisposeWith(d);
 
             this.WhenAnyValue(view => view.ViewModel!.CanDownloadAutomatically)

--- a/src/NexusMods.App.UI/Pages/LibraryPage/Collections/CollectionCardView.axaml.cs
+++ b/src/NexusMods.App.UI/Pages/LibraryPage/Collections/CollectionCardView.axaml.cs
@@ -65,10 +65,16 @@ public partial class CollectionCardView : ReactiveUserControl<ICollectionCardVie
                     {
                         >= 0.75 => "HighRating",
                         >= 0.5 => "MidRating",
-                        _ => "LowRating",
+                        >= 0.01 => "LowRating",
+                        _ => "NoRating",
                     };
                 })
-                .Subscribe(className => OverallRatingPanel.Classes.Add(className))
+                .Subscribe(className =>
+                    {
+                        OverallRatingPanel.Classes.Add(className);
+                        OverallRating.Text = className == "NoRating" ? "--" : ViewModel!.OverallRating.Value.ToString("P2");
+                    }
+                )
                 .DisposeWith(d);
         });
     }

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/UserControls/CollectionCards/CollectionCardStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/UserControls/CollectionCards/CollectionCardStyles.axaml
@@ -140,6 +140,14 @@
 
                 <!-- color changes for rating values -->
                 <Style Selector="^ StackPanel#OverallRatingPanel">
+                    <Style Selector="^.NoRating">
+                        <Style Selector="^ TextBlock#OverallRating">
+                            <Setter Property="Foreground" Value="{StaticResource NeutralTranslucentModerateBrush}" />
+                        </Style>
+                        <Style Selector="^ icons|UnifiedIcon#OverallRatingIcon">
+                            <Setter Property="Foreground" Value="{StaticResource NeutralTranslucentModerateBrush}" />
+                        </Style>
+                    </Style>
                     <Style Selector="^.LowRating">
                         <Style Selector="^ TextBlock#OverallRating">
                             <Setter Property="Foreground" Value="{StaticResource DangerStrongBrush}" />

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/UserControls/CollectionDownloadPage/CollectionDownloadPageStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/UserControls/CollectionDownloadPage/CollectionDownloadPageStyles.axaml
@@ -179,6 +179,14 @@
 
                                 <!-- color changes for rating values -->
                                 <Style Selector="^ StackPanel#OverallRatingPanel">
+                                    <Style Selector="^.NoRating">
+                                        <Style Selector="^ TextBlock#OverallRating">
+                                            <Setter Property="Foreground" Value="{StaticResource NeutralTranslucentModerateBrush}" />
+                                        </Style>
+                                        <Style Selector="^ icons|UnifiedIcon#OverallRatingIcon">
+                                            <Setter Property="Foreground" Value="{StaticResource NeutralTranslucentModerateBrush}" />
+                                        </Style>
+                                    </Style>
                                     <Style Selector="^.LowRating">
                                         <Style Selector="^ TextBlock#OverallRating">
                                             <Setter Property="Foreground" Value="{StaticResource DangerStrongBrush}" />

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/UserControls/CollectionDownloadPage/CollectionDownloadPageStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/UserControls/CollectionDownloadPage/CollectionDownloadPageStyles.axaml
@@ -19,7 +19,7 @@
 
         <Style Selector="^ DockPanel#Body">
             <Style Selector="^ Border#HeaderBorderBackground">
-                
+
                 <Style Selector="^ Border#HeaderBorder">
                     <Setter Property="HorizontalAlignment" Value="Stretch" />
                     <Setter Property="Padding" Value="24,24,24,16" />
@@ -181,10 +181,12 @@
                                 <Style Selector="^ StackPanel#OverallRatingPanel">
                                     <Style Selector="^.NoRating">
                                         <Style Selector="^ TextBlock#OverallRating">
-                                            <Setter Property="Foreground" Value="{StaticResource NeutralTranslucentModerateBrush}" />
+                                            <Setter Property="Foreground"
+                                                    Value="{StaticResource NeutralTranslucentModerateBrush}" />
                                         </Style>
                                         <Style Selector="^ icons|UnifiedIcon#OverallRatingIcon">
-                                            <Setter Property="Foreground" Value="{StaticResource NeutralTranslucentModerateBrush}" />
+                                            <Setter Property="Foreground"
+                                                    Value="{StaticResource NeutralTranslucentModerateBrush}" />
                                         </Style>
                                     </Style>
                                     <Style Selector="^.LowRating">
@@ -250,16 +252,16 @@
                     <!-- negative bottom margin to pull up the toolbar below -->
                     <Setter Property="Margin" Value="24,12,0,-2" />
                 </Style>
-                
+
                 <Style Selector="^ /template/ ContentPresenter#PART_SelectedContentHost">
                     <!-- can't do a bottom border on the tab header items -->
                     <Setter Property="BorderThickness" Value="0,1,0,0" />
                     <Setter Property="BorderBrush" Value="{StaticResource StrokeTranslucentWeakBrush}" />
                 </Style>
-                
+
                 <!-- tab content -->
                 <Style Selector="^ TabItem#InstructionsTab">
-                    
+
                     <!-- all expanders -->
                     <Style Selector="^ > ScrollViewer > StackPanel > Expander">
                         <Setter Property="HorizontalAlignment" Value="Stretch" />
@@ -303,11 +305,11 @@
 
                                 <Style Selector="^ > StackPanel">
                                     <Setter Property="Spacing" Value="{StaticResource Spacing-1}" />
-                                    
+
                                     <Style Selector="^ TextBlock">
                                         <Setter Property="TextWrapping" Value="Wrap" />
                                     </Style>
-                                    
+
                                     <!-- mod name -->
                                     <Style Selector="^ TextBlock:nth-child(1)">
                                         <Setter Property="Theme" Value="{StaticResource BodyLGBoldTheme}" />


### PR DESCRIPTION
Small PR that adds a `NoRating` class so we can style the success rating in grey if it's 0% instead of red. 0% isn't going to mean it's unsuccessful and so will do us for now.

![image](https://github.com/user-attachments/assets/28a423aa-a423-4277-bebb-9f21ea604358)

![image](https://github.com/user-attachments/assets/ba9bc3c1-140f-4582-a401-3e68e2a54a76)
