### PR TITLE
Prevent removal of collection required mods in loadout

### DIFF
--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridItemModel.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridItemModel.cs
@@ -173,9 +173,9 @@ public class TreeDataGridItemModel<TModel, TKey> : TreeDataGridItemModel, ITreeD
             if (disposing)
             {
                 Disposable.Dispose(
-                    _childrenCollectionInitialization,
                     _modelActivationDisposable,
                     _childrenObservableSerialDisposable,
+                    _childrenCollectionInitialization,
                     _childrenCollectionInitializationSerialDisposable,
                     _hasChildren,
                     IsSelected

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutViewModel.cs
@@ -76,6 +76,8 @@ public class LoadoutViewModel : APageViewModel<ILoadoutViewModel>, ILoadoutViewM
         var hasSelection = Adapter.SelectedModels
             .ObserveCountChanged()
             .Select(count => count > 0);
+            
+        
 
         var viewModFilesArgumentsSubject = new BehaviorSubject<Optional<LoadoutItemGroup.ReadOnly>>(Optional<LoadoutItemGroup.ReadOnly>.None); 
         
@@ -106,7 +108,7 @@ public class LoadoutViewModel : APageViewModel<ILoadoutViewModel>, ILoadoutViewM
 
                     var isReadonly = group.Value.AsLoadoutItem()
                         .GetThisAndParents()
-                        .Any(item => NexusCollectionItemLoadoutGroup.IsRequired.TryGetValue(item, out var isRequired) && isRequired);
+                        .Any(item => IsRequired(item.LoadoutItemId, connection));
 
                     var pageData = new PageData
                     {
@@ -123,15 +125,26 @@ public class LoadoutViewModel : APageViewModel<ILoadoutViewModel>, ILoadoutViewM
                 },
                 false
             );
+        
+        var hasValidRemoveSelection = Adapter.SelectedModels
+            .ObserveChanged()
+            .Select(changeEvent =>
+            {
+                // if all items are readonly, or list is empty, no valid selection
+                return !Adapter.SelectedModels.All(model => 
+                    model.TryGet<LoadoutComponents.LockedEnabledState>(LoadoutColumns.EnabledState.LockedEnabledStateComponentKey, out _));
+            });
 
-        RemoveItemCommand = hasSelection
+        RemoveItemCommand = hasValidRemoveSelection
             .ToReactiveCommand<Unit>(async (_, _) =>
             {
                 var ids = Adapter.SelectedModels
                     .SelectMany(static itemModel => GetLoadoutItemIds(itemModel))
-                    .ToHashSet();
+                    .ToHashSet()
+                    .Where(id => !IsRequired(id, connection))
+                    .ToArray();
 
-                if (ids.Count == 0) return;
+                if (ids.Length == 0) return;
                 using var tx = connection.BeginTransaction();
 
                 foreach (var id in ids)
@@ -197,7 +210,7 @@ public class LoadoutViewModel : APageViewModel<ILoadoutViewModel>, ILoadoutViewM
         var toggleableItems = ids
             .Select(loadoutItemId => LoadoutItem.Load(connection.Db, loadoutItemId))
             // Exclude collection required items
-            .Where(item => !(NexusCollectionItemLoadoutGroup.IsRequired.TryGetValue(item, out var isRequired) && isRequired))
+            .Where(item => !IsRequired(item.Id, connection))
             // Exclude items that are part of a collection that is disabled
             .Where(item => !(item.Parent.TryGetAsCollectionGroup(out var collectionGroup)
                              && collectionGroup.AsLoadoutItemGroup().AsLoadoutItem().IsDisabled)
@@ -291,6 +304,11 @@ public class LoadoutViewModel : APageViewModel<ILoadoutViewModel>, ILoadoutViewM
     private static IEnumerable<LoadoutItemId> GetLoadoutItemIds(CompositeItemModel<EntityId> itemModel)
     {
         return itemModel.Get<LoadoutComponents.LoadoutItemIds>(LoadoutColumns.EnabledState.LoadoutItemIdsComponentKey).ItemIds;
+    }
+
+    private static bool IsRequired(LoadoutItemId id, IConnection connection)
+    {
+        return NexusCollectionItemLoadoutGroup.IsRequired.TryGetValue(LoadoutItem.Load(connection.Db, id), out var isRequired) && isRequired;
     }
 }
 


### PR DESCRIPTION
- closes #2855
- part of #2598

## Details:
- Skip collection required items during removal operation
- Disable Remove button when selection only contains read-only items.