### PR TITLE
Add special Toggle states and behaviours for parent items in Loadout and Collection Views

### DIFF
--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/CompositeItemModel.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/CompositeItemModel.cs
@@ -352,6 +352,8 @@ public sealed class CompositeItemModel<TKey> : TreeDataGridItemModel<CompositeIt
     {
         if (!_isDisposed)
         {
+            _isDisposed = true;
+
             if (disposing)
             {
                 _trackedDisposables.Dispose();
@@ -370,8 +372,6 @@ public sealed class CompositeItemModel<TKey> : TreeDataGridItemModel<CompositeIt
                     }
                 }
             }
-
-            _isDisposed = true;
         }
 
         base.Dispose(disposing);

--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridItemModel.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridItemModel.cs
@@ -168,6 +168,8 @@ public class TreeDataGridItemModel<TModel, TKey> : TreeDataGridItemModel, ITreeD
     {
         if (!_isDisposed)
         {
+            _isDisposed = true;
+            
             if (disposing)
             {
                 Disposable.Dispose(
@@ -181,7 +183,6 @@ public class TreeDataGridItemModel<TModel, TKey> : TreeDataGridItemModel, ITreeD
             }
 
             _children = null!;
-            _isDisposed = true;
         }
 
         base.Dispose(disposing);

--- a/src/NexusMods.App.UI/Converters/IsNotNullConverter.cs
+++ b/src/NexusMods.App.UI/Converters/IsNotNullConverter.cs
@@ -14,6 +14,6 @@ public class IsNotNullConverter : IValueConverter
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        throw new NotImplementedException();
+        throw new NotSupportedException();
     }
 }

--- a/src/NexusMods.App.UI/Converters/IsNotNullConverter.cs
+++ b/src/NexusMods.App.UI/Converters/IsNotNullConverter.cs
@@ -1,0 +1,19 @@
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace NexusMods.App.UI.Converters;
+
+public class IsNotNullConverter : IValueConverter
+{
+    public static readonly IsNotNullConverter Instance = new IsNotNullConverter();
+    
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return value is not null;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/NexusMods.App.UI/Converters/IsNullConverter.cs
+++ b/src/NexusMods.App.UI/Converters/IsNullConverter.cs
@@ -14,6 +14,6 @@ public class IsNullConverter : IValueConverter
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        throw new NotImplementedException();
+        throw new NotSupportedException();
     }
 }

