### PR TITLE
Refactor and separate `IsEnabled` loadout column component into separate states

### DIFF
--- a/src/NexusMods.App.UI/Pages/BundledDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/BundledDataProvider.cs
@@ -65,6 +65,7 @@ public class BundledDataProvider : ILoadoutDataProvider
         parentItemModel.Add(SharedColumns.InstalledDate.ComponentKey, new DateComponent(value: item.GetCreatedAt()));
 
         LoadoutDataProviderHelper.AddCollection(_connection, parentItemModel, loadoutItem);
+        LoadoutDataProviderHelper.AddLockedEnabledState(parentItemModel, loadoutItem);
         LoadoutDataProviderHelper.AddIsEnabled(_connection, parentItemModel, loadoutItem);
 
         return parentItemModel;

--- a/src/NexusMods.App.UI/Pages/BundledDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/BundledDataProvider.cs
@@ -66,7 +66,7 @@ public class BundledDataProvider : ILoadoutDataProvider
 
         LoadoutDataProviderHelper.AddCollection(_connection, parentItemModel, loadoutItem);
         LoadoutDataProviderHelper.AddLockedEnabledState(parentItemModel, loadoutItem);
-        LoadoutDataProviderHelper.AddIsEnabled(_connection, parentItemModel, loadoutItem);
+        LoadoutDataProviderHelper.AddEnabledStateToggle(_connection, parentItemModel, loadoutItem);
 
         return parentItemModel;
     }

--- a/src/NexusMods.App.UI/Pages/BundledDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/BundledDataProvider.cs
@@ -5,6 +5,7 @@ using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.Collections;
 using NexusMods.App.UI.Controls;
+using NexusMods.App.UI.Pages.LoadoutPage;
 using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.MnemonicDB.Abstractions.DatomIterators;
 using NexusMods.MnemonicDB.Abstractions.Query;
@@ -63,7 +64,9 @@ public class BundledDataProvider : ILoadoutDataProvider
         parentItemModel.Add(SharedColumns.Name.StringComponentKey, new StringComponent(value: item.AsNexusCollectionItemLoadoutGroup().AsLoadoutItemGroup().AsLoadoutItem().Name));
         parentItemModel.Add(SharedColumns.Name.ImageComponentKey, new ImageComponent(value: ImagePipelines.ModPageThumbnailFallback));
         parentItemModel.Add(SharedColumns.InstalledDate.ComponentKey, new DateComponent(value: item.GetCreatedAt()));
+        parentItemModel.Add(LoadoutColumns.EnabledState.LoadoutItemIdsComponentKey, new LoadoutComponents.LoadoutItemIds(loadoutItem));
 
+        
         LoadoutDataProviderHelper.AddCollection(_connection, parentItemModel, loadoutItem);
         LoadoutDataProviderHelper.AddLockedEnabledState(parentItemModel, loadoutItem);
         LoadoutDataProviderHelper.AddEnabledStateToggle(_connection, parentItemModel, loadoutItem);

--- a/src/NexusMods.App.UI/Pages/ILoadoutDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/ILoadoutDataProvider.cs
@@ -93,7 +93,7 @@ public static class LoadoutDataProviderHelper
 
         AddCollection(connection, itemModel, loadoutItem);
         AddLockedEnabledState(itemModel, loadoutItem);
-        AddIsEnabled(connection, itemModel, loadoutItem);
+        AddEnabledStateToggle(connection, itemModel, loadoutItem);
 
         return itemModel;
     }
@@ -107,7 +107,7 @@ public static class LoadoutDataProviderHelper
         var isParentCollectionDisabledObservable = LoadoutItem.Observe(connection, collectionGroup.Id).Select(static item => item.IsDisabled).ToObservable();
 
         itemModel.AddObservable(
-            key: LoadoutColumns.IsEnabled.ParentCollectionDisabledComponentKey,
+            key: LoadoutColumns.EnabledState.ParentCollectionDisabledComponentKey,
             shouldAddObservable: isParentCollectionDisabledObservable,
             componentFactory: () => new LoadoutComponents.ParentCollectionDisabled()
         );
@@ -116,13 +116,13 @@ public static class LoadoutDataProviderHelper
     public static void AddLockedEnabledState(CompositeItemModel<EntityId> itemModel, LoadoutItem.ReadOnly loadoutItem)
     {
         if (IsLocked(loadoutItem))
-            itemModel.Add(LoadoutColumns.IsEnabled.LockedEnabledStateComponentKey, new LoadoutComponents.LockedEnabledState());
+            itemModel.Add(LoadoutColumns.EnabledState.LockedEnabledStateComponentKey, new LoadoutComponents.LockedEnabledState());
     }
 
