### PR TITLE
SDV Health Check fixes

### DIFF
--- a/src/Games/NexusMods.Games.StardewValley/Emitters/MissingSMAPIEmitter.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/MissingSMAPIEmitter.cs
@@ -33,7 +33,7 @@ public class MissingSMAPIEmitter : ILoadoutDiagnosticEmitter
             yield break;
         }
 
-        var isSMAPIEnabled = smapiLoadoutItems.Any(x => !x.AsLoadoutItemGroup().AsLoadoutItem().IsDisabled);
+        var isSMAPIEnabled = smapiLoadoutItems.Any(x => x.AsLoadoutItemGroup().AsLoadoutItem().IsEnabled());
         if (isSMAPIEnabled) yield break;
 
         yield return Diagnostics.CreateSMAPIRequiredButDisabled(

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/DependencyDiagnosticEmitterTests.Test_DisabledRequiredDependency_Collections.verified.txt
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/DependencyDiagnosticEmitterTests.Test_DisabledRequiredDependency_Collections.verified.txt
@@ -1,0 +1,17 @@
+﻿[Id] NexusMods.Games.StardewValley: 5
+[Title] Disabled Dependency
+[Summary] 'Farm Type Manager' requires 'Content Patcher' but it is disabled
+[Details]
+The mod **Farm Type Manager** requires **Content Patcher** to function, but **Content Patcher** is not enabled.
+
+
+### How to Resolve
+1. Enable **Content Patcher** in "Installed Mods"
+
+### Technical Details
+The `manifest.json` file included with **Farm Type Manager** lists **Content Patcher** as a requirement in order function. 
+
+The issue can arise in these scenarios:
+
+1. **Disabled Mod**: The required mod is disabled in the loadout
+2. **Incorrect Mod ID**: The manifest data for **Farm Type Manager** might be incorrect

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/DependencyDiagnosticEmitterTests.cs
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/DependencyDiagnosticEmitterTests.cs
@@ -73,21 +73,50 @@ public class DependencyDiagnosticEmitterTests : ALoadoutDiagnosticEmitterTest<De
         var dependent = disabledRequiredDependencyMessageData.SMAPIMod.ResolveData(ServiceProvider, Connection);
         dependent.AsLoadoutItem().ParentId.Should().Be(farmTypeManager.LoadoutItemGroupId, because: "Farm Type Manager is the dependent");
         
-        // Add extra enabled copy in another collection
-        var collectionA = (await CreateCollection(loadout.Id, "Collection A")).AsLoadoutItemGroup().LoadoutItemGroupId;
+        await VerifyDiagnostic(diagnostic);
+    }
+
+    [Fact]
+    public async Task Test_DisabledRequiredDependency_Collections()
+    {
+        var loadout = await CreateLoadout();
+        
+        var collectionA = (await CreateCollection(loadout, "Collection A")).AsLoadoutItemGroup().LoadoutItemGroupId;
+        var collectionB = (await CreateCollection(loadout, "Collection B")).AsLoadoutItemGroup().LoadoutItemGroupId;
+        
+        // SMAPI 4.1.10 (https://www.nexusmods.com/stardewvalley/mods/2400?tab=files)
+        await InstallModFromNexusMods(loadout, ModId.From(2400), FileId.From(119630), parent: collectionA);
+        
+        // Farm Type Manager 1.24.0 (https://www.nexusmods.com/stardewvalley/mods/3231?tab=files)
+        var farmTypeManager = await InstallModFromNexusMods(loadout, ModId.From(3231), FileId.From(117244), parent: collectionA);
+        
+        // Content Patcher 2.5.3 (https://www.nexusmods.com/stardewvalley/mods/1915?tab=files)
+        var contentPatcherCollectionB = await InstallModFromNexusMods(loadout, ModId.From(1915), FileId.From(124659), parent: collectionB);
+        
+        await ShouldHaveNoDiagnostics(loadout, because: "All required dependencies are installed and enabled");
+        
+        await DisableItem(collectionB);
+        
+        var diagnostic = await GetSingleDiagnostic(loadout);
+        var disabledRequiredDependencyMessageData = diagnostic.Should().BeOfType<Diagnostic<Diagnostics.DisabledRequiredDependencyMessageData>>(because: "Content Patcher is inside disabled collection and required by Farm Type Manager").Which.MessageData;
+        
+        var dependency = disabledRequiredDependencyMessageData.Dependency.ResolveData(ServiceProvider, Connection);
+        dependency.AsLoadoutItem().ParentId.Should().Be(contentPatcherCollectionB.LoadoutItemGroupId, because: "Content Patcher is the dependency");
+        
+        var dependent = disabledRequiredDependencyMessageData.SMAPIMod.ResolveData(ServiceProvider, Connection);
+        dependent.AsLoadoutItem().ParentId.Should().Be(farmTypeManager.LoadoutItemGroupId, because: "Farm Type Manager is the dependent");
+        
+        // Add a copy in another collection
         // Content Patcher 2.5.3 (https://www.nexusmods.com/stardewvalley/mods/1915?tab=files)
         var contentPatcherCollectionA = await InstallModFromNexusMods(loadout, ModId.From(1915), FileId.From(124659), parent: collectionA);
         
-        await ShouldHaveNoDiagnostics(loadout, because: "The dependency ContentPatcher in collectionA  is enabled");
+        await ShouldHaveNoDiagnostics(loadout, because: "The dependency ContentPatcher in collectionA is enabled");
+        
+        await DisableItem(contentPatcherCollectionA);
+        
+        var diagnostic2 = await GetSingleDiagnostic(loadout);
+        diagnostic2.Should().BeOfType<Diagnostic<Diagnostics.DisabledRequiredDependencyMessageData>>(because: "Both content patcher mods are disabled and required by Farm Type Manager");
 
-        await DisableItem(collectionA);
-        var parentDisabledDiagnostic = await GetSingleDiagnostic(loadout);
-        parentDisabledDiagnostic.Should().BeOfType<Diagnostic<Diagnostics.DisabledRequiredDependencyMessageData>>(because: "Content Patcher parent collection is disabled and required by Farm Type Manager");
-        
-        await EnableItem(contentPatcher);
-        
-        await ShouldHaveNoDiagnostics(loadout, because: "The dependency ContentPatcher outside the collection is enabled");
-        
         await VerifyDiagnostic(diagnostic);
     }
 
