### PR TITLE
Adds a reason to installer returning `NotSupported`

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Library.Installers/ALibraryArchiveInstaller.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Library.Installers/ALibraryArchiveInstaller.cs
@@ -38,7 +38,7 @@ public abstract class ALibraryArchiveInstaller : ALibraryFileInstaller, ILibrary
         if (!libraryFile.TryGetAsLibraryArchive(out var libraryArchive))
         {
             Logger.LogError("The provided library item `{Name}` (`{Id}`) is not a library archive!", libraryFile.AsLibraryItem().Name, libraryFile.Id);
-            return ValueTask.FromResult<InstallerResult>(new NotSupported());
+            return ValueTask.FromResult<InstallerResult>(new NotSupported(Reason: "The provided library item is not a library archive"));
         }
 
         return ExecuteAsync(libraryArchive, loadoutGroup, transaction, loadout, cancellationToken);

--- a/src/Abstractions/NexusMods.Abstractions.Library.Installers/ALibraryFileInstaller.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Library.Installers/ALibraryFileInstaller.cs
@@ -38,7 +38,7 @@ public abstract class ALibraryFileInstaller : ALibraryItemInstaller, ILibraryFil
         if (!libraryItem.TryGetAsLibraryFile(out var libraryFile))
         {
             Logger.LogError("The provided library item `{Name}` (`{Id}`) is not a library file!", libraryItem.Name, libraryItem.Id);
-            return ValueTask.FromResult<InstallerResult>(new NotSupported());
+            return ValueTask.FromResult<InstallerResult>(new NotSupported("The provided library item is not a library file"));
         }
 
         return ExecuteAsync(libraryFile, loadoutGroup, transaction, loadout, cancellationToken);

--- a/src/Abstractions/NexusMods.Abstractions.Library.Installers/InstallerResult.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Library.Installers/InstallerResult.cs
@@ -27,7 +27,17 @@ public readonly struct InstallerResult
     /// <summary>
     /// Gets whether the result is <see cref="NotSupported"/>.
     /// </summary>
-    public bool IsNotSupported => _value.IsT1;
+    public bool IsNotSupported(out string? reason)
+    {
+        if (!_value.IsT1)
+        {
+            reason = null;
+            return false;
+        }
+
+        reason = _value.AsT1.Reason;
+        return true;
+    }
 
     /// <summary/>
     public static implicit operator InstallerResult(Success x) => new(x);
@@ -46,4 +56,4 @@ public record struct Success;
 /// The input is not supported by the installer.
 /// </summary>
 [PublicAPI]
-public record struct NotSupported;
+public record struct NotSupported(string? Reason = null);

--- a/src/Games/NexusMods.Games.AdvancedInstaller.UI/AdvancedManualInstallerUI.cs
+++ b/src/Games/NexusMods.Games.AdvancedInstaller.UI/AdvancedManualInstallerUI.cs
@@ -49,11 +49,11 @@ public class AdvancedManualInstallerUI : ALibraryArchiveInstaller, IAdvancedInst
         Loadout.ReadOnly loadout,
         CancellationToken cancellationToken)
     {
-        if (Headless) return new NotSupported();
+        if (Headless) return new NotSupported(Reason: "The advanced manual installer can't be used in headless mode");
         var tree = LibraryArchiveTree.Create(libraryArchive);
         var (shouldInstall, deploymentData) = await GetDeploymentDataAsync(loadoutGroup.GetLoadoutItem(transaction).Name, tree, loadout);
 
-        if (!shouldInstall) return new NotSupported();
+        if (!shouldInstall) return new NotSupported(Reason: "The user chose to abort the installation");
 
         deploymentData.CreateLoadoutItems(tree, loadout, loadoutGroup, transaction);
         return new Success();

--- a/src/Games/NexusMods.Games.AdvancedInstaller/AdvancedManualInstaller.cs
+++ b/src/Games/NexusMods.Games.AdvancedInstaller/AdvancedManualInstaller.cs
@@ -39,7 +39,7 @@ public class AdvancedManualInstaller : ALibraryArchiveInstaller
         Loadout.ReadOnly loadout,
         CancellationToken cancellationToken)
     {
-        if (!IsActive) return ValueTask.FromResult<InstallerResult>(new NotSupported());
+        if (!IsActive) return ValueTask.FromResult<InstallerResult>(new NotSupported(Reason: "No UI is available for the installer"));
         return _handler.Value!.ExecuteAsync(libraryArchive, loadoutGroup, transaction, loadout, cancellationToken);
     }
 

--- a/src/Games/NexusMods.Games.FOMOD/FomodXmlInstaller.cs
+++ b/src/Games/NexusMods.Games.FOMOD/FomodXmlInstaller.cs
@@ -79,7 +79,7 @@ public class FomodXmlInstaller : ALibraryArchiveInstaller
         var tree = LibraryArchiveTree.Create(libraryArchive);
 
         var analyzerInfo = await FomodAnalyzer.AnalyzeAsync(tree, _fileSystem, _fileStore,cancellationToken);
