### PR TITLE
Load Order: Drag and Drop Setup and prepare data 

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Games/ILoadoutSortableItemProvider.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Games/ILoadoutSortableItemProvider.cs
@@ -47,7 +47,7 @@ public interface ILoadoutSortableItemProvider : IDisposable
     /// The relative index order of the moved items is preserved.
     /// Validity and outcome of the move may depend on game specific logic, so only some or none of the items may be moved.
     /// </summary>
-    Task MoveItemsTo(ISortableItem[] sourceItems, ISortableItem targetItem, TargetRelativePosition position, CancellationToken token);
+    Task MoveItemsTo(ISortableItem[] sourceItems, ISortableItem targetItem, TargetRelativePosition relativePosition, CancellationToken token);
 }
 
 /// <summary>

--- a/src/Abstractions/NexusMods.Abstractions.Games/ILoadoutSortableItemProvider.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Games/ILoadoutSortableItemProvider.cs
@@ -43,9 +43,25 @@ public interface ILoadoutSortableItemProvider : IDisposable
     Task SetRelativePosition(ISortableItem sortableItem, int delta, CancellationToken token);
     
     /// <summary>
-    /// Moves the given items to the target index in the sort order.
+    /// Moves the given items to be before or after the target item in ascending index sort order.
     /// The relative index order of the moved items is preserved.
     /// Validity and outcome of the move may depend on game specific logic, so only some or none of the items may be moved.
     /// </summary>
-    Task MoveItemsTo(ISortableItem[] sourceItems, int targetIndex, CancellationToken token);
+    Task MoveItemsTo(ISortableItem[] sourceItems, ISortableItem targetItem, TargetRelativePosition position, CancellationToken token);
+}
+
+/// <summary>
+/// The position items should be moved to, relative to the target item in ascending index order.
+/// </summary>
+public enum TargetRelativePosition
+{
+    /// <summary>
+    /// Items should be moved to be before the target item in ascending index order
+    /// </summary>
+    BeforeTarget,
+    
+    /// <summary>
+    /// Items should be moved to be after the target item in ascending index order
+    /// </summary>
+    AfterTarget,
 }

--- a/src/Abstractions/NexusMods.Abstractions.Games/ILoadoutSortableItemProvider.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Games/ILoadoutSortableItemProvider.cs
@@ -41,4 +41,11 @@ public interface ILoadoutSortableItemProvider : IDisposable
     /// <param name="sortableItem">item to move</param>
     /// <param name="delta">positive or negative index delta</param>
     Task SetRelativePosition(ISortableItem sortableItem, int delta, CancellationToken token);
+    
+    /// <summary>
+    /// Moves the given items to the target index in the sort order.
+    /// The relative index order of the moved items is preserved.
+    /// Validity and outcome of the move may depend on game specific logic, so only some or none of the items may be moved.
+    /// </summary>
+    Task MoveItemsTo(ISortableItem[] sourceItems, int targetIndex, CancellationToken token);
 }

--- a/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/SortOrder/RedMod/RedModSortableItemProvider.cs
+++ b/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/SortOrder/RedMod/RedModSortableItemProvider.cs
@@ -151,7 +151,7 @@ public class RedModSortableItemProvider : ILoadoutSortableItemProvider
     }
 
     /// <inheritdoc/>
-    public Task MoveItemsTo(ISortableItem[] sourceItems, ISortableItem targetItem, TargetRelativePosition position, CancellationToken token)
+    public Task MoveItemsTo(ISortableItem[] sourceItems, ISortableItem targetItem, TargetRelativePosition relativePosition, CancellationToken token)
     {
         // TODO: implement this method
         return Task.CompletedTask;

--- a/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/SortOrder/RedMod/RedModSortableItemProvider.cs
+++ b/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/SortOrder/RedMod/RedModSortableItemProvider.cs
@@ -151,7 +151,7 @@ public class RedModSortableItemProvider : ILoadoutSortableItemProvider
     }
 
     /// <inheritdoc/>
-    public Task MoveItemsTo(ISortableItem[] sourceItems, int targetIndex, CancellationToken token)
+    public Task MoveItemsTo(ISortableItem[] sourceItems, ISortableItem targetItem, TargetRelativePosition position, CancellationToken token)
     {
         // TODO: implement this method
         return Task.CompletedTask;

--- a/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/SortOrder/RedMod/RedModSortableItemProvider.cs
+++ b/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/SortOrder/RedMod/RedModSortableItemProvider.cs
@@ -150,6 +150,13 @@ public class RedModSortableItemProvider : ILoadoutSortableItemProvider
         }
     }
 
