### PR TITLE
[CLI] Hyperlinks for collection downloads for free users

### DIFF
--- a/src/NexusMods.Collections/CollectionDownloader.cs
+++ b/src/NexusMods.Collections/CollectionDownloader.cs
@@ -176,8 +176,9 @@ public class CollectionDownloader
     /// <summary>
     /// Downloads a file from nexus mods for premium users or opens the download page in the browser.
     /// </summary>
-    public async ValueTask Download(CollectionDownloadNexusMods.ReadOnly download, CancellationToken cancellationToken)
+    public async ValueTask Download(CollectionDownloadNexusMods.ReadOnly download, CancellationToken cancellationToken, CollectionDownload.ReadOnly[] downloads = null!)
     {
+        const int downloadLimit = 10;
         if (_loginManager.IsPremium)
         {
             await using var tempPath = _temporaryFileManager.CreateFile();
@@ -186,7 +187,10 @@ public class CollectionDownloader
         }
         else
         {
-            await _osInterop.OpenUrl(download.FileMetadata.GetUri(), logOutput: false, fireAndForget: true, cancellationToken: cancellationToken);
+            if (downloads.Length <= downloadLimit) 
+            {
+                await _osInterop.OpenUrl(download.FileMetadata.GetUri(), logOutput: false, fireAndForget: true, cancellationToken: cancellationToken);
+            }
         }
     }
 

--- a/src/NexusMods.Collections/DownloadCollectionJob.cs
+++ b/src/NexusMods.Collections/DownloadCollectionJob.cs
@@ -18,10 +18,6 @@ public class DownloadCollectionJob : IJobDefinitionWithStart<DownloadCollectionJ
     {
         var downloads = RevisionMetadata.Downloads.ToArray();
         
-        var requiredDownloads = downloads.Where(download =>
-            CollectionDownloader.DownloadMatchesItemType(download, ItemType) &&
-            !CollectionDownloader.GetStatus(download, Db).IsDownloaded()).ToArray();
-
         await Parallel.ForAsync(fromInclusive: 0, toExclusive: downloads.Length, parallelOptions: new ParallelOptions
         {
             CancellationToken = context.CancellationToken,
@@ -34,7 +30,7 @@ public class DownloadCollectionJob : IJobDefinitionWithStart<DownloadCollectionJ
 
             if (download.TryGetAsCollectionDownloadNexusMods(out var nexusModsDownload))
             {
-                await Downloader.Download(nexusModsDownload, token, requiredDownloads);
+                await Downloader.Download(nexusModsDownload, token);
             } else if (download.TryGetAsCollectionDownloadExternal(out var externalDownload))
             {
                 await Downloader.Download(externalDownload, token);

--- a/src/NexusMods.Collections/Verbs.cs
+++ b/src/NexusMods.Collections/Verbs.cs
@@ -47,8 +47,18 @@ internal static class Verbs
 
         var revisionMetadata = await nexusModsLibrary.GetOrAddCollectionRevision(collectionFile, CollectionSlug.From(slug), RevisionNumber.From((ulong)revision), token);
 
-        await collectionDownloader.DownloadItems(revisionMetadata, itemType: CollectionDownloader.ItemType.Required, db: connection.Db, cancellationToken: token);
-
+        try
+        {
+            await collectionDownloader.DownloadItems(revisionMetadata, itemType: CollectionDownloader.ItemType.Required, db: connection.Db,
+                cancellationToken: token
+            );
+        }
+        catch (OperationCanceledException e)
+        {
+            await renderer.Error(e.Message);
+            return 0;
+        }
+        
         var items = CollectionDownloader.GetItems(revisionMetadata, CollectionDownloader.ItemType.Required);
         var installJob = await InstallCollectionJob.Create(serviceProvider, loadout, collectionFile, revisionMetadata, items);
         return 0;

--- a/src/NexusMods.Collections/Verbs.cs
+++ b/src/NexusMods.Collections/Verbs.cs
@@ -58,10 +58,11 @@ internal static class Verbs
         }
         else
         {
-            var links = CollectionDownloader.GetMissingHyperlinks(revisionMetadata, db: connection.Db);
-            if (links.Count > 0)
+            var tuples = CollectionDownloader.GetMissingDownloadLinks(revisionMetadata, db: connection.Db, itemType: CollectionDownloader.ItemType.Required);
+            if (tuples.Count > 0)
             {
-                await renderer.Text("The following mods are missing from the collection:" + Environment.NewLine + string.Join(Environment.NewLine, links));
+                await renderer.TextLine($"Missing {tuples.Count} downloads:");
+                await renderer.Table(["Name", "Uri"], tuples.Select(t => new object[] { t.Download.Name, t.Uri.ToString() }));
                 return 0;
             }
         }


### PR DESCRIPTION
Fixes #2766 

This PR provides hyperlinks to all mods that are missing for collections when a free user tries to install a collection through CLI. Instead of opening all mod URLs at once for free users, this also cancels out future jobs which would have otherwise made an more exceptions due to missing mods.

Original PR: *This PR gets the number of required downloads for a collection and checks if it passes the limit condition (in this case 10 or less) before opening the URLs (only for free users).*