### PR TITLE
Displaying Sizes and Numbers using Humanize

### DIFF
--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/SizeComponent.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/SizeComponent.cs
@@ -14,7 +14,13 @@ public sealed class SizeComponent : AFormattedValueComponent<Size>, IItemModelCo
 {
     /// <inheritdoc/>
     public int CompareTo(SizeComponent? other) => Value.Value.CompareTo(other?.Value.Value ?? Size.Zero);
-    private static string _FormatValue(Size value) => ByteSize.FromBytes(value.Value).Humanize();
+
+    private static string _FormatValue(Size value)
+    {
+        var byteSize = ByteSize.FromBytes(value.Value);
+        return byteSize.Gigabytes < 1 ? byteSize.Humanize("0") : byteSize.Humanize("0.0");
+    }
+
     /// <inheritdoc/>
     protected override string FormatValue(Size value) => _FormatValue(value);
 
@@ -22,14 +28,24 @@ public sealed class SizeComponent : AFormattedValueComponent<Size>, IItemModelCo
     public SizeComponent(
         Size initialValue,
         IObservable<Size> valueObservable,
-        bool subscribeWhenCreated = false) : base(initialValue, _FormatValue(initialValue), valueObservable, subscribeWhenCreated) { }
+        bool subscribeWhenCreated = false) : base(initialValue, _FormatValue(initialValue), valueObservable,
+        subscribeWhenCreated
+    )
+    {
+    }
 
     /// <inheritdoc/>
     public SizeComponent(
         Size initialValue,
         Observable<Size> valueObservable,
-        bool subscribeWhenCreated = false) : base(initialValue, _FormatValue(initialValue), valueObservable, subscribeWhenCreated) { }
+        bool subscribeWhenCreated = false) : base(initialValue, _FormatValue(initialValue), valueObservable,
+        subscribeWhenCreated
+    )
+    {
+    }
 
     /// <inheritdoc/>
-    public SizeComponent(Size value) : base(value, _FormatValue(value)) { }
+    public SizeComponent(Size value) : base(value, _FormatValue(value))
+    {
+    }
 }

--- a/src/NexusMods.App.UI/Converters/SizeToStringTypeConverter.cs
+++ b/src/NexusMods.App.UI/Converters/SizeToStringTypeConverter.cs
@@ -1,0 +1,38 @@
+using Humanizer;
+using Humanizer.Bytes;
+using NexusMods.Paths;
+using ReactiveUI;
+
+namespace NexusMods.App.UI.Converters;
+
+/// <summary>
+/// NexusMods.Paths.Size To String Type Converter.
+/// </summary>
+public class SizeToStringTypeConverter : IBindingTypeConverter
+{
+    /// <inheritdoc/>
+    public int GetAffinityForObjects(Type fromType, Type toType)
+    {
+        if (fromType == typeof(Size) && toType == typeof(string))
+        {
+            return 999;
+        }
+
+        return 0;
+    }
+
+    /// <inheritdoc/>
+    public bool TryConvert(object? from, Type toType, object? conversionHint, out object result)
+    {
+        if (toType == typeof(string) && from is Size fromSize)
+        {
+            var byteSize = ByteSize.FromBytes(fromSize.Value);
+            result = byteSize.Gigabytes < 1 ? byteSize.Humanize("0") : byteSize.Humanize("0.0");
+
+            return true;
+        }
+        
+        result = null!;
+        return false;
+    }
+}

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadView.axaml.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadView.axaml.cs
@@ -10,6 +10,8 @@ using NexusMods.Icons;
 using NexusMods.MnemonicDB.Abstractions;
 using R3;
 using ReactiveUI;
+using Humanizer;
+using NexusMods.App.UI.Converters;
 
 namespace NexusMods.App.UI.Pages.CollectionDownload;
 
@@ -80,13 +82,13 @@ public partial class CollectionDownloadView : ReactiveUserControl<ICollectionDow
             this.OneWayBind(ViewModel, vm => vm.AuthorAvatar, view => view.AuthorAvatar.Source)
                 .DisposeWith(d);
             
-            this.OneWayBind(ViewModel, vm => vm.DownloadCount, view => view.NumDownloads.Text)
+            this.OneWayBind(ViewModel, vm => vm.DownloadCount, view => view.NumDownloads.Text, v => v.ToString("N0"))
                 .DisposeWith(d);
 
-            this.OneWayBind(ViewModel, vm => vm.EndorsementCount, view => view.Endorsements.Text)
+            this.OneWayBind(ViewModel, vm => vm.EndorsementCount, view => view.Endorsements.Text, v => Convert.ToInt32(v).ToMetric(null, 1))
                 .DisposeWith(d);
 
-            this.OneWayBind(ViewModel, vm => vm.TotalDownloads, view => view.TotalDownloads.Text)
+            this.OneWayBind(ViewModel, vm => vm.TotalDownloads, view => view.TotalDownloads.Text, v => Convert.ToInt32(v).ToMetric(null, 1))
                 .DisposeWith(d);
 
             this.OneWayBind(ViewModel, vm => vm.TotalSize, view => view.TotalSize.Text)
