### PR TITLE
Changed: Set the to MigrationService Transient

### DIFF
--- a/src/NexusMods.DataModel.SchemaVersions/Services.cs
+++ b/src/NexusMods.DataModel.SchemaVersions/Services.cs
@@ -9,7 +9,7 @@ public static class Services
     {
         services.AddSchemaVersionModel();
         services.AddMigrationLogItemModel();
-        services.AddSingleton<MigrationService>();
+        services.AddTransient<MigrationService>();
 
         // Migrations go here:
         return services


### PR DESCRIPTION
We keep the migration service in memory all the time, but it's only ran once at startup; so we don't actually need to keep it around. This makes it transient such that we don't unnecessarily keep it around.