### PR TITLE
Fix SortableItemProviders not being disposed correctly

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Games/ILoadoutSortableItemProvider.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Games/ILoadoutSortableItemProvider.cs
@@ -6,7 +6,7 @@ namespace NexusMods.Abstractions.Games;
 /// <summary>
 /// A loadout specific provider and manager of sortable items.
 /// </summary>
-public interface ILoadoutSortableItemProvider 
+public interface ILoadoutSortableItemProvider : IDisposable
 {
     /// <summary>
     /// The ISortableItemProviderFactory that created this provider
@@ -28,5 +28,5 @@ public interface ILoadoutSortableItemProvider
     /// </summary>
     /// <param name="sortableItem">item to move</param>
     /// <param name="delta">positive or negative index delta</param>
-    Task SetRelativePosition(ISortableItem sortableItem, int delta);
+    Task SetRelativePosition(ISortableItem sortableItem, int delta, CancellationToken token);
 }

--- a/src/Abstractions/NexusMods.Abstractions.Games/ISortableItemProviderFactory.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Games/ISortableItemProviderFactory.cs
@@ -7,7 +7,7 @@ namespace NexusMods.Abstractions.Games;
 /// <summary>
 /// A factory for creating providers for sortable items for specific loadouts
 /// </summary>
-public interface ISortableItemProviderFactory
+public interface ISortableItemProviderFactory : IDisposable
 {
     /// <summary>
     /// Returns a provider of sortable items for a specific loadout

--- a/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/SortOrder/RedMod/RedModSortableItemProviderFactory.cs
+++ b/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/SortOrder/RedMod/RedModSortableItemProviderFactory.cs
@@ -99,4 +99,12 @@ public class RedModSortableItemProviderFactory : ISortableItemProviderFactory
 
         throw new InvalidOperationException($"RedModSortableItemProviderFactory: provider not found for loadout {loadoutId}");
     }
+    
+    public void Dispose()
+    {
+        foreach (var provider in _providers.Values)
+        {
+            provider.Dispose();
+        }
+    }
 }