--- a/src/NexusMods.App.UI/Converters/IsNullConverter.cs
+++ b/src/NexusMods.App.UI/Converters/IsNullConverter.cs
@@ -1,0 +1,19 @@
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace NexusMods.App.UI.Converters;
+
+public class IsNullConverter : IValueConverter
+{
+    public static readonly IsNullConverter Instance = new IsNullConverter();
+    
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return value is null;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/NexusMods.App.UI/Pages/BundledDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/BundledDataProvider.cs
@@ -5,6 +5,7 @@ using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.Collections;
 using NexusMods.App.UI.Controls;
+using NexusMods.App.UI.Pages.LoadoutPage;
 using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.MnemonicDB.Abstractions.DatomIterators;
 using NexusMods.MnemonicDB.Abstractions.Query;
@@ -63,7 +64,9 @@ public class BundledDataProvider : ILoadoutDataProvider
         parentItemModel.Add(SharedColumns.Name.StringComponentKey, new StringComponent(value: item.AsNexusCollectionItemLoadoutGroup().AsLoadoutItemGroup().AsLoadoutItem().Name));
         parentItemModel.Add(SharedColumns.Name.ImageComponentKey, new ImageComponent(value: ImagePipelines.ModPageThumbnailFallback));
         parentItemModel.Add(SharedColumns.InstalledDate.ComponentKey, new DateComponent(value: item.GetCreatedAt()));
+        parentItemModel.Add(LoadoutColumns.EnabledState.LoadoutItemIdsComponentKey, new LoadoutComponents.LoadoutItemIds(loadoutItem));
 
+        
         LoadoutDataProviderHelper.AddCollection(_connection, parentItemModel, loadoutItem);
         LoadoutDataProviderHelper.AddLockedEnabledState(parentItemModel, loadoutItem);
         LoadoutDataProviderHelper.AddEnabledStateToggle(_connection, parentItemModel, loadoutItem);

--- a/src/NexusMods.App.UI/Pages/BundledDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/BundledDataProvider.cs
@@ -68,6 +68,7 @@ public class BundledDataProvider : ILoadoutDataProvider
 
         
         LoadoutDataProviderHelper.AddCollection(_connection, parentItemModel, loadoutItem);
+        LoadoutDataProviderHelper.AddParentCollectionDisabled(_connection, parentItemModel, loadoutItem);
         LoadoutDataProviderHelper.AddLockedEnabledState(parentItemModel, loadoutItem);
         LoadoutDataProviderHelper.AddEnabledStateToggle(_connection, parentItemModel, loadoutItem);
 

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionComponents.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionComponents.cs
@@ -113,12 +113,11 @@ public static class CollectionComponents
         {
             if (!_isDisposed)
             {
+                _isDisposed = true;
                 if (disposing)
                 {
                     Disposable.Dispose(CommandDownload, IsDownloading, _canDownload, _buttonText, _downloadStatus, _activationDisposable);
                 }
-
-                _isDisposed = true;
             }
 
             base.Dispose(disposing);
@@ -182,12 +181,11 @@ public static class CollectionComponents
         {
             if (!_isDisposed)
             {
+                _isDisposed = true;
                 if (disposing)
                 {
                     Disposable.Dispose(CommandOpenModal, ButtonText, _activationDisposable);
                 }
-
-                _isDisposed = true;
             }
 
             base.Dispose(disposing);
@@ -237,12 +235,12 @@ public static class CollectionComponents
         {
             if (!_isDisposed)
             {
+                _isDisposed = true;
+
                 if (disposing)
                 {
                     Disposable.Dispose(CommandInstall, _canInstall, _buttonText, _isInstalled, _activationDisposable);
                 }
-
-                _isDisposed = true;
             }
 
             base.Dispose(disposing);

--- a/src/NexusMods.App.UI/Pages/ILoadoutDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/ILoadoutDataProvider.cs
@@ -235,8 +235,7 @@ public static class LoadoutDataProviderHelper
         IObservable<IChangeSet<LoadoutItem.ReadOnly, EntityId>> linkedItemsObservable)
     {
         var isEnabledObservable = linkedItemsObservable
-            .TransformOnObservable(item => LoadoutItem.Observe(connection, item.Id))
-            .TransformImmutable(static item => !item.IsDisabled)
+            .TransformOnObservable(item => item.IsEnabledObservable(connection))
             .QueryWhenChanged(query =>
             {
                 var isEnabled = Optional<bool>.None;

--- a/src/NexusMods.App.UI/Pages/ILoadoutDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/ILoadoutDataProvider.cs
@@ -220,8 +220,7 @@ public static class LoadoutDataProviderHelper
             valueComponent: new ValueComponent<bool?>(
                 initialValue: true,
                 valueObservable: isEnabledObservable
-            ),
-            childrenItemIdsObservable: linkedItemsObservable.TransformImmutable(static item => item.LoadoutItemId)
+            )
         ));
     }
     

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutComponents.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutComponents.cs
@@ -96,18 +96,6 @@ public static class LoadoutComponents
             });
         }
 
-        public EnabledStateToggle(
-            ValueComponent<bool?> valueComponent,
-            IObservable<IChangeSet<LoadoutItemId, EntityId>> childrenItemIdsObservable)
-        {
-            _valueComponent = valueComponent;
-
-            _activationDisposable = this.WhenActivated((childrenItemIdsObservable), static (self, state, disposables) =>
-            {
-                self._valueComponent.Activate().AddTo(disposables);
-            });
-        }
-
         private bool _isDisposed;
         protected override void Dispose(bool disposing)
         {

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutComponents.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutComponents.cs
@@ -64,6 +64,11 @@ public static class LoadoutComponents
         public int CompareTo(LockedEnabledState? other) => 0;
     }
 
