### PR TITLE
Load Order tree migration: integration into `LoadOrderViewModel` and `GridAdapter`

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Games/ILoadoutSortableItemProvider.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Games/ILoadoutSortableItemProvider.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using DynamicData;
+using DynamicData.Kernel;
 using NexusMods.Abstractions.Loadouts;
 
 namespace NexusMods.Abstractions.Games;
@@ -28,6 +29,11 @@ public interface ILoadoutSortableItemProvider : IDisposable
     /// Change set of sortable items in the sort order
     /// </summary>
     public IObservable<IChangeSet<ISortableItem, Guid>> SortableItemsChangeSet { get; }
+    
+    /// <summary>
+    /// Returns the sortable item with the given id
+    /// </summary>
+    public Optional<ISortableItem> GetSortableItem(Guid itemId);
 
     /// <summary>
     /// Sets the relative position of a sortable item in the sort order

--- a/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/SortOrder/RedMod/RedModSortableItemProvider.cs
+++ b/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/SortOrder/RedMod/RedModSortableItemProvider.cs
@@ -97,6 +97,11 @@ public class RedModSortableItemProvider : ILoadoutSortableItemProvider
     }
 
 
+    public Optional<ISortableItem> GetSortableItem(Guid itemId)
+    {
+        return SortableItems.FirstOrOptional(item => item.ItemId.Equals(itemId));
+    }
+
     public async Task SetRelativePosition(ISortableItem sortableItem, int delta, CancellationToken token)
     {
         await _semaphore.WaitAsync(token);

--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/ICompositeColumnDefinition.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/ICompositeColumnDefinition.cs
@@ -22,16 +22,18 @@ public interface ICompositeColumnDefinition<TSelf>
     static virtual IColumn<CompositeItemModel<TKey>> CreateColumn<TKey>(
         Optional<string> columnHeader = default,
         Optional<ListSortDirection> sortDirection = default,
-        Optional<GridLength> width = default)
+        Optional<GridLength> width = default,
+        bool canUserSortColumn = true,
+        bool canUserResizeColumn = true)
         where TKey : notnull
     {
         return new CustomTemplateColumn<CompositeItemModel<TKey>>(
-            header: columnHeader.ValueOr(TSelf.GetColumnHeader()),
+            header: columnHeader.HasValue ? columnHeader.Value : TSelf.GetColumnHeader(),
             cellTemplateResourceKey: TSelf.GetColumnTemplateResourceKey(),
             options: new TemplateColumnOptions<CompositeItemModel<TKey>>
             {
-                CanUserSortColumn = true,
-                CanUserResizeColumn = true,
+                CanUserSortColumn = canUserSortColumn,
+                CanUserResizeColumn = canUserResizeColumn,
                 CompareAscending = static (a, b) => TSelf.Compare(Optional<CompositeItemModel<TKey>>.Create(a), b),
                 CompareDescending = static (a, b) => TSelf.Compare(Optional<CompositeItemModel<TKey>>.Create(b), a),
             },

--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/IItemModelComponent.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/IItemModelComponent.cs
@@ -42,10 +42,18 @@ public static partial class ColumnCreator
     public static IColumn<CompositeItemModel<TKey>> Create<TKey, TColumn>(
         Optional<string> columnHeader = default,
         Optional<ListSortDirection> sortDirection = default,
-        Optional<GridLength> width = default)
+        Optional<GridLength> width = default,
+        bool canUserSortColumn = true,
+        bool canUserResizeColumn = true)
         where TKey : notnull
         where TColumn : class, ICompositeColumnDefinition<TColumn>
     {
-        return TColumn.CreateColumn<TKey>(columnHeader: columnHeader, sortDirection: sortDirection, width: width);
+        return TColumn.CreateColumn<TKey>(
+            columnHeader: columnHeader,
+            sortDirection: sortDirection,
+            width: width,
+            canUserSortColumn: canUserSortColumn,
+            canUserResizeColumn: canUserResizeColumn
+        );
     }
 }

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/ILoadOrderViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/ILoadOrderViewModel.cs
@@ -12,7 +12,7 @@ public interface ILoadOrderViewModel : IViewModelInterface
     /// <summary>
     /// TreeDataGridAdapter for the Load Order, for setting up the TreeDataGrid
     /// </summary>
