### PR TITLE
Upgrade to the latest mnemonicdb and fix associated bugs

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,8 +16,8 @@
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.0.0" />
     <PackageVersion Include="Nerdbank.FullDuplexStream" Version="1.1.12" />
     <PackageVersion Include="Nerdbank.Streams" Version="2.11.79" />
-    <PackageVersion Include="NexusMods.MnemonicDB" Version="0.9.114" />
-    <PackageVersion Include="NexusMods.MnemonicDB.Abstractions" Version="0.9.114" />
+    <PackageVersion Include="NexusMods.MnemonicDB" Version="0.9.119" />
+    <PackageVersion Include="NexusMods.MnemonicDB.Abstractions" Version="0.9.119" />
     <PackageVersion Include="NexusMods.Hashing.xxHash3.Paths" Version="3.0.3" />
     <PackageVersion Include="NexusMods.Hashing.xxHash3" Version="3.0.3" />
     <PackageVersion Include="NexusMods.Paths" Version="0.15.0" />
@@ -140,7 +140,7 @@
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="ini-parser-netstandard" Version="2.5.2" />
     <PackageVersion Include="Mutagen.Bethesda.Skyrim" Version="0.44.0" />
-    <PackageVersion Include="NexusMods.MnemonicDB.SourceGenerator" Version="0.9.114" />
+    <PackageVersion Include="NexusMods.MnemonicDB.SourceGenerator" Version="0.9.119" />
     <PackageVersion Include="NLog.Extensions.Logging" Version="5.3.14" />
     <PackageVersion Include="OneOf" Version="3.0.271" />
     <PackageVersion Include="ReactiveUI.Fody" Version="19.5.41" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,8 +16,8 @@
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.0.0" />
     <PackageVersion Include="Nerdbank.FullDuplexStream" Version="1.1.12" />
     <PackageVersion Include="Nerdbank.Streams" Version="2.11.79" />
-    <PackageVersion Include="NexusMods.MnemonicDB" Version="0.9.119" />
-    <PackageVersion Include="NexusMods.MnemonicDB.Abstractions" Version="0.9.119" />
+    <PackageVersion Include="NexusMods.MnemonicDB" Version="0.9.121" />
+    <PackageVersion Include="NexusMods.MnemonicDB.Abstractions" Version="0.9.121" />
     <PackageVersion Include="NexusMods.Hashing.xxHash3.Paths" Version="3.0.3" />
     <PackageVersion Include="NexusMods.Hashing.xxHash3" Version="3.0.3" />
     <PackageVersion Include="NexusMods.Paths" Version="0.15.0" />
@@ -140,7 +140,7 @@
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="ini-parser-netstandard" Version="2.5.2" />
     <PackageVersion Include="Mutagen.Bethesda.Skyrim" Version="0.44.0" />
-    <PackageVersion Include="NexusMods.MnemonicDB.SourceGenerator" Version="0.9.119" />
+    <PackageVersion Include="NexusMods.MnemonicDB.SourceGenerator" Version="0.9.121" />
     <PackageVersion Include="NLog.Extensions.Logging" Version="5.3.14" />
     <PackageVersion Include="OneOf" Version="3.0.271" />
     <PackageVersion Include="ReactiveUI.Fody" Version="19.5.41" />

