### PR TITLE
Improved: Remove Jobs after Completing Them

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Jobs/IJobMonitorExtensions.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Jobs/IJobMonitorExtensions.cs
@@ -1,7 +1,5 @@
-using System.Diagnostics;
 using System.Reactive.Linq;
 using DynamicData;
-
 
 namespace NexusMods.Abstractions.Jobs;
 
@@ -26,6 +24,9 @@ public static class IJobMonitorExtensions
             .FilterOnObservable(job => job.ObservableStatus.Select(status => status.IsActive()));
     }
 
+    /// <summary>
+    /// Returns true if there is a job which satisfies the given predicate.
+    /// </summary>
     public static IObservable<bool> HasActiveJob<TJobType>(this IJobMonitor jobMonitor, Func<TJobType, bool> predicate)
         where TJobType : IJobDefinition
     {

--- a/src/NexusMods.Jobs/JobMonitor.cs
+++ b/src/NexusMods.Jobs/JobMonitor.cs
@@ -36,11 +36,6 @@ public sealed class JobMonitor : IJobMonitor, IDisposable
             .Filter(j => j.Definition is TJobDefinition);
     }
 
-    public void RegisterJob(IJob job)
-    {
-        _allJobs.AddOrUpdate(job);
-    }
-
     public void Dispose()
     {
         _compositeDisposable.Dispose();
@@ -67,6 +62,7 @@ public sealed class JobMonitor : IJobMonitor, IDisposable
                         _logger.LogError("Job {JobId} of type {JobType} failed", ctx.Id, typeof(TJobType));
                     }
                 }
+                _allJobs.Remove(ctx);
             }
         );
         return new JobTask<TJobType, TResultType>(ctx);
@@ -92,6 +88,7 @@ public sealed class JobMonitor : IJobMonitor, IDisposable
                         _logger.LogError("Job {JobId} of type {JobType} failed", ctx.Id, typeof(TJobType));
                     }
                 }
+                _allJobs.Remove(ctx);
             }
         );
         return new JobTask<TJobType, TResultType>(ctx);


### PR DESCRIPTION
This is a small patch to the jobs system to stop the jobs from endlessly increasing in size as the user uses the App for longer periods of time. Because keeping jobs around also keeps info tied to them around, including Datoms and other resources.

There's a few places that listen to active jobs; I've checked all of them after adding the patch:

- Determining if collections are downloaded.
- Determining if a game (any game) is currently running
- Download button on spine showing download completion.
- Login service.

I have manually confirmed none of the services are affected by this change; they work as they have previously without the patch.
    