### PR TITLE
Fix SDV diagnostic Verify test due to changes in URLs

### DIFF
--- a/tests/Games/NexusMods.Games.StardewValley.Tests/DependencyDiagnosticEmitterTests.Test_MissingRequiredDependency.verified.txt
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/DependencyDiagnosticEmitterTests.Test_MissingRequiredDependency.verified.txt
@@ -6,7 +6,7 @@ The mod **Farm Type Manager** requires **Content Patcher** to function, but **Co
 
 
 ### How to Resolve
-1. Download **Content Patcher** from [Nexus Mods](https://nexusmods.com/stardewvalley/mods/1915?mtm_source=nexusmodsapp&mtm_campaign=diagnostics)
+1. Download **Content Patcher** from [Nexus Mods](https://www.nexusmods.com/stardewvalley/mods/1915?mtm_source=nexusmodsapp)
 2. Add **Content Patcher** to the loadout. 
 
 ### Technical Details

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/DependencyDiagnosticEmitterTests.Test_RequiredDependencyIsOutdated.verified.txt
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/DependencyDiagnosticEmitterTests.Test_RequiredDependencyIsOutdated.verified.txt
@@ -5,7 +5,7 @@
 The mod **Farm Type Manager** requires **Content Patcher** version 2.0.0 or higher to function, but an older version of **Content Patcher** (1.30.4) is installed.
 
 ### How to Resolve
-1. Download the latest version of **Content Patcher** (version 2.0.0 or newer) from [Nexus Mods](https://nexusmods.com/stardewvalley/mods/1915?mtm_source=nexusmodsapp&mtm_campaign=diagnostics)
+1. Download the latest version of **Content Patcher** (version 2.0.0 or newer) from [Nexus Mods](https://www.nexusmods.com/stardewvalley/mods/1915?mtm_source=nexusmodsapp)
 2. Add the latest version of **Content Patcher** to the loadout
 3. Remove version 1.30.4 of **Content Patcher** from the loadout
 

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/MissingSMAPIEmitterTests.Test_SMAPIRequiredButNotInstalled.verified.txt
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/MissingSMAPIEmitterTests.Test_SMAPIRequiredButNotInstalled.verified.txt
@@ -5,7 +5,7 @@
 Stardew Modding API (SMAPI) is the mod loader required to run mods for Stardew Valley. The loadout contains 2 mod(s) that require SMAPI to work, but it is not installed.
 
 ### How to Resolve
-1. Download Stardew Modding API (SMAPI) from [Nexus Mods](https://nexusmods.com/stardewvalley/mods/2400?mtm_source=nexusmodsapp&mtm_campaign=diagnostics)
+1. Download Stardew Modding API (SMAPI) from [Nexus Mods](https://www.nexusmods.com/stardewvalley/mods/2400?mtm_source=nexusmodsapp&mtm_campaign=diagnostics)
 2. Add SMAPI to the loadout
 
 ### Technical Details

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/SMAPIModDatabaseCompatibilityDiagnosticEmitterTests.Test_ModCompatabilityAssumeBroken.verified.txt
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/SMAPIModDatabaseCompatibilityDiagnosticEmitterTests.Test_ModCompatabilityAssumeBroken.verified.txt
@@ -5,7 +5,7 @@
 The Stardew Modding API (SMAPI) mod compatibility list reports **Persistent Mines** as broken. This information is sourced from a combination of automated and community-submitted reports. 
 
 ### How to Resolve
-1. Check for a version of **Persistent Mines** newer than 1.0.1 on [Nexus Mods](https://nexusmods.com/stardewvalley/mods/14985?mtm_source=nexusmodsapp&mtm_campaign=diagnostics)
+1. Check for a version of **Persistent Mines** newer than 1.0.1 on [Nexus Mods](https://www.nexusmods.com/stardewvalley/mods/14985?mtm_source=nexusmodsapp)
 
 OR
 


### PR DESCRIPTION
Fix Stardew diagnostic verify tests failing due to URL changes with the added campaign