-    TreeDataGridAdapter<ILoadOrderItemModel, Guid> Adapter { get; }
+    TreeDataGridAdapter<CompositeItemModel<Guid>, Guid> Adapter { get; }
     
     /// <summary>
     /// Name of this sort order type

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderItemModel.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderItemModel.cs
@@ -34,7 +34,7 @@ public class LoadOrderItemModel : TreeDataGridItemModel<ILoadOrderItemModel, Gui
         ISortableItem sortableItem,
         IObservable<ListSortDirection> sortDirectionObservable,
         IObservable<int> lastIndexObservable,
-        Subject<MoveUpDownCommandPayload> commandSubject)
+        Subject<MoveUpCommandPayload> commandSubject)
     {
         InnerItem = sortableItem;
         SortIndex = sortableItem.SortIndex;
@@ -82,7 +82,7 @@ public class LoadOrderItemModel : TreeDataGridItemModel<ILoadOrderItemModel, Gui
         MoveUp = ReactiveUI.ReactiveCommand.Create(() =>
             {
                 var delta = _sortDirection == ListSortDirection.Ascending ? -1 : +1;
-                commandSubject.OnNext(new MoveUpDownCommandPayload(this, delta));
+                // commandSubject.OnNext(new MoveUpDownCommandPayload(this, delta));
             },
             canExecuteUp
         );
@@ -90,7 +90,7 @@ public class LoadOrderItemModel : TreeDataGridItemModel<ILoadOrderItemModel, Gui
         MoveDown = ReactiveUI.ReactiveCommand.Create(() =>
             {
                 var delta = _sortDirection == ListSortDirection.Ascending ? +1 : -1;
-                commandSubject.OnNext(new MoveUpDownCommandPayload(this, delta));
+                // commandSubject.OnNext(new MoveUpDownCommandPayload(this, delta));
             },
             canExecuteDown
         );

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderView.axaml.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderView.axaml.cs
@@ -17,7 +17,7 @@ public partial class LoadOrderView : ReactiveUserControl<ILoadOrderViewModel>
 
         this.WhenActivated(disposables =>
             {
-                TreeDataGridViewHelper.SetupTreeDataGridAdapter<LoadOrderView, ILoadOrderViewModel, ILoadOrderItemModel, Guid>(
+                TreeDataGridViewHelper.SetupTreeDataGridAdapter<LoadOrderView, ILoadOrderViewModel, CompositeItemModel<Guid>, Guid>(
                     this,
                     SortOrderTreeDataGrid,
                     vm => vm.Adapter

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderViewModel.cs
@@ -3,8 +3,8 @@ using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using Avalonia.Controls.Models.TreeDataGrid;
 using DynamicData;
-using DynamicData.Aggregation;
 using DynamicData.Binding;
+using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.Games;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Settings;
@@ -16,9 +16,9 @@ using NexusMods.App.UI.Controls.Alerts;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
 using CompositeDisposable = System.Reactive.Disposables.CompositeDisposable;
-using Disposable = System.Reactive.Disposables.Disposable;
 using ReactiveCommand = ReactiveUI.ReactiveCommand;
 using Unit = System.Reactive.Unit;
+using OneOf;
 
 namespace NexusMods.App.UI.Pages.Sorting;
 
@@ -41,11 +41,12 @@ public class LoadOrderViewModel : AViewModel<ILoadOrderViewModel>, ILoadOrderVie
 
     public AlertSettingsWrapper AlertSettingsWrapper { get; }
 
-    public TreeDataGridAdapter<ILoadOrderItemModel, Guid> Adapter { get; }
+    public TreeDataGridAdapter<CompositeItemModel<Guid>, Guid> Adapter { get; }
 
-    public LoadOrderViewModel(LoadoutId loadoutId, ISortableItemProviderFactory itemProviderFactory, ISettingsManager settingsManager)
+    public LoadOrderViewModel(LoadoutId loadoutId, ISortableItemProviderFactory itemProviderFactory, IServiceProvider serviceProvider)
     {
         var provider = itemProviderFactory.GetLoadoutSortableItemProvider(loadoutId);
+        var settingsManager = serviceProvider.GetRequiredService<ISettingsManager>();
 
         SortOrderName = itemProviderFactory.SortOrderName;
         SortOrderHeading = itemProviderFactory.SortOrderHeading;
@@ -69,7 +70,7 @@ public class LoadOrderViewModel : AViewModel<ILoadOrderViewModel>, ILoadOrderVie
             .QueryWhenChanged(query => !query.Items.Any() ? 0 : query.Items.Max(item => item.SortIndex))
             .Publish(!provider.SortableItems.Any() ? 0 : provider.SortableItems.Max(item => item.SortIndex));
 
-        var adapter = new LoadOrderTreeDataGridAdapter(provider, sortDirectionObservable, lastIndexObservable);
+        var adapter = new LoadOrderTreeDataGridAdapter(provider, sortDirectionObservable, serviceProvider);
         Adapter = adapter;
         Adapter.ViewHierarchical.Value = true;
 
@@ -110,8 +111,24 @@ public class LoadOrderViewModel : AViewModel<ILoadOrderViewModel>, ILoadOrderVie
                 adapter.MessageSubject
                     .SubscribeAwait(async (payload, cancellationToken) =>
                         {
-                            var (item, delta) = payload;
-                            await provider.SetRelativePosition(((LoadOrderItemModel)item).InnerItem, delta, cancellationToken);
+                            var (item, delta) = payload.Match(
+                                moveUpPayload =>
+                                {
+                                    var deltaUp = SortDirectionCurrent == ListSortDirection.Ascending ? -1 : +1;
+                                    return (provider.GetSortableItem(moveUpPayload.Item.Key), deltaUp);
+                                },
+                                moveDownPayload =>
+                                {
+                                    var deltaDown = SortDirectionCurrent == ListSortDirection.Ascending ? +1 : -1;
+                                    return (provider.GetSortableItem(moveDownPayload.Item.Key), deltaDown);
+                                }
+                            );
+                            
+                            if (!item.HasValue)
+                            {
+                                return;
+                            }
+                            await provider.SetRelativePosition(item.Value, delta, cancellationToken);
                         }
                     )
                     .DisposeWith(d);
@@ -120,42 +137,44 @@ public class LoadOrderViewModel : AViewModel<ILoadOrderViewModel>, ILoadOrderVie
     }
 }
 
-public readonly record struct MoveUpDownCommandPayload(ILoadOrderItemModel Item, int Delta);
+public readonly record struct MoveUpCommandPayload(CompositeItemModel<Guid> Item);
+public readonly record struct MoveDownCommandPayload(CompositeItemModel<Guid> Item);
 
-public class LoadOrderTreeDataGridAdapter : TreeDataGridAdapter<ILoadOrderItemModel, Guid>,
-    ITreeDataGirdMessageAdapter<MoveUpDownCommandPayload>
+
+public class LoadOrderTreeDataGridAdapter : TreeDataGridAdapter<CompositeItemModel<Guid>, Guid>,
+    ITreeDataGirdMessageAdapter<OneOf<MoveUpCommandPayload, MoveDownCommandPayload>>
 {
     private readonly ILoadoutSortableItemProvider _sortableItemsProvider;
-    private readonly IObservable<ListSortDirection> _sortDirectionObservable;
-    private readonly IObservable<int> _lastIndexObservable;
+    private readonly R3.Observable<ListSortDirection> _sortDirectionObservable;
     private readonly CompositeDisposable _disposables = new();
-    private readonly IObservable<ISortedChangeSet<ILoadOrderItemModel, Guid>> _sortedItems;
+    private readonly IObservable<ISortedChangeSet<CompositeItemModel<Guid>, Guid>> _sortedItems;
+    private readonly ILoadOrderDataProvider[] _loadOrderDataProviders;
 
-    public Subject<MoveUpDownCommandPayload> MessageSubject { get; } = new();
+    public Subject<OneOf<MoveUpCommandPayload, MoveDownCommandPayload>> MessageSubject { get; } = new();
     
-    private System.Reactive.Subjects.Subject<IComparer<ILoadOrderItemModel>> _resortSubject = new(); 
+    private System.Reactive.Subjects.Subject<IComparer<CompositeItemModel<Guid>>> _resortSubject = new(); 
 
     public LoadOrderTreeDataGridAdapter(
         ILoadoutSortableItemProvider sortableItemsProvider,
         IObservable<ListSortDirection> sortDirectionObservable,
-        IObservable<int> lastIndexObservable)
+        IServiceProvider serviceProvider)
     {
         _sortableItemsProvider = sortableItemsProvider;
-        _sortDirectionObservable = sortDirectionObservable;
-        _lastIndexObservable = lastIndexObservable;
+        _sortDirectionObservable = sortDirectionObservable.ToObservable();
 
-        var itemsChangeSet = _sortableItemsProvider.SortableItemsChangeSet
-            .Transform(ILoadOrderItemModel (item) => new LoadOrderItemModel(
-                    item,
-                    _sortDirectionObservable,
-                    _lastIndexObservable,
-                    MessageSubject
-                )
-            );
+        _loadOrderDataProviders = serviceProvider.GetServices<ILoadOrderDataProvider>().ToArray();
         
-        var ascendingComparer = SortExpressionComparer<ILoadOrderItemModel>.Ascending(item => item.SortIndex);
-        var descendingComparer = SortExpressionComparer<ILoadOrderItemModel>.Descending(item => item.SortIndex);
-        var comparerObservable = _sortDirectionObservable.Select(sortDirection =>
+        var itemsChangeSet = _loadOrderDataProviders
+            .Select(x => x.ObserveLoadOrder(_sortableItemsProvider, _sortDirectionObservable)).MergeChangeSets();
+        
+        var ascendingComparer = SortExpressionComparer<CompositeItemModel<Guid>>.Ascending(
+            item => item.Get<LoadOrderComponents.IndexComponent>(LoadOrderColumns.IndexColumn.IndexComponentKey).SortIndex.Value
+        );
+        var descendingComparer = SortExpressionComparer<CompositeItemModel<Guid>>.Descending(
+            item => item.Get<LoadOrderComponents.IndexComponent>(LoadOrderColumns.IndexColumn.IndexComponentKey).SortIndex.Value
+        );
+        
+        var comparerObservable = sortDirectionObservable.Select(sortDirection =>
             {
                 return sortDirection == ListSortDirection.Ascending
                     ? ascendingComparer
@@ -188,59 +207,62 @@ public class LoadOrderTreeDataGridAdapter : TreeDataGridAdapter<ILoadOrderItemMo
         activationDisposable.DisposeWith(_disposables);
     }
 
-    protected override IObservable<IChangeSet<ILoadOrderItemModel, Guid>> GetRootsObservable(bool viewHierarchical)
+    protected override void BeforeModelActivationHook(CompositeItemModel<Guid> model)
+    {
+        base.BeforeModelActivationHook(model);
+
+        model.SubscribeToComponentAndTrack<LoadOrderComponents.IndexComponent, LoadOrderTreeDataGridAdapter>(
+            key: LoadOrderColumns.IndexColumn.IndexComponentKey,
+            state: this,
+            factory: static (adapter, itemModel, component) => component.MoveUp
+                .Subscribe((adapter, itemModel, component),
+                    static (_, tuple) =>
+                    {
+                        var (adapter, itemModel, _) = tuple;
+                        adapter.MessageSubject.OnNext(new MoveUpCommandPayload(itemModel));
+                    }
+                )
+        );
+        
+        model.SubscribeToComponentAndTrack<LoadOrderComponents.IndexComponent, LoadOrderTreeDataGridAdapter>(
+            key: LoadOrderColumns.IndexColumn.IndexComponentKey,
+            state: this,
+            factory: static (adapter, itemModel, component) => component.MoveDown
+                .Subscribe((adapter, itemModel, component),
+                    static (_, tuple) =>
+                    {
+                        var (adapter, itemModel, _) = tuple;
+                        adapter.MessageSubject.OnNext(new MoveDownCommandPayload(itemModel));
+                    }
+                )
+        );
+    }
+    
+
+    protected override IObservable<IChangeSet<CompositeItemModel<Guid>, Guid>> GetRootsObservable(bool viewHierarchical)
     {
         return _sortedItems;
     }
 
-    protected override IColumn<ILoadOrderItemModel>[] CreateColumns(bool viewHierarchical)
+    protected override IColumn<CompositeItemModel<Guid>>[] CreateColumns(bool viewHierarchical)
     {
+        var indexColumn = ColumnCreator.Create<Guid, LoadOrderColumns.IndexColumn>(
+            columnHeader: _sortableItemsProvider.ParentFactory.IndexColumnHeader,
+            canUserSortColumn: false,
+            canUserResizeColumn: false
+        );
+        
+        var expanderColumn = ITreeDataGridItemModel<CompositeItemModel<Guid>, Guid>.CreateExpanderColumn(indexColumn);
+
         return
         [
-            // TODO: Use <see cref="ColumnCreator"/> to create the columns using interfaces
-            new HierarchicalExpanderColumn<ILoadOrderItemModel>(
-                inner: CreateIndexColumn(_sortableItemsProvider.ParentFactory.IndexColumnHeader),
-                childSelector: static model => model.Children,
-                hasChildrenSelector: static model => model.HasChildren.Value,
-                isExpandedSelector: static model => model.IsExpanded
-            )
-            {
-                Tag = "expander",
-            },
-            CreateNameColumn(_sortableItemsProvider.ParentFactory.NameColumnHeader),
+            expanderColumn,
+            ColumnCreator.Create<Guid, LoadOrderColumns.NameColumn>(
+                columnHeader: _sortableItemsProvider.ParentFactory.NameColumnHeader,
+                canUserSortColumn: false,
+                canUserResizeColumn: false
+            ),
         ];
-    }
-
-    internal static IColumn<ILoadOrderItemModel> CreateIndexColumn(string headerName)
-    {
-        return new CustomTemplateColumn<ILoadOrderItemModel>(
-            header: headerName,
-            cellTemplateResourceKey: "LoadOrderItemIndexColumnTemplate",
-            options: new TemplateColumnOptions<ILoadOrderItemModel>
-            {
-                CanUserSortColumn = false,
-                CanUserResizeColumn = false,
-            }
-        )
-        {
-            Id = "Index",
-        };
-    }
-
-    internal static IColumn<ILoadOrderItemModel> CreateNameColumn(string headerName)
-    {
-        return new CustomTemplateColumn<ILoadOrderItemModel>(
-            header: headerName,
-            cellTemplateResourceKey: "LoadOrderItemNameColumnTemplate",
-            options: new TemplateColumnOptions<ILoadOrderItemModel>
-            {
-                CanUserSortColumn = false,
-                CanUserResizeColumn = false,
-            }
-        )
-        {
-            Id = "Name",
-        };
     }
 
     private bool _isDisposed;

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGridLoadOrderResources.axaml
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGridLoadOrderResources.axaml
@@ -5,45 +5,47 @@
                     xmlns:controls="clr-namespace:NexusMods.App.UI.Controls"
                     xmlns:system="clr-namespace:System;assembly=System.Runtime">
 
-    <DataTemplate x:Key="LoadOrderItemIndexColumnTemplate"
-                  DataType="local:ILoadOrderItemModel">
-
-        <StackPanel x:Name="LoadOrderItemIndexColumnStack" Orientation="Horizontal" Spacing="12">
-            <controls:StandardButton x:Name="UpButton"
-                                     Command="{CompiledBinding MoveUp}"
-                                     LeftIcon="{x:Static icons:IconValues.ArrowUp}"
-                                     ShowIcon="IconOnly"
-                                     Size="Medium"
-                                     Type="Tertiary"
-                                     Fill="None" />
-            <Border x:Name="ItemIndexBorder">
-                <TextBlock x:Name="ItemIndex" Text="{CompiledBinding DisplaySortIndex}" />
-            </Border>
-            <controls:StandardButton x:Name="DownButton"
-                                     Command="{CompiledBinding MoveDown}"
-                                     LeftIcon="{x:Static icons:IconValues.ArrowDown}"
-                                     ShowIcon="IconOnly"
-                                     Size="Medium"
-                                     Type="Tertiary"
-                                     Fill="None" />
-            <Border x:Name="ItemIndexSeparator" />
-        </StackPanel>
-    </DataTemplate>
-
-    <DataTemplate x:Key="LoadOrderItemNameColumnTemplate"
-                  DataType="local:ILoadOrderItemModel">
-
-        <StackPanel x:Name="LoadOrderItemNameColumnStack" Orientation="Horizontal" Spacing="12">
-
-            <Border x:Name="ItemModImageBorder">
-                <icons:UnifiedIcon Value="{x:Static icons:IconValues.Nexus}" />
-            </Border>
-            <StackPanel Orientation="Vertical" VerticalAlignment="Center">
-                <TextBlock x:Name="ModName" Text="{CompiledBinding ModName}" />
-                <TextBlock x:Name="DisplayName" Text="{CompiledBinding DisplayName}" />
-            </StackPanel>
-        </StackPanel>
-    </DataTemplate>
+    <!-- TODO: remove these after styling has been fixed for the new composite based columns -->
+    <!-- Only left here as reference -->
+    <!-- <DataTemplate x:Key="LoadOrderItemIndexColumnTemplate" -->
+    <!--               DataType="local:ILoadOrderItemModel"> -->
+    <!-- -->
+    <!--     <StackPanel x:Name="LoadOrderItemIndexColumnStack" Orientation="Horizontal" Spacing="12"> -->
+    <!--         <controls:StandardButton x:Name="UpButton" -->
+    <!--                                  Command="{CompiledBinding MoveUp}" -->
+    <!--                                  LeftIcon="{x:Static icons:IconValues.ArrowUp}" -->
+    <!--                                  ShowIcon="IconOnly" -->
+    <!--                                  Size="Medium" -->
+    <!--                                  Type="Tertiary" -->
+    <!--                                  Fill="None" /> -->
+    <!--         <Border x:Name="ItemIndexBorder"> -->
+    <!--             <TextBlock x:Name="ItemIndex" Text="{CompiledBinding DisplaySortIndex}" /> -->
+    <!--         </Border> -->
+    <!--         <controls:StandardButton x:Name="DownButton" -->
+    <!--                                  Command="{CompiledBinding MoveDown}" -->
+    <!--                                  LeftIcon="{x:Static icons:IconValues.ArrowDown}" -->
+    <!--                                  ShowIcon="IconOnly" -->
+    <!--                                  Size="Medium" -->
+    <!--                                  Type="Tertiary" -->
+    <!--                                  Fill="None" /> -->
+    <!--         <Border x:Name="ItemIndexSeparator" /> -->
+    <!--     </StackPanel> -->
+    <!-- </DataTemplate> -->
+    <!-- -->
+    <!-- <DataTemplate x:Key="LoadOrderItemNameColumnTemplate" -->
+    <!--               DataType="local:ILoadOrderItemModel"> -->
+    <!-- -->
+    <!--     <StackPanel x:Name="LoadOrderItemNameColumnStack" Orientation="Horizontal" Spacing="12"> -->
+    <!-- -->
+    <!--         <Border x:Name="ItemModImageBorder"> -->
+    <!--             <icons:UnifiedIcon Value="{x:Static icons:IconValues.Nexus}" /> -->
+    <!--         </Border> -->
+    <!--         <StackPanel Orientation="Vertical" VerticalAlignment="Center"> -->
+    <!--             <TextBlock x:Name="ModName" Text="{CompiledBinding ModName}" /> -->
+    <!--             <TextBlock x:Name="DisplayName" Text="{CompiledBinding DisplayName}" /> -->
+    <!--         </StackPanel> -->
+    <!--     </StackPanel> -->
+    <!-- </DataTemplate> -->
 
     <!-- Composite columns -->
     <!-- Index Column -->

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGridLoadOrderResources.axaml
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGridLoadOrderResources.axaml
@@ -53,7 +53,8 @@
         </DataTemplate.DataType>
         
         <!-- IndexComponent -->
-        <controls:ComponentControl x:TypeArguments="system:Guid">
+        <controls:ComponentControl x:TypeArguments="system:Guid" 
+                                   Content="{CompiledBinding}">
             <controls:ComponentControl.ComponentTemplate>
                 <controls:ComponentTemplate x:TypeArguments="local:LoadOrderComponents+IndexComponent"
                                    ComponentKey="{x:Static local:LoadOrderColumns+IndexColumn.IndexComponentKey}">
@@ -103,7 +104,8 @@
             <StackPanel Orientation="Vertical" VerticalAlignment="Center">
                 
                 <!-- ModName -->
-                <controls:ComponentControl x:TypeArguments="system:Guid">
+                <controls:ComponentControl x:TypeArguments="system:Guid"
+                                           Content="{CompiledBinding}">
                     <controls:ComponentControl.ComponentTemplate>
                         <controls:ComponentTemplate x:TypeArguments="controls:StringComponent"
                                                     ComponentKey="{x:Static local:LoadOrderColumns+NameColumn.ModNameComponentKey}">
@@ -119,7 +121,8 @@
                 </controls:ComponentControl>
                 
                 <!-- DisplayName -->
-                <controls:ComponentControl x:TypeArguments="system:Guid">
+                <controls:ComponentControl x:TypeArguments="system:Guid"
+                                           Content="{CompiledBinding}">
                     <controls:ComponentControl.ComponentTemplate>
                         <controls:ComponentTemplate x:TypeArguments="controls:StringComponent"
                                                     ComponentKey="{x:Static local:LoadOrderColumns+NameColumn.NameComponentKey}">

--- a/src/NexusMods.App.UI/Pages/Sorting/SortingSelection/SortingSelectionViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/SortingSelection/SortingSelectionViewModel.cs
@@ -2,7 +2,6 @@ using System.Collections.ObjectModel;
 using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.Games;
 using NexusMods.Abstractions.Loadouts;
-using NexusMods.Abstractions.Settings;
 using NexusMods.Abstractions.UI;
 using NexusMods.MnemonicDB.Abstractions;
 
@@ -12,14 +11,12 @@ public class SortingSelectionViewModel : AViewModel<ISortingSelectionViewModel>,
 {
     private readonly LoadoutId _loadoutId;
     private readonly IConnection _connection;
-    private readonly ISettingsManager _settingsManager;
     public ReadOnlyObservableCollection<ILoadOrderViewModel> LoadOrderViewModels { get; }
 
     public SortingSelectionViewModel(IServiceProvider serviceProvider, LoadoutId loadutId)
     {
         _loadoutId = loadutId;
         _connection = serviceProvider.GetRequiredService<IConnection>();
-        _settingsManager = serviceProvider.GetRequiredService<ISettingsManager>();
 
         var loadout = Loadout.Load(_connection.Db, _loadoutId);
         var sortableItemProviders = loadout
@@ -29,7 +26,7 @@ public class SortingSelectionViewModel : AViewModel<ISortingSelectionViewModel>,
 
         LoadOrderViewModels = new ReadOnlyObservableCollection<ILoadOrderViewModel>(
             new ObservableCollection<ILoadOrderViewModel>(
-                sortableItemProviders.Select(provider => new LoadOrderViewModel(_loadoutId, provider, _settingsManager))
+                sortableItemProviders.Select(provider => new LoadOrderViewModel(_loadoutId, provider, serviceProvider))
             )
         );
     }

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/TreeDataGridBaseStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/TreeDataGridBaseStyles.axaml
@@ -3,9 +3,7 @@
         xmlns:converters1="clr-namespace:NexusMods.Themes.NexusFluentDark.Converters"
         xmlns:icons="clr-namespace:NexusMods.Icons;assembly=NexusMods.Icons"
         xmlns:files="clr-namespace:NexusMods.App.UI.Controls.Trees.Files;assembly=NexusMods.App.UI"
-        xmlns:converters="clr-namespace:NexusMods.App.UI.Converters;assembly=NexusMods.App.UI"
-        xmlns:controls="clr-namespace:NexusMods.App.UI.Controls;assembly=NexusMods.App.UI"
-        xmlns:system="clr-namespace:System;assembly=System.Runtime">
+        xmlns:converters="clr-namespace:NexusMods.App.UI.Converters;assembly=NexusMods.App.UI">
 
     <Design.PreviewWith>
         <Border Classes="Low" Padding="16">
@@ -28,25 +26,24 @@
         
         <!-- TODO: Fix this to work with CompositeItemModel<Guid>-->
         <!-- needs to be a resource and not set by a style so we can add Clasess based on DataContext -->
-        <!-- <ControlTemplate x:Key="LoadOrderItemTreeRowTemplate" -->
-        <!--                  TargetType="TreeDataGridRow" -->
-        <!--                  x:DataType="controls:CompositeItemModel(system:Guid)"> -->
-        <!--     <Border x:Name="RowBorder" -->
-        <!--             Background="{TemplateBinding Background}" -->
-        <!--             BorderBrush="{TemplateBinding BorderBrush}" -->
-        <!--             BorderThickness="{TemplateBinding BorderThickness}" -->
-        <!--             CornerRadius="{TemplateBinding CornerRadius}" -->
-        <!--             Classes.IsActive="{CompiledBinding StyleFlags,  -->
-        <!--                 Converter={x:Static converters:CompositeStyleFlagConverter.Instance},  -->
-        <!--                 ConverterParameter=IsActive}" -->
-        <!--     > -->
-        <!--         <TreeDataGridCellsPresenter Name="PART_CellsPresenter" -->
-        <!--                                     CornerRadius="{TemplateBinding CornerRadius}" -->
-        <!--                                     ElementFactory="{TemplateBinding ElementFactory}" -->
-        <!--                                     Items="{TemplateBinding Columns}" -->
-        <!--                                     Rows="{TemplateBinding Rows}" /> -->
-        <!--     </Border> -->
-        <!-- </ControlTemplate> -->
+        <ControlTemplate x:Key="LoadOrderItemTreeRowTemplate"
+                         TargetType="TreeDataGridRow">
+            <Border x:Name="RowBorder"
+                    Background="{TemplateBinding Background}"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    BorderThickness="{TemplateBinding BorderThickness}"
+                    CornerRadius="{TemplateBinding CornerRadius}"
+                    >
+                    <!-- Classes.IsActive="{CompiledBinding StyleFlags, -->
+                    <!--     Converter={x:Static converters:CompositeStyleFlagConverter.Instance}, -->
+                    <!--     ConverterParameter=IsActive}"> -->
+                <TreeDataGridCellsPresenter Name="PART_CellsPresenter"
+                                            CornerRadius="{TemplateBinding CornerRadius}"
+                                            ElementFactory="{TemplateBinding ElementFactory}"
+                                            Items="{TemplateBinding Columns}"
+                                            Rows="{TemplateBinding Rows}" />
+            </Border>
+        </ControlTemplate>
 
 
         <!-- if we have this control theme here, we can override styles properly -->

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/TreeDataGridBaseStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/TreeDataGridBaseStyles.axaml
@@ -3,8 +3,9 @@
         xmlns:converters1="clr-namespace:NexusMods.Themes.NexusFluentDark.Converters"
         xmlns:icons="clr-namespace:NexusMods.Icons;assembly=NexusMods.Icons"
         xmlns:files="clr-namespace:NexusMods.App.UI.Controls.Trees.Files;assembly=NexusMods.App.UI"
-        xmlns:sorting="clr-namespace:NexusMods.App.UI.Pages.Sorting;assembly=NexusMods.App.UI"
-        xmlns:converters="clr-namespace:NexusMods.App.UI.Converters;assembly=NexusMods.App.UI">
+        xmlns:converters="clr-namespace:NexusMods.App.UI.Converters;assembly=NexusMods.App.UI"
+        xmlns:controls="clr-namespace:NexusMods.App.UI.Controls;assembly=NexusMods.App.UI"
+        xmlns:system="clr-namespace:System;assembly=System.Runtime">
 
     <Design.PreviewWith>
         <Border Classes="Low" Padding="16">
@@ -24,24 +25,28 @@
         <SolidColorBrush x:Key="TreeDataGridHeaderForegroundPointerOverBrush" Color="White" />
         <SolidColorBrush x:Key="TreeDataGridHeaderForegroundPressedBrush" Color="White" />
         <SolidColorBrush x:Key="TreeDataGridSelectedCellBackgroundBrush" Color="White" Opacity="0.4" />
-
+        
+        <!-- TODO: Fix this to work with CompositeItemModel<Guid>-->
         <!-- needs to be a resource and not set by a style so we can add Clasess based on DataContext -->
-        <ControlTemplate x:Key="LoadOrderItemTreeRowTemplate"
-                         TargetType="TreeDataGridRow"
-                         x:DataType="sorting:ILoadOrderItemModel">
-            <Border x:Name="RowBorder"
-                    Background="{TemplateBinding Background}"
-                    BorderBrush="{TemplateBinding BorderBrush}"
-                    BorderThickness="{TemplateBinding BorderThickness}"
-                    CornerRadius="{TemplateBinding CornerRadius}"
-                    Classes.IsActive="{CompiledBinding IsActive}">
-                <TreeDataGridCellsPresenter Name="PART_CellsPresenter"
-                                            CornerRadius="{TemplateBinding CornerRadius}"
-                                            ElementFactory="{TemplateBinding ElementFactory}"
-                                            Items="{TemplateBinding Columns}"
-                                            Rows="{TemplateBinding Rows}" />
-            </Border>
-        </ControlTemplate>
+        <!-- <ControlTemplate x:Key="LoadOrderItemTreeRowTemplate" -->
+        <!--                  TargetType="TreeDataGridRow" -->
+        <!--                  x:DataType="controls:CompositeItemModel(system:Guid)"> -->
+        <!--     <Border x:Name="RowBorder" -->
+        <!--             Background="{TemplateBinding Background}" -->
+        <!--             BorderBrush="{TemplateBinding BorderBrush}" -->
+        <!--             BorderThickness="{TemplateBinding BorderThickness}" -->
+        <!--             CornerRadius="{TemplateBinding CornerRadius}" -->
+        <!--             Classes.IsActive="{CompiledBinding StyleFlags,  -->
+        <!--                 Converter={x:Static converters:CompositeStyleFlagConverter.Instance},  -->
+        <!--                 ConverterParameter=IsActive}" -->
+        <!--     > -->
+        <!--         <TreeDataGridCellsPresenter Name="PART_CellsPresenter" -->
+        <!--                                     CornerRadius="{TemplateBinding CornerRadius}" -->
+        <!--                                     ElementFactory="{TemplateBinding ElementFactory}" -->
+        <!--                                     Items="{TemplateBinding Columns}" -->
+        <!--                                     Rows="{TemplateBinding Rows}" /> -->
+        <!--     </Border> -->
+        <!-- </ControlTemplate> -->
 
 
         <!-- if we have this control theme here, we can override styles properly -->


### PR DESCRIPTION
- Part of #2885 

This actually moves the view over to using the new `CompositeItemModel` based tree items and updates all the functionality and bindings to work with the new system.

Some styling fixes work is going to be necessary, after which the leftover code from the previous approach can be cleaned up.

In particular, the `IsActive` styling has some issues due to `x:DataType` not being able to accept Types with type parameters correctly:
- https://github.com/AvaloniaUI/Avalonia/pull/18379
PR is merged but not released yet.