+    public sealed class MixLockedAndParentDisabled : ReactiveR3Object, IItemModelComponent<MixLockedAndParentDisabled>, IComparable<MixLockedAndParentDisabled>
+    {
+        public int CompareTo(MixLockedAndParentDisabled? other) => 0;
+    }
+
     public sealed class EnabledStateToggle : ReactiveR3Object, IItemModelComponent<EnabledStateToggle>, IComparable<EnabledStateToggle>
     {
         public ReactiveCommand<Unit> CommandToggle { get; } = new();
@@ -147,6 +152,7 @@ public static class LoadoutColumns
         public static readonly ComponentKey EnabledStateToggleComponentKey = ComponentKey.From(ColumnTemplateResourceKey + "_" + nameof(LoadoutComponents.EnabledStateToggle));
         public static readonly ComponentKey ParentCollectionDisabledComponentKey = ComponentKey.From(ColumnTemplateResourceKey + "_" + nameof(LoadoutComponents.ParentCollectionDisabled));
         public static readonly ComponentKey LockedEnabledStateComponentKey = ComponentKey.From(ColumnTemplateResourceKey + "_" + nameof(LoadoutComponents.LockedEnabledState));
+        public static readonly ComponentKey MixLockedAndParentDisabledComponentKey = ComponentKey.From(ColumnTemplateResourceKey + "_" + nameof(LoadoutComponents.MixLockedAndParentDisabled));
         public static string GetColumnHeader() => "Actions";
         public static string GetColumnTemplateResourceKey() => ColumnTemplateResourceKey;
     }

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutViewModel.cs
@@ -210,7 +210,7 @@ public class LoadoutViewModel : APageViewModel<ILoadoutViewModel>, ILoadoutViewM
 
     private static IEnumerable<LoadoutItemId> GetLoadoutItemIds(CompositeItemModel<EntityId> itemModel)
     {
-        return itemModel.Get<LoadoutComponents.EnabledStateToggle>(LoadoutColumns.EnabledState.EnabledStateToggleComponentKey).ItemIds;
+        return itemModel.Get<LoadoutComponents.LoadoutItemIds>(LoadoutColumns.EnabledState.LoadoutItemIdsComponentKey).ItemIds;
     }
 }
 
@@ -245,14 +245,19 @@ public class LoadoutTreeDataGridAdapter :
             state: this,
             factory: static (self, itemModel, component) => component.CommandToggle.Subscribe((self, itemModel, component), static (_, tuple) =>
             {
-                var (self, _, component) = tuple;
+                var (self, itemModel, component) = tuple;
                 var isEnabled = component.Value.Value;
-                var ids = component.ItemIds.ToArray();
+                var ids = GetLoadoutItemIds(itemModel).ToArray();
                 var shouldEnable = !isEnabled ?? false;
 
                 self.MessageSubject.OnNext(new ToggleEnableState(ids, shouldEnable));
             })
         );
