### PR TITLE
Avoid running the FileStore garbage collector in fire and forget 

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.GC/GarbageCollectorRunMode.cs
+++ b/src/Abstractions/NexusMods.Abstractions.GC/GarbageCollectorRunMode.cs
@@ -21,4 +21,9 @@ public enum GarbageCollectorRunMode
     /// complete. The task is scheduled on the thread pool.
     /// </summary>
     RunAsyncInBackground,
+
+    /// <summary>
+    /// Runs the garbage collection in the background, waiting asynchronously for it to complete.
+    /// </summary>
+    RunAsynchronously,
 }

--- a/src/Abstractions/NexusMods.Abstractions.GC/IGarbageCollectorRunner.cs
+++ b/src/Abstractions/NexusMods.Abstractions.GC/IGarbageCollectorRunner.cs
@@ -20,5 +20,5 @@ public interface IGarbageCollectorRunner
     /// </summary>
     /// <param name="gcRunMode">The mode to run the GC in.</param>
     // ReSharper disable once InconsistentNaming
-    void RunWithMode(GarbageCollectorRunMode gcRunMode);
+    Task RunWithMode(GarbageCollectorRunMode gcRunMode);
 }

--- a/src/Abstractions/NexusMods.Abstractions.Library/ILibraryService.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Library/ILibraryService.cs
@@ -47,5 +47,5 @@ public interface ILibraryService
     /// </summary>
     /// <param name="libraryItems">The items to remove from the library.</param>
     /// <param name="gcRunMode">Defines how the garbage collector should be run</param>
-    Task RemoveItems(IEnumerable<LibraryItem.ReadOnly> libraryItems, GarbageCollectorRunMode gcRunMode = GarbageCollectorRunMode.RunAsyncInBackground);
+    Task RemoveItems(IEnumerable<LibraryItem.ReadOnly> libraryItems, GarbageCollectorRunMode gcRunMode = GarbageCollectorRunMode.RunAsynchronously);
 }

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -1568,7 +1568,7 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
         await tx.Commit();
         
         // Execute the garbage collector
-        _garbageCollectorRunner.RunWithMode(gcRunMode);
+        await _garbageCollectorRunner.RunWithMode(gcRunMode);
     }
 
     public async Task ResetToOriginalGameState(GameInstallation installation, LocatorId[] locatorIds)

--- a/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -1550,7 +1550,7 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
 
 
     /// <inheritdoc />
-    public async Task DeleteLoadout(LoadoutId loadoutId, GarbageCollectorRunMode gcRunMode = GarbageCollectorRunMode.RunAsyncInBackground)
+    public async Task DeleteLoadout(LoadoutId loadoutId, GarbageCollectorRunMode gcRunMode = GarbageCollectorRunMode.RunAsynchronously)
     {
         var loadout = Loadout.Load(Connection.Db, loadoutId);
         var metadata = GameInstallMetadata.Load(Connection.Db, loadout.InstallationInstance.GameMetadataId);

--- a/src/NexusMods.DataModel/GarbageCollectorRunner.cs
+++ b/src/NexusMods.DataModel/GarbageCollectorRunner.cs
@@ -27,7 +27,7 @@ public class GarbageCollectorRunner(ISettingsManager settings, NxFileStore store
     }
     
     /// <inheritdoc />
-    public void RunWithMode(GarbageCollectorRunMode gcRunMode)
+    public async Task RunWithMode(GarbageCollectorRunMode gcRunMode)
     {
         switch (gcRunMode)
         {
@@ -36,6 +36,9 @@ public class GarbageCollectorRunner(ISettingsManager settings, NxFileStore store
                 break;
             case GarbageCollectorRunMode.RunAsyncInBackground:
                 RunAsync().FireAndForget(_logger);
+                break;
+            case GarbageCollectorRunMode.RunAsynchronously:
+                await RunAsync();
                 break;
             case GarbageCollectorRunMode.DoNotRun:
                 break;

--- a/src/NexusMods.Library/LibraryService.cs
+++ b/src/NexusMods.Library/LibraryService.cs
@@ -70,6 +70,6 @@ public sealed class LibraryService : ILibraryService
             tx.Delete(item.Id, true);
 
         await tx.Commit();
-        _gcRunner.RunWithMode(gcRunMode);
+        await _gcRunner.RunWithMode(gcRunMode);
     }
 }

--- a/src/NexusMods.Library/LibraryService.cs
+++ b/src/NexusMods.Library/LibraryService.cs
@@ -63,7 +63,7 @@ public sealed class LibraryService : ILibraryService
 
         return InstallLoadoutItemJob.Create(_serviceProvider, libraryItem, parent.Value, itemInstaller, fallbackInstaller);
     }
-    public async Task RemoveItems(IEnumerable<LibraryItem.ReadOnly> libraryItems, GarbageCollectorRunMode gcRunMode = GarbageCollectorRunMode.RunAsyncInBackground)
+    public async Task RemoveItems(IEnumerable<LibraryItem.ReadOnly> libraryItems, GarbageCollectorRunMode gcRunMode = GarbageCollectorRunMode.RunAsynchronously)
     {
         using var tx = _connection.BeginTransaction();
         foreach (var item in libraryItems)


### PR DESCRIPTION
The GC behavior is very non deterministic and can be left around to be killed by an application close.

I changed most usage instances to prefer awaiting the results rather than fire and forgetting them.

I ran into a number of issues related to GC execution not being deterministic while debugging 
- #2944 

This Pr should make the behaviour more predictable and surface any exceptions or issues happening during GC.