### PR TITLE
Update `ReprocessGameUpdates` to re-query game locators for IDs

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -477,14 +477,16 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
     /// </summary>
     private async ValueTask<Loadout.ReadOnly> ReprocessGameUpdates(Loadout.ReadOnly loadout)
     {
-        var diskState = loadout.Installation.DiskStateEntries
-            .Select(part => ((GamePath)part.Path, part.Hash));
-        
-        var suggestedVersionDefinition = _fileHashService.SuggestVersionData(loadout.InstallationInstance, diskState);
-        if (!suggestedVersionDefinition.HasValue)
+        var gameLocatorResults = loadout.InstallationInstance.Locator.Find(loadout.InstallationInstance.Game);
+
+        // NOTE(erri120): It would be very odd if we re-query the game, and it's not installed anymore
+        if (!gameLocatorResults.TryGetFirst(result => result.Store == loadout.InstallationInstance.Store, out var gameLocatorResult))
+        {
+            _logger.LogCritical("Found no installation of the game `{Store}`/`{Game}` anymore!", loadout.InstallationInstance.Store, loadout.InstallationInstance.Game.Name);
             return loadout;
-        
-        var newLocatorIds = suggestedVersionDefinition.Value.LocatorIds;
+        }
+
+        var newLocatorIds = gameLocatorResult.Metadata.ToLocatorIds().ToArray();
 
         var locatorAdditions = loadout.LocatorIds.Except(newLocatorIds).Count();
         var locatorRemovals = newLocatorIds.Except(loadout.LocatorIds).Count();
@@ -513,11 +515,17 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
         {
             tx.Delete(file, false);
         }
-        
-        
-        
-        // Update the version and locator ids
-        tx.Add(loadout, Loadout.GameVersion, suggestedVersionDefinition.Value.VanityVersion);
+
+        if (_fileHashService.TryGetVanityVersion((gameLocatorResult.Store, newLocatorIds), out var vanityVersion))
+        {
+            tx.Add(loadout, Loadout.GameVersion, vanityVersion);
+        }
+        else
+        {
+            tx.Add(loadout, Loadout.GameVersion, VanityVersion.DefaultValue);
+            _logger.LogWarning("Found no vanity version for locator IDs `{LocatorIds}` (`{Store}`)", newLocatorIds, gameLocatorResult.Store);
+        }
+
         foreach (var id in loadout.LocatorIds) 
             tx.Retract(loadout, Loadout.LocatorIds, id);
         foreach (var id in newLocatorIds)

--- a/src/NexusMods.StandardGameLocators/Unknown/UnknownLocatorResultMetadata.cs
+++ b/src/NexusMods.StandardGameLocators/Unknown/UnknownLocatorResultMetadata.cs
@@ -7,7 +7,7 @@ namespace NexusMods.StandardGameLocators.Unknown;
 /// <see cref="IGameLocatorResultMetadata"/> implementation for nothing.
 /// </summary>
 [PublicAPI]
-public record UnknownLocatorResultMetadata : IGameLocatorResultMetadata
+public record UnknownLocatorResultMetadata(LocatorId[] LocatorIds) : IGameLocatorResultMetadata
 {
-    public IEnumerable<LocatorId> ToLocatorIds() => [LocatorId.From("StubbedGameState.zip")];
+    public IEnumerable<LocatorId> ToLocatorIds() => LocatorIds;
 }

--- a/tests/NexusMods.StandardGameLocators.TestHelpers/UniversalStubbedGameLocator.cs
+++ b/tests/NexusMods.StandardGameLocators.TestHelpers/UniversalStubbedGameLocator.cs
@@ -10,6 +10,8 @@ public class UniversalStubbedGameLocator<TGame> : IGameLocator, IDisposable
     private readonly TemporaryPath _path;
     private readonly Version? _version;
 
+    public LocatorId[] LocatorIds { get; set; } = [LocatorId.From("StubbedGameState.zip")];
+
     public UniversalStubbedGameLocator(
         IFileSystem fileSystem,
         TemporaryFileManager fileManager,
@@ -37,7 +39,7 @@ public class UniversalStubbedGameLocator<TGame> : IGameLocator, IDisposable
             _path,
             _path.Path.FileSystem,
             GameStore.Unknown,
-            new UnknownLocatorResultMetadata(),
+            new UnknownLocatorResultMetadata(LocatorIds),
             _version ?? new Version(1, 0, 0, 0));
     }
 


### PR DESCRIPTION
Part of #2887.

Before, the method would find a matching vanity version based on the current disk state. This approach was flawed and resulted in the bug shown in #2887. This PR changes the behavior to re-query the game locator IDs directly from the game locator.