+    }
+    
+    private static IEnumerable<LoadoutItemId> GetLoadoutItemIds(CompositeItemModel<EntityId> itemModel)
+    {
+        return itemModel.Get<LoadoutComponents.LoadoutItemIds>(LoadoutColumns.EnabledState.LoadoutItemIdsComponentKey).ItemIds;
     }
 
     protected override IColumn<CompositeItemModel<EntityId>>[] CreateColumns(bool viewHierarchical)

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutViewModel.cs
@@ -153,7 +153,12 @@ public class LoadoutViewModel : APageViewModel<ILoadoutViewModel>, ILoadoutViewM
             {
                 var toggleableItems = message.Ids
                     .Select(loadoutItemId => LoadoutItem.Load(connection.Db, loadoutItemId))
+                    // Exclude collection required items
                     .Where(item => !(NexusCollectionItemLoadoutGroup.IsRequired.TryGetValue(item, out var isRequired) && isRequired))
+                    // Exclude items that are part of a collection that is disabled
+                    .Where(item => !(item.Parent.TryGetAsCollectionGroup(out var collectionGroup)
+                                     && collectionGroup.AsLoadoutItemGroup().AsLoadoutItem().IsDisabled)
+                    )
                     .ToArray();
 
                 if (toggleableItems.Length == 0) return;

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/TreeDataGridLoadoutResources.axaml
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/TreeDataGridLoadoutResources.axaml
@@ -74,7 +74,7 @@
                         <DataTemplate DataType="{x:Type local:LoadoutComponents+LockedEnabledState}">
                             <controls:StandardButton
                                 Size="Small"
-                                LeftIcon="{x:Static icons:IconValues.Lock}"
+                                LeftIcon="{x:Static icons:IconValues.Collections}"
                                 RightIcon="{x:Static icons:IconValues.ToggleOn}"
                                 ShowIcon="Both"
                                 ShowLabel="False"

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/TreeDataGridLoadoutResources.axaml
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/TreeDataGridLoadoutResources.axaml
@@ -65,7 +65,23 @@
                         </DataTemplate>
                     </controls:ComponentTemplate.DataTemplate>
                 </controls:ComponentTemplate>
-
+                
+                <!-- mix of locked enabled and parent disabled -> indeterminate -->
+                <controls:ComponentTemplate x:TypeArguments="local:LoadoutComponents+MixLockedAndParentDisabled"
+                                            ComponentKey="{x:Static local:LoadoutColumns+EnabledState.MixLockedAndParentDisabledComponentKey}">
+                    <controls:ComponentTemplate.DataTemplate>
+                        <DataTemplate DataType="{x:Type local:LoadoutComponents+MixLockedAndParentDisabled}">
+                            <controls:StandardButton
+                                Size="Small"
+                                LeftIcon="{x:Static icons:IconValues.Collections}"
+                                RightIcon="{x:Static icons:IconValues.ToggleIndeterminate}"
+                                ShowIcon="Both"
+                                ShowLabel="False"/>
+                            <!-- TODO: add ToolTip ?-->
+                        </DataTemplate>
+                    </controls:ComponentTemplate.DataTemplate>
+                </controls:ComponentTemplate>
+                
                 <!-- normal toggle -->
                 <controls:ComponentTemplate x:TypeArguments="local:LoadoutComponents+EnabledStateToggle"
                                             ComponentKey="{x:Static local:LoadoutColumns+EnabledState.EnabledStateToggleComponentKey}">

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/TreeDataGridLoadoutResources.axaml
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/TreeDataGridLoadoutResources.axaml
@@ -34,6 +34,23 @@
 
         <controls:MultiComponentControl x:TypeArguments="abstractions:EntityId" Content="{CompiledBinding}">
             <controls:MultiComponentControl.AvailableTemplates>
+                
+                <!-- mix of locked enabled and parent disabled -> indeterminate -->
+                <controls:ComponentTemplate x:TypeArguments="local:LoadoutComponents+MixLockedAndParentDisabled"
+                                            ComponentKey="{x:Static local:LoadoutColumns+EnabledState.MixLockedAndParentDisabledComponentKey}">
+                    <controls:ComponentTemplate.DataTemplate>
+                        <DataTemplate DataType="{x:Type local:LoadoutComponents+MixLockedAndParentDisabled}">
+                            <controls:StandardButton
+                                Size="Small"
+                                LeftIcon="{x:Static icons:IconValues.Collections}"
+                                RightIcon="{x:Static icons:IconValues.ToggleIndeterminate}"
+                                ShowIcon="Both"
+                                ShowLabel="False"/>
+                            <!-- TODO: add ToolTip ?-->
+                        </DataTemplate>
+                    </controls:ComponentTemplate.DataTemplate>
+                </controls:ComponentTemplate>
+                
                 <!-- parent collection disabled -->
                 <controls:ComponentTemplate x:TypeArguments="local:LoadoutComponents+ParentCollectionDisabled"
                                             ComponentKey="{x:Static local:LoadoutColumns+EnabledState.ParentCollectionDisabledComponentKey}">
@@ -62,22 +79,6 @@
                                 ShowIcon="Both"
                                 ShowLabel="False"
                                 ToolTip.Tip="Mod cannot be turned off as it is as part of a read only collection. Switch off the collection to turn off this mod"/>
-                        </DataTemplate>
-                    </controls:ComponentTemplate.DataTemplate>
-                </controls:ComponentTemplate>
-                
-                <!-- mix of locked enabled and parent disabled -> indeterminate -->
-                <controls:ComponentTemplate x:TypeArguments="local:LoadoutComponents+MixLockedAndParentDisabled"
-                                            ComponentKey="{x:Static local:LoadoutColumns+EnabledState.MixLockedAndParentDisabledComponentKey}">
-                    <controls:ComponentTemplate.DataTemplate>
-                        <DataTemplate DataType="{x:Type local:LoadoutComponents+MixLockedAndParentDisabled}">
-                            <controls:StandardButton
-                                Size="Small"
-                                LeftIcon="{x:Static icons:IconValues.Collections}"
-                                RightIcon="{x:Static icons:IconValues.ToggleIndeterminate}"
-                                ShowIcon="Both"
-                                ShowLabel="False"/>
-                            <!-- TODO: add ToolTip ?-->
                         </DataTemplate>
                     </controls:ComponentTemplate.DataTemplate>
                 </controls:ComponentTemplate>

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/TreeDataGridLoadoutResources.axaml
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/TreeDataGridLoadoutResources.axaml
@@ -45,8 +45,8 @@
                                 LeftIcon="{x:Static icons:IconValues.Collections}"
                                 RightIcon="{x:Static icons:IconValues.ToggleIndeterminate}"
                                 ShowIcon="Both"
-                                ShowLabel="False"/>
-                            <!-- TODO: add ToolTip ?-->
+                                ShowLabel="False"
+                                ToolTip.Tip="Contains mods that are both on and off and can't be interacted with due to their parent collections"/>
                         </DataTemplate>
                     </controls:ComponentTemplate.DataTemplate>
                 </controls:ComponentTemplate>
@@ -62,7 +62,7 @@
                                 RightIcon="{x:Static icons:IconValues.ToggleOff}"
                                 ShowIcon="Both"
                                 ShowLabel="False"
-                                ToolTip.Tip="Mod cannot be switched on as it is as part of a read only collection. Switch on the collection to switch on this mod"/>
+                                ToolTip.Tip="Mod's collection is switched off. Switch on the collection to switch on this mod"/>
                         </DataTemplate>
                     </controls:ComponentTemplate.DataTemplate>
                 </controls:ComponentTemplate>

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/TreeDataGridLoadoutResources.axaml
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/TreeDataGridLoadoutResources.axaml
@@ -3,7 +3,8 @@
                     xmlns:controls="clr-namespace:NexusMods.App.UI.Controls"
                     xmlns:abstractions="clr-namespace:NexusMods.MnemonicDB.Abstractions;assembly=NexusMods.MnemonicDB.Abstractions"
                     xmlns:local="clr-namespace:NexusMods.App.UI.Pages.LoadoutPage"
-                    xmlns:icons="clr-namespace:NexusMods.Icons;assembly=NexusMods.Icons">
+                    xmlns:icons="clr-namespace:NexusMods.Icons;assembly=NexusMods.Icons"
+                    xmlns:converters="clr-namespace:NexusMods.App.UI.Converters">
 
     <!-- Collections -->
     <DataTemplate x:Key="{x:Static local:LoadoutColumns+Collections.ColumnTemplateResourceKey}">
@@ -70,13 +71,23 @@
                                             ComponentKey="{x:Static local:LoadoutColumns+EnabledState.EnabledStateToggleComponentKey}">
                     <controls:ComponentTemplate.DataTemplate>
                         <DataTemplate DataType="{x:Type local:LoadoutComponents+EnabledStateToggle}">
-                            <ToggleSwitch Classes="Compact"
-                                          HorizontalAlignment="Center"
-                                          Command="{CompiledBinding CommandToggle}"
-                                          IsChecked="{CompiledBinding Value.Value, Mode=OneWay}"
-                                          OnContent="{x:Null}"
-                                          OffContent="{x:Null}">
-                            </ToggleSwitch>
+                            <Panel>
+                                <Button Command="{CompiledBinding CommandToggle}"
+                                        Theme="{x:Null}"
+                                        Background="Transparent"
+                                        BorderThickness="0"
+                                        IsVisible="{CompiledBinding Value.Value, Converter={x:Static converters:IsNullConverter.Instance}}">
+                                    <icons:UnifiedIcon Value="{x:Static icons:IconValues.ToggleIndeterminate}"
+                                                       Size="40"/>
+                                </Button>
+                                <ToggleSwitch Classes="Compact"
+                                              HorizontalAlignment="Center"
+                                              Command="{CompiledBinding CommandToggle}"
+                                              IsChecked="{CompiledBinding Value.Value, Mode=OneWay}"
+                                              OnContent="{x:Null}"
+                                              OffContent="{x:Null}"
+                                              IsVisible="{CompiledBinding Value.Value, Converter={x:Static converters:IsNotNullConverter.Instance}}"/>
+                            </Panel>
                         </DataTemplate>
                     </controls:ComponentTemplate.DataTemplate>
                 </controls:ComponentTemplate>

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/TreeDataGridLoadoutResources.axaml
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/TreeDataGridLoadoutResources.axaml
@@ -100,7 +100,7 @@
                                     <icons:UnifiedIcon Value="{x:Static icons:IconValues.ToggleIndeterminate}"
                                                        Size="40"/>
                                 </Button>
-                                <ToggleSwitch Classes="Compact"
+                                <ToggleSwitch Classes="ExtraSmall"
                                               HorizontalAlignment="Center"
                                               Command="{CompiledBinding CommandToggle}"
                                               IsChecked="{CompiledBinding Value.Value, Mode=OneWay}"

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/TreeDataGridLoadoutResources.axaml
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/TreeDataGridLoadoutResources.axaml
@@ -88,6 +88,9 @@
                     <controls:ComponentTemplate.DataTemplate>
                         <DataTemplate DataType="{x:Type local:LoadoutComponents+EnabledStateToggle}">
                             <Panel>
+                                <!-- NOTE(Al12rs): ToggleSwitch allows users to change its UI state even if the underlying IsChecked bound value didn't change -->
+                                <!--    This can happen in case the value is Null (indeterminate state), where pressing the toggle might not change the value -->
+                                <!--    As a workaround we show a button with the indeterminate state icon instead -->
                                 <Button Command="{CompiledBinding CommandToggle}"
                                         Theme="{x:Null}"
                                         Background="Transparent"

--- a/src/NexusMods.App.UI/Pages/LocalFileDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/LocalFileDataProvider.cs
@@ -131,6 +131,8 @@ internal class LocalFileDataProvider : ILibraryDataProvider, ILoadoutDataProvide
         LoadoutDataProviderHelper.AddCollections(parentItemModel, linkedItemsObservable);
         LoadoutDataProviderHelper.AddLockedEnabledStates(parentItemModel, linkedItemsObservable);
         LoadoutDataProviderHelper.AddEnabledStateToggle(_connection, parentItemModel, linkedItemsObservable);
+        LoadoutDataProviderHelper.AddLoadoutItemIds(parentItemModel, linkedItemsObservable);
+        
 
         return parentItemModel;
     }

