### PR TITLE
Log the SMAPI mapping errors as warnings so we don't get error popups

### DIFF
--- a/src/Games/NexusMods.Games.StardewValley/Emitters/SMAPIGameVersionDiagnosticEmitter.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/SMAPIGameVersionDiagnosticEmitter.cs
@@ -323,7 +323,7 @@ public class SMAPIGameVersionDiagnosticEmitter : ILoadoutDiagnosticEmitter
         }
         catch (Exception e)
         {
-            _logger.LogError(e, "Exception while getting JSON data from {Uri}", dataUri);
+            _logger.LogWarning(e, "Exception while getting JSON data from {Uri}", dataUri);
             return null;
         }
     }


### PR DESCRIPTION
As part of #2616 this PR changes the SMAPI metadata download errors from a `.LogError` to `.LogWarning`. The code was already resiliant (didn't cause crashes) but we were logging errors which caused the error popups. Verified that the dialog no longer shows up after this PR and that we don't spam the log with tons of errors, only one error per launch.