### PR TITLE
TreeDataGrid Adapter support for drag/drop events

### DIFF
--- a/.github/workflows/networking_tests.yaml
+++ b/.github/workflows/networking_tests.yaml
@@ -7,18 +7,13 @@ on:
 jobs:
   build:
     
-    name: Test ${{ matrix.project }} (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    name: Test Networking
+    runs-on: [self-hosted]
     
     environment: test
     
     env:
       NEXUS_API_KEY: ${{ secrets.NEXUS_API_KEY }}
-    
-    strategy:
-      matrix:
-        #os: [ubuntu-latest, windows-latest, macos-latest]
-        os: [self-hosted]
 
     steps:
       - uses: actions/checkout@v3

--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridViewHelper.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridViewHelper.cs
@@ -55,6 +55,13 @@ public static class TreeDataGridViewHelper
                     .Subscribe((view, getAdapter), static (eventArgs, state) =>
                             state.getAdapter(state.view.ViewModel!).OnRowDragStarted(eventArgs.sender, eventArgs.e))
                     .AddTo(disposables);
+                
+                Observable.FromEventHandler<TreeDataGridRowDragEventArgs>(
+                        addHandler: handler => treeDataGrid.RowDragOver += handler,
+                        removeHandler: handler => treeDataGrid.RowDragOver -= handler)
+                    .Subscribe((view, getAdapter), static (eventArgs, state) =>
+                        state.getAdapter(state.view.ViewModel!).OnRowDragOver(eventArgs.sender, eventArgs.e))
+                    .AddTo(disposables);
 
                 Observable.FromEventHandler<TreeDataGridRowDragEventArgs>(
                         addHandler: handler => treeDataGrid.RowDrop += handler,

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderView.axaml
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderView.axaml
@@ -58,11 +58,9 @@
 
                 <!-- right column (tree data grid) -->
                 <TreeDataGrid Grid.Column="1" x:Name="SortOrderTreeDataGrid"
-                              AutoDragDropRows="False"
                               CanUserResizeColumns="False"
                               CanUserSortColumns="False"
-                              ShowColumnHeaders="True"
-                              RowDrop="OnRowDrop">
+                              ShowColumnHeaders="True">
 
                     <TreeDataGrid.Resources>
                         <ResourceDictionary>

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderView.axaml.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderView.axaml.cs
@@ -114,31 +114,5 @@ public partial class LoadOrderView : ReactiveUserControl<ILoadOrderViewModel>
             }
         );
     }
-
-    private void OnRowDrop(object? sender, TreeDataGridRowDragEventArgs e)
-    {
-        
-        // NOTE(Al12rs): This is important in case the source is read-only, otherwise TreeDataGrid will attempt to
-        // move the items, updating the source collection, throwing an exception in the process.
-        e.Handled = true;
-
-        var dataObject = e.Inner.Data as DataObject;
-        var a = dataObject?.Get("TreeDataGridDragInfo");
-        var dragInfo = a as DragInfo;
-        if (dragInfo is null) return;
-
-        var source = dragInfo.Source;
-        var indices = dragInfo.Indexes;
-
-        var models = new List<CompositeItemModel<Guid>>();
-
-        foreach (var modelIndex in indices)
-        {
-            var rowIndex = source.Rows.ModelIndexToRowIndex(modelIndex);
-            var row = source.Rows[rowIndex];
-            var model = row.Model;
-            if (model is CompositeItemModel<Guid> loadOrderItemModel)
-                models.Add(loadOrderItemModel);
-        }
-    }
+    
 }

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderView.axaml.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderView.axaml.cs
@@ -1,7 +1,8 @@
 using System.ComponentModel;
 using System.Reactive.Disposables;
-using System.Reactive.Linq;
 using Avalonia.Controls;
+using Avalonia.Controls.Models.TreeDataGrid;
+using Avalonia.Input;
 using Avalonia.ReactiveUI;
 using NexusMods.App.UI.Controls;
 using NexusMods.App.UI.Extensions;
