### PR TITLE
Update outgoing Nexus Mods links

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/Models/CollectionMetadata.cs
+++ b/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/Models/CollectionMetadata.cs
@@ -79,9 +79,4 @@ public partial class CollectionMetadata : IModelDefinition
     /// The background image resource.
     /// </summary>
     public static readonly ReferenceAttribute<PersistedDbResource> BackgroundImageResource = new(Namespace, nameof(BackgroundImageResource)) { IsOptional = true };
-
-    public partial struct ReadOnly
-    {
-        public Uri GetUri(GameDomain gameDomain) => NexusModsUrlBuilder.CreateCollectionsUri(gameDomain, Slug);
-    }
 }

--- a/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/Models/CollectionRevisionMetadata.cs
+++ b/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/Models/CollectionRevisionMetadata.cs
@@ -53,21 +53,4 @@ public partial class CollectionRevisionMetadata : IModelDefinition
     /// The total number of ratings this revision has.
     /// </summary>
     public static readonly UInt64Attribute TotalRatings = new(Namespace, nameof(TotalRatings)) { IsOptional = true };
-    
-    public partial struct ReadOnly
-    {
-        /// <summary>
-        /// The URL to the Nexus Mods page for this collection revision.
-        /// </summary>
-        /// <param name="gameDomain">The game domain for the collection.</param>
-        /// <returns>The URI to the collection revision page.</returns>
-        public Uri GetUri(GameDomain gameDomain) => NexusModsUrlBuilder.CreateCollectionRevisionUri(gameDomain, Collection.Slug, RevisionNumber);
-
-        /// <summary>
-        /// The URL to the Nexus Mods bugs page for this collection revision.
-        /// </summary>
-        /// <param name="gameDomain">The game domain for the collection.</param>
-        /// <returns>The URI to the collection revision bugs page.</returns>
-        public Uri GetBugsUri(GameDomain gameDomain) => NexusModsUrlBuilder.CreateCollectionRevisionBugsUri(gameDomain, Collection.Slug, RevisionNumber);
-    }
 }

--- a/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/NexusModsFileMetadata.cs
+++ b/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/NexusModsFileMetadata.cs
@@ -48,15 +48,4 @@ public partial class NexusModsFileMetadata : IModelDefinition
     /// Library Files that link to this file.
     /// </summary>
     public static readonly BackReferenceAttribute<NexusModsLibraryItem> LibraryFiles = new(NexusModsLibraryItem.FileMetadata);
-
-    public partial struct ReadOnly
-    {
-        public Uri GetUri()
-        {
-            // NOTE(erri120): This URI shows a single download button for the exact file
-            // The nmm=1 turns the button into a nxm:// link, without nmm=1 the button will download the file through the browser
-            // Example: https://www.nexusmods.com/stardewvalley/mods/29140?tab=files&file_id=115276&nmm=1
-            return NexusModsUrlBuilder.CreateGenericUri($"{ModPage.GetBaseUrl()}?tab=files&file_id={Uid.FileId}&nmm=1");
-        }
-    }
 }

--- a/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/NexusModsModPageMetadata.cs
+++ b/src/Abstractions/NexusMods.Abstractions.NexusModsLibrary/NexusModsModPageMetadata.cs
@@ -63,10 +63,4 @@ public partial class NexusModsModPageMetadata : IModelDefinition
     /// Back-reference to all files from this page.
     /// </summary>
     public static readonly BackReferenceAttribute<NexusModsFileMetadata> Files = new(NexusModsFileMetadata.ModPage);
-
-    public partial struct ReadOnly
-    {
-        public string GetBaseUrl() => $"https://nexusmods.com/{GameDomain}/mods/{Uid.ModId}";
-        public Uri GetUri() => NexusModsUrlBuilder.CreateGenericUri(GetBaseUrl());
-    }
 }

--- a/src/Abstractions/NexusMods.Abstractions.Telemetry/NexusModsURLBuilder.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Telemetry/NexusModsURLBuilder.cs
@@ -1,3 +1,4 @@
+using DynamicData.Kernel;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.WebUtilities;
 using NexusMods.Abstractions.NexusWebApi.Types;
@@ -5,15 +6,16 @@ using NexusMods.Abstractions.NexusWebApi.Types.V2;
 
 namespace NexusMods.Abstractions.Telemetry;
 