-    public static void AddIsEnabled(IConnection connection, CompositeItemModel<EntityId> itemModel, LoadoutItem.ReadOnly loadoutItem)
+    public static void AddEnabledStateToggle(IConnection connection, CompositeItemModel<EntityId> itemModel, LoadoutItem.ReadOnly loadoutItem)
     {
         var isEnabledObservable = LoadoutItem.Observe(connection, loadoutItem.Id).Select(static item => (bool?)!item.IsDisabled);
-        itemModel.Add(LoadoutColumns.IsEnabled.IsEnabledComponentKey, new LoadoutComponents.IsEnabled(
+        itemModel.Add(LoadoutColumns.EnabledState.EnabledStateToggleComponentKey, new LoadoutComponents.EnabledStateToggle(
             valueComponent: new ValueComponent<bool?>(
                 initialValue: !loadoutItem.IsDisabled,
                 valueObservable: isEnabledObservable
@@ -184,13 +184,13 @@ public static class LoadoutDataProviderHelper
             .ToObservable();
 
         parentItemModel.AddObservable(
-            key: LoadoutColumns.IsEnabled.LockedEnabledStateComponentKey,
+            key: LoadoutColumns.EnabledState.LockedEnabledStateComponentKey,
             shouldAddObservable: isLockedObservable,
             componentFactory: () => new LoadoutComponents.LockedEnabledState()
         );
     }
 
-    public static void AddIsEnabled(
+    public static void AddEnabledStateToggle(
         IConnection connection,
         CompositeItemModel<EntityId> parentItemModel,
         IObservable<IChangeSet<LoadoutItem.ReadOnly, EntityId>> linkedItemsObservable)
@@ -216,7 +216,7 @@ public static class LoadoutDataProviderHelper
                 return isEnabled.HasValue ? isEnabled.Value : null;
             });
 
-        parentItemModel.Add(LoadoutColumns.IsEnabled.IsEnabledComponentKey, new LoadoutComponents.IsEnabled(
+        parentItemModel.Add(LoadoutColumns.EnabledState.EnabledStateToggleComponentKey, new LoadoutComponents.EnabledStateToggle(
             valueComponent: new ValueComponent<bool?>(
                 initialValue: true,
                 valueObservable: isEnabledObservable

--- a/src/NexusMods.App.UI/Pages/ILoadoutDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/ILoadoutDataProvider.cs
@@ -220,8 +220,7 @@ public static class LoadoutDataProviderHelper
             valueComponent: new ValueComponent<bool?>(
                 initialValue: true,
                 valueObservable: isEnabledObservable
-            ),
-            childrenItemIdsObservable: linkedItemsObservable.TransformImmutable(static item => item.LoadoutItemId)
+            )
         ));
     }
     

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutComponents.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutComponents.cs
@@ -96,18 +96,6 @@ public static class LoadoutComponents
             });
         }
 
-        public EnabledStateToggle(
-            ValueComponent<bool?> valueComponent,
-            IObservable<IChangeSet<LoadoutItemId, EntityId>> childrenItemIdsObservable)
-        {
-            _valueComponent = valueComponent;
-
-            _activationDisposable = this.WhenActivated((childrenItemIdsObservable), static (self, state, disposables) =>
-            {
-                self._valueComponent.Activate().AddTo(disposables);
-            });
-        }
-
         private bool _isDisposed;
         protected override void Dispose(bool disposing)
         {

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutComponents.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutComponents.cs
@@ -24,7 +24,7 @@ public static class LoadoutComponents
         public int CompareTo(LockedEnabledState? other) => 0;
     }
 
-    public sealed class IsEnabled : ReactiveR3Object, IItemModelComponent<IsEnabled>, IComparable<IsEnabled>
+    public sealed class EnabledStateToggle : ReactiveR3Object, IItemModelComponent<EnabledStateToggle>, IComparable<EnabledStateToggle>
     {
         public ReactiveCommand<Unit> CommandToggle { get; } = new();
 
@@ -37,7 +37,7 @@ public static class LoadoutComponents
             f1: static x => x.AsEnumerable()
         );
 
-        public int CompareTo(IsEnabled? other)
+        public int CompareTo(EnabledStateToggle? other)
         {
             var (a, b) = (Value.Value, other?.Value.Value);
             return (a, b) switch
@@ -52,7 +52,7 @@ public static class LoadoutComponents
         private readonly IDisposable _activationDisposable;
         private readonly IDisposable? _idsObservable;
 
-        public IsEnabled(
+        public EnabledStateToggle(
             ValueComponent<bool?> valueComponent,
             LoadoutItemId itemId)
         {
@@ -65,7 +65,7 @@ public static class LoadoutComponents
             });
         }
 
-        public IsEnabled(
+        public EnabledStateToggle(
             ValueComponent<bool?> valueComponent,
             IObservable<IChangeSet<LoadoutItemId, EntityId>> childrenItemIdsObservable)
         {
@@ -117,17 +117,17 @@ public static class LoadoutColumns
     }
 
     [UsedImplicitly]
-    public sealed class IsEnabled : ICompositeColumnDefinition<IsEnabled>
+    public sealed class EnabledState : ICompositeColumnDefinition<EnabledState>
     {
         public static int Compare<TKey>(CompositeItemModel<TKey> a, CompositeItemModel<TKey> b) where TKey : notnull
         {
-            var aValue = a.GetOptional<LoadoutComponents.IsEnabled>(key: IsEnabledComponentKey);
-            var bValue = a.GetOptional<LoadoutComponents.IsEnabled>(key: IsEnabledComponentKey);
+            var aValue = a.GetOptional<LoadoutComponents.EnabledStateToggle>(key: EnabledStateToggleComponentKey);
+            var bValue = a.GetOptional<LoadoutComponents.EnabledStateToggle>(key: EnabledStateToggleComponentKey);
             return aValue.Compare(bValue);
         }
 
-        public const string ColumnTemplateResourceKey = nameof(LoadoutColumns) + "_" + nameof(IsEnabled);
-        public static readonly ComponentKey IsEnabledComponentKey = ComponentKey.From(ColumnTemplateResourceKey + "_" + nameof(LoadoutComponents.IsEnabled));
+        public const string ColumnTemplateResourceKey = nameof(LoadoutColumns) + "_" + nameof(EnabledState);
+        public static readonly ComponentKey EnabledStateToggleComponentKey = ComponentKey.From(ColumnTemplateResourceKey + "_" + nameof(LoadoutComponents.EnabledStateToggle));
         public static readonly ComponentKey ParentCollectionDisabledComponentKey = ComponentKey.From(ColumnTemplateResourceKey + "_" + nameof(LoadoutComponents.ParentCollectionDisabled));
         public static readonly ComponentKey LockedEnabledStateComponentKey = ComponentKey.From(ColumnTemplateResourceKey + "_" + nameof(LoadoutComponents.LockedEnabledState));
         public static string GetColumnHeader() => "Actions";

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutComponents.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutComponents.cs
@@ -18,6 +18,11 @@ public static class LoadoutComponents
     {
         public int CompareTo(ParentCollectionDisabled? other) => 0;
     }
+    
+    public sealed class LockedEnabledState : ReactiveR3Object, IItemModelComponent<LockedEnabledState>, IComparable<LockedEnabledState>
+    {
+        public int CompareTo(LockedEnabledState? other) => 0;
+    }
 
     public sealed class IsEnabled : ReactiveR3Object, IItemModelComponent<IsEnabled>, IComparable<IsEnabled>
     {
@@ -31,9 +36,6 @@ public static class LoadoutComponents
             f0: static x => x.AsEnumerable(),
             f1: static x => x.AsEnumerable()
         );
-
-        private readonly ValueComponent<bool> _isLockedComponent;
-        public IReadOnlyBindableReactiveProperty<bool> IsLocked => _isLockedComponent.Value;
 
         public int CompareTo(IsEnabled? other)
         {
@@ -52,12 +54,10 @@ public static class LoadoutComponents
 
         public IsEnabled(
             ValueComponent<bool?> valueComponent,
-            LoadoutItemId itemId,
-            bool isLocked)
+            LoadoutItemId itemId)
         {
             _valueComponent = valueComponent;
             _ids = new[] { itemId };
-            _isLockedComponent = new ValueComponent<bool>(value: isLocked);
 
             _activationDisposable = this.WhenActivated(static (self, disposables) =>
             {
@@ -67,16 +67,13 @@ public static class LoadoutComponents
 
         public IsEnabled(
             ValueComponent<bool?> valueComponent,
-            IObservable<IChangeSet<LoadoutItemId, EntityId>> childrenItemIdsObservable,
-            ValueComponent<bool> isLockedComponent)
+            IObservable<IChangeSet<LoadoutItemId, EntityId>> childrenItemIdsObservable)
         {
             _valueComponent = valueComponent;
             _ids = new ObservableHashSet<LoadoutItemId>();
-            _isLockedComponent = isLockedComponent;
 
             _activationDisposable = this.WhenActivated((childrenItemIdsObservable), static (self, state, disposables) =>
             {
-                self._isLockedComponent.Activate().AddTo(disposables);
                 self._valueComponent.Activate().AddTo(disposables);
             });
 
@@ -90,7 +87,7 @@ public static class LoadoutComponents
             {
                 if (disposing)
                 {
-                    Disposable.Dispose(_activationDisposable, _valueComponent, _isLockedComponent, _idsObservable ?? Disposable.Empty);
+                    Disposable.Dispose(_activationDisposable, _valueComponent, _idsObservable ?? Disposable.Empty);
                 }
 
                 _isDisposed = true;
@@ -132,6 +129,7 @@ public static class LoadoutColumns
         public const string ColumnTemplateResourceKey = nameof(LoadoutColumns) + "_" + nameof(IsEnabled);
         public static readonly ComponentKey IsEnabledComponentKey = ComponentKey.From(ColumnTemplateResourceKey + "_" + nameof(LoadoutComponents.IsEnabled));
         public static readonly ComponentKey ParentCollectionDisabledComponentKey = ComponentKey.From(ColumnTemplateResourceKey + "_" + nameof(LoadoutComponents.ParentCollectionDisabled));
+        public static readonly ComponentKey LockedEnabledStateComponentKey = ComponentKey.From(ColumnTemplateResourceKey + "_" + nameof(LoadoutComponents.LockedEnabledState));
         public static string GetColumnHeader() => "Actions";
         public static string GetColumnTemplateResourceKey() => ColumnTemplateResourceKey;
     }

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutViewModel.cs
@@ -210,7 +210,7 @@ public class LoadoutViewModel : APageViewModel<ILoadoutViewModel>, ILoadoutViewM
 
     private static IEnumerable<LoadoutItemId> GetLoadoutItemIds(CompositeItemModel<EntityId> itemModel)
     {
-        return itemModel.Get<LoadoutComponents.EnabledStateToggle>(LoadoutColumns.EnabledState.EnabledStateToggleComponentKey).ItemIds;
+        return itemModel.Get<LoadoutComponents.LoadoutItemIds>(LoadoutColumns.EnabledState.LoadoutItemIdsComponentKey).ItemIds;
     }
 }
 
@@ -245,14 +245,19 @@ public class LoadoutTreeDataGridAdapter :
             state: this,
             factory: static (self, itemModel, component) => component.CommandToggle.Subscribe((self, itemModel, component), static (_, tuple) =>
             {
-                var (self, _, component) = tuple;
+                var (self, itemModel, component) = tuple;
                 var isEnabled = component.Value.Value;
-                var ids = component.ItemIds.ToArray();
+                var ids = GetLoadoutItemIds(itemModel).ToArray();
                 var shouldEnable = !isEnabled ?? false;
 
                 self.MessageSubject.OnNext(new ToggleEnableState(ids, shouldEnable));
             })
         );
+    }
+    
+    private static IEnumerable<LoadoutItemId> GetLoadoutItemIds(CompositeItemModel<EntityId> itemModel)
+    {
+        return itemModel.Get<LoadoutComponents.LoadoutItemIds>(LoadoutColumns.EnabledState.LoadoutItemIdsComponentKey).ItemIds;
     }
 
     protected override IColumn<CompositeItemModel<EntityId>>[] CreateColumns(bool viewHierarchical)

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutViewModel.cs
@@ -210,7 +210,7 @@ public class LoadoutViewModel : APageViewModel<ILoadoutViewModel>, ILoadoutViewM
 
     private static IEnumerable<LoadoutItemId> GetLoadoutItemIds(CompositeItemModel<EntityId> itemModel)
     {
-        return itemModel.Get<LoadoutComponents.IsEnabled>(LoadoutColumns.IsEnabled.IsEnabledComponentKey).ItemIds;
+        return itemModel.Get<LoadoutComponents.EnabledStateToggle>(LoadoutColumns.EnabledState.EnabledStateToggleComponentKey).ItemIds;
     }
 }
 
@@ -240,8 +240,8 @@ public class LoadoutTreeDataGridAdapter :
     {
         base.BeforeModelActivationHook(model);
 
-        model.SubscribeToComponentAndTrack<LoadoutComponents.IsEnabled, LoadoutTreeDataGridAdapter>(
-            key: LoadoutColumns.IsEnabled.IsEnabledComponentKey,
+        model.SubscribeToComponentAndTrack<LoadoutComponents.EnabledStateToggle, LoadoutTreeDataGridAdapter>(
+            key: LoadoutColumns.EnabledState.EnabledStateToggleComponentKey,
             state: this,
             factory: static (self, itemModel, component) => component.CommandToggle.Subscribe((self, itemModel, component), static (_, tuple) =>
             {
@@ -264,7 +264,7 @@ public class LoadoutTreeDataGridAdapter :
             viewHierarchical ? ITreeDataGridItemModel<CompositeItemModel<EntityId>, EntityId>.CreateExpanderColumn(nameColumn) : nameColumn,
             ColumnCreator.Create<EntityId, SharedColumns.InstalledDate>(),
             ColumnCreator.Create<EntityId, LoadoutColumns.Collections>(),
-            ColumnCreator.Create<EntityId, LoadoutColumns.IsEnabled>(),
+            ColumnCreator.Create<EntityId, LoadoutColumns.EnabledState>(),
         ];
     }
 

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/TreeDataGridLoadoutResources.axaml
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/TreeDataGridLoadoutResources.axaml
@@ -38,17 +38,13 @@
                                             ComponentKey="{x:Static local:LoadoutColumns+IsEnabled.ParentCollectionDisabledComponentKey}">
                     <controls:ComponentTemplate.DataTemplate>
                         <DataTemplate DataType="{x:Type local:LoadoutComponents+ParentCollectionDisabled}">
-                            <StackPanel Orientation="Horizontal">
-                                <icons:UnifiedIcon Value="{x:Static icons:IconValues.Collections}" Size="20"/>
-                                <ToggleSwitch Classes="Compact" HorizontalAlignment="Center" IsEnabled="false" IsChecked="False">
-                                    <ToggleSwitch.OnContent>
-                                        <ContentControl />
-                                    </ToggleSwitch.OnContent>
-                                    <ToggleSwitch.OffContent>
-                                        <ContentControl />
-                                    </ToggleSwitch.OffContent>
-                                </ToggleSwitch>
-                            </StackPanel>
+                            <controls:StandardButton
+                                Size="Small"
+                                LeftIcon="{x:Static icons:IconValues.Collections}"
+                                RightIcon="{x:Static icons:IconValues.ToggleOff}"
+                                ShowIcon="Both"
+                                ShowLabel="False"
+                                ToolTip.Tip="Mod cannot be switched on as it is as part of a read only collection. Switch on the collection to switch on this mod"/>
                         </DataTemplate>
                     </controls:ComponentTemplate.DataTemplate>
                 </controls:ComponentTemplate>
@@ -58,14 +54,12 @@
                                             ComponentKey="{x:Static local:LoadoutColumns+IsEnabled.IsEnabledComponentKey}">
                     <controls:ComponentTemplate.DataTemplate>
                         <DataTemplate DataType="{x:Type local:LoadoutComponents+IsEnabled}">
-                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                                <icons:UnifiedIcon Value="{x:Static icons:IconValues.Lock}" Size="18" IsVisible="{CompiledBinding IsLocked.Value}"/>
-
+                            <Panel>
                                 <ToggleSwitch Classes="Compact"
                                               HorizontalAlignment="Center"
                                               Command="{CompiledBinding CommandToggle}"
                                               IsChecked="{CompiledBinding Value.Value, Mode=OneWay}"
-                                              IsEnabled="{CompiledBinding !IsLocked.Value}">
+                                              IsVisible="{CompiledBinding !IsLocked.Value}">
                                     <ToggleSwitch.OnContent>
                                         <ContentControl />
                                     </ToggleSwitch.OnContent>
@@ -73,7 +67,16 @@
                                         <ContentControl />
                                     </ToggleSwitch.OffContent>
                                 </ToggleSwitch>
-                            </StackPanel>
+                                <controls:StandardButton
+                                    Size="Small"
+                                    LeftIcon="{x:Static icons:IconValues.Lock}"
+                                    RightIcon="{x:Static icons:IconValues.ToggleOn}"
+                                    ShowIcon="Both"
+                                    ShowLabel="False"
+                                    IsVisible="{CompiledBinding IsLocked.Value}"
+                                    ToolTip.Tip="Mod cannot be turned off as it is as part of a read only collection. Switch off the collection to turn off this mod"/>
+                            </Panel>
+                            
                         </DataTemplate>
                     </controls:ComponentTemplate.DataTemplate>
                 </controls:ComponentTemplate>

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/TreeDataGridLoadoutResources.axaml
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/TreeDataGridLoadoutResources.axaml
@@ -48,35 +48,35 @@
                         </DataTemplate>
                     </controls:ComponentTemplate.DataTemplate>
                 </controls:ComponentTemplate>
+                
+                <!-- Locked enabled -->
+                <controls:ComponentTemplate x:TypeArguments="local:LoadoutComponents+LockedEnabledState"
+                                            ComponentKey="{x:Static local:LoadoutColumns+IsEnabled.LockedEnabledStateComponentKey}">
+                    <controls:ComponentTemplate.DataTemplate>
+                        <DataTemplate DataType="{x:Type local:LoadoutComponents+LockedEnabledState}">
+                            <controls:StandardButton
+                                Size="Small"
+                                LeftIcon="{x:Static icons:IconValues.Lock}"
+                                RightIcon="{x:Static icons:IconValues.ToggleOn}"
+                                ShowIcon="Both"
+                                ShowLabel="False"
+                                ToolTip.Tip="Mod cannot be turned off as it is as part of a read only collection. Switch off the collection to turn off this mod"/>
+                        </DataTemplate>
+                    </controls:ComponentTemplate.DataTemplate>
+                </controls:ComponentTemplate>
 
                 <!-- normal toggle -->
                 <controls:ComponentTemplate x:TypeArguments="local:LoadoutComponents+IsEnabled"
                                             ComponentKey="{x:Static local:LoadoutColumns+IsEnabled.IsEnabledComponentKey}">
                     <controls:ComponentTemplate.DataTemplate>
                         <DataTemplate DataType="{x:Type local:LoadoutComponents+IsEnabled}">
-                            <Panel>
-                                <ToggleSwitch Classes="Compact"
-                                              HorizontalAlignment="Center"
-                                              Command="{CompiledBinding CommandToggle}"
-                                              IsChecked="{CompiledBinding Value.Value, Mode=OneWay}"
-                                              IsVisible="{CompiledBinding !IsLocked.Value}">
-                                    <ToggleSwitch.OnContent>
-                                        <ContentControl />
-                                    </ToggleSwitch.OnContent>
-                                    <ToggleSwitch.OffContent>
-                                        <ContentControl />
-                                    </ToggleSwitch.OffContent>
-                                </ToggleSwitch>
-                                <controls:StandardButton
-                                    Size="Small"
-                                    LeftIcon="{x:Static icons:IconValues.Lock}"
-                                    RightIcon="{x:Static icons:IconValues.ToggleOn}"
-                                    ShowIcon="Both"
-                                    ShowLabel="False"
-                                    IsVisible="{CompiledBinding IsLocked.Value}"
-                                    ToolTip.Tip="Mod cannot be turned off as it is as part of a read only collection. Switch off the collection to turn off this mod"/>
-                            </Panel>
-                            
+                            <ToggleSwitch Classes="Compact"
+                                          HorizontalAlignment="Center"
+                                          Command="{CompiledBinding CommandToggle}"
+                                          IsChecked="{CompiledBinding Value.Value, Mode=OneWay}"
+                                          OnContent="{x:Null}"
+                                          OffContent="{x:Null}">
+                            </ToggleSwitch>
                         </DataTemplate>
                     </controls:ComponentTemplate.DataTemplate>
                 </controls:ComponentTemplate>

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/TreeDataGridLoadoutResources.axaml
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/TreeDataGridLoadoutResources.axaml
@@ -25,8 +25,8 @@
         </controls:ComponentControl>
     </DataTemplate>
 
-    <!-- Enabled -->
-    <DataTemplate x:Key="{x:Static local:LoadoutColumns+IsEnabled.ColumnTemplateResourceKey}">
+    <!-- Enabled State -->
+    <DataTemplate x:Key="{x:Static local:LoadoutColumns+EnabledState.ColumnTemplateResourceKey}">
         <DataTemplate.DataType>
             <x:Type TypeName="controls:CompositeItemModel" x:TypeArguments="abstractions:EntityId" />
         </DataTemplate.DataType>
@@ -35,7 +35,7 @@
             <controls:MultiComponentControl.AvailableTemplates>
                 <!-- parent collection disabled -->
                 <controls:ComponentTemplate x:TypeArguments="local:LoadoutComponents+ParentCollectionDisabled"
-                                            ComponentKey="{x:Static local:LoadoutColumns+IsEnabled.ParentCollectionDisabledComponentKey}">
+                                            ComponentKey="{x:Static local:LoadoutColumns+EnabledState.ParentCollectionDisabledComponentKey}">
                     <controls:ComponentTemplate.DataTemplate>
                         <DataTemplate DataType="{x:Type local:LoadoutComponents+ParentCollectionDisabled}">
                             <controls:StandardButton
@@ -49,9 +49,9 @@
                     </controls:ComponentTemplate.DataTemplate>
                 </controls:ComponentTemplate>
                 
-                <!-- Locked enabled -->
+                <!-- locked enabled state -->
                 <controls:ComponentTemplate x:TypeArguments="local:LoadoutComponents+LockedEnabledState"
-                                            ComponentKey="{x:Static local:LoadoutColumns+IsEnabled.LockedEnabledStateComponentKey}">
+                                            ComponentKey="{x:Static local:LoadoutColumns+EnabledState.LockedEnabledStateComponentKey}">
                     <controls:ComponentTemplate.DataTemplate>
                         <DataTemplate DataType="{x:Type local:LoadoutComponents+LockedEnabledState}">
                             <controls:StandardButton
@@ -66,10 +66,10 @@
                 </controls:ComponentTemplate>
 
                 <!-- normal toggle -->
-                <controls:ComponentTemplate x:TypeArguments="local:LoadoutComponents+IsEnabled"
-                                            ComponentKey="{x:Static local:LoadoutColumns+IsEnabled.IsEnabledComponentKey}">
+                <controls:ComponentTemplate x:TypeArguments="local:LoadoutComponents+EnabledStateToggle"
+                                            ComponentKey="{x:Static local:LoadoutColumns+EnabledState.EnabledStateToggleComponentKey}">
                     <controls:ComponentTemplate.DataTemplate>
-                        <DataTemplate DataType="{x:Type local:LoadoutComponents+IsEnabled}">
+                        <DataTemplate DataType="{x:Type local:LoadoutComponents+EnabledStateToggle}">
                             <ToggleSwitch Classes="Compact"
                                           HorizontalAlignment="Center"
                                           Command="{CompiledBinding CommandToggle}"

--- a/src/NexusMods.App.UI/Pages/LocalFileDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/LocalFileDataProvider.cs
@@ -131,6 +131,8 @@ internal class LocalFileDataProvider : ILibraryDataProvider, ILoadoutDataProvide
         LoadoutDataProviderHelper.AddCollections(parentItemModel, linkedItemsObservable);
         LoadoutDataProviderHelper.AddLockedEnabledStates(parentItemModel, linkedItemsObservable);
         LoadoutDataProviderHelper.AddEnabledStateToggle(_connection, parentItemModel, linkedItemsObservable);
+        LoadoutDataProviderHelper.AddLoadoutItemIds(parentItemModel, linkedItemsObservable);
+        
 
         return parentItemModel;
     }

--- a/src/NexusMods.App.UI/Pages/LocalFileDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/LocalFileDataProvider.cs
@@ -129,6 +129,7 @@ internal class LocalFileDataProvider : ILibraryDataProvider, ILoadoutDataProvide
 
         LoadoutDataProviderHelper.AddDateComponent(parentItemModel, localFile.GetCreatedAt(), linkedItemsObservable);
         LoadoutDataProviderHelper.AddCollections(parentItemModel, linkedItemsObservable);
+        LoadoutDataProviderHelper.AddLockedEnabledStates(parentItemModel, linkedItemsObservable);
         LoadoutDataProviderHelper.AddIsEnabled(_connection, parentItemModel, linkedItemsObservable);
 
         return parentItemModel;

--- a/src/NexusMods.App.UI/Pages/LocalFileDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/LocalFileDataProvider.cs
@@ -130,7 +130,7 @@ internal class LocalFileDataProvider : ILibraryDataProvider, ILoadoutDataProvide
         LoadoutDataProviderHelper.AddDateComponent(parentItemModel, localFile.GetCreatedAt(), linkedItemsObservable);
         LoadoutDataProviderHelper.AddCollections(parentItemModel, linkedItemsObservable);
         LoadoutDataProviderHelper.AddLockedEnabledStates(parentItemModel, linkedItemsObservable);
-        LoadoutDataProviderHelper.AddIsEnabled(_connection, parentItemModel, linkedItemsObservable);
+        LoadoutDataProviderHelper.AddEnabledStateToggle(_connection, parentItemModel, linkedItemsObservable);
 
         return parentItemModel;
     }

--- a/src/NexusMods.App.UI/Pages/NexusModsDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/NexusModsDataProvider.cs
@@ -273,6 +273,7 @@ public class NexusModsDataProvider : ILibraryDataProvider, ILoadoutDataProvider
             LoadoutDataProviderHelper.AddCollections(parentItemModel, linkedItemsObservable);
             LoadoutDataProviderHelper.AddLockedEnabledStates(parentItemModel, linkedItemsObservable);
             LoadoutDataProviderHelper.AddEnabledStateToggle(_connection, parentItemModel, linkedItemsObservable);
+            LoadoutDataProviderHelper.AddLoadoutItemIds(parentItemModel, linkedItemsObservable);
 
             return parentItemModel;
         });

--- a/src/NexusMods.App.UI/Pages/NexusModsDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/NexusModsDataProvider.cs
@@ -271,6 +271,7 @@ public class NexusModsDataProvider : ILibraryDataProvider, ILoadoutDataProvider
 
             LoadoutDataProviderHelper.AddDateComponent(parentItemModel, modPage.GetCreatedAt(), linkedItemsObservable);
             LoadoutDataProviderHelper.AddCollections(parentItemModel, linkedItemsObservable);
+            LoadoutDataProviderHelper.AddLockedEnabledStates(parentItemModel, linkedItemsObservable);
             LoadoutDataProviderHelper.AddIsEnabled(_connection, parentItemModel, linkedItemsObservable);
 
             return parentItemModel;

--- a/src/NexusMods.App.UI/Pages/NexusModsDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/NexusModsDataProvider.cs
@@ -272,7 +272,7 @@ public class NexusModsDataProvider : ILibraryDataProvider, ILoadoutDataProvider
             LoadoutDataProviderHelper.AddDateComponent(parentItemModel, modPage.GetCreatedAt(), linkedItemsObservable);
             LoadoutDataProviderHelper.AddCollections(parentItemModel, linkedItemsObservable);
             LoadoutDataProviderHelper.AddLockedEnabledStates(parentItemModel, linkedItemsObservable);
-            LoadoutDataProviderHelper.AddIsEnabled(_connection, parentItemModel, linkedItemsObservable);
+            LoadoutDataProviderHelper.AddEnabledStateToggle(_connection, parentItemModel, linkedItemsObservable);
 
             return parentItemModel;
         });

