### PR TITLE
Tree views sorting: Actions, Version, EnabledState and Collection columns

### DIFF
--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridAdapter.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridAdapter.cs
@@ -125,16 +125,6 @@ public abstract class TreeDataGridAdapter<TModel, TKey> : ReactiveR3Object
                 .Subscribe()
                 .AddTo(disposables);
 
-            self.Source.AsObservable()
-                // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
-                .Where(source => source is not null)
-                .Subscribe(static (source) =>
-                    {
-                        var sortColumn = source.Columns.FirstOrOptional(column => column.SortDirection is not null);
-                        if (sortColumn.HasValue) source.SortBy(sortColumn.Value, sortColumn.Value.SortDirection!.Value);
-                    }
-                );
-
             Disposable.Create(self._selectionModelsSerialDisposable, static serialDisposable => serialDisposable.Disposable = null).AddTo(disposables);
         });
     }

--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridAdapter.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridAdapter.cs
@@ -8,6 +8,7 @@ using NexusMods.App.UI.Extensions;
 using ObservableCollections;
 using R3;
 using System.Reactive.Linq;
+using DynamicData.Kernel;
 
 namespace NexusMods.App.UI.Controls;
 
@@ -123,6 +124,16 @@ public abstract class TreeDataGridAdapter<TModel, TKey> : ReactiveR3Object
                 .Switch()
                 .Subscribe()
                 .AddTo(disposables);
+
+            self.Source.AsObservable()
+                // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+                .Where(source => source is not null)
+                .Subscribe(static (source) =>
+                    {
+                        var sortColumn = source.Columns.FirstOrOptional(column => column.SortDirection is not null);
+                        if (sortColumn.HasValue) source.SortBy(sortColumn.Value, sortColumn.Value.SortDirection!.Value);
+                    }
+                );
 
             Disposable.Create(self._selectionModelsSerialDisposable, static serialDisposable => serialDisposable.Disposable = null).AddTo(disposables);
         });

--- a/src/NexusMods.App.UI/Pages/LibraryPage/LibraryComponents.cs
+++ b/src/NexusMods.App.UI/Pages/LibraryPage/LibraryComponents.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using DynamicData;
+using DynamicData.Kernel;
 using JetBrains.Annotations;
 using NexusMods.Abstractions.Library.Models;
 using NexusMods.Abstractions.UI;
@@ -76,15 +77,26 @@ public static class LibraryColumns
             var aInstall = a.GetOptional<LibraryComponents.InstallAction>(key: InstallComponentKey);
             var bInstall = b.GetOptional<LibraryComponents.InstallAction>(key: InstallComponentKey);
 
-            if (aInstall.HasValue && bInstall.HasValue) return aInstall.Value.CompareTo(bInstall.Value);
-            if (aInstall.HasValue) return -1;
-            if (bInstall.HasValue) return 1;
-
             var aUpdate = a.GetOptional<LibraryComponents.UpdateAction>(key: UpdateComponentKey);
             var bUpdate = b.GetOptional<LibraryComponents.UpdateAction>(key: UpdateComponentKey);
-            if (aUpdate.HasValue && bUpdate.HasValue) return aUpdate.Value.CompareTo(bUpdate.Value);
 
-            return 0;
+            var orderA = GetOrder(aInstall, aUpdate);
+            var orderB = GetOrder(bInstall, bUpdate);
+
+            return orderA.CompareTo(orderB);
+            
+            int GetOrder(Optional<LibraryComponents.InstallAction> install, Optional<LibraryComponents.UpdateAction> update)
+            {
+                var isUpdateAvailable = update.HasValue;
+                var hasInstallButton = install is { HasValue: true, Value.IsInstalled.Value: false };
+                var isInstalled = install is { HasValue: true, Value.IsInstalled.Value: true };
+
+                if (isUpdateAvailable && hasInstallButton) return 1;
+                if (hasInstallButton) return 2;
+                if (isUpdateAvailable) return 3;
+                if (isInstalled) return 4;
+                return 5;
+            }
         }
 
         public const string ColumnTemplateResourceKey = nameof(LibraryColumns) + "_" + nameof(Actions);