-// NOTE(erri120): This class consolidates all URL tracking parameter related
-// functionality. Anything that exposes a URL to the user that points to
-// Nexus Mods should use this class.
-// Everything in here is hardcoded and parameter values shouldn't be changed.
-// New methods can be added after talking with the team about this.
-
+/// NOTE(erri120): This class consolidates all URL tracking parameter related
+/// functionality. Anything that exposes a URL to the user that points to
+/// Nexus Mods should use this class.
+/// Everything in here is hardcoded and parameter values shouldn't be changed.
+/// New methods can be added after talking with the team about this.
 [PublicAPI]
 public static class NexusModsUrlBuilder
 {
+    private const string BaseUrl = "https://www.nexusmods.com";
+    private const string UsersBaseUrl = "https://users.nexusmods.com";
     private const string ParameterValueSource = "nexusmodsapp";
 
     // From https://matomo.org/faq/reports/what-is-campaign-tracking-and-why-it-is-important/
@@ -25,13 +27,33 @@ public static class NexusModsUrlBuilder
     private const string ParameterNameGroup    = "mtm_group";
 
     /// <summary>
+    /// Campaign value for everything related to updating mods in the app.
+    /// </summary>
+    public const string CampaignUpdates = "updates";
+
+    /// <summary>
+    /// Campaign value for everything related to using collections in the app.
+    /// </summary>
+    public const string CampaignCollections = "collections";
+
+    /// <summary>
+    /// Campaign value for everything related to Nexus Mods Premium.
+    /// </summary>
+    public const string CampaignPremium = "premium";
+
+    /// <summary>
+    /// Campaign values for everything related to diagnostics.
+    /// </summary>
+    public const string CampaignDiagnostics = "diagnostics";
+
+    /// <summary>
     /// Creates a new URI by adding tracking parameters to the given <paramref name="baseUrl"/>.
     /// </summary>
-    public static Uri CreateUri(string baseUrl, string? campaign = null, string? medium = null)
+    public static Uri CreateUri(string baseUrl, string? source = ParameterValueSource, string? campaign = null, string? medium = null)
     {
         var parameters = new Dictionary<string, string?>
         {
-            { ParameterNameSource, ParameterValueSource },
+            { ParameterNameSource, source },
             { ParameterNameCampaign, campaign },
             { ParameterNameMedium, medium },
         };
@@ -41,42 +63,93 @@ public static class NexusModsUrlBuilder
     }
 
     /// <summary>
-    /// Creates a new URI by adding tracking parameters to the given <paramref name="baseUrl"/>.
+    /// Uri for the user settings page.
+    /// </summary>
+    /// <example>
+    /// <c>https://users.nexusmods.com</c>
+    /// </example>
+    public static readonly Uri UserSettingsUri = CreateUri(UsersBaseUrl);
+
+    /// <summary>
+    /// Returns a URI for a user profile.
+    /// </summary>
+    public static Uri GetProfileUri(UserId userId, string? source = ParameterValueSource, string? campaign = null)
+    {
+        // https://www.nexusmods.com/users/6672467
+        var url = $"{BaseUrl}/users/{userId}";
+        return CreateUri(url, source: source, campaign: campaign);
+    }
+
+    /// <summary>
+    /// Returns a URI for a game page.
+    /// </summary>
+    public static Uri GetGameUri(GameDomain gameDomain, string? source = ParameterValueSource, string? campaign = null)
+    {
+        // https://www.nexusmods.com/games/stardewvalley
+        var url = $"{BaseUrl}/games/{gameDomain}";
+        return CreateUri(url, source: source, campaign: campaign);
+    }
+
+    /// <summary>
+    /// Returns a URI for a mod page.
+    /// </summary>
+    public static Uri GetModUri(GameDomain gameDomain, ModId modId, string? source = ParameterValueSource, string? campaign = null)
+    {
+        // https://www.nexusmods.com/stardewvalley/mods/2400
+        var url = $"{BaseUrl}/{gameDomain}/mods/{modId}";
+        return CreateUri(url, source: source, campaign: campaign);
+    }
+
+    /// <summary>
+    /// Returns a URI for a file download page.
     /// </summary>
     /// <remarks>
-    /// Use this method if you have a generic URL to Nexus Mods.
+    /// <paramref name="useNxmLink"/> changes how the download button on the page behaves. If set to
+    /// <c>true</c>, the download button will open an NXM link, if set to <c>false</c> the download
+    /// will happen in the browser.
     /// </remarks>
-    public static Uri CreateGenericUri(string baseUrl) => CreateUri(baseUrl);
-
-    /// <summary>
-    /// Creates a Uri that sends the user to the website to download a file.
-    /// This file will be installed via the NXM handler.
-    /// </summary>
-    /// <param name="fileId">Unique ID for a mod file associated with a game, <see cref="FileId"/>.</param>
-    /// <param name="gameId">Unique identifier for an individual game hosted on Nexus.</param>
-    /// <param name="withNxm">True if to use nxm handler, else false.</param>
-    public static Uri CreateModFileDownloadUri(FileId fileId, GameId gameId, bool withNxm = true)
+    public static Uri GetFileDownloadUri(GameDomain gameDomain, ModId modId, FileId fileId, bool useNxmLink, string? source = ParameterValueSource, string? campaign = null)
     {
-        return CreateUri($"https://www.nexusmods.com/Core/Libs/Common/Widgets/DownloadPopUp?id={fileId}&game_id={gameId}&nmm={Convert.ToInt32(withNxm)}");
+        // https://www.nexusmods.com/stardewvalley/mods/2400?tab=files&file_id=128328&nmm=0
+        // https://www.nexusmods.com/stardewvalley/mods/2400?tab=files&file_id=128328&nmm=1
+        var url = $"{BaseUrl}/{gameDomain}/mods/{modId}?tab=files&file_id={fileId}&nmm={Convert.ToInt32(useNxmLink)}";
+        return CreateUri(url, source: source, campaign: campaign);
     }
 
-    public static Uri CreateCollectionsUri(GameDomain gameDomain, CollectionSlug collectionSlug) => CreateUri($"https://next.nexusmods.com/{gameDomain}/collections/{collectionSlug}", campaign: "collections");
-
-    public static Uri CreateCollectionRevisionUri(GameDomain gameDomain, CollectionSlug collectionSlug, RevisionNumber revisionNumber) => CreateUri($"https://next.nexusmods.com/{gameDomain}/collections/{collectionSlug}/revisions/{revisionNumber}", campaign: "collections");
-   
-    public static Uri CreateCollectionRevisionBugsUri(GameDomain gameDomain, CollectionSlug collectionSlug, RevisionNumber revisionNumber) => CreateUri($"https://next.nexusmods.com/{gameDomain}/collections/{collectionSlug}/revisions/{revisionNumber}/bugs", campaign: "collections");
-    
-    public static Uri LearAboutPremiumUri => CreateUri("https://next.nexusmods.com/premium");
-
-    public static Uri UpgradeToPremiumUri => CreateUri("https://users.nexusmods.com/account/billing/premium");
+    /// <summary>
+    /// Returns a URI for a collection page.
+    /// </summary>
+    public static Uri GetCollectionUri(GameDomain gameDomain, CollectionSlug collectionSlug, Optional<RevisionNumber> revisionNumber, string? source = ParameterValueSource, string? campaign = null)
+    {
+        // https://www.nexusmods.com/games/stardewvalley/collections/tckf0m
+        // https://www.nexusmods.com/games/stardewvalley/collections/tckf0m/revisions/80
+        var url = $"{BaseUrl}/games/{gameDomain}/collections/{collectionSlug}{(revisionNumber.HasValue ? $"/revisions/{revisionNumber.Value}" : string.Empty)}";
+        return CreateUri(url, source: source, campaign: campaign);
+    }
 
     /// <summary>
-    /// Creates a new URI pointing to a mod on Nexus Mods. This should only be used
-    /// by diagnostics.
+    /// Returns a URI for the bugs page of a collection.
     /// </summary>
-    public static Uri CreateDiagnosticUri(string game, string modId)
+    public static Uri GetCollectionBugsUri(GameDomain gameDomain, CollectionSlug collectionSlug, Optional<RevisionNumber> revisionNumber, string? source = ParameterValueSource, string? campaign = null)
     {
-        return CreateUri($"https://nexusmods.com/{game}/mods/{modId}", campaign: "diagnostics");
+        // https://www.nexusmods.com/games/stardewvalley/collections/tckf0m/revisions/80/bugs
+        var url = $"{BaseUrl}/games/{gameDomain}/collections/{collectionSlug}{(revisionNumber.HasValue ? $"/revisions/{revisionNumber.Value}" : string.Empty)}/bugs";
+        return CreateUri(url, source: source, campaign: campaign);
     }
+
+    /// <summary>
+    /// Uri for the premium benefits page.
+    /// </summary>
+    /// <example>
+    /// <c>https://www.nexusmods.com/premium</c>
+    /// </example>
+    public static readonly Uri LearAboutPremiumUri = CreateUri($"{BaseUrl}/premium", campaign: CampaignPremium);
+
+    /// <summary>
+    /// Uri for the upgrade to premium page.
+    /// </summary>
+    /// <example>
+    /// <c></c>
+    /// </example>
+    public static readonly Uri UpgradeToPremiumUri = CreateUri($"{UsersBaseUrl}/account/billing/premium", campaign: CampaignPremium);
 }
