### PR TITLE
Fix `ActionIngestFromDisk` return value

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -823,6 +823,9 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
                     tx.Add(existingRecord.Value.Id, LoadoutFile.Hash, node.Disk.Hash);
                     tx.Add(existingRecord.Value.Id, LoadoutFile.Size, node.Disk.Size);
                     
+                    // Mark that we ingested a file
+                    ingestedFiles = true;
+                    
                     // Skip the rest of this process
                     continue;
                 }


### PR DESCRIPTION
Small regression of #2919 that had no impact since return value is currently unused.
Still supposed to return true if something was added/changed.