--- a/src/NexusMods.Icons/IconValues.cs
+++ b/src/NexusMods.Icons/IconValues.cs
@@ -435,13 +435,6 @@ public static class IconValues
     // https://pictogrammers.com/library/mdi/icon/star/
     public static readonly IconValue Star = new ProjektankerIcon("mdi-star");
 
-    // https://pictogrammers.com/library/mdi/icon/toggle-switch/
-    public static readonly IconValue ToggleOn = new ProjektankerIcon("mdi-toggle-switch");
-    
-    // https://pictogrammers.com/library/mdi/icon/toggle-switch-off-outline/
-    public static readonly IconValue ToggleOff = new ProjektankerIcon("mdi-toggle-switch-off-outline");
-
-
 #endregion
 
 #region Custom Icons
@@ -603,6 +596,24 @@ public static class IconValues
             new Rect(0, 0, 16, 16 )
     ));
     
+    
+    // Toggle On icon
+    public static readonly IconValue ToggleOn = new SimpleVectorIcon(new SimpleVectorIconImage(
+        "M7 7C4.23858 7 2 9.23858 2 12C2 14.7614 4.23858 17 7 17H17C19.7614 17 22 14.7614 22 12C22 9.23858 19.7614 7 17 7H7ZM17 15.3329C18.841 15.3329 20.3333 13.8405 20.3333 11.9996C20.3333 10.1586 18.841 8.66626 17 8.66626C15.1591 8.66626 13.6667 10.1586 13.6667 11.9996C13.6667 13.8405 15.1591 15.3329 17 15.3329Z",
+        new Rect(0, 0, 24, 24 )
+    ));
+    
+    // Toggle Off icon
+    public static readonly IconValue ToggleOff = new SimpleVectorIcon(new SimpleVectorIconImage(
+        "M7 8H17C19.2091 8 21 9.79086 21 12C21 14.2091 19.2091 16 17 16H7C4.79086 16 3 14.2091 3 12C3 9.79086 4.79086 8 7 8ZM2 12C2 9.23858 4.23858 7 7 7H17C19.7614 7 22 9.23858 22 12C22 14.7614 19.7614 17 17 17H7C4.23858 17 2 14.7614 2 12ZM7 14.5C8.38071 14.5 9.5 13.3807 9.5 12C9.5 10.6193 8.38071 9.5 7 9.5C5.61929 9.5 4.5 10.6193 4.5 12C4.5 13.3807 5.61929 14.5 7 14.5Z",
+        new Rect(0, 0, 24, 24 )
+    ));
+    
+    // Toggle Indeterminate icon
+    public static readonly IconValue ToggleIndeterminate = new SimpleVectorIcon(new SimpleVectorIconImage(
+        "M19 12C19 13.1046 18.1046 14 17 14C15.8954 14 15 13.1046 15 12C15 10.8954 15.8954 10 17 10C18.1046 10 19 10.8954 19 12Z M7 7C4.23858 7 2 9.23858 2 12C2 14.7614 4.23858 17 7 17H17C19.7614 17 22 14.7614 22 12C22 9.23858 19.7614 7 17 7H7ZM21 12C21 14.2091 19.2091 16 17 16C14.7909 16 13 14.2091 13 12C13 9.79086 14.7909 8 17 8C19.2091 8 21 9.79086 21 12Z",
+        new Rect(0, 0, 24, 24 )
+    ));
     public static readonly IconValue AvatarTest = new IconValue(new AvaloniaImage(new Bitmap(AssetLoader.Open(new Uri("avares://NexusMods.App.UI/Assets/DesignTime/cyberpunk_game.png")))));
 
 #endregion

