### PR TITLE
Fix suggested folder name in Advanced Installer

### DIFF
--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/SelectLocation/SelectLocationViewModel.cs
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/SelectLocation/SelectLocationViewModel.cs
@@ -64,10 +64,11 @@ public class SelectLocationViewModel : AViewModel<ISelectLocationViewModel>,
         foreach (var (locationId, fullPath) in register.GetTopLevelLocations())
         {
             suggestedEntries.Add(new SuggestedEntryViewModel(
-                Guid.NewGuid(),
-                fullPath,
-                locationId,
-                new GamePath(locationId, RelativePath.Empty)));
+                id: Guid.NewGuid(),
+                absolutePath: fullPath,
+                associatedLocation: locationId,
+                relativeToTopLevelLocation: new GamePath(locationId, RelativePath.Empty)
+            ));
 
             // Add nested locations to suggested entries.
             foreach (var nestedLocation in register.GetNestedLocations(locationId))
@@ -75,10 +76,11 @@ public class SelectLocationViewModel : AViewModel<ISelectLocationViewModel>,
                 var nestedFullPath = register.GetResolvedPath(nestedLocation);
                 var relativePath = nestedFullPath.RelativeTo(fullPath);
                 suggestedEntries.Add(new SuggestedEntryViewModel(
-                    Guid.NewGuid(),
-                    nestedFullPath,
-                    nestedLocation,
-                    new GamePath(locationId, relativePath)));
+                    id: Guid.NewGuid(),
+                    absolutePath: nestedFullPath,
+                    associatedLocation: nestedLocation,
+                    relativeToTopLevelLocation: new GamePath(locationId, relativePath)
+                ));
             }
         }
 

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/SelectLocation/SuggestedEntry/SuggestedEntryViewModel.cs
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/Content/Right/SelectLocation/SuggestedEntry/SuggestedEntryViewModel.cs
@@ -38,8 +38,8 @@ public class SuggestedEntryViewModel : AViewModel<ISuggestedEntryViewModel>, ISu
         AssociatedLocation = associatedLocation;
         RelativeToTopLevelLocation = relativeToTopLevelLocation;
 
-        Title = title == string.Empty ? associatedLocation.Value.ToString() : title;
-        Subtitle = subtitle == string.Empty ? AbsolutePath.ToString() : subtitle;
+        Title = string.IsNullOrEmpty(title) ? associatedLocation.ToString() : title;
+        Subtitle = string.IsNullOrEmpty(subtitle) ? AbsolutePath.ToString() : subtitle;
 
         CreateMappingCommand = ReactiveCommand.Create(() => { });
     }


### PR DESCRIPTION
Using `LocationId.ToString()` instead of `LocationId.Value.ToString()`.

Fixes #2463.

![image](https://github.com/user-attachments/assets/187f4fd2-5b5b-447c-817b-9d1195463ff9)
