### PR TITLE
Remove DebugAssert that checks for disposed item in TreeDataGridItemModel GetChildren

### DIFF
--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridItemModel.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridItemModel.cs
@@ -74,9 +74,7 @@ public class TreeDataGridItemModel<TModel, TKey> : TreeDataGridItemModel, ITreeD
         get
         {
             // NOTE(erri120): When this item model gets disposed, all children get disposed, and then
-            // we clear the children observable list which triggers the TreeDataGrid. If HasChildren
-            // is still True, TreeDataGrid will try and access this which won't work because we're disposed.
-            Debug.Assert(!_isDisposed);
+            // we clear the children observable list which can trigger the TreeDataGrid to access this.
             if (_isDisposed) return [];
             _childrenCollectionInitialization.OnNext(true);
             return _childrenView;


### PR DESCRIPTION
- fixes #2804 

The access to the children is expected and not avoidable after they are cleared, so the assert can be removed.