-

--- a/src/Games/NexusMods.Games.Larian/BaldursGate3/BaldursGate3.cs
+++ b/src/Games/NexusMods.Games.Larian/BaldursGate3/BaldursGate3.cs
@@ -11,6 +11,7 @@ using NexusMods.Abstractions.IO.StreamFactories;
 using NexusMods.Abstractions.Library.Installers;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Loadouts.Synchronizers;
+using NexusMods.Abstractions.NexusWebApi.Types;
 using NexusMods.Abstractions.NexusWebApi.Types.V2;
 using NexusMods.Games.Generic.Installers;
 using NexusMods.Games.Larian.BaldursGate3.Emitters;
@@ -30,6 +31,7 @@ public class BaldursGate3 : AGame, ISteamGame, IGogGame
     public IEnumerable<uint> SteamIds => [1086940u];
     public IEnumerable<long> GogIds => [1456460669];
     public override GameId GameId => GameId.From(3474);
+    public static readonly GameDomain StaticDomain = GameDomain.From("baldursgate3");
     public override SupportType SupportType => SupportType.Official;
 
     public override HashSet<FeatureStatus> Features { get; } =

--- a/src/Games/NexusMods.Games.Larian/BaldursGate3/Emitters/DependencyDiagnosticEmitter.cs
+++ b/src/Games/NexusMods.Games.Larian/BaldursGate3/Emitters/DependencyDiagnosticEmitter.cs
@@ -8,6 +8,7 @@ using NexusMods.Abstractions.Diagnostics.Values;
 using NexusMods.Abstractions.GameLocators.Stores.Steam;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Loadouts.Extensions;
