### PR TITLE
Allow pages to specify serializable page data

### DIFF
--- a/src/NexusMods.App.UI/Pages/Diagnostics/Details/DiagnosticDetailsPage.cs
+++ b/src/NexusMods.App.UI/Pages/Diagnostics/Details/DiagnosticDetailsPage.cs
@@ -1,6 +1,7 @@
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.Diagnostics;
+using NexusMods.Abstractions.Loadouts;
 using NexusMods.App.UI.Controls.MarkdownRenderer;
 using NexusMods.App.UI.WorkspaceSystem;
 
@@ -10,8 +11,23 @@ public record DiagnosticDetailsPageContext : IPageFactoryContext
 {
     public required Diagnostic Diagnostic { get; init; }
 
+    public required LoadoutId LoadoutId { get; init; }
+
     /// <inheritdoc/>
     public bool IsEphemeral => true;
+
+    /// <inheritdoc/>
+    public PageData GetSerializablePageData()
+    {
+        return new PageData
+        {
+            FactoryId = DiagnosticListPageFactory.StaticId,
+            Context = new DiagnosticListPageContext
+            {
+                LoadoutId = LoadoutId,
+            },
+        };
+    }
 }
 
 [UsedImplicitly]

--- a/src/NexusMods.App.UI/Pages/Diagnostics/List/DiagnosticListViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/Diagnostics/List/DiagnosticListViewModel.cs
@@ -152,6 +152,7 @@ internal class DiagnosticListViewModel : APageViewModel<IDiagnosticListViewModel
                                     Context = new DiagnosticDetailsPageContext
                                     {
                                         Diagnostic = diagnostic,
+                                        LoadoutId = LoadoutId,
                                     },
                                 };
 

--- a/src/NexusMods.App.UI/WorkspaceSystem/Page/IPageFactoryContext.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Page/IPageFactoryContext.cs
@@ -12,6 +12,11 @@ public interface IPageFactoryContext
     bool IsEphemeral => false;
 
     /// <summary>
+    /// Alternative <see cref="PageData"/> to persist when <see cref="IsEphemeral"/> is <c>true</c>.
+    /// </summary>
+    PageData? GetSerializablePageData() => null;
+
+    /// <summary>
     /// Gets the tracking name.
     /// </summary>
     string TrackingName => GetType().Name;

--- a/src/NexusMods.App.UI/WorkspaceSystem/PanelTab/PanelTabViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/PanelTab/PanelTabViewModel.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Reactive;
 using DynamicData.Kernel;
 using NexusMods.Abstractions.UI;
@@ -45,12 +46,20 @@ public class PanelTabViewModel : AViewModel<IPanelTabViewModel>, IPanelTabViewMo
 
     public TabData? ToData()
     {
-        if (Contents.PageData.Context.IsEphemeral) return null;
+        var pageData = Contents.PageData;
+        if (pageData.Context.IsEphemeral)
+        {
+            var serializablePageData = pageData.Context.GetSerializablePageData();
+            if (serializablePageData is null) return null;
+
+            Debug.Assert(!serializablePageData.Context.IsEphemeral);
+            pageData = serializablePageData;
+        }
 
         return new TabData
         {
             Id = Id,
-            PageData = Contents.PageData,
+            PageData = pageData,
         };
     }
 }


### PR DESCRIPTION
Resolves #2682.

Ephemeral pages can now specify another page to be serialized instead. This allows the diagnostics details page to specify the diagnostics list page.