+    /// <inheritdoc/>
+    public Task MoveItemsTo(ISortableItem[] sourceItems, int targetIndex, CancellationToken token)
+    {
+        // TODO: implement this method
+        return Task.CompletedTask;
+    }
+
     /// <summary>
     /// Returns the list of RedMod folder names, sorted by the load order, that are enabled in the loadout
     /// </summary>

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderView.axaml.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderView.axaml.cs
@@ -20,7 +20,8 @@ public partial class LoadOrderView : ReactiveUserControl<ILoadOrderViewModel>
         TreeDataGridViewHelper.SetupTreeDataGridAdapter<LoadOrderView, ILoadOrderViewModel, CompositeItemModel<Guid>, Guid>(
             this,
             SortOrderTreeDataGrid,
-            vm => vm.Adapter
+            vm => vm.Adapter,
+            enableDragAndDrop: true
         );
 
         this.WhenActivated(disposables =>

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderViewModel.cs
@@ -131,8 +131,7 @@ public class LoadOrderViewModel : AViewModel<ILoadOrderViewModel>, ILoadOrderVie
                             if (eventArgs.Position != TreeDataGridRowDropPosition.Inside) return;
                             
                             // Update the drop position for the inside case to be before or after
-                            var positionY = eventArgs.Inner.GetPosition(eventArgs.TargetRow).Y / eventArgs.TargetRow.Bounds.Height;
-                            eventArgs.Position = positionY < 0.5 ? TreeDataGridRowDropPosition.Before : TreeDataGridRowDropPosition.After;
+                            eventArgs.Position = PointerIsInVerticalTopHalf(eventArgs) ? TreeDataGridRowDropPosition.Before : TreeDataGridRowDropPosition.After;
                         }
                     );
                 
@@ -166,12 +165,10 @@ public class LoadOrderViewModel : AViewModel<ILoadOrderViewModel>, ILoadOrderVie
                                     relativePosition = TargetRelativePosition.AfterTarget;
                                     break;
                                 case TreeDataGridRowDropPosition.Inside when SortDirectionCurrent == ListSortDirection.Ascending:
-                                    var positionY = eventArgs.Inner.GetPosition(eventArgs.TargetRow).Y / eventArgs.TargetRow.Bounds.Height;
-                                    relativePosition = positionY < 0.5 ? TargetRelativePosition.BeforeTarget : TargetRelativePosition.AfterTarget;
+                                    relativePosition = PointerIsInVerticalTopHalf(eventArgs) ? TargetRelativePosition.BeforeTarget : TargetRelativePosition.AfterTarget;
                                     break;
                                 case TreeDataGridRowDropPosition.Inside when SortDirectionCurrent == ListSortDirection.Descending:
-                                    var positionY2 = eventArgs.Inner.GetPosition(eventArgs.TargetRow).Y / eventArgs.TargetRow.Bounds.Height;
-                                    relativePosition = positionY2 < 0.5 ? TargetRelativePosition.AfterTarget : TargetRelativePosition.BeforeTarget;
+                                    relativePosition = PointerIsInVerticalTopHalf(eventArgs) ? TargetRelativePosition.AfterTarget : TargetRelativePosition.BeforeTarget;
                                     break;
                                 case TreeDataGridRowDropPosition.None:
                                     // Invalid target, no move
@@ -186,6 +183,12 @@ public class LoadOrderViewModel : AViewModel<ILoadOrderViewModel>, ILoadOrderVie
                     .DisposeWith(d);
             }
         );
+    }
+    
+    private static bool PointerIsInVerticalTopHalf(TreeDataGridRowDragEventArgs eventArgs)
+    {
+        var positionY = eventArgs.Inner.GetPosition(eventArgs.TargetRow).Y / eventArgs.TargetRow.Bounds.Height;
+        return positionY < 0.5;
     }
 }
 

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderViewModel.cs
@@ -181,7 +181,8 @@ public class LoadOrderViewModel : AViewModel<ILoadOrderViewModel>, ILoadOrderVie
                             }
                             
                             await provider.MoveItemsTo(sourceItems, targetItem.Value, relativePosition, cancellationToken);
-                        })
+                        },
+                        awaitOperation: AwaitOperation.Drop)
                     .DisposeWith(d);
             }
         );


### PR DESCRIPTION
- Part of #2276 


## Details:
- Added stubbed `MoveIitems` method to `ILoadoutSortableItemProvider` that will contain the main moving logic for RedMods.
- Normalized the drag/drop event data in the `LoadOrderViewModel` depending on the `SortDirectionCurrent`.
- Made Drop position `Inside` result in either `Before` or `After` to avoid dropped items not moving due to drop position being too central.
- Enabled drag and drop in the UI for testing. Items won't move but it is possible to drag them and see the effects.



Next step is to implement the main logic inside `MoveItems`
