### PR TITLE
Backup files in first synchronize pass instead of second pass

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/Rules/ActionMapping.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/Rules/ActionMapping.cs
@@ -57,7 +57,7 @@ public class ActionMapping
             Axx_Xxx_i => IngestFromDisk,
             Axx_xxx_I => IngestFromDisk,
             Axx_Xxx_I => IngestFromDisk,
-            AxA_xxx_i => DoNothing,
+            AxA_xxx_i => BackupFile,
             AxA_XxX_i => DoNothing,
             AxA_xxx_I => DoNothing,
             AxA_XxX_I => DoNothing,


### PR DESCRIPTION
Part of #2887.

Before: `DiskExists | LoadoutExists | DiskEqualsLoadout -> DoNothing`
After: `DiskExists | LoadoutExists | DiskEqualsLoadout -> BackupFile`

While debugging #2887 I've noticed that when managing a game, we don't backup files in the "first pass". We only backup in the "second pass" when we have previous state:

`DiskExists | PrevExists | LoadoutExists | DiskEqualsPrev | PrevEqualsLoadout | DiskEqualsLoadout -> BackupFile`

This PR updates the behavior of the first pass where we don't have previous state to match the behavior of the second pass.