--- a/src/NexusMods.App.UI/Pages/LocalFileDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/LocalFileDataProvider.cs
@@ -130,6 +130,7 @@ internal class LocalFileDataProvider : ILibraryDataProvider, ILoadoutDataProvide
         LoadoutDataProviderHelper.AddDateComponent(parentItemModel, localFile.GetCreatedAt(), linkedItemsObservable);
         LoadoutDataProviderHelper.AddCollections(parentItemModel, linkedItemsObservable);
         LoadoutDataProviderHelper.AddParentCollectionsDisabled(_connection, parentItemModel, linkedItemsObservable);
+        LoadoutDataProviderHelper.AddMixLockedAndParentDisabled(_connection, parentItemModel, linkedItemsObservable);
         LoadoutDataProviderHelper.AddLockedEnabledStates(parentItemModel, linkedItemsObservable);
         LoadoutDataProviderHelper.AddEnabledStateToggle(_connection, parentItemModel, linkedItemsObservable);
         LoadoutDataProviderHelper.AddLoadoutItemIds(parentItemModel, linkedItemsObservable);

--- a/src/NexusMods.App.UI/Pages/LocalFileDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/LocalFileDataProvider.cs
@@ -129,6 +129,7 @@ internal class LocalFileDataProvider : ILibraryDataProvider, ILoadoutDataProvide
 
         LoadoutDataProviderHelper.AddDateComponent(parentItemModel, localFile.GetCreatedAt(), linkedItemsObservable);
         LoadoutDataProviderHelper.AddCollections(parentItemModel, linkedItemsObservable);
