### PR TITLE
Fix spine active item at startup

### DIFF
--- a/src/NexusMods.App.UI/Controls/Spine/SpineViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/Spine/SpineViewModel.cs
@@ -88,138 +88,138 @@ public class SpineViewModel : AViewModel<ISpineViewModel>, ISpineViewModel
         var workspaceController = windowManager.ActiveWorkspaceController;
 
         this.WhenActivated(disposables =>
-                {
-                    var loadouts = Loadout.ObserveAll(_conn);
+            {
+                var loadouts = Loadout.ObserveAll(_conn);
 
-                    loadouts
-                        .Filter(loadout => loadout.IsVisible())
-                        .TransformAsync(async loadout =>
-                            {
-                                await using var iconStream = await ((IGame)loadout.InstallationInstance.Game).Icon.GetStreamAsync();
-
-                                var vm = serviceProvider.GetRequiredService<IImageButtonViewModel>();
-                                vm.Name = loadout.InstallationInstance.Game.Name + " - " + loadout.Name;
-                                vm.Image = LoadImageFromStream(iconStream);
-                                vm.LoadoutBadgeViewModel = new LoadoutBadgeViewModel(_conn, _syncService, hideOnSingleLoadout: true);
-                                vm.LoadoutBadgeViewModel.LoadoutValue = loadout;
-                                vm.IsActive = false;
-                                vm.WorkspaceContext = new LoadoutContext { LoadoutId = loadout.LoadoutId };
-                                vm.Click = ReactiveCommand.Create(() => ChangeToLoadoutWorkspace(loadout.LoadoutId));
-                                return vm;
-                            }
-                        )
-                        .OnUI()
-                        .OnItemRemoved(loadoutSpineItem =>
-                            {
-                                if (loadoutSpineItem.WorkspaceContext is LoadoutContext loadoutContext)
-                                    workspaceController.UnregisterWorkspaceByContext<LoadoutContext>(context => loadoutContext == context);
-                            })
-                    .SortAndBind(out _loadoutSpineItems, LoadoutComparerInstance)
-                    .SubscribeWithErrorLogging()
-                    .DisposeWith(disposables);
-
-                // Create Left Menus for each workspace on demand
-                workspaceController.AllWorkspaces
-                    .ToObservableChangeSet()
-                    .OnItemAdded(workspace =>
-                    {
-                        if (_leftMenus.TryGetValue(workspace.Id, out _))
-                        {
-                            return;
-                        }
-                            
-                        try
-                        {
-                            var leftMenu = workspaceAttachmentsFactory.CreateLeftMenuFor(
-                                workspace.Context,
-                                workspace.Id,
-                                workspaceController
-                            );
-
-                            if (leftMenu == null)
-                            {
-                                throw new InvalidDataException("LeftMenu factory returned a null view model");
-                            }
-                            
-                            _leftMenus.Add(workspace.Id, leftMenu);
-                        }
-                        catch (Exception e)
-                        {
-                            _logger.LogError(e, "Exception while creating left menu for context {Context}", workspace.Context);
-                        }
-                    })
-                    .OnItemRemoved(workspace => _leftMenus.Remove(workspace.Id, out _))
-                    .SubscribeWithErrorLogging()
-                    .DisposeWith(disposables);
-
-                // Navigate away from the Loadout workspace if the Loadout is removed
                 loadouts
+                    .Filter(loadout => loadout.IsVisible())
+                    .TransformAsync(async loadout =>
+                        {
+                            await using var iconStream = await ((IGame)loadout.InstallationInstance.Game).Icon.GetStreamAsync();
+
+                            var vm = serviceProvider.GetRequiredService<IImageButtonViewModel>();
+                            vm.Name = loadout.InstallationInstance.Game.Name + " - " + loadout.Name;
+                            vm.Image = LoadImageFromStream(iconStream);
+                            vm.LoadoutBadgeViewModel = new LoadoutBadgeViewModel(_conn, _syncService, hideOnSingleLoadout: true);
+                            vm.LoadoutBadgeViewModel.LoadoutValue = loadout;
+                            vm.IsActive = false;
+                            vm.WorkspaceContext = new LoadoutContext { LoadoutId = loadout.LoadoutId };
+                            vm.Click = ReactiveCommand.Create(() => ChangeToLoadoutWorkspace(loadout.LoadoutId));
+                            return vm;
+                        }
+                    )
                     .OnUI()
-                    .OnItemRemoved(loadout =>
+                    .OnItemRemoved(loadoutSpineItem =>
                         {
-                            if (workspaceController.ActiveWorkspace.Context is LoadoutContext activeLoadoutContext &&
-                                activeLoadoutContext.LoadoutId == loadout.LoadoutId)
-                            {
-                                workspaceController.ChangeOrCreateWorkspaceByContext<HomeContext>(() => new PageData
-                                    {
-                                        FactoryId = MyGamesPageFactory.StaticId,
-                                        Context = new MyGamesPageContext(),
-                                    }
-                                );
-                            }
-                        }, false
-                    )
-                    .SubscribeWithErrorLogging()
-                    .DisposeWith(disposables);
+                            if (loadoutSpineItem.WorkspaceContext is LoadoutContext loadoutContext)
+                                workspaceController.UnregisterWorkspaceByContext<LoadoutContext>(context => loadoutContext == context);
+                        })
+                .SortAndBind(out _loadoutSpineItems, LoadoutComparerInstance)
+                .SubscribeWithErrorLogging()
+                .DisposeWith(disposables);
 
-                // Update the LeftMenuViewModel when the active workspace changes
-                workspaceController.WhenAnyValue(controller => controller.ActiveWorkspace)
-                    .Select(workspace => workspace.Id)
-                    .Select(workspaceId => _leftMenus.GetValueOrDefault(workspaceId))
-                    .BindToVM(this, vm => vm.LeftMenuViewModel)
-                    .DisposeWith(disposables);
+            // Create Left Menus for each workspace on demand
+            workspaceController.AllWorkspaces
+                .ToObservableChangeSet()
+                .OnItemAdded(workspace =>
+                {
+                    if (_leftMenus.TryGetValue(workspace.Id, out _))
+                    {
+                        return;
+                    }
+                        
+                    try
+                    {
+                        var leftMenu = workspaceAttachmentsFactory.CreateLeftMenuFor(
+                            workspace.Context,
+                            workspace.Id,
+                            workspaceController
+                        );
 
-                // Update the active spine item when the active workspace changes
-                workspaceController
-                    .WhenAnyValue(controller => controller.ActiveWorkspace)
-                    .Select(workspace => workspace.Context)
-                    .WhereNotNull()
-                    .SubscribeWithErrorLogging(context =>
+                        if (leftMenu == null)
                         {
-                            var itemToActivate = _specialSpineItems
-                                .Concat(_loadoutSpineItems)
-                                .FirstOrDefault(spineItem => spineItem.WorkspaceContext?.Equals(context) == true);
-
-                            if (itemToActivate == null)
-                                return;
-
-                            if (_activeSpineItem != null)
-                                _activeSpineItem.IsActive = false;
-
-                            itemToActivate.IsActive = true;
-                            _activeSpineItem = itemToActivate;
+                            throw new InvalidDataException("LeftMenu factory returned a null view model");
                         }
-                    )
-                    .DisposeWith(disposables);
+                        
+                        _leftMenus.Add(workspace.Id, leftMenu);
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.LogError(e, "Exception while creating left menu for context {Context}", workspace.Context);
+                    }
+                })
+                .OnItemRemoved(workspace => _leftMenus.Remove(workspace.Id, out _))
+                .SubscribeWithErrorLogging()
+                .DisposeWith(disposables);
 
-                // Update the active spine item if the loadoutList changes
-                _loadoutSpineItems.ToObservableChangeSet()
-                    .SubscribeWithErrorLogging(_ =>
+            // Navigate away from the Loadout workspace if the Loadout is removed
+            loadouts
+                .OnUI()
+                .OnItemRemoved(loadout =>
+                    {
+                        if (workspaceController.ActiveWorkspace.Context is LoadoutContext activeLoadoutContext &&
+                            activeLoadoutContext.LoadoutId == loadout.LoadoutId)
                         {
-                            if (_activeSpineItem is not { WorkspaceContext: LoadoutContext loadoutContext }) return;
-
-                            // The spine item might have been replaced with a new one (TransformAsync)
-                            var newSpineItem = _loadoutSpineItems.FirstOrDefault(
-                                spineItem => loadoutContext.Equals(spineItem.WorkspaceContext)
+                            workspaceController.ChangeOrCreateWorkspaceByContext<HomeContext>(() => new PageData
+                                {
+                                    FactoryId = MyGamesPageFactory.StaticId,
+                                    Context = new MyGamesPageContext(),
+                                }
                             );
-                            if (newSpineItem == null) return;
-
-                            _activeSpineItem.IsActive = false;
-                            newSpineItem.IsActive = true;
-                            _activeSpineItem = newSpineItem;
                         }
-                    )
-                    .DisposeWith(disposables);
+                    }, false
+                )
+                .SubscribeWithErrorLogging()
+                .DisposeWith(disposables);
+
+            // Update the LeftMenuViewModel when the active workspace changes
+            workspaceController.WhenAnyValue(controller => controller.ActiveWorkspace)
+                .Select(workspace => workspace.Id)
+                .Select(workspaceId => _leftMenus.GetValueOrDefault(workspaceId))
+                .BindToVM(this, vm => vm.LeftMenuViewModel)
+                .DisposeWith(disposables);
+
+            // Update the active spine item when the active workspace changes
+            workspaceController
+                .WhenAnyValue(controller => controller.ActiveWorkspace)
+                .Select(workspace => workspace.Context)
+                .WhereNotNull()
+                .SubscribeWithErrorLogging(context =>
+                    {
+                        var itemToActivate = _specialSpineItems
+                            .Concat(_loadoutSpineItems)
+                            .FirstOrDefault(spineItem => spineItem.WorkspaceContext?.Equals(context) == true);
+
+                        if (itemToActivate == null)
+                            return;
+
+                        if (_activeSpineItem != null)
+                            _activeSpineItem.IsActive = false;
+
+                        itemToActivate.IsActive = true;
+                        _activeSpineItem = itemToActivate;
+                    }
+                )
+                .DisposeWith(disposables);
+
+            // Update the active spine item if the loadoutList changes
+            _loadoutSpineItems.ToObservableChangeSet()
+                .SubscribeWithErrorLogging(_ =>
+                    {
+                        if (_activeSpineItem is not { WorkspaceContext: LoadoutContext loadoutContext }) return;
+
+                        // The spine item might have been replaced with a new one (TransformAsync)
+                        var newSpineItem = _loadoutSpineItems.FirstOrDefault(
+                            spineItem => loadoutContext.Equals(spineItem.WorkspaceContext)
+                        );
+                        if (newSpineItem == null) return;
+
+                        _activeSpineItem.IsActive = false;
+                        newSpineItem.IsActive = true;
+                        _activeSpineItem = newSpineItem;
+                    }
+                )
+                .DisposeWith(disposables);
             }
         );
     }


### PR DESCRIPTION
- Fix #2780 

Ignore whitespace changes when reviewing since I fixed a bad indentation.

I think this is a regression caused by the changes we made to the Db, one of those assumptions about data being populated immediately no longer being valid.

I made it work regardless of that and cleaned up some of the old code a bit. 