### PR TITLE
Fix `BodyMDBoldTheme` error

### DIFF
--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/UserControls/MessageBox/MessageBoxStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/UserControls/MessageBox/MessageBoxStyles.axaml
@@ -32,7 +32,7 @@
         </Style>
         
         <Style Selector="^ TextBlock#MessageTextBlockBold">
-            <Setter Property="Theme" Value="{StaticResource BodyMDBoldTheme}" />
+            <Setter Property="Theme" Value="{StaticResource BodyMDSemiTheme}" />
         </Style>
     </Style>
     


### PR DESCRIPTION
Just a matter of updating the reference to the new semi version.

Happened by unfortunate timing, the PR for the new dialog didn't have the UI Styling refactor changes yet, and the refactor PR didn't have the dialog.