--- a/src/Games/NexusMods.Games.RedEngine/RedModDeployTool.cs
+++ b/src/Games/NexusMods.Games.RedEngine/RedModDeployTool.cs
@@ -36,8 +36,6 @@ public class RedModDeployTool : ITool
 
     public async Task Execute(Loadout.ReadOnly loadout, CancellationToken cancellationToken)
     {
-        // TODO: re-enable once we have proper sorting
-        return;
         var exe = RedModPath.CombineChecked(loadout.InstallationInstance);
         var deployFolder = RedModDeployFolder.CombineChecked(loadout.InstallationInstance);
 

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderViewModel.cs
@@ -112,7 +112,7 @@ public class LoadOrderViewModel : AViewModel<ILoadOrderViewModel>, ILoadOrderVie
                     .SubscribeAwait(async (payload, cancellationToken) =>
                         {
                             var (item, delta) = payload;
-                            await provider.SetRelativePosition(((LoadOrderItemModel)item).InnerItem, delta);
+                            await provider.SetRelativePosition(((LoadOrderItemModel)item).InnerItem, delta, cancellationToken);
                         }
                     )
                     .DisposeWith(d);

--- a/tests/Games/NexusMods.Games.RedEngine.Tests/RedModDeployToolTests.cs
+++ b/tests/Games/NexusMods.Games.RedEngine.Tests/RedModDeployToolTests.cs
@@ -11,14 +11,14 @@ using Xunit.Abstractions;
 
 namespace NexusMods.Games.RedEngine.Tests;
 
-// TODO: Re-enable this once we have a proper sort implementation.
-/*
 public class RedModDeployToolTests : ACyberpunkIsolatedGameTest<Cyberpunk2077Game>
 {
+    private readonly ITestOutputHelper _testOutputHelper;
     private readonly RedModDeployTool _tool;
 
-    public RedModDeployToolTests(ITestOutputHelper helper) : base(helper)
+    public RedModDeployToolTests(ITestOutputHelper helper, ITestOutputHelper testOutputHelper) : base(helper)
     {
+        _testOutputHelper = testOutputHelper;
         _tool = ServiceProvider.GetServices<ITool>().OfType<RedModDeployTool>().Single();
     }
 
@@ -32,7 +32,6 @@ public class RedModDeployToolTests : ACyberpunkIsolatedGameTest<Cyberpunk2077Gam
     }
 
     [Theory]
-    [Trait("FlakeyTest", "True")]
     [InlineData("Driver_Shotguns", 3)]
     [InlineData("Driver_Shotguns", -3)]
     [InlineData("Driver_Shotguns", -11)]
@@ -41,49 +40,58 @@ public class RedModDeployToolTests : ACyberpunkIsolatedGameTest<Cyberpunk2077Gam
     [InlineData("maestros_of_synth_the_dirge", -11)]
     public async Task MovingModsRelativelyResultsInCorrectOrdering(string name, int delta)
     {
-        var loadout = await CreateLoadout();
+        try
+        {
+            var loadout = await CreateLoadout();
 
-        var factory = ServiceProvider.GetRequiredService<RedModSortableItemProviderFactory>();
-        // Wait for the factory to pick up the loadouts
-        await Task.Delay(TimeSpan.FromSeconds(1));
+            var factory = ServiceProvider.GetRequiredService<RedModSortableItemProviderFactory>();
+            // Wait for the factory to pick up the loadouts
+            await Task.Delay(TimeSpan.FromSeconds(1));
         
-        var provider = factory.GetLoadoutSortableItemProvider(loadout);
+            var provider = factory.GetLoadoutSortableItemProvider(loadout);
 
-        var tsc1 = new TaskCompletionSource<Unit>();
-        // avoid stalling the test on failure
-        using var cts = new CancellationTokenSource();
-        cts.CancelAfter(TimeSpan.FromSeconds(30));
-        cts.Token.Register(() => tsc1.TrySetCanceled(), useSynchronizationContext: false);
+            var tsc1 = new TaskCompletionSource<Unit>();
+            // avoid stalling the test on failure
+            using var cts = new CancellationTokenSource();
+            cts.CancelAfter(TimeSpan.FromSeconds(30));
+            cts.Token.Register(() => tsc1.TrySetCanceled(), useSynchronizationContext: false);
 
-        // listen for the order to be updated
-        provider.SortableItems
-            .WhenAnyValue(coll => coll.Count)
-            .Where(count => count == 12)
-            .Distinct()
-            .Subscribe(_ =>
-                {
-                    if (!tsc1.Task.IsCompleted)
+            // listen for the order to be updated
+            using var _ = provider.SortableItems
+                .WhenAnyValue(coll => coll.Count)
+                .Where(count => count == 12)
+                .Distinct()
+                .Subscribe(_ =>
                     {
-                        tsc1.SetResult(Unit.Default);
+                        if (!tsc1.Task.IsCompleted)
+                        {
+                            tsc1.SetResult(Unit.Default);
+                        }
                     }
-                }
-            );
+                );
         
-        // NOTE(Al12rs): Correctness of test depends also on order of mods added to the loadout,
-        // e.g. if RedMods are added one by one rather than in batch, that can affect the order.
-        loadout = await AddRedMods(loadout);
+            // NOTE(Al12rs): Correctness of test depends also on order of mods added to the loadout,
+            // e.g. if RedMods are added one by one rather than in batch, that can affect the order.
+            loadout = await AddRedMods(loadout);
         
-        // wait for the order to be updated
-        await tsc1.Task;
+            // wait for the order to be updated
+            await tsc1.Task;
 
-        var order = provider.SortableItems;
-        var specificRedMod = order.OfType<RedModSortableItem>().Single(g => g.DisplayName == name);
+            var order = provider.SortableItems;
+            var specificRedMod = order.OfType<RedModSortableItem>().Single(g => g.DisplayName == name);
 
-        await provider.SetRelativePosition(specificRedMod, delta);
+            var cts2 = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            var token = cts2.Token;
+            await provider.SetRelativePosition(specificRedMod, delta, token);
 
-        loadout = loadout.Rebase();
+            loadout = loadout.Rebase();
 
-        await Verify(await WriteLoadoutFile(loadout)).UseParameters(name, delta);
+            await Verify(await WriteLoadoutFile(loadout)).UseParameters(name, delta);
+        } catch (Exception e)
+        {
+            _testOutputHelper.WriteLine(e.ToString());
+            throw;
+        }
     }
 
 
@@ -115,4 +123,3 @@ public class RedModDeployToolTests : ACyberpunkIsolatedGameTest<Cyberpunk2077Gam
         return loadout;
     }
 }
-*/


### PR DESCRIPTION
This could cause the provider to commit changes to a disposed Connection, causing crashes.