+using NexusMods.Abstractions.NexusWebApi.Types.V2;
 using NexusMods.Abstractions.Resources;
 using NexusMods.Abstractions.Telemetry;
 using NexusMods.Games.Larian.BaldursGate3.Utils.LsxXmlParsing;
@@ -215,8 +216,8 @@ public class DependencyDiagnosticEmitter : ILoadoutDiagnosticEmitter
             .ToArray();
     }
 
-    private static readonly NamedLink NexusModsLink = new("Nexus Mods - Baldur's Gate 3", NexusModsUrlBuilder.CreateGenericUri("https://nexusmods.com/baldursgate3"));
-    private static readonly NamedLink BG3SENexusModsLink = new("Nexus Mods", NexusModsUrlBuilder.CreateGenericUri("https://www.nexusmods.com/baldursgate3/mods/2172"));
+    private static readonly NamedLink NexusModsLink = new("Nexus Mods - Baldur's Gate 3", NexusModsUrlBuilder.GetGameUri(BaldursGate3.StaticDomain, campaign: NexusModsUrlBuilder.CampaignDiagnostics));
+    private static readonly NamedLink BG3SENexusModsLink = new("Nexus Mods", NexusModsUrlBuilder.GetModUri(BaldursGate3.StaticDomain, ModId.From(2172), campaign: NexusModsUrlBuilder.CampaignDiagnostics));
 
 #endregion Helpers
 }

--- a/src/Games/NexusMods.Games.MountAndBlade2Bannerlord/Diagnostics/BannerlordDiagnosticEmitter.cs
+++ b/src/Games/NexusMods.Games.MountAndBlade2Bannerlord/Diagnostics/BannerlordDiagnosticEmitter.cs
@@ -7,7 +7,9 @@ using NexusMods.Abstractions.Diagnostics.Emitters;
 using NexusMods.Abstractions.Diagnostics.Values;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Loadouts.Extensions;
+using NexusMods.Abstractions.NexusWebApi.Types.V2;
 using NexusMods.Abstractions.Resources;
+using NexusMods.Abstractions.Telemetry;
 using NexusMods.Games.MountAndBlade2Bannerlord.Models;
 namespace NexusMods.Games.MountAndBlade2Bannerlord.Diagnostics;
 