-        if (analyzerInfo is null) return new NotSupported();
+        if (analyzerInfo is null) return new NotSupported(Reason: "Found no FOMOD data in the archive");
 
         await using var tmpFolder = _temporaryFileManager.CreateFolder();
         await analyzerInfo.DumpToFileSystemAsync(tmpFolder.Path.Combine(analyzerInfo.PathPrefix));

--- a/src/Games/NexusMods.Games.StardewValley/Installers/GenericInstaller.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Installers/GenericInstaller.cs
@@ -43,7 +43,7 @@ public class GenericInstaller : ALibraryArchiveInstaller
         foreach (var fileEntry in libraryArchive.Children)
         {
             var path = fileEntry.Path;
-            if (path.InFolder(Constants.ContentFolder)) return new NotSupported();
+            if (path.InFolder(Constants.ContentFolder)) return new NotSupported(Reason: "The installer doesn't support putting files in the Content folder");
 
             var inModsFolder = path.InFolder(Constants.ModsFolder);
             if (previousInMods.HasValue)
@@ -52,7 +52,7 @@ public class GenericInstaller : ALibraryArchiveInstaller
                 // packages to be installed into the root of the game folder
                 // /foo
                 // /Mods/bar
-                if (previousInMods.Value != inModsFolder) return new NotSupported();
+                if (previousInMods.Value != inModsFolder) return new NotSupported(Reason: "The installer doesn't support a mix of files going into the root directory and the mods directory");
             }
             else
             {

--- a/src/Games/NexusMods.Games.StardewValley/Installers/SMAPIInstaller.cs
+++ b/src/Games/NexusMods.Games.StardewValley/Installers/SMAPIInstaller.cs
@@ -63,11 +63,11 @@ public class SMAPIInstaller : ALibraryArchiveInstaller
             return parentName.Equals(targetParentName);
         }, out var installDataFile);
 
-        if (!foundInstallDataFile) return new NotSupported();
+        if (!foundInstallDataFile) return new NotSupported(Reason: "Found no SMAPI installation data file in the archive");
         if (!installDataFile.AsLibraryFile().TryGetAsLibraryArchive(out var installDataArchive))
         {
             Logger.LogError("Expected Library Item `{LibraryItem}` (`{Id}`) to be an archive", installDataFile.AsLibraryFile().AsLibraryItem().Name, installDataFile.Id);
-            return new NotSupported();
+            return new NotSupported(Reason: "Expected the installation data file to be an archive");
         }
 
         var isUnix = _osInformation.IsUnix();

--- a/src/NexusMods.Library/InstallLoadoutItemJob.cs
+++ b/src/NexusMods.Library/InstallLoadoutItemJob.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.Games;
 using NexusMods.Abstractions.Jobs;
 using NexusMods.Abstractions.Library.Installers;
@@ -13,6 +14,7 @@ namespace NexusMods.Library;
 
 internal class InstallLoadoutItemJob : IJobDefinitionWithStart<InstallLoadoutItemJob, LoadoutItemGroup.ReadOnly>, IInstallLoadoutItemJob
 {
+    public required ILogger Logger { get; init; }
     public ILibraryItemInstaller? Installer { get; init; }
     public ILibraryItemInstaller? FallbackInstaller { get; init; }
     public LibraryItem.ReadOnly LibraryItem { get; init; }
@@ -31,6 +33,7 @@ internal class InstallLoadoutItemJob : IJobDefinitionWithStart<InstallLoadoutIte
         var group = LoadoutItemGroup.Load(libraryItem.Db, groupId);
         var job = new InstallLoadoutItemJob
         {
+            Logger = serviceProvider.GetRequiredService<ILogger<InstallLoadoutItemJob>>(),
             Installer = installer,
             FallbackInstaller = fallbackInstaller,
             LibraryItem = libraryItem,
@@ -106,8 +109,13 @@ internal class InstallLoadoutItemJob : IJobDefinitionWithStart<InstallLoadoutIte
 
             // TODO(erri120): add safeguards to only allow groups to be added to the parent groups
             var result = await installer.ExecuteAsync(LibraryItem, loadoutGroup, transaction, loadout, context.CancellationToken);
-            if (result.IsNotSupported)
+            if (result.IsNotSupported(out var reason))
             {
+                if (reason is not null && Logger.IsEnabled(LogLevel.Trace))
+                {
+                    Logger.LogTrace("Installer doesn't support library item `{LibraryItem}` because \"{Reason}\"", LibraryItem.Name, reason);
+                }
+
                 transaction.Dispose();
                 continue;
             }

--- a/tests/Games/NexusMods.Games.StardewValley.Tests/GenericInstallerTests.cs
+++ b/tests/Games/NexusMods.Games.StardewValley.Tests/GenericInstallerTests.cs
@@ -52,7 +52,8 @@ public class GenericInstallerTests : ALibraryArchiveInstallerTests<GenericInstal
         };
 
         var result = await _installer.ExecuteAsync(libraryArchive, group, tx, loadout, CancellationToken.None);
-        result.IsNotSupported.Should().BeTrue();
+        result.IsNotSupported(out var reason).Should().BeTrue();
+        reason.Should().Be("The installer doesn't support putting files in the Content folder");
     }
 
     [Theory]


### PR DESCRIPTION
Providing more debug information for us, currently just set to log level `Trace`.