@@ -120,12 +149,14 @@ public class DependencyDiagnosticEmitterTests : ALoadoutDiagnosticEmitterTest<De
         // Test disabled cases
         await DisableItem(farmTypeManager);
         
+        await ShouldHaveNoDiagnostics(loadout, because: "The dependant Farm Type Manager is disabled");
         (await GetAllDiagnostics(loadout)).OfType<Diagnostic<Diagnostics.RequiredDependencyIsOutdatedMessageData>>()
             .Should().BeEmpty(because: "The dependant Farm Type Manager is disabled");
         
         await EnableItem(farmTypeManager);
         await DisableItem(contentPatcher);
         
+        await ShouldHaveNoDiagnostics(loadout, because: "The outdated dependency Content Patcher is disabled");
         (await GetAllDiagnostics(loadout)).OfType<Diagnostic<Diagnostics.RequiredDependencyIsOutdatedMessageData>>()
             .Should().BeEmpty(because: "The outdated dependency Content Patcher is disabled");
         

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/DependencyDiagnosticEmitterTests.cs
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/DependencyDiagnosticEmitterTests.cs
@@ -82,7 +82,7 @@ public class DependencyDiagnosticEmitterTests : ALoadoutDiagnosticEmitterTest<De
 
         await DisableItem(collectionA);
         var parentDisabledDiagnostic = await GetSingleDiagnostic(loadout);
-        diagnostic.Should().BeOfType<Diagnostic<Diagnostics.DisabledRequiredDependencyMessageData>>(because: "Content Patcher parent collection is disabled and required by Farm Type Manager");
+        parentDisabledDiagnostic.Should().BeOfType<Diagnostic<Diagnostics.DisabledRequiredDependencyMessageData>>(because: "Content Patcher parent collection is disabled and required by Farm Type Manager");
         
         await EnableItem(contentPatcher);
         

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/DependencyDiagnosticEmitterTests.cs
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/DependencyDiagnosticEmitterTests.cs
@@ -62,7 +62,7 @@ public class DependencyDiagnosticEmitterTests : ALoadoutDiagnosticEmitterTest<De
 
         await ShouldHaveNoDiagnostics(loadout, because: "All required dependencies are installed and enabled");
 
-        await DisableMod(contentPatcher);
+        await DisableItem(contentPatcher);
 
         var diagnostic = await GetSingleDiagnostic(loadout);
         var disabledRequiredDependencyMessageData = diagnostic.Should().BeOfType<Diagnostic<Diagnostics.DisabledRequiredDependencyMessageData>>(because: "Content Patcher is disabled and required by Farm Type Manager").Which.MessageData;