@@ -19,8 +21,8 @@ namespace NexusMods.Games.MountAndBlade2Bannerlord.Diagnostics;
 /// </summary>
 internal partial class BannerlordDiagnosticEmitter : ILoadoutDiagnosticEmitter
 {
-    private static NamedLink _blseLink = new("Bannerlord Software Extender", new Uri("https://www.nexusmods.com/mountandblade2bannerlord/mods/1"));
-    private static NamedLink _harmonyLink = new("Harmony", new Uri("https://www.nexusmods.com/mountandblade2bannerlord/mods/2006"));
+    private static readonly NamedLink BlseLink = new("Bannerlord Software Extender", NexusModsUrlBuilder.GetModUri(Bannerlord.DomainStatic, ModId.From(1), campaign: NexusModsUrlBuilder.CampaignDiagnostics));
+    private static readonly NamedLink HarmonyLink = new("Harmony",NexusModsUrlBuilder.GetModUri(Bannerlord.DomainStatic, ModId.From(2006), campaign: NexusModsUrlBuilder.CampaignDiagnostics));
     private readonly IResourceLoader<BannerlordModuleLoadoutItem.ReadOnly, ModuleInfoExtended> _manifestPipeline;
     private readonly ILogger _logger;
 
@@ -58,7 +60,7 @@ internal partial class BannerlordDiagnosticEmitter : ILoadoutDiagnosticEmitter
         // Emit diagnostics
         var isBlseInstalled = loadout.IsBLSEInstalled();
         if (isBlseInstalled && !IsHarmonyAvailable(modulesOnly, isEnabledDict))
-            yield return Diagnostics.CreateMissingHarmony(_harmonyLink);
+            yield return Diagnostics.CreateMissingHarmony(HarmonyLink);
 
         foreach (var moduleAndMod in isEnabledDict)
         {
@@ -96,7 +98,7 @@ internal partial class BannerlordDiagnosticEmitter : ILoadoutDiagnosticEmitter
                 ModId: missingUnversioned.Module.Id,
                 ModName: missingUnversioned.Module.Name,
                 DependencyId: missingUnversioned.Dependency.Id,
-                BLSELink: _blseLink
+                BLSELink: BlseLink
             ),
             
             // Missing Unversioned Dependency

--- a/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/Cyberpunk2077Game.cs
+++ b/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/Cyberpunk2077Game.cs
@@ -11,6 +11,7 @@ using NexusMods.Abstractions.IO;
 using NexusMods.Abstractions.IO.StreamFactories;
 using NexusMods.Abstractions.Library.Installers;
 using NexusMods.Abstractions.Loadouts.Synchronizers;
+using NexusMods.Abstractions.NexusWebApi.Types;
 using NexusMods.Abstractions.NexusWebApi.Types.V2;
 using NexusMods.Games.FOMOD;
 using NexusMods.Games.RedEngine.Cyberpunk2077.Emitters;
@@ -24,6 +25,7 @@ namespace NexusMods.Games.RedEngine.Cyberpunk2077;
 [UsedImplicitly]
 public class Cyberpunk2077Game : AGame, ISteamGame, IGogGame, IEpicGame
 {
+    public static readonly GameDomain StaticDomain = GameDomain.From("cyberpunk2077");
     public static GameId GameIdStatic => GameId.From(3333);
     private readonly IServiceProvider _serviceProvider;
     private readonly IConnection _connection;

--- a/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/Emitters/PatternBasedDependencyEmitter.cs
+++ b/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/Emitters/PatternBasedDependencyEmitter.cs
@@ -12,6 +12,7 @@ using NexusMods.Abstractions.IO;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Loadouts.Extensions;
 using NexusMods.Abstractions.Loadouts.Synchronizers;
+using NexusMods.Abstractions.Telemetry;
 using NexusMods.Extensions.BCL;
 using NexusMods.MnemonicDB.Abstractions.Query;
 using NexusMods.Paths;
@@ -181,7 +182,7 @@ public class PatternBasedDependencyEmitter : ILoadoutDiagnosticEmitter
             {
                 // Missing mod
                 var parent = row.File.AsLoadoutItem().Parent;
-                var downloadLink = new NamedLink("Nexus Mods", new($"https://www.nexusmods.com/cyberpunk2077/mods/{row.Pattern.ModId}"));
+                var downloadLink = new NamedLink("Nexus Mods", NexusModsUrlBuilder.GetModUri(Cyberpunk2077Game.StaticDomain, row.Pattern.ModId, campaign: NexusModsUrlBuilder.CampaignDiagnostics));
                 if (row.MatchingSegment.HasValue)
                 {
                     yield return Diagnostics.CreateMissingModWithKnownNexusUriWithStringSegment(

--- a/src/Games/NexusMods.Games.StardewValley/Emitters/Helpers.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Emitters/Helpers.cs
@@ -5,6 +5,7 @@ using NexusMods.Abstractions.Diagnostics.Values;
 using NexusMods.Abstractions.Games;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.Loadouts.Extensions;
+using NexusMods.Abstractions.NexusWebApi.Types.V2;
 using NexusMods.Abstractions.Resources;
 using NexusMods.Abstractions.Telemetry;
 using NexusMods.Extensions.BCL;
@@ -17,8 +18,8 @@ namespace NexusMods.Games.StardewValley.Emitters;
 
 internal static class Helpers
 {
-    public static readonly NamedLink NexusModsLink = new("Nexus Mods", NexusModsUrlBuilder.CreateGenericUri("https://nexusmods.com/stardewvalley"));
-    public static readonly NamedLink SMAPILink = new("Nexus Mods", NexusModsUrlBuilder.CreateDiagnosticUri(StardewValley.DomainStatic.Value, "2400"));
+    public static readonly NamedLink NexusModsLink = new("Nexus Mods", NexusModsUrlBuilder.GetGameUri(StardewValley.DomainStatic, campaign: NexusModsUrlBuilder.CampaignDiagnostics));
+    public static readonly NamedLink SMAPILink = new("Nexus Mods", NexusModsUrlBuilder.GetModUri(StardewValley.DomainStatic, ModId.From(2400), campaign: NexusModsUrlBuilder.CampaignDiagnostics));
 
     public static ISemanticVersion GetGameVersion(Loadout.ReadOnly loadout)
     {

--- a/src/Games/NexusMods.Games.StardewValley/WebAPI/SMAPIWebApi.cs
+++ b/src/Games/NexusMods.Games.StardewValley/WebAPI/SMAPIWebApi.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 using DynamicData.Kernel;
 using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.Diagnostics.Values;
+using NexusMods.Abstractions.NexusWebApi.Types.V2;
 using NexusMods.Abstractions.Telemetry;
 using NexusMods.Paths;
 using StardewModdingAPI;
@@ -86,7 +87,7 @@ internal sealed class SMAPIWebApi : ISMAPIWebApi
 
                         if (nexusId is not null)
                         {
-                            var uri = NexusModsUrlBuilder.CreateDiagnosticUri(StardewValley.DomainStatic.Value, nexusId.Value.ToString());
+                            var uri = NexusModsUrlBuilder.GetModUri(StardewValley.DomainStatic, ModId.From((uint)nexusId.Value));
                             nexusModsLink = uri.WithName("Nexus Mods");
                         }
 

--- a/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsDownloadJob.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsDownloadJob.cs
@@ -44,7 +44,7 @@ public class NexusModsDownloadJob : IDownloadJob, IJobDefinitionWithStart<NexusM
         }
         catch (Exception e)
         {
-            Logger.LogError(e, "Exception while downloading `{Url}`", FileMetadata.GetUri());
+            Logger.LogError(e, "Exception while downloading file `{GameId}/{ModId}/{FileId}`", FileMetadata.Uid.GameId, FileMetadata.ModPage.Uid.ModId, FileMetadata.Uid.FileId);
             throw;
         }
     }

--- a/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsLibrary.cs
+++ b/src/Networking/NexusMods.Networking.NexusWebApi/NexusModsLibrary.cs
@@ -11,6 +11,7 @@ using NexusMods.Abstractions.NexusWebApi.DTOs;
 using NexusMods.Abstractions.NexusWebApi.Types;
 using NexusMods.Abstractions.NexusWebApi.Types.V2;
 using NexusMods.Abstractions.NexusWebApi.Types.V2.Uid;
+using NexusMods.Abstractions.Telemetry;
 using NexusMods.Extensions.BCL;
 using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.Networking.HttpDownloader;
@@ -210,7 +211,8 @@ public partial class NexusModsLibrary
 
         var uri = await GetDownloadUri(file, nxmData, cancellationToken: cancellationToken);
 
-        var httpJob = HttpDownloadJob.Create(_serviceProvider, uri, modPage.GetUri(), destination);
+        var domain = await _mappingCache.TryGetDomainAsync(gameId, cancellationToken);
+        var httpJob = HttpDownloadJob.Create(_serviceProvider, uri, NexusModsUrlBuilder.GetModUri(domain.Value, modId), destination);
         var nexusJob = NexusModsDownloadJob.Create(_serviceProvider, httpJob, file);
 
         return nexusJob;
@@ -223,7 +225,8 @@ public partial class NexusModsLibrary
     {
         var uri = await GetDownloadUri(fileMetadata, Optional<(NXMKey, DateTime)>.None, cancellationToken: cancellationToken);
 
-        var httpJob = HttpDownloadJob.Create(_serviceProvider, uri, fileMetadata.ModPage.GetUri(), destination);
+        var domain = await _mappingCache.TryGetDomainAsync(fileMetadata.Uid.GameId, cancellationToken);
+        var httpJob = HttpDownloadJob.Create(_serviceProvider, uri, NexusModsUrlBuilder.GetModUri(domain.Value, fileMetadata.ModPage.Uid.ModId), destination);
         var nexusJob = NexusModsDownloadJob.Create(_serviceProvider, httpJob, fileMetadata);
 
         return nexusJob;

--- a/src/NexusMods.App.UI/Controls/TopBar/TopBarViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/TopBar/TopBarViewModel.cs
@@ -142,21 +142,18 @@ public class TopBarViewModel : AViewModel<ITopBarViewModel>, ITopBarViewModel
             var userInfo = await _loginManager.GetUserInfoAsync();
             if (userInfo is null) return;
 
-            var userId = userInfo.UserId.Value;
-            var uri = NexusModsUrlBuilder.CreateGenericUri($"https://nexusmods.com/users/{userId}");
+            var uri = NexusModsUrlBuilder.GetProfileUri(userInfo.UserId);
             await osInterop.OpenUrl(uri);
         });
 
         OpenNexusModsAccountSettingsCommand = ReactiveCommand.CreateFromTask(async () =>
         {
-            var uri = NexusModsUrlBuilder.CreateGenericUri("https://users.nexusmods.com");
-            await osInterop.OpenUrl(uri);
+            await osInterop.OpenUrl(NexusModsUrlBuilder.UserSettingsUri);
         });
 
         OpenNexusModsPremiumCommand = ReactiveCommand.CreateFromTask(async () =>
         {
-            var uri = NexusModsUrlBuilder.CreateGenericUri("https://users.nexusmods.com/account/billing/premium");
-            await osInterop.OpenUrl(uri);
+            await osInterop.OpenUrl(NexusModsUrlBuilder.UpgradeToPremiumUri);
         });
         
         OpenDiscordCommand = ReactiveCommand.CreateFromTask(async () => { await osInterop.OpenUrl(ConstantLinks.DiscordUri); });

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadViewModel.cs
@@ -9,6 +9,7 @@ using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.NexusModsLibrary.Models;
 using NexusMods.Abstractions.NexusWebApi;
 using NexusMods.Abstractions.NexusWebApi.Types;
+using NexusMods.Abstractions.Telemetry;
 using NexusMods.App.UI.Controls;
 using NexusMods.App.UI.Controls.MarkdownRenderer;
 using NexusMods.App.UI.Controls.Navigation;
@@ -166,7 +167,7 @@ public sealed class CollectionDownloadViewModel : APageViewModel<ICollectionDown
                 var gameDomain = await mappingCache.TryGetDomainAsync(_collection.GameId, cancellationToken);
                 if (!gameDomain.HasValue) throw new NotSupportedException($"Expected a valid game domain for `{_collection.GameId}`");
 
-                var uri = _collection.GetUri(gameDomain.Value);
+                var uri = NexusModsUrlBuilder.GetCollectionUri(gameDomain.Value, _collection.Slug, revisionMetadata.RevisionNumber, campaign: NexusModsUrlBuilder.CampaignCollections);
                 await osInterop.OpenUrl(uri, logOutput: false, fireAndForget: true, cancellationToken: cancellationToken);
             },
             awaitOperation: AwaitOperation.Sequential,

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/ManualDownloadRequiredOverlay.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/ManualDownloadRequiredOverlay.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.Library;
 using NexusMods.Abstractions.NexusModsLibrary.Models;
 using NexusMods.Abstractions.NexusWebApi;
+using NexusMods.Abstractions.Telemetry;
 using NexusMods.App.UI.Extensions;
 using NexusMods.App.UI.Overlays;
 using NexusMods.CrossPlatform.Process;
@@ -74,8 +75,9 @@ public class ManualDownloadRequiredOverlayViewModel : AOverlayViewModel<IManualD
         Instructions = downloadEntity.AsCollectionDownload().Instructions.ValueOr(string.Empty);
         
         var gameDomain =  mappingCache.TryGetDomain(downloadEntity.AsCollectionDownload().CollectionRevision.Collection.GameId, CancellationToken.None);
-        var revisionBugsUri = downloadEntity.AsCollectionDownload().CollectionRevision.GetBugsUri(gameDomain.Value);
-        
+        var revision = downloadEntity.AsCollectionDownload().CollectionRevision;
+        var revisionBugsUri = NexusModsUrlBuilder.GetCollectionBugsUri(gameDomain.Value, revision.Collection.Slug, revision.RevisionNumber, campaign: NexusModsUrlBuilder.CampaignCollections);
+
         CommandCancel = new ReactiveCommand(_ => { base.Close(); });
 
         CommandOpenBrowser = new ReactiveCommand(

--- a/src/NexusMods.App.UI/Pages/LibraryPage/LibraryViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LibraryPage/LibraryViewModel.cs
@@ -156,7 +156,7 @@ public class LibraryViewModel : APageViewModel<ILibraryViewModel>, ILibraryViewM
             executeAsync: async (_, cancellationToken) =>
             {
                 var gameDomain = (await _gameIdMappingCache.TryGetDomainAsync(game.GameId, cancellationToken));
-                var gameUri = NexusModsUrlBuilder.CreateGenericUri($"https://www.nexusmods.com/{gameDomain}");
+                var gameUri = NexusModsUrlBuilder.GetGameUri(gameDomain.Value);
                 await osInterop.OpenUrl(gameUri, cancellationToken: cancellationToken);
             },
             awaitOperation: AwaitOperation.Parallel,
@@ -245,9 +245,9 @@ public class LibraryViewModel : APageViewModel<ILibraryViewModel>, ILibraryViewM
             // Open download page for every unique file.
             foreach (var file in updatesOnPage.NewestUniqueFileForEachMod())
             {
-                var modFileUrl = NexusModsUrlBuilder.CreateModFileDownloadUri(file.Uid.FileId, file.Uid.GameId);
                 var osInterop = _serviceProvider.GetRequiredService<IOSInterop>();
-                await osInterop.OpenUrl(modFileUrl, cancellationToken: cancellationToken);
+                var uri = NexusModsUrlBuilder.GetFileDownloadUri(file.ModPage.GameDomain, file.ModPage.Uid.ModId, file.Uid.FileId, useNxmLink: true, campaign: NexusModsUrlBuilder.CampaignUpdates);
+                await osInterop.OpenUrl(uri, cancellationToken: cancellationToken);
             }
         }
         else

--- a/src/NexusMods.Collections/Verbs.cs
+++ b/src/NexusMods.Collections/Verbs.cs
@@ -58,7 +58,7 @@ internal static class Verbs
         }
         else
         {
-            var tuples = CollectionDownloader.GetMissingDownloadLinks(revisionMetadata, db: connection.Db, itemType: CollectionDownloader.ItemType.Required);
+            var tuples = collectionDownloader.GetMissingDownloadLinks(revisionMetadata, db: connection.Db, itemType: CollectionDownloader.ItemType.Required);
             if (tuples.Count > 0)
             {
                 await renderer.TextLine($"Missing {tuples.Count} downloads:");

--- a/tests/NexusMods.Telemetry.Tests/NexusModsURLBuilderTests.cs
+++ b/tests/NexusMods.Telemetry.Tests/NexusModsURLBuilderTests.cs
@@ -1,0 +1,64 @@
+using DynamicData.Kernel;
+using FluentAssertions;
+using NexusMods.Abstractions.NexusWebApi.Types;
+using NexusMods.Abstractions.NexusWebApi.Types.V2;
+using NexusMods.Abstractions.Telemetry;
+using Xunit;
+
+namespace NexusMods.Telemetry.Tests;
+
+public class NexusModsUrlBuilderTests
+{
+    private const string StardewValley = "stardewvalley";
+
+    [Theory]
+    [InlineData(6672467ul, "https://www.nexusmods.com/users/6672467")]
+    public void Test_GetProfileUri(ulong userId, string expected)
+    {
+        var actual = NexusModsUrlBuilder.GetProfileUri(UserId.From(userId), source: null).ToString();
+        actual.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(StardewValley, "https://www.nexusmods.com/games/stardewvalley")]
+    public void Test_GetGameUri(string gameDomain, string expected)
+    {
+        var actual = NexusModsUrlBuilder.GetGameUri(GameDomain.From(gameDomain), source: null).ToString();
+        actual.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(StardewValley, 2400, "https://www.nexusmods.com/stardewvalley/mods/2400")]
+    public void Test_GetModUri(string gameDomain, uint modId, string expected)
+    {
+        var actual = NexusModsUrlBuilder.GetModUri(GameDomain.From(gameDomain), ModId.From(modId), source: null).ToString();
+        actual.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(StardewValley, 2400, 128328, false, "https://www.nexusmods.com/stardewvalley/mods/2400?tab=files&file_id=128328&nmm=0")]
+    [InlineData(StardewValley, 2400, 128328, true, "https://www.nexusmods.com/stardewvalley/mods/2400?tab=files&file_id=128328&nmm=1")]
+    public void Test_GetFileDownloadUri(string gameDomain, uint modId, uint fileId, bool useNxmLink, string expected)
+    {
+        var actual = NexusModsUrlBuilder.GetFileDownloadUri(GameDomain.From(gameDomain), ModId.From(modId), FileId.From(fileId), useNxmLink, source: null).ToString();
+        actual.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(StardewValley, "tckf0m", null, "https://www.nexusmods.com/games/stardewvalley/collections/tckf0m")]
+    [InlineData(StardewValley, "tckf0m", 80ul, "https://www.nexusmods.com/games/stardewvalley/collections/tckf0m/revisions/80")]
+    public void Test_GetCollectionUri(string gameDomain, string collectionSlug, ulong? revisionNumber, string expected)
+    {
+        var actual = NexusModsUrlBuilder.GetCollectionUri(GameDomain.From(gameDomain), CollectionSlug.From(collectionSlug), revisionNumber.HasValue ? RevisionNumber.From(revisionNumber.Value) : default(Optional<RevisionNumber>), source: null).ToString();
+        actual.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(StardewValley, "tckf0m", null, "https://www.nexusmods.com/games/stardewvalley/collections/tckf0m/bugs")]
+    [InlineData(StardewValley, "tckf0m", 80ul, "https://www.nexusmods.com/games/stardewvalley/collections/tckf0m/revisions/80/bugs")]
+    public void Test_GetCollectionBugsUri(string gameDomain, string collectionSlug, ulong? revisionNumber, string expected)
+    {
+        var actual = NexusModsUrlBuilder.GetCollectionBugsUri(GameDomain.From(gameDomain), CollectionSlug.From(collectionSlug), revisionNumber.HasValue ? RevisionNumber.From(revisionNumber.Value) : default(Optional<RevisionNumber>), source: null).ToString();
+        actual.Should().Be(expected);
+    }
+}


### PR DESCRIPTION
Resolves #2951.

Every link going to Nexus Mods is now created in the `NexusModsUrlBuilder`. I did a full solution search for links and I updated every hardcoded link to use the builder.

I've also updated our campaigns, many links previously didn't had any tracking campaigns but now they do.