### PR TITLE
Update Strawberry Shake (GraphQL Client)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -42,7 +42,7 @@
     <PackageVersion Include="SmartFormat" Version="3.5.1" />
     <PackageVersion Include="Spectre.Console.Testing" Version="0.49.1" />
     <PackageVersion Include="SteamKit2" Version="3.0.0" />
-    <PackageVersion Include="StrawberryShake.Server" Version="14.1.0" />
+    <PackageVersion Include="StrawberryShake.Server" Version="15.0.3" />
     <PackageVersion Include="System.Linq" Version="4.3.0" />
     <PackageVersion Include="System.Text.Json" Version="9.0.0" VersionOverride="9.0.0" />
     <PackageVersion Include="TextMateSharp.Grammars" Version="1.0.64" />


### PR DESCRIPTION
# Bug Report

## Summary
Currently to build the app you need both .NET 8 and .NET 9. This is because Strawberry Shake took awhile to upgrade to .NET 9. 

## Steps to reproduce
Build the app with only .NET 9 on a machine, you get a build error. 

## Fix

Update to Strawberry Shake 15