@@ -103,13 +103,13 @@ public class DependencyDiagnosticEmitterTests : ALoadoutDiagnosticEmitterTest<De
         dependent.AsLoadoutItem().ParentId.Should().Be(farmTypeManager.LoadoutItemGroupId, because: "Farm Type Manager is the dependent");
 
         // Test disabled cases
-        await DisableMod(farmTypeManager);
+        await DisableItem(farmTypeManager);
         
         (await GetAllDiagnostics(loadout)).OfType<Diagnostic<Diagnostics.RequiredDependencyIsOutdatedMessageData>>()
             .Should().BeEmpty(because: "The dependant Farm Type Manager is disabled");
         
-        await EnableMod(farmTypeManager);
-        await DisableMod(contentPatcher);
+        await EnableItem(farmTypeManager);
+        await DisableItem(contentPatcher);
         
         (await GetAllDiagnostics(loadout)).OfType<Diagnostic<Diagnostics.RequiredDependencyIsOutdatedMessageData>>()
             .Should().BeEmpty(because: "The outdated dependency Content Patcher is disabled");

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/MissingSMAPIEmitterTests.cs
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/MissingSMAPIEmitterTests.cs
@@ -49,25 +49,36 @@ public class MissingSMAPIEmitterTests : ALoadoutDiagnosticEmitterTest<Dependency
     public async Task Test_SMAPIRequiredButDisabled()
     {
         var loadout = await CreateLoadout();
+        
+        var collectionA = (await CreateCollection(loadout, "Collection A")).AsLoadoutItemGroup().LoadoutItemGroupId;
+        var collectionB = (await CreateCollection(loadout, "Collection B")).AsLoadoutItemGroup().LoadoutItemGroupId;
 
         // Content Patcher 2.5.3 (https://www.nexusmods.com/stardewvalley/mods/1915?tab=files)
-        await InstallModFromNexusMods(loadout, ModId.From(1915), FileId.From(124659));
+        await InstallModFromNexusMods(loadout, ModId.From(1915), FileId.From(124659), parent: collectionA);
 
         // Farm Type Manager 1.24.0 (https://www.nexusmods.com/stardewvalley/mods/3231?tab=files)
-        await InstallModFromNexusMods(loadout, ModId.From(3231), FileId.From(117244));
+        await InstallModFromNexusMods(loadout, ModId.From(3231), FileId.From(117244), parent: collectionA);
 
         // SMAPI 4.1.10 (https://www.nexusmods.com/stardewvalley/mods/2400?tab=files)
-        var smapi = await InstallModFromNexusMods(loadout, ModId.From(2400), FileId.From(119630));
+        var smapi = await InstallModFromNexusMods(loadout, ModId.From(2400), FileId.From(119630), parent: collectionB);
 
         await ShouldHaveNoDiagnostics(loadout, because: "SMAPI is installed and enabled");
 
-        await DisableMod(smapi);
+        await DisableItem(smapi);
 
         var diagnostic = await GetSingleDiagnostic(loadout);
         var smapiRequiredButDisabledMessageData = diagnostic.Should().BeOfType<Diagnostic<Diagnostics.SMAPIRequiredButDisabledMessageData>>(because: "SMAPI is required for 2 mods but disabled").Which.MessageData;
 
         smapiRequiredButDisabledMessageData.ModCount.Should().Be(2, because: "the loadout contains 2 SMAPI mods");
-
+        
+        await EnableItem(smapi);
+        await DisableItem(collectionB);
+        
+        var parentDisabledDiagnostic = await GetSingleDiagnostic(loadout);
+        var smapiRequiredButParentDisabledMessageData = parentDisabledDiagnostic.Should().BeOfType<Diagnostic<Diagnostics.SMAPIRequiredButDisabledMessageData>>(because: "SMAPI is required for 2 mods but smapi parent collection is disabled").Which.MessageData;
+        
+        smapiRequiredButParentDisabledMessageData.ModCount.Should().Be(2, because: "the loadout contains 2 SMAPI mods");
+        
         await VerifyDiagnostic(diagnostic);
     }
 }

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/MissingSMAPIEmitterTests.cs
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/MissingSMAPIEmitterTests.cs
@@ -61,7 +61,7 @@ public class MissingSMAPIEmitterTests : ALoadoutDiagnosticEmitterTest<Dependency
 
         await ShouldHaveNoDiagnostics(loadout, because: "SMAPI is installed and enabled");
 