--- a/src/NexusMods.Icons/IconValues.cs
+++ b/src/NexusMods.Icons/IconValues.cs
@@ -435,11 +435,12 @@ public static class IconValues
     // https://pictogrammers.com/library/mdi/icon/star/
     public static readonly IconValue Star = new ProjektankerIcon("mdi-star");
 
-    // https://pictogrammers.com/library/mdi/icon/toggle-switch-outline/
-    public static readonly IconValue ToggleOff = new ProjektankerIcon("mdi-toggle-switch-outline");
-
+    // https://pictogrammers.com/library/mdi/icon/toggle-switch/
+    public static readonly IconValue ToggleOn = new ProjektankerIcon("mdi-toggle-switch");
+    
     // https://pictogrammers.com/library/mdi/icon/toggle-switch-off-outline/
-    public static readonly IconValue ToggleOn = new ProjektankerIcon("mdi-toggle-switch-off-outline");
+    public static readonly IconValue ToggleOff = new ProjektankerIcon("mdi-toggle-switch-off-outline");
+
 
 #endregion
 

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Icons/IconsStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/Icons/IconsStyles.axaml
@@ -64,8 +64,6 @@
                     <icons:UnifiedIcon Classes="DragVertical" />
                     <icons:UnifiedIcon Classes="Search" />
                     <icons:UnifiedIcon Classes="Home" />
