### PR TITLE
Silence SMAPI API exceptions

### DIFF
--- a/src/Games/NexusMods.Games.StardewValley/WebAPI/SMAPIWebApi.cs
+++ b/src/Games/NexusMods.Games.StardewValley/WebAPI/SMAPIWebApi.cs
@@ -70,7 +70,7 @@ internal sealed class SMAPIWebApi : ISMAPIWebApi
             }
             catch (Exception e)
             {
-                _logger.LogError(e, "Exception contacting {Url}", ApiBaseUrl);
+                _logger.LogWarning(e, "Exception contacting {Url}", ApiBaseUrl);
             }
 
             if (apiResult is not null)


### PR DESCRIPTION
Switch SMAPI API failures to warnings to avoid spamming users with the Exception dialog.
- Closes #2821