### PR TITLE
Skip result validation for xdg-settings

### DIFF
--- a/src/NexusMods.CrossPlatform/Process/XDGSettingsDependency.cs
+++ b/src/NexusMods.CrossPlatform/Process/XDGSettingsDependency.cs
@@ -17,7 +17,8 @@ internal class XDGSettingsDependency : ExecutableRuntimeDependency
     {
         var command = Cli
             .Wrap("xdg-settings")
-            .WithArguments($"set default-url-scheme-handler {uriScheme} {desktopFile}");
+            .WithArguments($"set default-url-scheme-handler {uriScheme} {desktopFile}")
+            .WithValidation(CommandResultValidation.None);
 
         return command;
     }


### PR DESCRIPTION
Resolves #2796. Even though the app got registered correctly, `xdg-settings` still returns non-zero exit codes sometimes for no apparent reason. It also doesn't send any message over stdout or stderr.