-                    <icons:UnifiedIcon Classes="ToggleSwitch" />
-                    <icons:UnifiedIcon Classes="ToggleSwitchOff" />
                     <icons:UnifiedIcon Classes="Game" />
                     <icons:UnifiedIcon Classes="Undo" />
                     <icons:UnifiedIcon Classes="Redo" />
@@ -147,6 +145,9 @@
                     <icons:UnifiedIcon Classes="Epic" />
                     <icons:UnifiedIcon Classes="GitHub" />
                     <icons:UnifiedIcon Classes="Premium" />
+                    <icons:UnifiedIcon Classes="ToggleSwitchOn" />
+                    <icons:UnifiedIcon Classes="ToggleSwitchOff" />
+                    <icons:UnifiedIcon Classes="ToggleSwitchIndeterminate" />
                 </WrapPanel>
                 <WrapPanel>
                     <icons:UnifiedIcon Classes="PanelAllFull" />
@@ -403,13 +404,6 @@
         <Setter Property="Value" Value="{x:Static icons:IconValues.Home}" />
     </Style>
 
-    <Style Selector="icons|UnifiedIcon.ToggleSwitch">
-        <Setter Property="Value" Value="{x:Static icons:IconValues.ToggleOn}" />
-    </Style>
-
-    <Style Selector="icons|UnifiedIcon.ToggleSwitchOff">
-        <Setter Property="Value" Value="{x:Static icons:IconValues.ToggleOff}" />
-    </Style>
 
     <Style Selector="icons|UnifiedIcon.Game">
         <Setter Property="Value" Value="{x:Static icons:IconValues.Game}" />