+        LoadoutDataProviderHelper.AddParentCollectionsDisabled(_connection, parentItemModel, linkedItemsObservable);
         LoadoutDataProviderHelper.AddLockedEnabledStates(parentItemModel, linkedItemsObservable);
         LoadoutDataProviderHelper.AddEnabledStateToggle(_connection, parentItemModel, linkedItemsObservable);
         LoadoutDataProviderHelper.AddLoadoutItemIds(parentItemModel, linkedItemsObservable);

--- a/src/NexusMods.App.UI/Pages/NexusModsDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/NexusModsDataProvider.cs
@@ -273,6 +273,7 @@ public class NexusModsDataProvider : ILibraryDataProvider, ILoadoutDataProvider
             LoadoutDataProviderHelper.AddCollections(parentItemModel, linkedItemsObservable);
             LoadoutDataProviderHelper.AddLockedEnabledStates(parentItemModel, linkedItemsObservable);
             LoadoutDataProviderHelper.AddEnabledStateToggle(_connection, parentItemModel, linkedItemsObservable);
+            LoadoutDataProviderHelper.AddLoadoutItemIds(parentItemModel, linkedItemsObservable);
 
             return parentItemModel;
         });

--- a/src/NexusMods.App.UI/Pages/NexusModsDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/NexusModsDataProvider.cs
@@ -272,6 +272,7 @@ public class NexusModsDataProvider : ILibraryDataProvider, ILoadoutDataProvider
             LoadoutDataProviderHelper.AddDateComponent(parentItemModel, modPage.GetCreatedAt(), linkedItemsObservable);
             LoadoutDataProviderHelper.AddCollections(parentItemModel, linkedItemsObservable);
             LoadoutDataProviderHelper.AddParentCollectionsDisabled(_connection, parentItemModel, linkedItemsObservable);
