### PR TITLE
Don't send exceptions in debug builds

### DIFF
--- a/src/NexusMods.Telemetry/TrackingDataSender.cs
+++ b/src/NexusMods.Telemetry/TrackingDataSender.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.Logging;
 using NexusMods.Abstractions.NexusWebApi;
 using NexusMods.Abstractions.NexusWebApi.Types;
+using NexusMods.App.BuildInfo;
 using NexusMods.Paths;
 
 namespace NexusMods.Telemetry;
@@ -41,7 +42,7 @@ internal sealed class TrackingDataSender : ITrackingDataSender, IDisposable
         _httpClient = httpClient;
         _writer = new ArrayBufferWriter<byte>();
 
-        if (exceptionSource is not null)
+        if (exceptionSource is not null && !CompileConstants.IsDebug)
         {
             _disposable = exceptionSource.Exceptions
                 .Select(static msg => msg.Exception)


### PR DESCRIPTION
We only want to see exceptions from releases.