### PR TITLE
Add Load Order `CompositeItemModel` components and DataProvider

### DIFF
--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/AValueComponent.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/AValueComponent.cs
@@ -85,10 +85,21 @@ public class ValueComponent<T> : AValueComponent<T>
         IObservable<T> valueObservable,
         bool subscribeWhenCreated = false) : base(initialValue, valueObservable, subscribeWhenCreated) { }
 
-    public ValueComponent(
+    public ValueComponent(T value) : base(value) { }
+}
+
+public class ComparableValueComponent<T> : AValueComponent<T>, IItemModelComponent<ComparableValueComponent<T>>, IComparable<ComparableValueComponent<T>>
+where T : IComparable<T>
+{
+    public int CompareTo(ComparableValueComponent<T>? other)
+    {
+        return other is null ? 1 : Value.Value.CompareTo(other.Value.Value);
+    }
+
+    public ComparableValueComponent(
         T initialValue,
-        Observable<T> valueObservable,
+        IObservable<T> valueObservable,
         bool subscribeWhenCreated = false) : base(initialValue, valueObservable, subscribeWhenCreated) { }
 
-    public ValueComponent(T value) : base(value) { }
+    public ComparableValueComponent(T value) : base(value) { }
 }

--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/AValueComponent.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/AValueComponent.cs
@@ -78,28 +78,26 @@ public abstract class AValueComponent<T> : ReactiveR3Object, IItemModelComponent
     }
 }
 
-public class ValueComponent<T> : AValueComponent<T>
+public class ValueComponent<T> : AValueComponent<T>, IItemModelComponent<ValueComponent<T>>, IComparable<ValueComponent<T>>
 {
+    private readonly IComparer<T>? _comparer;
+
     public ValueComponent(
         T initialValue,
         IObservable<T> valueObservable,
-        bool subscribeWhenCreated = false) : base(initialValue, valueObservable, subscribeWhenCreated) { }
-
-    public ValueComponent(T value) : base(value) { }
-}
-
-public class ComparableValueComponent<T> : AValueComponent<T>, IItemModelComponent<ComparableValueComponent<T>>, IComparable<ComparableValueComponent<T>>
-where T : IComparable<T>
-{
-    public int CompareTo(ComparableValueComponent<T>? other)
+        bool subscribeWhenCreated = false,
+        IComparer<T>? comparer = null) : base(initialValue, valueObservable, subscribeWhenCreated)
     {
-        return other is null ? 1 : Value.Value.CompareTo(other.Value.Value);
+        _comparer = comparer;
     }
 
-    public ComparableValueComponent(
-        T initialValue,
-        IObservable<T> valueObservable,
-        bool subscribeWhenCreated = false) : base(initialValue, valueObservable, subscribeWhenCreated) { }
-
-    public ComparableValueComponent(T value) : base(value) { }
+    public ValueComponent(T value) : base(value) { }
+    
+    public int CompareTo(ValueComponent<T>? other)
+    {
+        if (other is null) return 1;
+        var comparer = _comparer ?? Comparer<T>.Default;
+        return comparer.Compare(Value.Value, other.Value.Value);
+    }
 }
+

--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/AValueComponent.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/AValueComponent.cs
@@ -80,7 +80,7 @@ public abstract class AValueComponent<T> : ReactiveR3Object, IItemModelComponent
 
 public class ValueComponent<T> : AValueComponent<T>, IItemModelComponent<ValueComponent<T>>, IComparable<ValueComponent<T>>
 {
-    private readonly IComparer<T>? _comparer;
+    private readonly IComparer<T> _comparer;
 
     public ValueComponent(
         T initialValue,
@@ -88,16 +88,18 @@ public class ValueComponent<T> : AValueComponent<T>, IItemModelComponent<ValueCo
         bool subscribeWhenCreated = false,
         IComparer<T>? comparer = null) : base(initialValue, valueObservable, subscribeWhenCreated)
     {
-        _comparer = comparer;
+        _comparer = comparer ?? Comparer<T>.Default;
     }
 
-    public ValueComponent(T value) : base(value) { }
+    public ValueComponent(T value, IComparer<T>? comparer = null) : base(value)
+    {
+        _comparer = comparer ?? Comparer<T>.Default;
+    }
     
     public int CompareTo(ValueComponent<T>? other)
     {
         if (other is null) return 1;
-        var comparer = _comparer ?? Comparer<T>.Default;
-        return comparer.Compare(Value.Value, other.Value.Value);
+        return _comparer.Compare(Value.Value, other.Value.Value);
     }
 }
 