+            LoadoutDataProviderHelper.AddMixLockedAndParentDisabled(_connection, parentItemModel, linkedItemsObservable);
             LoadoutDataProviderHelper.AddLockedEnabledStates(parentItemModel, linkedItemsObservable);
             LoadoutDataProviderHelper.AddEnabledStateToggle(_connection, parentItemModel, linkedItemsObservable);
             LoadoutDataProviderHelper.AddLoadoutItemIds(parentItemModel, linkedItemsObservable);

--- a/src/NexusMods.App.UI/Pages/NexusModsDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/NexusModsDataProvider.cs
@@ -271,6 +271,7 @@ public class NexusModsDataProvider : ILibraryDataProvider, ILoadoutDataProvider
 
             LoadoutDataProviderHelper.AddDateComponent(parentItemModel, modPage.GetCreatedAt(), linkedItemsObservable);
             LoadoutDataProviderHelper.AddCollections(parentItemModel, linkedItemsObservable);
+            LoadoutDataProviderHelper.AddParentCollectionsDisabled(_connection, parentItemModel, linkedItemsObservable);
             LoadoutDataProviderHelper.AddLockedEnabledStates(parentItemModel, linkedItemsObservable);
             LoadoutDataProviderHelper.AddEnabledStateToggle(_connection, parentItemModel, linkedItemsObservable);
             LoadoutDataProviderHelper.AddLoadoutItemIds(parentItemModel, linkedItemsObservable);

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/TreeDataGridActionsColumnStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/TreeDataGridActionsColumnStyles.axaml
@@ -41,12 +41,22 @@
                 <!-- <Setter Property="Background" Value="DarkRed" /> -->
                 <Style Selector="^ Button">
                     <Setter Property="Padding" Value="0" />
+                    <Setter Property="Background" Value="{StaticResource SurfaceTransparentBrush}" />
+                    <Setter Property="Foreground" Value="{StaticResource NeutralModerateBrush}" />
+
                     <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
-                        <Setter Property="Background" Value="{DynamicResource SurfaceTransparentBrush}" />
+                        <Setter Property="Background" Value="{StaticResource SurfaceTransparentBrush}" />
+                        <Setter Property="Foreground" Value="{StaticResource NeutralStrongBrush}" />
+                    </Style>
+                    
+                    <Style Selector="^:pressed /template/ ContentPresenter#PART_ContentPresenter">
+                        <Setter Property="Background" Value="{StaticResource SurfaceTransparentBrush}" />
+                        <Setter Property="Foreground" Value="{StaticResource NeutralWeakBrush}" />
                     </Style>
                 </Style>
             </Style>
-        </Style>
 
+        </Style>
     </Style>
