### PR TITLE
Continue downloading collection files after exception

### DIFF
--- a/src/NexusMods.Collections/CollectionDownloader.cs
+++ b/src/NexusMods.Collections/CollectionDownloader.cs
@@ -254,6 +254,7 @@ public class CollectionDownloader
         var job = new DownloadCollectionJob
         {
             Downloader = this,
+            Logger = _serviceProvider.GetRequiredService<ILogger<DownloadCollectionJob>>(),
             RevisionMetadata = revisionMetadata,
             Db = db,
             ItemType = itemType,

--- a/src/NexusMods.Collections/DownloadCollectionJob.cs
+++ b/src/NexusMods.Collections/DownloadCollectionJob.cs
@@ -1,6 +1,5 @@
-using DynamicData.Kernel;
+using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.Jobs;
-using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.NexusModsLibrary.Models;
 using NexusMods.MnemonicDB.Abstractions;
 
@@ -8,6 +7,7 @@ namespace NexusMods.Collections;
 
 public class DownloadCollectionJob : IJobDefinitionWithStart<DownloadCollectionJob, R3.Unit>
 {
+    public required ILogger<DownloadCollectionJob> Logger { get; init; }
     public required CollectionRevisionMetadata.ReadOnly RevisionMetadata { get; init; }
     public required CollectionDownloader.ItemType ItemType { get; init; }
     public required CollectionDownloader Downloader { get; init; }
@@ -28,12 +28,24 @@ public class DownloadCollectionJob : IJobDefinitionWithStart<DownloadCollectionJ
             if (!CollectionDownloader.DownloadMatchesItemType(download, ItemType)) return;
             if (CollectionDownloader.GetStatus(download, Db).IsDownloaded()) return;
 
-            if (download.TryGetAsCollectionDownloadNexusMods(out var nexusModsDownload))
+            try
             {
-                await Downloader.Download(nexusModsDownload, token);
-            } else if (download.TryGetAsCollectionDownloadExternal(out var externalDownload))
+                if (download.TryGetAsCollectionDownloadNexusMods(out var nexusModsDownload))
+                {
+                    await Downloader.Download(nexusModsDownload, token);
+                }
+                else if (download.TryGetAsCollectionDownloadExternal(out var externalDownload))
+                {
+                    await Downloader.Download(externalDownload, token);
+                }
+            }
+            catch (OperationCanceledException)
             {
-                await Downloader.Download(externalDownload, token);
+                // ignored
+            }
+            catch (Exception e)
+            {
+                Logger.LogError(e, "Exception while downloading `{DownloadName}` from `{CollectionName}/{RevisionNumber}`", download.Name, download.CollectionRevision.Collection.Slug, download.CollectionRevision.RevisionNumber);
             }
         });
 


### PR DESCRIPTION
Resolves #2816.

`Parallel.ForAsync` will cancel all cancellation tokens if one loop iteration throws an exception. This means that if a download fails for some reason we'd stop downloading everything else as well. This PR adds a `try/catch` so that we keep downloading.