### PR TITLE
Cleanup empty directories when switching loadouts

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -837,7 +837,6 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
             var prevLoadout = Loadout.Load(loadout.Db, lastAppliedId);
             if (prevLoadout.IsValid())
             {
-                await Synchronize(prevLoadout);
                 await DeactivateCurrentLoadout(loadout.InstallationInstance);
                 await ActivateLoadout(loadout);
                 return loadout.Rebase();

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -608,14 +608,14 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
         }
         tx.Add(gameMetadataId, GameInstallMetadata.LastScannedDiskStateTransaction, EntityId.From(tx.ThisTxId.Value));
 
-        await tx.Commit();
+        var result = await tx.Commit();
 
-        gameMetadata.Rebase();
+        var newMetadata = gameMetadata.Rebase(result.Db);
 
         // Clean up empty directories
         if (foldersWithDeletedFiles.Count > 0)
         {
-            CleanDirectories(foldersWithDeletedFiles, gameMetadata.DiskStateEntries, gameInstallation);
+            CleanDirectories(foldersWithDeletedFiles, newMetadata.DiskStateEntries, gameInstallation);
         }
     }
 

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -553,7 +553,7 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
         var gameMetadataId = gameInstallation.GameMetadataId;
         var gameMetadata = GameInstallMetadata.Load(Connection.Db, gameMetadataId);
         var register = gameInstallation.LocationsRegister;
-        var deletedFiles = new HashSet<(GamePath GamePath, AbsolutePath FullPath)>();
+        HashSet<(GamePath GamePath, AbsolutePath FullPath)> foldersWithDeletedFiles = [];
 
         foreach (var action in ActionsInOrder)
         {
@@ -574,7 +574,7 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
                     break;
 
                 case Actions.DeleteFromDisk:
-                    ActionDeleteFromDisk(syncTree, register, tx, gameInstallation.GameMetadataId, deletedFiles);
+                    ActionDeleteFromDisk(syncTree, register, tx, gameInstallation.GameMetadataId, foldersWithDeletedFiles);
                     break;
 
                 case Actions.ExtractToDisk:
@@ -609,6 +609,14 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
         tx.Add(gameMetadataId, GameInstallMetadata.LastScannedDiskStateTransaction, EntityId.From(tx.ThisTxId.Value));
 
         await tx.Commit();
+
+        gameMetadata.Rebase();
+
+        // Clean up empty directories
+        if (foldersWithDeletedFiles.Count > 0)
+        {
+            CleanDirectories(foldersWithDeletedFiles, gameMetadata.DiskStateEntries, gameInstallation);
+        }
     }
 
     private void WarnOfConflict(Dictionary<GamePath, SyncNode> tree)
@@ -757,12 +765,13 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
                 continue;
             var resolvedPath = register.GetResolvedPath(path);
             resolvedPath.Delete();
-            foldersWithDeletedFiles.Add((path, resolvedPath.Parent));
 
             
-            // Don't delete the entry if we're just going to replace it
+            // Only delete the entry if we're not going to replace it
             if (!node.Actions.HasFlag(Actions.ExtractToDisk))
             {
+                foldersWithDeletedFiles.Add((path, resolvedPath.Parent));
+
                 var id = node.Disk.EntityId;
                 tx.Retract(id, DiskStateEntry.Path, ((EntityId)gameMetadataId, path.LocationId, path.Path));
                 tx.Retract(id, DiskStateEntry.Hash, node.Disk.Hash);


### PR DESCRIPTION
- Fixes #2077 

## Details:
- Added the empty directory cleanup code to the `DeactivateCurrentLoadout` path
- Implemented a regression test for cleaning up folders when switching profiles
- Fixed previous loadout being applied twice during loadout switch (`DeactivateCurrentLoadout` already applies previous loadout).


## Some context:
Before the switch to our new system handling game updates we used to have the concept of a Vanilla loadout.

During remove loadout or unamange game operations we would switch to the Vanilla loadout, so all synchronize operations could be seen as applying some loadout. Unamanging the game and switching a loadout were doing the same loadout switch operation.

The new system has the concept of Deactivating a loadout, which is used during loadout removal or during game unmanage operations. 

`DeactivateCurrentLoadout` is also used when switching loadouts, where the current loadout is first applied, then the default state is applied, then the new loadout is applied. This seems excessive, setting the state to default state should be unnecessary during profile switch and it should be possible to switch from one loadout directly to the next one.

The current approach can also leave the game in a situation where no loadout is applied, and no loadout can be applied, in case the application is closed or crashes after the `DeactivateCurrentLoadout` completes but before the activation of the next loadout is done (this happened to me a couple of times during debugging, probably not very likely to happen to actual users, but I would still prefer to avoid it).

I think the profile switch operation is matched poorly by the blocks currently used to make it. I think we can make some adjustments to the functions to make them more reusable and share more code between the higher level operations. I don't think profile switch should be composed by top level operations. I would rather use Profile switch to compose other high level operations.
