### PR TITLE
Fix "control already has a parent"-exception

### DIFF
--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/ColumnContentControl.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/ColumnContentControl.cs
@@ -123,8 +123,15 @@ public abstract class AReactiveContentControl<TContent> : ContentControl
         // because the parent is generic, and generics don't work in style selectors...
         var border = new Border();
         if (newClass.HasValue) border.Classes.Set(newClass.Value, true);
-        border.Child = contentControl;
 
+        // NOTE(erri120): need to make sure that the fallback control is properly detached from
+        // the old border before attaching to the new border.
+        if (contentControl?.Parent is Border existingBorder)
+        {
+            existingBorder.Child = null;
+        }
+
+        border.Child = contentControl;
         Presenter.Content = border;
     }
 


### PR DESCRIPTION
Repro using the Library tree:

- Install a mod
- Uninstall the mod
- Install the mod again
- Get `InvalidOperationException`

The exception was thrown because we try to set a control as child of a new border while it was still a child of the old border. This only happens for fallback controls as they are only created once.

The PR properly detaches those controls before assigning them to something else.