### PR TITLE
Use fallback page instead of breaking the workspace

### DIFF
--- a/src/NexusMods.App.UI/WorkspaceSystem/Page/PageFactoryController.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Page/PageFactoryController.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using DynamicData.Kernel;
+using NexusMods.App.UI.Pages;
 using NexusMods.App.UI.Windows;
 
 namespace NexusMods.App.UI.WorkspaceSystem;
@@ -46,6 +47,7 @@ public class PageFactoryController
     {
         var factory = GetFactory(pageData);
         var page = factory.Create(pageData.Context);
+
         page.ViewModel.WindowId = windowId;
         page.ViewModel.WorkspaceId = workspaceId;
         page.ViewModel.PanelId = panelId;

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
@@ -423,8 +423,7 @@ public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceVie
             _logger.LogError(e, "Exception creating page for factory `{FactoryId}` with context `{Context}`", pageData.FactoryId, pageData.Context);
 
             var defaultPageData = GetDefaultPageData();
-            OpenPageReplaceTab(defaultPageData, replaceTab, selectTab, checkOtherPanels: false);
-            return;
+            newTabPage = _factoryController.Create(defaultPageData, WindowId, Id, panel.Id, tab.Id);
         }
 
         tab.Header.Icon = newTabPage.ViewModel.TabIcon;

--- a/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Workspace/WorkspaceViewModel.cs
@@ -59,15 +59,18 @@ public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceVie
     public ReadOnlyObservableCollection<IPanelResizerViewModel> Resizers => _resizers;
 
     private readonly ILogger _logger;
+    private readonly ILoggerFactory _loggerFactory;
     private readonly IWorkspaceController _workspaceController;
     private readonly PageFactoryController _factoryController;
 
     public WorkspaceViewModel(
-        ILogger<WorkspaceViewModel> logger,
+        ILoggerFactory loggerFactory,
         IWorkspaceController workspaceController,
         PageFactoryController factoryController)
     {
-        _logger = logger;
+        _logger = loggerFactory.CreateLogger<WorkspaceViewModel>();
+        _loggerFactory = loggerFactory;
+
         _workspaceController = workspaceController;
         _factoryController = factoryController;
 
@@ -352,7 +355,7 @@ public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceVie
         );
     }
 
-    private PageData GetDefaultPageData()
+    public PageData GetDefaultPageData()
     {
         var allDetails = _factoryController.GetAllDetails(Context).ToArray();
         var pageData = new PageData
@@ -360,8 +363,8 @@ public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceVie
             FactoryId = NewTabPageFactory.StaticId,
             Context = new NewTabPageContext
             {
-                DiscoveryDetails = allDetails
-            }
+                DiscoveryDetails = allDetails,
+            },
         };
 
         return pageData;
@@ -408,7 +411,22 @@ public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceVie
         if (!tab.Contents.ViewModel.CanClose()) return;
 
         // Replace the tab contents
-        var newTabPage = _factoryController.Create(pageData, WindowId, Id, panel.Id, tab.Id);
+
+        Page newTabPage;
+
+        try
+        {
+            newTabPage = _factoryController.Create(pageData, WindowId, Id, panel.Id, tab.Id);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Exception creating page for factory `{FactoryId}` with context `{Context}`", pageData.FactoryId, pageData.Context);
+
+            var defaultPageData = GetDefaultPageData();
+            OpenPageReplaceTab(defaultPageData, replaceTab, selectTab, checkOtherPanels: false);
+            return;
+        }
+
         tab.Header.Icon = newTabPage.ViewModel.TabIcon;
         tab.Header.Title = newTabPage.ViewModel.TabTitle;
 
@@ -474,7 +492,7 @@ public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceVie
                 var (panelId, logicalBounds) = panel;
                 if (panelId == PanelId.DefaultValue)
                 {
-                    var panelViewModel = new PanelViewModel(_workspaceController, _factoryController)
+                    var panelViewModel = new PanelViewModel(_loggerFactory.CreateLogger<PanelViewModel>(), _workspaceController, _factoryController)
                     {
                         WindowId = WindowId,
                         WorkspaceId = Id,
@@ -554,7 +572,7 @@ public class WorkspaceViewModel : AViewModel<IWorkspaceViewModel>, IWorkspaceVie
 
             foreach (var panel in data.Panels)
             {
-                var vm = new PanelViewModel(_workspaceController, _factoryController)
+                var vm = new PanelViewModel(_loggerFactory.CreateLogger<PanelViewModel>(), _workspaceController, _factoryController)
                 {
                     WindowId = WindowId,
                     WorkspaceId = Id,

--- a/src/NexusMods.App.UI/WorkspaceSystem/WorkspaceController/IWorkspaceController.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/WorkspaceController/IWorkspaceController.cs
@@ -142,4 +142,9 @@ public interface IWorkspaceController
     public OpenPageBehavior GetDefaultOpenPageBehavior(
         PageData requestedPage,
         NavigationInput input);
+
+    /// <summary>
+    /// Gets the page data for the default page.
+    /// </summary>
+    PageData GetDefaultPageData(WorkspaceId workspaceId);
 }

--- a/src/NexusMods.App.UI/WorkspaceSystem/WorkspaceController/WorkspaceController.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/WorkspaceController/WorkspaceController.cs
@@ -129,7 +129,7 @@ internal sealed class WorkspaceController : ReactiveObject, IWorkspaceController
         Dispatcher.UIThread.VerifyAccess();
 
         var vm = new WorkspaceViewModel(
-            logger: _loggerFactory.CreateLogger<WorkspaceViewModel>(),
+            loggerFactory: _loggerFactory,
             workspaceController: this,
             factoryController: _pageFactoryController
         )
@@ -435,5 +435,11 @@ internal sealed class WorkspaceController : ReactiveObject, IWorkspaceController
             OpenPageBehaviorType.NewTab => new OpenPageBehavior.NewTab(selectedPanel.Id),
             OpenPageBehaviorType.NewPanel => new OpenPageBehavior.NewPanel(Optional<WorkspaceGridState>.None),
         };
+    }
+
+    public PageData GetDefaultPageData(WorkspaceId workspaceId)
+    {
+        if (!TryGetWorkspace(workspaceId, out WorkspaceViewModel? workspace)) throw new InvalidOperationException();
+        return workspace.GetDefaultPageData();
     }
 }


### PR DESCRIPTION
Fixes #2735 opening the default page. This should guarantee that we don't end up in a situation where the workspace is completely broken.