### PR TITLE
Verify entity before accessing name

### DIFF
--- a/src/NexusMods.App.UI/DiagnosticSystem/LoadoutItemGroupFormatter.cs
+++ b/src/NexusMods.App.UI/DiagnosticSystem/LoadoutItemGroupFormatter.cs
@@ -11,7 +11,14 @@ internal sealed class LoadoutItemGroupFormatter(IConnection conn) : IValueFormat
     public void Format(IDiagnosticWriter writer, ref DiagnosticWriterState state, LoadoutItemGroupReference value)
     {
         // TODO: custom markdown control
-        var mod = LoadoutItemGroup.Load(conn.Db, value.DataId);
-        writer.Write(ref state, $"{mod.AsLoadoutItem().Name}");
+        var loadoutItemGroup = LoadoutItemGroup.Load(conn.Db, value.DataId);
+        if (loadoutItemGroup.IsValid())
+        {
+            writer.Write(ref state, $"{loadoutItemGroup.AsLoadoutItem().Name}");
+        }
+        else
+        {
+            writer.Write(ref state, $"Invalid LoadoutItemGroup entity: {value.DataId}");
+        }
     }
 }

--- a/src/NexusMods.App.UI/DiagnosticSystem/LoadoutReferenceFormatter.cs
+++ b/src/NexusMods.App.UI/DiagnosticSystem/LoadoutReferenceFormatter.cs
@@ -11,9 +11,13 @@ internal sealed class LoadoutReferenceFormatter(IConnection conn) : IValueFormat
     {
         // TODO: custom markdown control
         var loadout = Loadout.Load(conn.Db, value.DataId);
-        if (loadout.IsValid()) 
+        if (loadout.IsValid())
+        {
             writer.Write(ref state, loadout.Name);
+        }
         else
-            writer.Write(ref state, "MISSING LOADOUT");
+        {
+            writer.Write(ref state, $"Invalid Loadout entity: {value.DataId}");
+        }
     }
 }


### PR DESCRIPTION
Fixes #2793, instead of throwing an exception we verify the entity and write an error message if it's invalid.