--- a/src/NexusMods.App.UI/Pages/LibraryPage/LibraryComponents.cs
+++ b/src/NexusMods.App.UI/Pages/LibraryPage/LibraryComponents.cs
@@ -23,9 +23,19 @@ public static class LibraryColumns
     {
         public static int Compare<TKey>(CompositeItemModel<TKey> a, CompositeItemModel<TKey> b) where TKey : notnull
         {
-            var aValue = a.GetOptional<StringComponent>(key: CurrentVersionComponentKey);
-            var bValue = b.GetOptional<StringComponent>(key: CurrentVersionComponentKey);
-            return aValue.Compare(bValue);
+            var aVersion = a.GetOptional<StringComponent>(key: CurrentVersionComponentKey);
+            var bVersion = b.GetOptional<StringComponent>(key: CurrentVersionComponentKey);
+            
+            var aNewVersion = a.GetOptional<LibraryComponents.NewVersionAvailable>(key: NewVersionComponentKey);
+            var bNewVersion = b.GetOptional<LibraryComponents.NewVersionAvailable>(key: NewVersionComponentKey);
+            
+            // Compare based on the presence of new versions
+            return (aNewVersion.HasValue, bNewVersion.HasValue) switch
+            {
+                (true, false) => 1,
+                (false, true) => -1,
+                _ => aVersion.Compare(bVersion),
+            };
         }
 
         public const string ColumnTemplateResourceKey = nameof(LibraryColumns) + "_" + nameof(ItemVersion);

--- a/src/NexusMods.App.UI/Pages/LibraryPage/LibraryComponents.cs
+++ b/src/NexusMods.App.UI/Pages/LibraryPage/LibraryComponents.cs
@@ -1,20 +1,16 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive.Disposables;
 using DynamicData;
 using JetBrains.Annotations;
 using NexusMods.Abstractions.Library.Models;
-using NexusMods.Abstractions.NexusModsLibrary;
 using NexusMods.Abstractions.UI;
 using NexusMods.Abstractions.UI.Extensions;
 using NexusMods.App.UI.Controls;
 using NexusMods.App.UI.Extensions;
 using NexusMods.MnemonicDB.Abstractions;
-using NexusMods.MnemonicDB.Abstractions.IndexSegments;
 using NexusMods.Networking.NexusWebApi;
 using ObservableCollections;
 using OneOf;
 using R3;
-using ReactiveUI;
 using Disposable = R3.Disposable;
 
 namespace NexusMods.App.UI.Pages.LibraryPage;

--- a/src/NexusMods.App.UI/Pages/LibraryPage/LibraryViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LibraryPage/LibraryViewModel.cs
@@ -409,14 +409,14 @@ public class LibraryTreeDataGridAdapter :
 
     protected override IColumn<CompositeItemModel<EntityId>>[] CreateColumns(bool viewHierarchical)
     {
-        var nameColumn = ColumnCreator.Create<EntityId, SharedColumns.Name>(sortDirection: ListSortDirection.Ascending);
+        var nameColumn = ColumnCreator.Create<EntityId, SharedColumns.Name>();
 
         return
         [
             viewHierarchical ? ITreeDataGridItemModel<CompositeItemModel<EntityId>, EntityId>.CreateExpanderColumn(nameColumn) : nameColumn,
             ColumnCreator.Create<EntityId, LibraryColumns.ItemVersion>(),
             ColumnCreator.Create<EntityId, LibraryColumns.ItemSize>(),
-            ColumnCreator.Create<EntityId, LibraryColumns.DownloadedDate>(),
+            ColumnCreator.Create<EntityId, LibraryColumns.DownloadedDate>(sortDirection: ListSortDirection.Descending),
             ColumnCreator.Create<EntityId, SharedColumns.InstalledDate>(),
             ColumnCreator.Create<EntityId, LibraryColumns.Actions>(),
         ];

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutComponents.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutComponents.cs
@@ -122,7 +122,7 @@ public static class LoadoutColumns
         public static int Compare<TKey>(CompositeItemModel<TKey> a, CompositeItemModel<TKey> b) where TKey : notnull
         {
             var aValue = a.GetOptional<StringComponent>(key: ComponentKey);
-            var bValue = a.GetOptional<StringComponent>(key: ComponentKey);
+            var bValue = b.GetOptional<StringComponent>(key: ComponentKey);
             return aValue.Compare(bValue);
         }
 
@@ -138,7 +138,7 @@ public static class LoadoutColumns
         public static int Compare<TKey>(CompositeItemModel<TKey> a, CompositeItemModel<TKey> b) where TKey : notnull
         {
             var aValue = a.GetOptional<LoadoutComponents.EnabledStateToggle>(key: EnabledStateToggleComponentKey);
-            var bValue = a.GetOptional<LoadoutComponents.EnabledStateToggle>(key: EnabledStateToggleComponentKey);
+            var bValue = b.GetOptional<LoadoutComponents.EnabledStateToggle>(key: EnabledStateToggleComponentKey);
             return aValue.Compare(bValue);
         }
 

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutViewModel.cs
@@ -262,12 +262,12 @@ public class LoadoutTreeDataGridAdapter :
 
     protected override IColumn<CompositeItemModel<EntityId>>[] CreateColumns(bool viewHierarchical)
     {
-        var nameColumn = ColumnCreator.Create<EntityId, SharedColumns.Name>(sortDirection: ListSortDirection.Ascending);
+        var nameColumn = ColumnCreator.Create<EntityId, SharedColumns.Name>();
 
         return
         [
             viewHierarchical ? ITreeDataGridItemModel<CompositeItemModel<EntityId>, EntityId>.CreateExpanderColumn(nameColumn) : nameColumn,
-            ColumnCreator.Create<EntityId, SharedColumns.InstalledDate>(),
+            ColumnCreator.Create<EntityId, SharedColumns.InstalledDate>(sortDirection: ListSortDirection.Descending),
             ColumnCreator.Create<EntityId, LoadoutColumns.Collections>(),
             ColumnCreator.Create<EntityId, LoadoutColumns.EnabledState>(),
         ];


### PR DESCRIPTION
- Closes #2801 
- Part of #2778 
- Part of #1229


## Details:

- Tried implementing default sorting for TreeDataGrid views to mediocre results:
The sorting is applied while the tree is still being populated, and doesn't enforce sorting as new items come in, so it is only kinda sorted...
Edit: Removed since it was inconsistent
- Sorted Library Actions column as requested here https://github.com/Nexus-Mods/NexusMods.App/issues/2801#issuecomment-2710966531
- Sorted Library Version column as requested here: https://github.com/Nexus-Mods/NexusMods.App/issues/2801#issuecomment-2710977261
- Fixed bug in Collection and EnabledState column sorting, where same value was compared against itself 