### PR TITLE
Sort Mods Alphabetically By Name While Being Case-insensitive

### DIFF
--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/SharedColumns.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/SharedColumns.cs
@@ -14,7 +14,10 @@ public static class SharedColumns
         {
             var aValue = a.GetOptional<StringComponent>(StringComponentKey);
             var bValue = b.GetOptional<StringComponent>(StringComponentKey);
-            return aValue.Compare(bValue);
+            var aName = aValue.HasValue ? aValue.Value.Value.ToString() : string.Empty;
+            var bName = bValue.HasValue ? bValue.Value.Value.ToString() : string.Empty;
+            
+            return string.Compare(aName, bName, StringComparison.OrdinalIgnoreCase);
         }
 
         public const string ColumnTemplateResourceKey = Prefix + "Name";


### PR DESCRIPTION
Fixes #2824.

Sorts the mods alphabetically by the string name while being case-insensitive. 

![NexusMods Issue #2824](https://github.com/user-attachments/assets/8537eaca-bd2c-41b5-a25a-dc2a15555423)
