### PR TITLE
Remove timeout and cancel exception from CliServer

### DIFF
--- a/src/NexusMods.SingleProcess/CliServer.cs
+++ b/src/NexusMods.SingleProcess/CliServer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Sockets;
 using Microsoft.Extensions.Hosting;
@@ -12,7 +13,7 @@ namespace NexusMods.SingleProcess;
 /// A long-running service that listens for incoming connections from clients and executes them as if they ran
 /// on as CLI command.
 /// </summary>
-public class CliServer : IHostedService, IDisposable
+public sealed class CliServer : IHostedService, IDisposable
 {
     private readonly CancellationTokenSource _cancellationTokenSource = new();
     private CancellationToken Token => _cancellationTokenSource.Token;
@@ -20,10 +21,7 @@ public class CliServer : IHostedService, IDisposable
     private bool _started;
 
     private TcpListener? _tcpListener;
-    private Task? _listenerTask;
-
-    private readonly List<Task> _runningClients = [];
-    private readonly CliSettings _settings;
+    private readonly ConcurrentDictionary<Guid, Task> _runningClients = [];
 
     private readonly IServiceProvider _serviceProvider;
     private readonly ILogger<CliServer> _logger;
@@ -45,7 +43,7 @@ public class CliServer : IHostedService, IDisposable
         _configurator = configurator;
         _syncFile = syncFile;
 
-        _settings = settingsManager.Get<CliSettings>();
+        settingsManager.Get<CliSettings>();
     }
     
     /// <summary>
@@ -65,7 +63,7 @@ public class CliServer : IHostedService, IDisposable
     {
         _tcpListener = new TcpListener(IPAddress.Loopback, 0);
         _tcpListener.Start();
-        _listenerTask = Task.Run(async () => await StartListeningAsync(), _cancellationTokenSource.Token);
+        Task.Run(async () => await StartListeningAsync(), _cancellationTokenSource.Token);
         var port = ((IPEndPoint)_tcpListener.LocalEndpoint).Port;
 
         if (!_syncFile.TrySetMain(port))
@@ -84,11 +82,12 @@ public class CliServer : IHostedService, IDisposable
         {
             try
             {
-                CleanClosedConnections();
-
                 var found = await _tcpListener!.AcceptTcpClientAsync(Token);
                 found.NoDelay = true; // Disable Nagle's algorithm to reduce delay.
-                _runningClients.Add(Task.Run(() => HandleClientAsync(found), Token));
+
+                var id = Guid.NewGuid();
+                var task = Task.Run(() => HandleClientAsync(id, found), Token);
+                _ = _runningClients.GetOrAdd(id, task);
 
                 _logger.LogInformation("Accepted TCP connection from {RemoteEndPoint}", ((IPEndPoint)found.Client.RemoteEndPoint!).Port);
             }
@@ -107,49 +106,36 @@ public class CliServer : IHostedService, IDisposable
     /// <summary>
     /// Handle a client connection
     /// </summary>
-    /// <param name="client"></param>
-    /// <returns></returns>
-    /// <exception cref="NotImplementedException"></exception>
-    private async Task HandleClientAsync(TcpClient client)
+    private async Task HandleClientAsync(Guid id, TcpClient client)
     {
-        var stream = client.GetStream();
-
-        var (arguments, renderer) = await ProxiedRenderer.Create(_serviceProvider, stream);
-        await _configurator.RunAsync(arguments, renderer, Token);
-        client.Dispose();
-    }
-    
-    /// <summary>
-    /// Clears up any closed connections in the <see cref="_runningClients"/> dictionary
-    /// </summary>
-    /// <exception cref="NotImplementedException"></exception>
-    private void CleanClosedConnections()
-    {
-        // Snapshot the dictionary before we modify it
-        foreach(var task in _runningClients.ToArray())
+        try
         {
-            if (task.IsCompleted)
-                _runningClients.Remove(task);
+            var stream = client.GetStream();
+
+            var (arguments, renderer) = await ProxiedRenderer.Create(_serviceProvider, stream);
+            await _configurator.RunAsync(arguments, renderer, Token);
+        }
+        finally
+        {
+            client.Dispose();
+            _runningClients.Remove(id, out _);
         }
     }
-    
+
     /// <inheritdoc />
-    public Task StartAsync(CancellationToken cancellationToken)
-    {
-        return Task.CompletedTask;
-    }
+    public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
     /// <inheritdoc />
     public async Task StopAsync(CancellationToken cancellationToken)
     {
         if (!_started) return; 
-        
+
         // Ditch this value and don't wait on it because it otherwise blocks the shutdown even when *no-one* is 
         // waiting on the token
         _ = _cancellationTokenSource.CancelAsync();
-        
+
         _tcpListener?.Stop();
-        await Task.WhenAll(_runningClients);
+        await Task.WhenAll(_runningClients.Values.ToArray());
         _started = false;
     }
 

--- a/src/NexusMods.SingleProcess/CliSettings.cs
+++ b/src/NexusMods.SingleProcess/CliSettings.cs
@@ -47,11 +47,6 @@ public class CliSettings() : ISettings
     }
 
     /// <summary>
-    /// The amount of time the TCPListener will pause waiting for new connections before checking if it should exit.
-    /// </summary>
-    public TimeSpan ListenTimeout { get; set; } = TimeSpan.FromSeconds(1);
-    
-    /// <summary>
     /// If true the CLI backend will be started, otherwise it will not be started, and CLI commands will not be available.
     /// </summary>
     public bool StartCliBackend { get; set; } = true;


### PR DESCRIPTION
Before, the CliServer would create a cancellation token source that cancels after 1 second inside a while loop and use that token for `AcceptTcpClientAsync`. This meant that every second we're creating new token sources and every second we'd throw an `OperationCanceledException`.

This seemed very unusual, I couldn't figure out why we'd want that, so I updated the code to just use the main cancellation token.