--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/CompositeItemModel.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/CompositeItemModel.cs
@@ -240,17 +240,21 @@ public sealed class CompositeItemModel<TKey> : TreeDataGridItemModel<CompositeIt
     /// </summary>
     public void SetStyleFlag(string flag, bool value)
     {
+        var modified = false;
         if (value)
         {
-            _styleFlags.Add(flag);
+            modified = _styleFlags.Add(flag);
         }
         else
         {
-            _styleFlags.Remove(flag);
+            modified = _styleFlags.Remove(flag);
         }
-        
-        // Note(Al12rs): 
-        RaisePropertyChanged(new PropertyChangedEventArgs(nameof(StyleFlags)));
+
+        if (modified)
+        {
+            // Note(Al12rs): We need UI bindings to StyleFlags to be notified when the contents of the collection change
+            RaisePropertyChanged(new PropertyChangedEventArgs(nameof(StyleFlags)));
+        } 
     }
 
     /// <summary>

--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/ICompositeColumnDefinition.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/ICompositeColumnDefinition.cs
@@ -20,12 +20,13 @@ public interface ICompositeColumnDefinition<TSelf>
     static abstract int Compare<TKey>(CompositeItemModel<TKey> a, CompositeItemModel<TKey> b) where TKey : notnull;
 
     static virtual IColumn<CompositeItemModel<TKey>> CreateColumn<TKey>(
+        Optional<string> columnHeader = default,
         Optional<ListSortDirection> sortDirection = default,
         Optional<GridLength> width = default)
         where TKey : notnull
     {
         return new CustomTemplateColumn<CompositeItemModel<TKey>>(
-            header: TSelf.GetColumnHeader(),
+            header: columnHeader.ValueOr(TSelf.GetColumnHeader()),
             cellTemplateResourceKey: TSelf.GetColumnTemplateResourceKey(),
             options: new TemplateColumnOptions<CompositeItemModel<TKey>>
             {

--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/IItemModelComponent.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/IItemModelComponent.cs
@@ -40,11 +40,12 @@ public interface IItemModelComponent<in TSelf> : IItemModelComponent
 public static partial class ColumnCreator
 {
     public static IColumn<CompositeItemModel<TKey>> Create<TKey, TColumn>(
+        Optional<string> columnHeader = default,
         Optional<ListSortDirection> sortDirection = default,
         Optional<GridLength> width = default)
         where TKey : notnull
         where TColumn : class, ICompositeColumnDefinition<TColumn>
     {
-        return TColumn.CreateColumn<TKey>(sortDirection, width);
+        return TColumn.CreateColumn<TKey>(columnHeader: columnHeader, sortDirection: sortDirection, width: width);
     }
 }

--- a/src/NexusMods.App.UI/Converters/CompositeStyleFlagConverter.cs
+++ b/src/NexusMods.App.UI/Converters/CompositeStyleFlagConverter.cs
@@ -1,0 +1,30 @@
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace NexusMods.App.UI.Converters;
+
+
+/// <summary>
+/// Returns true if the parameter flag is contained in the flag list.
+/// The Flags property may need manual raising of property change notifications when the collection is modified to make the binding reactive.
+/// </summary>
+public class CompositeStyleFlagConverter : IValueConverter
+{
+    
+    public static CompositeStyleFlagConverter Instance { get; } = new();
+    
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is not IReadOnlyList<string> flags || parameter is not string flagName || targetType != typeof(bool))
+        {
+            throw new ArgumentException();
+        }
+
+        return flags.Contains(flagName);
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotSupportedException();
+    }
+}

--- a/src/NexusMods.App.UI/NexusMods.App.UI.csproj
+++ b/src/NexusMods.App.UI/NexusMods.App.UI.csproj
@@ -735,6 +735,9 @@
         <Compile Update="LeftMenu\Items\ApplyControl\ApplyControlDesignViewModel.cs">
           <DependentUpon>IApplyControlViewModel.cs</DependentUpon>
         </Compile>
+        <Compile Update="Pages\Sorting\LoadOrder\TreeDataGrid\LoadOrderDataProvider.cs">
+          <DependentUpon>ILoadOrderDataProvider.cs</DependentUpon>
+        </Compile>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NexusMods.App.UI/NexusMods.App.UI.csproj.DotSettings
+++ b/src/NexusMods.App.UI/NexusMods.App.UI.csproj.DotSettings
@@ -18,6 +18,7 @@
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=pages_005Cmodlibrary_005Cdownloadslibrary/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=pages_005Cmodlibrary_005Cfileorigins/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=pages_005Csorting_005Cloadorder/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=pages_005Csorting_005Cloadorder_005Ctreedatagrid/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=pages_005Csorting_005Csortingselection/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=pages_005Csorting_005Csortingselectionview/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=theme_005Ccontrolsgallery/@EntryIndexedValue">True</s:Boolean>

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGrid/ILoadOrderDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGrid/ILoadOrderDataProvider.cs
@@ -1,0 +1,10 @@
+using DynamicData;
+using NexusMods.Abstractions.Games;
+using NexusMods.App.UI.Controls;
+
+namespace NexusMods.App.UI.Pages.Sorting;
+
+public interface ILoadOrderDataProvider
+{
+    IObservable<IChangeSet<CompositeItemModel<Guid>, Guid>> ObserveLoadOrder(ILoadoutSortableItemProvider sortableItemProvider);
+}

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGrid/LoadOrderComponents.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGrid/LoadOrderComponents.cs
@@ -31,20 +31,6 @@ public static class LoadOrderComponents
             // Data is sorted by the Adapter, not the treeDataGrid, this should not be called
             throw new NotSupportedException();
         }