+
 </Styles>

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/TreeDataGridActionsColumnStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/TreeDataGridActionsColumnStyles.axaml
@@ -1,0 +1,52 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:icons="clr-namespace:NexusMods.Icons;assembly=NexusMods.Icons"
+        xmlns:controls="clr-namespace:NexusMods.App.UI.Controls;assembly=NexusMods.App.UI">
+
+    <Style Selector="TreeDataGridTemplateCell">
+        <!-- <Setter Property="Background" Value="Blue" /> -->
+
+        <!-- loadout -> actions cell -->
+        <Style Selector="^.LoadoutColumns_EnabledState">
+            <Setter Property="HorizontalAlignment" Value="Left" />
+
+            <Style Selector="^ Border.LoadoutColumns_EnabledState_LockedEnabledState">
+                <!-- <Setter Property="Background" Value="DarkSlateGray" /> -->
+                <Style Selector="^ controls|StandardButton">
+                    <Style Selector="^ /template/ icons|UnifiedIcon#PART_RightIcon">
+                        <Setter Property="Size" Value="24" />
+                    </Style>
+                </Style>
+            </Style>
+
+            <Style Selector="^ Border.LoadoutColumns_EnabledState_ParentCollectionDisabled">
+                <!-- <Setter Property="Background" Value="DarkOliveGreen" /> -->
+                <Style Selector="^ controls|StandardButton">
+                    <Style Selector="^ /template/ icons|UnifiedIcon#PART_RightIcon">
+                        <Setter Property="Size" Value="24" />
+                    </Style>
+                </Style>
+            </Style>
+
+            <Style Selector="^ Border.LoadoutColumns_EnabledState_MixLockedAndParentDisabled">
+                <!-- <Setter Property="Background" Value="DarkSlateBlue" /> -->
+                <Style Selector="^ controls|StandardButton">
+                    <Style Selector="^ /template/ icons|UnifiedIcon#PART_RightIcon">
+                        <Setter Property="Size" Value="24" />
+                    </Style>
+                </Style>
+            </Style>
+
+            <Style Selector="^ Border.LoadoutColumns_EnabledState_EnabledStateToggle">
+                <!-- <Setter Property="Background" Value="DarkRed" /> -->
+                <Style Selector="^ Button">
+                    <Setter Property="Padding" Value="0" />
+                    <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+                        <Setter Property="Background" Value="{DynamicResource SurfaceTransparentBrush}" />
+                    </Style>
+                </Style>
+            </Style>
+        </Style>
+
+    </Style>
+</Styles>

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/StylesIndex.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/StylesIndex.axaml
@@ -39,6 +39,7 @@
     <StyleInclude Source="/Styles/Controls/TreeDataGrid/TreeDataGridSortOrderStyles.axaml" />
     <StyleInclude Source="/Styles/Controls/TreeDataGrid/TreeDataGridCollectionDownloadStyles.axaml" />
     <StyleInclude Source="/Styles/Controls/TreeDataGrid/TreeDataGridOtherStyles.axaml" />
+    <StyleInclude Source="/Styles/Controls/TreeDataGrid/TreeDataGridActionsColumnStyles.axaml" />
     
     <StyleInclude Source="/Styles/Controls/TextBox/TextBoxStyles.axaml" />
     <StyleInclude Source="/Styles/Controls/ProgressBar/ProgressBarStyles.axaml" />


### PR DESCRIPTION
- Closes #2782
- Part of #2598 


## Details:
- Fixed a ObjectDisposedException in ITreeItemModel by marking item as disposed before removing child items
- Implemented Parent collection disabled state for page (parent) loadout entries
- Implement parent items toggling functionality in case of presence of Locked enabled child items
- Implemented item toggling functionality in the CollectionLoadoutPage
- Fix ToggleSwitch not updating correctly when being set to three state by showing a custom button with an icon instead
- Add `MixLockedParentDisabled` special collection indeterminate state in case all children are either locked or parent disabled

## Future improvements
@insomnious
- [ ] Toggle Indeterminate state has been replaced with a button and an icon, the behavior and appearance can be improved to make it appear more like a normal `ToggleSwitch` (see `TreeDataGridLoadoutResources.axaml` L94).
- [x] The Collection + Indeterminate state shown in case all children are either collection disabled or locked doesn't have a tooltip at the moment  