-        await DisabledMod(smapi);
+        await DisableMod(smapi);
 
         var diagnostic = await GetSingleDiagnostic(loadout);
         var smapiRequiredButDisabledMessageData = diagnostic.Should().BeOfType<Diagnostic<Diagnostics.SMAPIRequiredButDisabledMessageData>>(because: "SMAPI is required for 2 mods but disabled").Which.MessageData;

--- a/tests/Games/NexusMods.Games.TestFramework/AIsolatedGameTest.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/AIsolatedGameTest.cs
@@ -9,12 +9,10 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.Diagnostics;
 using NexusMods.Abstractions.FileExtractor;
-using NexusMods.Abstractions.FileStore;
 using NexusMods.Abstractions.GameLocators;
 using NexusMods.Abstractions.Games;
 using NexusMods.Abstractions.GC;
 using NexusMods.Abstractions.GuidedInstallers;
-using NexusMods.Abstractions.HttpDownloader;
 using NexusMods.Abstractions.IO;
 using NexusMods.Abstractions.IO.StreamFactories;
 using NexusMods.Abstractions.Library;
@@ -23,15 +21,14 @@ using NexusMods.Abstractions.Library.Models;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Loadouts.Extensions;
 using NexusMods.Abstractions.Loadouts.Synchronizers;
-using NexusMods.Abstractions.MnemonicDB.Attributes;
 using NexusMods.Abstractions.NexusWebApi.Types.V2;
-using NexusMods.Abstractions.Serialization;
 using NexusMods.App.BuildInfo;
 using NexusMods.DataModel;
 using NexusMods.Games.FOMOD;
 using NexusMods.Hashing.xxHash3;
 using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.MnemonicDB.Abstractions.BuiltInEntities;
+using NexusMods.MnemonicDB.Abstractions.ElementComparers;
 using NexusMods.MnemonicDB.Abstractions.Models;
 using NexusMods.Networking.NexusWebApi;
 using NexusMods.Paths;
@@ -117,10 +114,11 @@ public abstract class AIsolatedGameTest<TTest, TGame> : IAsyncLifetime where TGa
         return await LibraryService.AddDownload(downloadJob);
     }
 
-    public async Task<LoadoutItemGroup.ReadOnly> InstallModFromNexusMods(LoadoutId loadoutId, ModId modId, FileId fileId, ILibraryItemInstaller? installer = null)
+    public async Task<LoadoutItemGroup.ReadOnly> InstallModFromNexusMods(LoadoutId loadoutId, ModId modId, FileId fileId,  
+        Optional<LoadoutItemGroupId> parent = default, ILibraryItemInstaller? installer = null)
     {
         var libraryFile = await DownloadModFromNexusMods(modId, fileId);
-        return await LibraryService.InstallItem(libraryFile.AsLibraryItem(), loadoutId, installer: installer);
+        return await LibraryService.InstallItem(libraryFile.AsLibraryItem(), loadoutId, parent: parent, installer: installer);
     }
 
     public async Task<LibraryArchive.ReadOnly> RegisterLocalArchive(AbsolutePath file)
@@ -351,6 +349,57 @@ public abstract class AIsolatedGameTest<TTest, TGame> : IAsyncLifetime where TGa
     /// </summary>
     protected void Refresh<T>(ref T entity) where T : IReadOnlyModel<T>
         => entity = T.Create(Connection.Db, entity.Id);
+
+    protected async ValueTask<CollectionGroup.ReadOnly> CreateCollection(LoadoutId loadoutId, string name)
+    {
+        using var tx = Connection.BeginTransaction();
+        var collection = new CollectionGroup.New(tx, out var id)
+        {
+            IsReadOnly = false,
+            LoadoutItemGroup = new LoadoutItemGroup.New(tx, id)
+            {
+                IsGroup = true,
+                LoadoutItem = new LoadoutItem.New(tx, id)
+                {
+                    LoadoutId = loadoutId,
+                    Name = name,
+                },
+            },
+        };
+        
+        var result = await tx.Commit();
+        return result.Remap(collection);
+    }
+    
+    protected async ValueTask EnableMod(EntityId entityId)
+    {
+        using var tx = Connection.BeginTransaction();
+        tx.Retract(entityId, LoadoutItem.Disabled, Null.Instance);
+        await tx.Commit();
+    }
+
+    protected async ValueTask DisableMod(EntityId entityId)
+    {
+        using var tx = Connection.BeginTransaction();
+        tx.Add(entityId, LoadoutItem.Disabled, Null.Instance);
+        await tx.Commit();
+    }
+    
+    protected async ValueTask EnableModParent(EntityId entityId)
+    {
+        using var tx = Connection.BeginTransaction();
+        var parentId = LoadoutItem.Load(Connection.Db, entityId).ParentId;
+        tx.Retract(parentId, LoadoutItem.Disabled, Null.Instance);
+        await tx.Commit();
+    }
+    
+    protected async ValueTask DisableModParent(EntityId entityId)
+    {
+        using var tx = Connection.BeginTransaction();
+        var parentId = LoadoutItem.Load(Connection.Db, entityId).ParentId;
+        tx.Retract(parentId, LoadoutItem.Disabled, Null.Instance);
+        await tx.Commit();
+    }
 
     /// <summary>
     /// Creates a ZIP archive using <see cref="ZipArchive"/> and returns the

