### PR TITLE
Fix deadlock for component subscriptions

### DIFF
--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/CompositeItemModel.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/CompositeItemModel.cs
@@ -168,7 +168,7 @@ public sealed class CompositeItemModel<TKey> : TreeDataGridItemModel<CompositeIt
         Func<TComponent> componentFactory)
         where TComponent : class, IItemModelComponent<TComponent>, IComparable<TComponent>
     {
-        return shouldAddObservable.Subscribe((this, key, componentFactory), static (shouldAdd, tuple) =>
+        return shouldAddObservable.ObserveOnUIThreadDispatcher().Subscribe((this, key, componentFactory), static (shouldAdd, tuple) =>
         {
             var (self, key, componentFactory) = tuple;
 
@@ -195,7 +195,7 @@ public sealed class CompositeItemModel<TKey> : TreeDataGridItemModel<CompositeIt
         where T : notnull
         where TComponent : class, IItemModelComponent<TComponent>, IComparable<TComponent>
     {
-        return observable.Subscribe((this, key, observable, componentFactory), static (optionalValue, tuple) =>
+        return observable.ObserveOnUIThreadDispatcher().Subscribe((this, key, observable, componentFactory), static (optionalValue, tuple) =>
         {
             var (self, key, observable, componentFactory) = tuple;
 


### PR DESCRIPTION
@Al12rs and I found another deadlock that happened because the DB event thread was calling `R3.BehaviorSubject.OnNext` which locked the subject and then triggered an activation on the UI thread which does a subscribe on the subject which is locked and thus we got a deadlock.

The subject in question was on the collection download page https://github.com/Nexus-Mods/NexusMods.App/blob/e18a22d31d51de5618f53facea31168bfb5f20eb/src/NexusMods.App.UI/Pages/CollectionDataProvider.cs#L140 the entire method needs some cleaning up later.

This PR should prevent any future deadlocks from happening in regards to subscriptions.