-
-        internal static string IndexToOrdinal(int sortIndex)
-        {
-            var displayIndex = sortIndex + 1;
-            var suffix = displayIndex switch
-            {
-                11 or 12 or 13 => "th",
-                _ when displayIndex % 10 == 1 => "st",
-                _ when displayIndex % 10 == 2 => "nd",
-                _ when displayIndex % 10 == 3 => "rd",
-                _ => "th"
-            };
-            return $"{displayIndex}{suffix}";
-        }
     }
 }
 

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGrid/LoadOrderComponents.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGrid/LoadOrderComponents.cs
@@ -12,33 +12,27 @@ public static class LoadOrderComponents
     public sealed class IndexComponent : ReactiveR3Object, IItemModelComponent<IndexComponent>, IComparable<IndexComponent>
     {
         private readonly ValueComponent<int> _index;
-        private readonly ValueComponent<ListSortDirection> _sortDirection;
+        private readonly ValueComponent<string> _displaySortIndex;
 
         public ReactiveCommand<Unit> MoveUp { get; } = new();
         public ReactiveCommand<Unit> MoveDown { get; } = new();
 
         public IReadOnlyBindableReactiveProperty<int> SortIndex => _index.Value;
+        public IReadOnlyBindableReactiveProperty<string> DisplaySortIndex => _displaySortIndex.Value;
 
-        public IndexComponent(
-            ValueComponent<int> index,
-            ValueComponent<ListSortDirection> sortDirection)
+        public IndexComponent(ValueComponent<int> index, ValueComponent<string> displaySortIndex)
         {
             _index = index;
-            _sortDirection = sortDirection;
+            _displaySortIndex = displaySortIndex;
         }
 
         public int CompareTo(IndexComponent? other)
         {
-            // depends on sort direction
-            return _sortDirection.Value.Value switch
-            {
-                ListSortDirection.Ascending => SortIndex.Value.CompareTo(other?.SortIndex.Value),
-                ListSortDirection.Descending => -SortIndex.Value.CompareTo(other?.SortIndex.Value),
-                _ => throw new InvalidEnumArgumentException()
-            };
+            // Data is sorted by the Adapter, not the treeDataGrid, this should not be called
+            throw new NotSupportedException();
         }
 
-        internal static string ConvertZeroIndexToOrdinalNumber(int sortIndex)
+        internal static string IndexToOrdinal(int sortIndex)
         {
             var displayIndex = sortIndex + 1;
             var suffix = displayIndex switch

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGrid/LoadOrderComponents.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGrid/LoadOrderComponents.cs
@@ -1,0 +1,98 @@
+using System.ComponentModel;
+using JetBrains.Annotations;
+using NexusMods.Abstractions.UI;
+using NexusMods.App.UI.Controls;
+using R3;
+using static NexusMods.App.UI.Pages.Sorting.LoadOrderComponents;
+
+namespace NexusMods.App.UI.Pages.Sorting;
+
+public static class LoadOrderComponents
+{
+    public sealed class IndexComponent : ReactiveR3Object, IItemModelComponent<IndexComponent>, IComparable<IndexComponent>
+    {
+        private readonly ValueComponent<int> _index;
+        private readonly ValueComponent<ListSortDirection> _sortDirection;
+
+        public ReactiveCommand<Unit> MoveUp { get; } = new();
+        public ReactiveCommand<Unit> MoveDown { get; } = new();
+
+        public IReadOnlyBindableReactiveProperty<int> SortIndex => _index.Value;
+
+        public IndexComponent(
+            ValueComponent<int> index,
+            ValueComponent<ListSortDirection> sortDirection)
+        {
+            _index = index;
+            _sortDirection = sortDirection;
+        }
+
+        public int CompareTo(IndexComponent? other)
+        {
+            // depends on sort direction
+            return _sortDirection.Value.Value switch
+            {
+                ListSortDirection.Ascending => SortIndex.Value.CompareTo(other?.SortIndex.Value),
+                ListSortDirection.Descending => -SortIndex.Value.CompareTo(other?.SortIndex.Value),
+                _ => throw new InvalidEnumArgumentException()
+            };
+        }
+
+        internal static string ConvertZeroIndexToOrdinalNumber(int sortIndex)
+        {
+            var displayIndex = sortIndex + 1;
+            var suffix = displayIndex switch
+            {
+                11 or 12 or 13 => "th",
+                _ when displayIndex % 10 == 1 => "st",
+                _ when displayIndex % 10 == 2 => "nd",
+                _ when displayIndex % 10 == 3 => "rd",
+                _ => "th"
+            };
+            return $"{displayIndex}{suffix}";
+        }
+    }
+}
+
+public static class LoadOrderColumns
+{
+    [UsedImplicitly]
+    public sealed class IndexColumn : ICompositeColumnDefinition<IndexColumn>
+    {
+        public const string ColumnTemplateResourceKey = nameof(LoadOrderColumns) + "_" + nameof(IndexColumn);
+
+        public static readonly ComponentKey IndexComponentKey = ComponentKey.From(ColumnTemplateResourceKey + "_" + nameof(IndexComponent));
+
+        public static int Compare<TKey>(CompositeItemModel<TKey> a, CompositeItemModel<TKey> b) where TKey : notnull
+        {
+            throw new NotImplementedException();
+        }
+
+        // The header name should be set on column creation as it is game dependent
+        public static string GetColumnHeader() => throw new NotSupportedException();
+
+        public static string GetColumnTemplateResourceKey() => ColumnTemplateResourceKey;
+
+    }
+
+    [UsedImplicitly]
+    public sealed class NameColumn : ICompositeColumnDefinition<NameColumn>
+    {
+        public const string ColumnTemplateResourceKey = nameof(LoadOrderColumns) + "_" + nameof(NameColumn);
+
+        public static readonly ComponentKey NameComponentKey = ComponentKey.From(ColumnTemplateResourceKey + "_" + "DisplayNameComponent");
+        public static readonly ComponentKey ModNameComponentKey = ComponentKey.From(ColumnTemplateResourceKey + "_" + "ModNameComponent");
+
+        public static int Compare<TKey>(CompositeItemModel<TKey> a, CompositeItemModel<TKey> b) where TKey : notnull
+        {
+            throw new NotImplementedException();
+        }
+
+        // The header name should be set on column creation as it is game dependent
+        public static string GetColumnHeader() => throw new NotSupportedException();
+
+        public static string GetColumnTemplateResourceKey() => ColumnTemplateResourceKey;
+    }
+
+    public static readonly ComponentKey IsActiveComponentKey = ComponentKey.From(nameof(LoadOrderColumns) + "_" + "IsActiveComponent");
+}

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGrid/LoadOrderDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGrid/LoadOrderDataProvider.cs
@@ -1,6 +1,7 @@
 using System.Reactive.Linq;
 using DynamicData;
 using DynamicData.Binding;
+using Humanizer;
 using NexusMods.Abstractions.Games;
 using NexusMods.App.UI.Controls;
 using ReactiveUI;
@@ -36,11 +37,11 @@ public class LoadOrderDataProvider : ILoadOrderDataProvider
             new ValueComponent<bool>(sortableItem.IsActive, sortableItem.WhenAnyValue(item => item.IsActive)));
 
         // SortIndex
-        var displayIndexObservable = sortableItem.WhenAnyValue(item => item.SortIndex).Select(IndexComponent.IndexToOrdinal);
+        var displayIndexObservable = sortableItem.WhenAnyValue(item => item.SortIndex).Select(index => index.Ordinalize());
         compositeModel.Add(LoadOrderColumns.IndexColumn.IndexComponentKey,
             new IndexComponent(
                 new ValueComponent<int>(sortableItem.SortIndex, sortableItem.WhenAnyValue(item => item.SortIndex)),
-                new ValueComponent<string>(IndexComponent.IndexToOrdinal(sortableItem.SortIndex), displayIndexObservable)
+                new ValueComponent<string>(sortableItem.SortIndex.Ordinalize(), displayIndexObservable)
             )
         );
 

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGrid/LoadOrderDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGrid/LoadOrderDataProvider.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel;
 using System.Reactive.Linq;
 using DynamicData;
 using DynamicData.Binding;
@@ -34,7 +33,7 @@ public class LoadOrderDataProvider : ILoadOrderDataProvider
 
         // IsActive
         compositeModel.Add(LoadOrderColumns.IsActiveComponentKey,
-            new ComparableValueComponent<bool>(sortableItem.IsActive, sortableItem.WhenAnyValue(item => item.IsActive)));
+            new ValueComponent<bool>(sortableItem.IsActive, sortableItem.WhenAnyValue(item => item.IsActive)));
 
         // SortIndex
         var displayIndexObservable = sortableItem.WhenAnyValue(item => item.SortIndex).Select(IndexComponent.IndexToOrdinal);

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGrid/LoadOrderDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGrid/LoadOrderDataProvider.cs
@@ -1,0 +1,50 @@
+using System.ComponentModel;
+using System.Reactive.Linq;
+using DynamicData;
+using DynamicData.Binding;
+using NexusMods.Abstractions.Games;
+using NexusMods.App.UI.Controls;
+using ReactiveUI;
+using static NexusMods.App.UI.Pages.Sorting.LoadOrderComponents;
+
+namespace NexusMods.App.UI.Pages.Sorting;
+
+public class LoadOrderDataProvider : ILoadOrderDataProvider
+{
+    
+    public IObservable<IChangeSet<CompositeItemModel<Guid>, Guid>> ObserveLoadOrder(ILoadoutSortableItemProvider sortableItemProvider)
+    {
+        return sortableItemProvider.SortableItems
+            .ToObservableChangeSet(item => item.ItemId)
+            .Transform( item => ToLoadOrderItemModel(item));
+    }
+
+
+    private CompositeItemModel<Guid> ToLoadOrderItemModel(ISortableItem sortableItem)
+    {
+        var compositeModel = new CompositeItemModel<Guid>(sortableItem.ItemId);
+
+        // DisplayName
+        compositeModel.Add(LoadOrderColumns.NameColumn.NameComponentKey,
+            new StringComponent(sortableItem.DisplayName, sortableItem.WhenAnyValue(item => item.DisplayName)));
+
+        // ModName
+        compositeModel.Add(LoadOrderColumns.NameColumn.ModNameComponentKey,
+            new StringComponent(sortableItem.ModName, sortableItem.WhenAnyValue(item => item.ModName)));
+
+        // IsActive
+        compositeModel.Add(LoadOrderColumns.IsActiveComponentKey,
+            new ComparableValueComponent<bool>(sortableItem.IsActive, sortableItem.WhenAnyValue(item => item.IsActive)));
+
+        // SortIndex
+        var displayIndexObservable = sortableItem.WhenAnyValue(item => item.SortIndex).Select(IndexComponent.IndexToOrdinal);
+        compositeModel.Add(LoadOrderColumns.IndexColumn.IndexComponentKey,
+            new IndexComponent(
+                new ValueComponent<int>(sortableItem.SortIndex, sortableItem.WhenAnyValue(item => item.SortIndex)),
+                new ValueComponent<string>(IndexComponent.IndexToOrdinal(sortableItem.SortIndex), displayIndexObservable)
+            )
+        );
+
+        return compositeModel;
+    }
+}


### PR DESCRIPTION
- Part of #2885

## Details:
- Adds preliminary support for Row level `CompositeItemModel` styling through `StyleFlags` property
- Adds option to set ColumnHeader name at creation time (load order header name is game specific)
- Adds Components for Load Order items
- Adds LoadOrderDataProvider that converts `SortableItems` to `CompositeItemModels` (not yet in use)