### PR TITLE
Fixes around the game hashes DB building

### DIFF
--- a/src/Networking/NexusMods.Networking.GOG/CLI/Verbs.cs
+++ b/src/Networking/NexusMods.Networking.GOG/CLI/Verbs.cs
@@ -40,16 +40,11 @@ public static class Verbs
         [Injected] IRenderer renderer,
         [Injected] JsonSerializerOptions jsonSerializerOptions,
         [Injected] IClient client, 
-        [Option("g", "gameName", "Game to index")] ILocatableGame game,
+        [Option("p", "productId", "Product Id to index")] long productId,
         [Option("o", "output", "The output folder to write the index to")] AbsolutePath output,
         [Option("v", "verify", "Verify the files are hashed properly. This takes longer to execute but ensures the files are downloaded correctly.", true)] bool verify,
         [Injected] CancellationToken token)
     {
-        if (game is not IGogGame gogGame)
-        {
-            await renderer.Error("Game is not a GOG game");
-            return -1;
-        }
 
         var indentedOptions = new JsonSerializerOptions(jsonSerializerOptions)
         {
@@ -59,7 +54,6 @@ public static class Verbs
 
         await using (var _ = await renderer.WithProgress())
         {
-            await foreach (var productId in gogGame.GogIds.WithProgress(renderer, "Product Ids").WithCancellation(token))
             {
                 await foreach (var os in Enum.GetValues<OS>().WithProgress(renderer, "Operating Systems Builds").WithCancellation(token))
                 {

--- a/src/NexusMods.App.Cli/Services.cs
+++ b/src/NexusMods.App.Cli/Services.cs
@@ -30,6 +30,7 @@ public static class Services
                 .AddOptionParser<Uri>(u => (new Uri(u), null))
                 .AddOptionParser<Version>(v => (Version.Parse(v), null))
                 .AddOptionParser<string>(s => (s, null))
+                .AddOptionParser<long>(l => (long.Parse(l), null))
                 .AddOptionParser<Matcher, MatcherParser>()
                 .AddOptionParser<ILocatableGame, LocatableGameParser>()
                 .AddOptionParser<ITool, ToolParser>();


### PR DESCRIPTION
Adds a few fixes around the game hashes DB creation and indexing

* Switches both the GOG and Steam indexing verbs over to using ids instead of game names. This will allow us to index games that we don't yet support, as well as DLC and optional products
* Some error handling around db packing, we can now fail out specific app versions that have incorrect (or missing data)