### PR TITLE
Upgrade Avalonia packages and add Load Order "IsActive" styling

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,9 +1,9 @@
 <Project>
   <ItemGroup>
-    <PackageVersion Include="Avalonia.AvaloniaEdit" Version="11.1.0" />
+    <PackageVersion Include="Avalonia.AvaloniaEdit" Version="11.2.0" />
     <PackageVersion Include="Avalonia.Labs.Panels" Version="11.2.0" />
     <PackageVersion Include="Avalonia.Skia" Version="11.2.4" />
-    <PackageVersion Include="AvaloniaEdit.TextMate" Version="11.1.0" />
+    <PackageVersion Include="AvaloniaEdit.TextMate" Version="11.2.0" />
     <PackageVersion Include="Jitbit.FastCache" Version="1.1.0" />
     <PackageVersion Include="K4os.Compression.LZ4" Version="1.3.8" />
     <PackageVersion Include="Bannerlord.ModuleManager" Version="6.0.246" />
@@ -32,12 +32,12 @@
     <PackageVersion Include="NLog" Version="5.2.8" />
     <PackageVersion Include="Noggog.CSharpExt" Version="2.67.3" />
     <PackageVersion Include="NuGet.Versioning" Version="6.12.1" />
-    <PackageVersion Include="ObservableCollections" Version="3.3.2" />
-    <PackageVersion Include="ObservableCollections.R3" Version="3.3.2" />
+    <PackageVersion Include="ObservableCollections" Version="3.3.3" />
+    <PackageVersion Include="ObservableCollections.R3" Version="3.3.3" />
     <PackageVersion Include="QoiSharp" Version="1.0.0" />
     <PackageVersion Include="QRCoder" Version="1.6.0" />
-    <PackageVersion Include="R3" Version="1.2.9" />
-    <PackageVersion Include="R3Extensions.Avalonia" Version="1.2.9" />
+    <PackageVersion Include="R3" Version="1.3.0" />
+    <PackageVersion Include="R3Extensions.Avalonia" Version="1.3.0" />
     <PackageVersion Include="ReactiveUI" Version="20.1.63" />
     <PackageVersion Include="SmartFormat" Version="3.5.1" />
     <PackageVersion Include="Spectre.Console.Testing" Version="0.49.1" />
@@ -45,7 +45,7 @@
     <PackageVersion Include="StrawberryShake.Server" Version="15.0.3" />
     <PackageVersion Include="System.Linq" Version="4.3.0" />
     <PackageVersion Include="System.Text.Json" Version="9.0.0" VersionOverride="9.0.0" />
-    <PackageVersion Include="TextMateSharp.Grammars" Version="1.0.64" />
+    <PackageVersion Include="TextMateSharp.Grammars" Version="1.0.65" />
     <PackageVersion Include="OpenTelemetry" Version="1.10.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
@@ -66,15 +66,15 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
     <PackageVersion Include="NetEscapades.EnumGenerators" Version="1.0.0-beta07" PrivateAssets="all" ExcludeAssets="compile;runtime" />
-    <PackageVersion Include="Avalonia" Version="11.2.4" />
-    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.2.4" />
+    <PackageVersion Include="Avalonia" Version="11.2.6" />
+    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.2.6" />
     <PackageVersion Include="Avalonia.Controls.TreeDataGrid" Version="11.1.1" />
-    <PackageVersion Include="Avalonia.Desktop" Version="11.2.4" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.2.4" />
-    <PackageVersion Include="Avalonia.Headless" Version="11.2.4" />
-    <PackageVersion Include="Avalonia.ReactiveUI" Version="11.2.4" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.2.4" />
-    <PackageVersion Include="Projektanker.Icons.Avalonia.MaterialDesign" Version="9.4.1" />
+    <PackageVersion Include="Avalonia.Desktop" Version="11.2.6" />
+    <PackageVersion Include="Avalonia.Diagnostics" Version="11.2.6" />
+    <PackageVersion Include="Avalonia.Headless" Version="11.2.6" />
+    <PackageVersion Include="Avalonia.ReactiveUI" Version="11.2.6" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.2.6" />
+    <PackageVersion Include="Projektanker.Icons.Avalonia.MaterialDesign" Version="9.6.1" />
     <PackageVersion Include="Avalonia.Svg.Skia" Version="11.2.0.2" />
     <PackageVersion Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.0-rc2" />
     <!-- keep this version in sync with Avalonia (https://github.com/whistyun/Markdown.Avalonia?tab=readme-ov-file#nuget) -->

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderViewModel.cs
@@ -202,7 +202,8 @@ public class LoadOrderTreeDataGridAdapter : TreeDataGridAdapter<CompositeItemMod
     protected override void BeforeModelActivationHook(CompositeItemModel<Guid> model)
     {
         base.BeforeModelActivationHook(model);
-
+        
+        // Move up command
         model.SubscribeToComponentAndTrack<LoadOrderComponents.IndexComponent, LoadOrderTreeDataGridAdapter>(
             key: LoadOrderColumns.IndexColumn.IndexComponentKey,
             state: this,
@@ -216,6 +217,7 @@ public class LoadOrderTreeDataGridAdapter : TreeDataGridAdapter<CompositeItemMod
                 )
         );
         
+        // Move down command
         model.SubscribeToComponentAndTrack<LoadOrderComponents.IndexComponent, LoadOrderTreeDataGridAdapter>(
             key: LoadOrderColumns.IndexColumn.IndexComponentKey,
             state: this,
@@ -225,6 +227,20 @@ public class LoadOrderTreeDataGridAdapter : TreeDataGridAdapter<CompositeItemMod
                     {
                         var (adapter, itemModel, _) = tuple;
                         adapter.MessageSubject.OnNext(new MoveDownCommandPayload(itemModel));
+                    }
+                )
+        );
+        
+        // IsActive styling
+        model.SubscribeToComponentAndTrack<ValueComponent<bool>, LoadOrderTreeDataGridAdapter>(
+            key: LoadOrderColumns.IsActiveComponentKey,
+            state: this,
+            factory: static (adapter, itemModel, component) => component.Value
+                .Subscribe((adapter, itemModel, component),
+                    static (_, tuple) =>
+                    {
+                        var (_, itemModel, component) = tuple;
+                        itemModel.SetStyleFlag(LoadOrderColumns.IsActiveStyleTag, component.Value.Value);
                     }
                 )
         );

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGrid/LoadOrderComponents.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGrid/LoadOrderComponents.cs
@@ -97,4 +97,5 @@ public static class LoadOrderColumns
     }
 
     public static readonly ComponentKey IsActiveComponentKey = ComponentKey.From(nameof(LoadOrderColumns) + "_" + "IsActiveComponent");
