### PR TITLE
Fix Test: remove leftover code

### DIFF
--- a/tests/Games/NexusMods.Games.StardewValley.Tests/DependencyDiagnosticEmitterTests.cs
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/DependencyDiagnosticEmitterTests.cs
@@ -149,14 +149,12 @@ public class DependencyDiagnosticEmitterTests : ALoadoutDiagnosticEmitterTest<De
         // Test disabled cases
         await DisableItem(farmTypeManager);
         
-        await ShouldHaveNoDiagnostics(loadout, because: "The dependant Farm Type Manager is disabled");
         (await GetAllDiagnostics(loadout)).OfType<Diagnostic<Diagnostics.RequiredDependencyIsOutdatedMessageData>>()
             .Should().BeEmpty(because: "The dependant Farm Type Manager is disabled");
         
         await EnableItem(farmTypeManager);
         await DisableItem(contentPatcher);
         
-        await ShouldHaveNoDiagnostics(loadout, because: "The outdated dependency Content Patcher is disabled");
         (await GetAllDiagnostics(loadout)).OfType<Diagnostic<Diagnostics.RequiredDependencyIsOutdatedMessageData>>()
             .Should().BeEmpty(because: "The outdated dependency Content Patcher is disabled");
         


### PR DESCRIPTION
`Test_RequiredDependencyIsOutdated` is failing due to some test code that was accidentally committed.

If an Outdated dep is disabled, you will get a `Disabled` or `Missing` dependency diagnostic instead, so it won't be empty.  