@@ -716,5 +710,17 @@
     </Style>
     <Style Selector="icons|UnifiedIcon.TrayArrowDown">
         <Setter Property="Value" Value="{x:Static icons:IconValues.TrayArrowDown}" />
+    </Style>
+    
+    <Style Selector="icons|UnifiedIcon.ToggleSwitchOn">
+        <Setter Property="Value" Value="{x:Static icons:IconValues.ToggleOn}" />
+    </Style>
+
+    <Style Selector="icons|UnifiedIcon.ToggleSwitchOff">
+        <Setter Property="Value" Value="{x:Static icons:IconValues.ToggleOff}" />
+    </Style>
+    
+    <Style Selector="icons|UnifiedIcon.ToggleSwitchIndeterminate">
+        <Setter Property="Value" Value="{x:Static icons:IconValues.ToggleIndeterminate}" />
     </Style>
 </Styles>


### PR DESCRIPTION
- Part of #2782 
- And part of #2598 

The `IsEnabled` component contained the normal toggle, plus the `IsLocked` state plus the `LoadoutItemIds`.
To implement all the possible state combinations for parent and child items it is better to separate these.

This also includes the UI and icons changes by @insomnious from #2795


This shouldn't change the current behaviour much, except for showing the Toggle rather than parent items showing Toggle rather than Locked state if at least one child is Togglable. 