### PR TITLE
Pass revision directly

### DIFF
--- a/src/NexusMods.App.UI/Pages/LibraryPage/Collections/CollectionCardViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LibraryPage/Collections/CollectionCardViewModel.cs
@@ -30,11 +30,10 @@ public class CollectionCardViewModel : AViewModel<ICollectionCardViewModel>, ICo
         IResourceLoader<EntityId, Bitmap> userAvatarPipeline,
         IWindowManager windowManager,
         WorkspaceId workspaceId,
-        IConnection connection,
-        RevisionId revision,
+        CollectionRevisionMetadata.ReadOnly revision,
         LoadoutId targetLoadout)
     {
-        _revision = CollectionRevisionMetadata.FindByRevisionId(connection.Db, revision).First();
+        _revision = revision;
         _collection = _revision.Collection;
 
         var workspaceController = windowManager.ActiveWorkspaceController;

--- a/src/NexusMods.App.UI/Pages/LibraryPage/LibraryViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LibraryPage/LibraryViewModel.cs
@@ -200,8 +200,7 @@ public class LibraryViewModel : APageViewModel<ILibraryViewModel>, ILibraryViewM
                     userAvatarPipeline: userAvatarPipeline,
                     windowManager: WindowManager,
                     workspaceId: WorkspaceId,
-                    connection: _connection,
-                    revision: revision.RevisionId,
+                    revision: revision,
                     targetLoadout: _loadout)
                 )
                 .Bind(out _collections)


### PR DESCRIPTION
Doesn't do a lookup anymore and just passes the revision directly, fixes #2749.

The bug was caused because we'd observe all revisions and create cards out of them, the cards constructor would get passed an ID and do a lookup for the revision using LINQ `First()` which throws an exception if there are no items in the source enumerable. This can happen if the collection gets deleted, which sends the user to the library and then there's probably a race condition where the revision gets deleted while we try to create the collection card.

With this PR we won't get an exception, the card will disappear immediately.