### PR TITLE
Don't re-insert files that change during ingestion

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -789,21 +789,50 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
         public required LoadoutFile.New LoadoutFileEntry { get; init; }
     }
 
-    private bool ActionIngestFromDisk(Dictionary<GamePath, SyncNode> syncTree, Loadout.ReadOnly loadout, ITransaction tx, ref EntityId? overridesGroup)
+    private bool ActionIngestFromDisk(Dictionary<GamePath, SyncNode> syncTree, Loadout.ReadOnly loadout, ITransaction tx, ref EntityId? overridesGroupId)
     {
-        overridesGroup ??= GetOrCreateOverridesGroup(tx, loadout);
+        overridesGroupId ??= GetOrCreateOverridesGroup(tx, loadout);
+        var newGroup = true;
+        LoadoutItemGroup.ReadOnly? overridesGroup = null;
+        if (!overridesGroupId.Value.InPartition(PartitionId.Temp))
+        {
+            newGroup = false;
+            overridesGroup = LoadoutItemGroup.Load(loadout.Db, overridesGroupId.Value);
+        }
+
         var ingestedFiles = false;
         
         foreach (var (path, node) in syncTree)
         {
             if (!node.Actions.HasFlag(Actions.IngestFromDisk))
                 continue;
-            
-            // Entry was added or modified
+
+            // If the overrides group is not new, we need to check if the file is already in the overrides group
+            if (!newGroup)
+            {
+                var existingRecord = overridesGroup!.Value.Children
+                    .OfTypeLoadoutItemWithTargetPath()
+                    .FirstOrOptional(c => c.TargetPath == path);
+
+                if (existingRecord.HasValue)
+                {
+                    // Update the disk entry
+                    tx.Add(node.Disk.EntityId, DiskStateEntry.LastModified, new DateTimeOffset(node.Disk.LastModifiedTicks, TimeSpan.Zero));
+                    
+                    // Update the file entry
+                    tx.Add(existingRecord.Value.Id, LoadoutFile.Hash, node.Disk.Hash);
+                    tx.Add(existingRecord.Value.Id, LoadoutFile.Size, node.Disk.Size);
+                    
+                    // Skip the rest of this process
+                    continue;
+                }
+            }
+
+            // Entry was added
             var id = tx.TempId();
             var loadoutItem = new LoadoutItem.New(tx, id)
             {
-                ParentId = overridesGroup.Value,
+                ParentId = overridesGroupId.Value,
                 LoadoutId = loadout.Id,
                 Name = path.FileName,
             };

--- a/tests/NexusMods.DataModel.Synchronizer.Tests/GeneralFileManagementTests.SynchronizerFileManagementTest.verified.md
+++ b/tests/NexusMods.DataModel.Synchronizer.Tests/GeneralFileManagementTests.SynchronizerFileManagementTest.verified.md
@@ -72,10 +72,9 @@ Updated the new file and synced it.
 | {Game, Data/image.dds} | 0x9829BF9CBC5991D2 | 85.484 KB |
 | {Game, README.txt} | 0x284B31336E242FFA | 26 B |
 | {Game, StubbedGame.exe} | 0xAD76A8A9233B7238 | 209 KB |
-### Loadout A - (2)
+### Loadout A - (1)
 | Path | Hash | Size | Disabled | Deleted |
 | --- | --- | --- | --- | --- |
-| {Game, bin/newFile.txt} | 0x673E3C493921A2D5 | 12 B |   |   |
 | {Game, bin/newFile.txt} | 0xB4E7270703F5F646 | 21 B |   |   |
 
 


### PR DESCRIPTION
Fixes issue-2908

We were not looking for and re-using existing external file records when ingesting changes. This would also cause the "duplicate key" exception on subsequent applies and in the "preview changes" dialogs