@@ -95,15 +97,15 @@ public partial class CollectionDownloadView : ReactiveUserControl<ICollectionDow
             this.OneWayBind(ViewModel, vm => vm.OverallRating, view => view.OverallRating.Text)
                 .DisposeWith(d);
 
-            this.OneWayBind(ViewModel, vm => vm.RequiredDownloadsCount, view => view.RequiredDownloadsCount.Text)
+            this.OneWayBind(ViewModel, vm => vm.RequiredDownloadsCount, view => view.RequiredDownloadsCount.Text, v => v.ToString("N0"))
                 .DisposeWith(d);
 
-            this.OneWayBind(ViewModel, vm => vm.OptionalDownloadsCount, view => view.OptionalDownloadsCount.Text)
+            this.OneWayBind(ViewModel, vm => vm.OptionalDownloadsCount, view => view.OptionalDownloadsCount.Text, v => v.ToString("N0"))
                 .DisposeWith(d);
 
             this.OneWayBind(ViewModel, vm => vm.RevisionNumber, view => view.Revision.Text, revision => $"Revision {revision}")
                 .DisposeWith(d);
-
+            
             this.WhenAnyValue(
                     view => view.ViewModel!.IsUpdateAvailable.Value,
                     view => view.ViewModel!.NewestRevisionNumber.Value)
@@ -188,7 +190,7 @@ public partial class CollectionDownloadView : ReactiveUserControl<ICollectionDow
                 .Subscribe(className =>
                     {
                         OverallRatingPanel.Classes.Add(className);
-                        OverallRating.Text = className == "NoRating" ? "--" : ViewModel!.OverallRating.Value.ToString("P2");
+                        OverallRating.Text = className == "NoRating" ? "--" : ViewModel!.OverallRating.Value.ToString("P0");
                     }
                 )
                 .DisposeWith(d);
@@ -222,5 +224,8 @@ public partial class CollectionDownloadView : ReactiveUserControl<ICollectionDow
                 }).DisposeWith(d);
         });
     }
+
+    
+    
 }
 

--- a/src/NexusMods.App.UI/Pages/LibraryPage/Collections/CollectionCardView.axaml.cs
+++ b/src/NexusMods.App.UI/Pages/LibraryPage/Collections/CollectionCardView.axaml.cs
@@ -38,7 +38,7 @@ public partial class CollectionCardView : ReactiveUserControl<ICollectionCardVie
             this.OneWayBind(ViewModel, vm => vm.RevisionNumber, view => view.RevisionText.Text, revision => $"Revision {revision}")
                 .DisposeWith(d);
             
-            this.OneWayBind(ViewModel, vm => vm.NumDownloads, view => view.ModsCountText.Text, count => $"{count} Mods")
+            this.OneWayBind(ViewModel, vm => vm.NumDownloads, view => view.ModsCountText.Text, count => $"{count:N0} Mods")
                 .DisposeWith(d);
 
             this.OneWayBind(ViewModel, vm => vm.TotalSize, view => view.TotalSize.Text)

--- a/src/NexusMods.App/Startup.cs
+++ b/src/NexusMods.App/Startup.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NexusMods.App.BuildInfo;
 using NexusMods.App.UI;
+using NexusMods.App.UI.Converters;
 using NexusMods.App.UI.Windows;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
@@ -109,7 +110,9 @@ public class Startup
 
         Locator.CurrentMutable.UnregisterCurrent(typeof(IViewLocator));
         Locator.CurrentMutable.Register(serviceProvider.GetRequiredService<InjectedViewLocator>, typeof(IViewLocator));
-
+        
+        Locator.CurrentMutable.RegisterConstant<IBindingTypeConverter>(new SizeToStringTypeConverter());
+        
         var logger = serviceProvider.GetRequiredService<ILogger<Startup>>();
         ObservableSystem.RegisterUnhandledExceptionHandler(exception =>
         {


### PR DESCRIPTION
It's been a long time coming but here goes...

Size (`NexusMods.Paths.Size`) now has a ReactiveUI `IBindingTypeConverter` which is globally registered. Whenever a Size is bound to a UI control (normally a TextBlock's Text property) it automatically kicks in.

When SizeComponent is used in a TreeDataGrid, Humanize is directly used without the above converter.

Humanize returns either a single decimal point if 1 GB in size or greater, no decimal points if not.

Numbers can be formatted either by Humanize (if need it to say 1.1k instead of 1123) or by using "N0" format for it to have thousand separators. Generally applied in the code-behind in the OneWayBind's

Should we also be using Humanize if we just want thousand separators ?

![image](https://github.com/user-attachments/assets/57f636da-d425-4466-9bff-842fddcc4be5)

![image](https://github.com/user-attachments/assets/375aff5c-80d8-4107-b92e-07e929cd166d)

Closes https://github.com/Nexus-Mods/NexusMods.App/issues/2372