--- a/src/Abstractions/NexusMods.Abstractions.Library.Models/LibraryItem.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Library.Models/LibraryItem.cs
@@ -38,7 +38,7 @@ public partial class LibraryItem
         public bool TryGetAsDownloadedFile(out DownloadedFile.ReadOnly result) {
             // This is same as source generator would make, just that we don't
             // currently don't autogenerate conversions for multiple levels of include.
-            var casted = new DownloadedFile.ReadOnly(Db, IndexSegment, Id);
+            var casted = new DownloadedFile.ReadOnly(Db, EntitySegment, Id);
             if (casted.IsValid()) {
                 result = casted;
                 return true;
@@ -54,7 +54,7 @@ public partial class LibraryItem
         public bool TryGetAsLocalFile(out LocalFile.ReadOnly result) {
             // This is same as source generator would make, just that we don't
             // currently don't autogenerate conversions for multiple levels of include.
-            var casted = new LocalFile.ReadOnly(Db, IndexSegment, Id);
+            var casted = new LocalFile.ReadOnly(Db, EntitySegment, Id);
             if (casted.IsValid()) {
                 result = casted;
                 return true;

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts/Models/DiskStateExtensions.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts/Models/DiskStateExtensions.cs
@@ -42,8 +42,8 @@ public static class DiskStateExtensions
         // Get an as-of db for the last applied loadout
         var asOfDb = metadata.Db.Connection.AsOf(txId);
         // Get the attributes for the entries in the disk state
-        var segment = asOfDb.Datoms(DiskStateEntry.Game, metadata.Id);
-        return new Entities<DiskStateEntry.ReadOnly>(new EntityIds(segment, 0, segment.Count), asOfDb);
+        var segment = asOfDb.GetBackRefs(DiskStateEntry.Game, metadata.Id);
+        return new Entities<DiskStateEntry.ReadOnly>(segment, asOfDb);
     }
     
     /// <summary>
@@ -53,7 +53,7 @@ public static class DiskStateExtensions
     {
         return DiskStateAsOf(metadata, TxId.From(tx.Id.Value));
     }
-    
+
     /// <summary>
     /// Load the disk state of the game as of the last applied loadout
     /// </summary>
@@ -62,14 +62,9 @@ public static class DiskStateExtensions
         // No previously applied loadout, return an empty state
         if (!metadata.Contains(GameInstallMetadata.LastSyncedLoadout))
         {
-            return EmptyState;
+            return new(new EntityIds { Data = new byte[sizeof(uint)] }, metadata.Db);
         }
+
         return metadata.DiskStateAsOf(metadata.LastSyncedLoadoutTransaction);
     }
-    
-    private static readonly Entities<DiskStateEntry.ReadOnly> EmptyState = new();
-    
-
-
-    
 }

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts/Models/DiskStateExtensions.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts/Models/DiskStateExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using DynamicData.Kernel;
 using NexusMods.Abstractions.GameLocators;
 using NexusMods.MnemonicDB.Abstractions;
@@ -42,8 +43,11 @@ public static class DiskStateExtensions
         // Get an as-of db for the last applied loadout
         var asOfDb = metadata.Db.Connection.AsOf(txId);
         // Get the attributes for the entries in the disk state
-        var segment = asOfDb.GetBackRefs(DiskStateEntry.Game, metadata.Id);
-        return new Entities<DiskStateEntry.ReadOnly>(segment, asOfDb);
+
+        var ret = DiskStateEntry.FindByGame(asOfDb, metadata.Id);
+        asOfDb.BulkCache(ret.EntityIds);
+        
+        return ret;
     }
     
     /// <summary>

--- a/src/NexusMods.DataModel.SchemaVersions/Migrations/_0005_MD5Hashes.cs
+++ b/src/NexusMods.DataModel.SchemaVersions/Migrations/_0005_MD5Hashes.cs
@@ -40,7 +40,7 @@ internal class _0005_MD5Hashes : ITransactionalMigration
             .Select(entity =>
             {
                 // NOTE(erri120): need to use the IndexSegment because we don't want resolved datoms for removed attributes
-                foreach (var datom in entity.IndexSegment)
+                foreach (var datom in entity.EntitySegment)
                 {
                     if (attributesToRemove.Contains(datom.A)) return datom;
                 }


### PR DESCRIPTION
This updates to the latest MnemonicDB. A few things had to change in this PR to remain compatible:

* Some `.Datoms` calls now return specific index types. For example `EntitySegment` is a much smaller version of `IndexSegment` that only stores the `A` and `V` parts of the datom resulting in a fairly substantial reduction in memory usage
* Some of our iterations over entities now use `.TryGetValue` which is much faster as internally it's setup to use .NET's SIMD operations over `Span<AttributeId>` 

Aside from the below changes, the rest of the API is hasn't changed, it uses less memory and is quite a bit faster