@@ -115,8 +116,28 @@ public partial class LoadOrderView : ReactiveUserControl<ILoadOrderViewModel>
 
     private void OnRowDrop(object? sender, TreeDataGridRowDragEventArgs e)
     {
+        
         // NOTE(Al12rs): This is important in case the source is read-only, otherwise TreeDataGrid will attempt to
         // move the items, updating the source collection, throwing an exception in the process.
         e.Handled = true;
+
+        var dataObject = e.Inner.Data as DataObject;
+        var a = dataObject?.Get("TreeDataGridDragInfo");
+        var dragInfo = a as DragInfo;
+        if (dragInfo is null) return;
+
+        var source = dragInfo.Source;
+        var indices = dragInfo.Indexes;
+
+        var models = new List<LoadOrderItemModel>();
+
+        foreach (var modelIndex in indices)
+        {
+            var rowIndex = source.Rows.ModelIndexToRowIndex(modelIndex);
+            var row = source.Rows[rowIndex];
+            var model = row.Model;
+            if (model is LoadOrderItemModel loadOrderItemModel)
+                models.Add(loadOrderItemModel);
+        }
     }
 }

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderView.axaml.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderView.axaml.cs
@@ -16,15 +16,15 @@ public partial class LoadOrderView : ReactiveUserControl<ILoadOrderViewModel>
     public LoadOrderView()
     {
         InitializeComponent();
+        
+        TreeDataGridViewHelper.SetupTreeDataGridAdapter<LoadOrderView, ILoadOrderViewModel, CompositeItemModel<Guid>, Guid>(
+            this,
+            SortOrderTreeDataGrid,
+            vm => vm.Adapter
+        );
 
         this.WhenActivated(disposables =>
             {
-                TreeDataGridViewHelper.SetupTreeDataGridAdapter<LoadOrderView, ILoadOrderViewModel, CompositeItemModel<Guid>, Guid>(
-                    this,
-                    SortOrderTreeDataGrid,
-                    vm => vm.Adapter
-                );
-
                 // TreeDataGrid Source
                 this.OneWayBind(ViewModel,
                         vm => vm.Adapter.Source.Value,

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderView.axaml.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderView.axaml.cs
@@ -7,6 +7,7 @@ using Avalonia.ReactiveUI;
 using NexusMods.App.UI.Controls;
 using NexusMods.App.UI.Extensions;
 using ReactiveUI;
+using Guid = System.Guid;
 
 namespace NexusMods.App.UI.Pages.Sorting;
 
@@ -129,14 +130,14 @@ public partial class LoadOrderView : ReactiveUserControl<ILoadOrderViewModel>
         var source = dragInfo.Source;
         var indices = dragInfo.Indexes;
 
-        var models = new List<LoadOrderItemModel>();
+        var models = new List<CompositeItemModel<Guid>>();
 
         foreach (var modelIndex in indices)
         {
             var rowIndex = source.Rows.ModelIndexToRowIndex(modelIndex);
             var row = source.Rows[rowIndex];
             var model = row.Model;
-            if (model is LoadOrderItemModel loadOrderItemModel)
+            if (model is CompositeItemModel<Guid> loadOrderItemModel)
                 models.Add(loadOrderItemModel);
         }
     }


### PR DESCRIPTION
- Part of #2276

This adds a `enableDragAndDrop` parameter to the setup of the `TreeDataGridAdapter`.
This enables drag and drop support on the tree and provides two subjects for `RowDragStarted` and `RowDrop` events.

Added code to extract the source and target models from the event data.
The original eventArgs are still passed to the subject since they can contain useful data like drop position, or can allow altering the state of the Drag indicator (can drop, can't drop etc).   

I checked with breakpoints that the extraction of the `sourceModels` and `targetModel` worked fine. 