+    public static readonly string IsActiveStyleTag = "IsActive";
 }

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/TreeDataGridBaseStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/TreeDataGridBaseStyles.axaml
@@ -4,8 +4,11 @@
         xmlns:icons="clr-namespace:NexusMods.Icons;assembly=NexusMods.Icons"
         xmlns:files="clr-namespace:NexusMods.App.UI.Controls.Trees.Files;assembly=NexusMods.App.UI"
         xmlns:converters="clr-namespace:NexusMods.App.UI.Converters;assembly=NexusMods.App.UI"
-        xmlns:controls="clr-namespace:NexusMods.App.UI.Controls;assembly=NexusMods.App.UI">
-
+        xmlns:controls="clr-namespace:NexusMods.App.UI.Controls;assembly=NexusMods.App.UI"
+        xmlns:system="clr-namespace:System;assembly=System.Runtime">
+    <!-- NOTE(Al12rs): Keep: `xmlns:system="clr-namespace:System;assembly=System.Runtime"` even if marked as unused -->
+    <!-- See false positive error and note for CompositeItemModel later down the file -->
+    
     <Design.PreviewWith>
         <Border Classes="Low" Padding="16">
             <TreeDataGrid Width="400" Height="200" />

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/TreeDataGridBaseStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/TreeDataGridBaseStyles.axaml
@@ -3,7 +3,8 @@
         xmlns:converters1="clr-namespace:NexusMods.Themes.NexusFluentDark.Converters"
         xmlns:icons="clr-namespace:NexusMods.Icons;assembly=NexusMods.Icons"
         xmlns:files="clr-namespace:NexusMods.App.UI.Controls.Trees.Files;assembly=NexusMods.App.UI"
-        xmlns:converters="clr-namespace:NexusMods.App.UI.Converters;assembly=NexusMods.App.UI">
+        xmlns:converters="clr-namespace:NexusMods.App.UI.Converters;assembly=NexusMods.App.UI"
+        xmlns:controls="clr-namespace:NexusMods.App.UI.Controls;assembly=NexusMods.App.UI">
 
     <Design.PreviewWith>
         <Border Classes="Low" Padding="16">
@@ -24,19 +25,19 @@
         <SolidColorBrush x:Key="TreeDataGridHeaderForegroundPressedBrush" Color="White" />
         <SolidColorBrush x:Key="TreeDataGridSelectedCellBackgroundBrush" Color="White" Opacity="0.4" />
         
-        <!-- TODO: Fix this to work with CompositeItemModel<Guid>-->
         <!-- needs to be a resource and not set by a style so we can add Clasess based on DataContext -->
+        <!-- NOTE(Al12rs): CompositeItemModel with new x:TypeArguments syntax works fine, but Rider doesn't like it. -->
         <ControlTemplate x:Key="LoadOrderItemTreeRowTemplate"
-                         TargetType="TreeDataGridRow">
+                         TargetType="TreeDataGridRow"
+                         x:DataType="{x:Type controls:CompositeItemModel, x:TypeArguments=system:Guid}">
             <Border x:Name="RowBorder"
                     Background="{TemplateBinding Background}"
                     BorderBrush="{TemplateBinding BorderBrush}"
                     BorderThickness="{TemplateBinding BorderThickness}"
                     CornerRadius="{TemplateBinding CornerRadius}"
-                    >
-                    <!-- Classes.IsActive="{CompiledBinding StyleFlags, -->
-                    <!--     Converter={x:Static converters:CompositeStyleFlagConverter.Instance}, -->
-                    <!--     ConverterParameter=IsActive}"> -->
+                    Classes.IsActive="{CompiledBinding StyleFlags,
+                        Converter={x:Static converters:CompositeStyleFlagConverter.Instance},
+                        ConverterParameter=IsActive}">
                 <TreeDataGridCellsPresenter Name="PART_CellsPresenter"
                                             CornerRadius="{TemplateBinding CornerRadius}"
                                             ElementFactory="{TemplateBinding ElementFactory}"


### PR DESCRIPTION
- Fixes #2941 
![image](https://github.com/user-attachments/assets/8df950a6-f4bc-42d2-b79a-00c533dd97a9)


Upgrade several Avalonia packages to their latest versions and add IsActive styling to Load Order now that x:DataType supports type parameters.

NOTE: Rider still gives an error for the type parameter, but building and running works fine.

Upgrade packages:

- Avalonia
- AvaloniaEdit
- R3
- ObservableCollections
And other packages related to them