--- a/tests/Games/NexusMods.Games.TestFramework/AIsolatedGameTest.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/AIsolatedGameTest.cs
@@ -371,33 +371,17 @@ public abstract class AIsolatedGameTest<TTest, TGame> : IAsyncLifetime where TGa
         return result.Remap(collection);
     }
     
-    protected async ValueTask EnableMod(EntityId entityId)
+    protected async ValueTask EnableItem(EntityId entityId)
     {
         using var tx = Connection.BeginTransaction();
         tx.Retract(entityId, LoadoutItem.Disabled, Null.Instance);
         await tx.Commit();
     }
 
-    protected async ValueTask DisableMod(EntityId entityId)
+    protected async ValueTask DisableItem(EntityId entityId)
     {
         using var tx = Connection.BeginTransaction();
         tx.Add(entityId, LoadoutItem.Disabled, Null.Instance);
-        await tx.Commit();
-    }
-    
-    protected async ValueTask EnableModParent(EntityId entityId)
-    {
-        using var tx = Connection.BeginTransaction();
-        var parentId = LoadoutItem.Load(Connection.Db, entityId).ParentId;
-        tx.Retract(parentId, LoadoutItem.Disabled, Null.Instance);
-        await tx.Commit();
-    }
-    
-    protected async ValueTask DisableModParent(EntityId entityId)
-    {
-        using var tx = Connection.BeginTransaction();
-        var parentId = LoadoutItem.Load(Connection.Db, entityId).ParentId;
-        tx.Retract(parentId, LoadoutItem.Disabled, Null.Instance);
         await tx.Commit();
     }
 

--- a/tests/Games/NexusMods.Games.TestFramework/ALoadoutDiagnosticEmitterTest.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/ALoadoutDiagnosticEmitterTest.cs
@@ -56,7 +56,7 @@ public class ALoadoutDiagnosticEmitterTest<TTest, TGame, TEmitter> : AIsolatedGa
         await tx.Commit();
     }
 
-    protected async ValueTask DisabledMod(EntityId entityId)
+    protected async ValueTask DisableMod(EntityId entityId)
     {
         using var tx = Connection.BeginTransaction();
         tx.Add(entityId, LoadoutItem.Disabled, Null.Instance);

--- a/tests/Games/NexusMods.Games.TestFramework/ALoadoutDiagnosticEmitterTest.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/ALoadoutDiagnosticEmitterTest.cs
@@ -49,20 +49,6 @@ public class ALoadoutDiagnosticEmitterTest<TTest, TGame, TEmitter> : AIsolatedGa
         diagnostics.Should().BeEmpty(because: because);
     }
 
-    protected async ValueTask EnableMod(EntityId entityId)
-    {
-        using var tx = Connection.BeginTransaction();
-        tx.Retract(entityId, LoadoutItem.Disabled, Null.Instance);
-        await tx.Commit();
-    }
-
-    protected async ValueTask DisableMod(EntityId entityId)
-    {
-        using var tx = Connection.BeginTransaction();
-        tx.Add(entityId, LoadoutItem.Disabled, Null.Instance);
-        await tx.Commit();
-    }
-
     protected async ValueTask VerifyDiagnostic(Diagnostic diagnostic, [CallerFilePath] string sourceFile = "")
     {
         var diagnosticWriter = ServiceProvider.GetRequiredService<IDiagnosticWriter>();


### PR DESCRIPTION
- Fixes parts of #2687

Fixed three bugs, each covered by new tests cases:

- RequiredDependencyIsOutdated
Appears when the dependency is disabled on the loadout - should only appear when enabled 
- SMAPIRequiredButDisabled
Does not appear when SMAPI is in a disabled collection.
- DisabledRequiredDependency
Appears if there is at least a disabled version of the dependency, even though there are enabled versions

I think remaining bugs listed on #2687 might be fixed by updating SMAPI submodule, but I haven't gotten around to looking into that yet.