### PR TITLE
Adds Parent Mod column to Load Order UI

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Games/ISortableItemProviderFactory.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Games/ISortableItemProviderFactory.cs
@@ -52,11 +52,6 @@ public interface ISortableItemProviderFactory : IDisposable
     /// Header text for the display name column
     /// </summary>
     string DisplayNameColumnHeader { get; }
-    
-    /// <summary>
-    /// Header text for the parent mod column
-    /// </summary>
-    string ParentModNameColumnHeader { get; }
 
     /// <summary>
     /// Title text to display in case there are no sortable items to sort

--- a/src/Abstractions/NexusMods.Abstractions.Games/ISortableItemProviderFactory.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Games/ISortableItemProviderFactory.cs
@@ -49,10 +49,15 @@ public interface ISortableItemProviderFactory : IDisposable
     string IndexColumnHeader { get; }
     
     /// <summary>
-    /// Header text for the name column
+    /// Header text for the display name column
     /// </summary>
-    string NameColumnHeader { get; }
+    string DisplayNameColumnHeader { get; }
     
+    /// <summary>
+    /// Header text for the parent mod column
+    /// </summary>
+    string ParentModNameColumnHeader { get; }
+
     /// <summary>
     /// Title text to display in case there are no sortable items to sort
     /// </summary>

--- a/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/SortOrder/RedMod/RedModSortableItemProviderFactory.cs
+++ b/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/SortOrder/RedMod/RedModSortableItemProviderFactory.cs
@@ -30,7 +30,8 @@ public class RedModSortableItemProviderFactory : ISortableItemProviderFactory
 
     public string IndexColumnHeader => "Load Order";
 
-    public string NameColumnHeader => "REDmod Name";
+    public string DisplayNameColumnHeader => "REDmod Name";
+    public string ParentModNameColumnHeader => "Parent mod";
 
     public string EmptyStateMessageTitle => "No REDmods detected";
     public string EmptyStateMessageContents => "Some mods contain REDmod items that alter core gameplay elements. When detected, they will appear here for load order configuration.";

--- a/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/SortOrder/RedMod/RedModSortableItemProviderFactory.cs
+++ b/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/SortOrder/RedMod/RedModSortableItemProviderFactory.cs
@@ -31,8 +31,6 @@ public class RedModSortableItemProviderFactory : ISortableItemProviderFactory
     public string IndexColumnHeader => "Load Order";
 
     public string DisplayNameColumnHeader => "REDmod Name";
-    public string ParentModNameColumnHeader => "Parent mod";
-
     public string EmptyStateMessageTitle => "No REDmods detected";
     public string EmptyStateMessageContents => "Some mods contain REDmod items that alter core gameplay elements. When detected, they will appear here for load order configuration.";
     public string LearnMoreUrl => "https://nexus-mods.github.io/NexusMods.App/users/games/Cyberpunk2077/#redmod-load-ordering";

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderViewDesignViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderViewDesignViewModel.cs
@@ -77,8 +77,13 @@ public class LoadOrderTreeDataGridDesignAdapter : TreeDataGridAdapter<CompositeI
         return
         [
             expanderColumn,
-            ColumnCreator.Create<Guid, LoadOrderColumns.NameColumn>(
-                columnHeader: "Name",
+            ColumnCreator.Create<Guid, LoadOrderColumns.DisplayNameColumn>(
+                columnHeader: "DisplayName",
+                canUserSortColumn: false,
+                canUserResizeColumn: false
+            ),
+            ColumnCreator.Create<Guid, LoadOrderColumns.ModNameColumn>(
+                columnHeader: "ModName",
                 canUserSortColumn: false,
                 canUserResizeColumn: false
             ),
@@ -88,9 +93,9 @@ public class LoadOrderTreeDataGridDesignAdapter : TreeDataGridAdapter<CompositeI
     private CompositeItemModel<Guid> CreateDesignModel(string name, Guid guid, int sortIndex, bool isActive)
     {
         var model = new CompositeItemModel<Guid>(guid);
-        model.Add(LoadOrderColumns.NameColumn.NameComponentKey, new StringComponent(name));
+        model.Add(LoadOrderColumns.DisplayNameColumn.DisplayNameComponentKey, new StringComponent(name));
+        model.Add(LoadOrderColumns.ModNameColumn.ModNameComponentKey, new StringComponent(name));
         model.Add(LoadOrderColumns.IsActiveComponentKey, new ValueComponent<bool>(isActive));
-
 
         model.Add(LoadOrderColumns.IndexColumn.IndexComponentKey,
             new LoadOrderComponents.IndexComponent(

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderViewModel.cs
@@ -273,11 +273,16 @@ public class LoadOrderTreeDataGridAdapter : TreeDataGridAdapter<CompositeItemMod
         return
         [
             expanderColumn,
-            ColumnCreator.Create<Guid, LoadOrderColumns.NameColumn>(
-                columnHeader: _sortableItemsProvider.ParentFactory.NameColumnHeader,
+            ColumnCreator.Create<Guid, LoadOrderColumns.DisplayNameColumn>(
+                columnHeader: _sortableItemsProvider.ParentFactory.DisplayNameColumnHeader,
                 canUserSortColumn: false,
                 canUserResizeColumn: false
             ),
+            ColumnCreator.Create<Guid, LoadOrderColumns.ModNameColumn>(
+                columnHeader: _sortableItemsProvider.ParentFactory.ParentModNameColumnHeader,
+                canUserSortColumn: false,
+                canUserResizeColumn: false
+            )
         ];
     }
 

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/LoadOrderViewModel.cs
@@ -279,7 +279,6 @@ public class LoadOrderTreeDataGridAdapter : TreeDataGridAdapter<CompositeItemMod
                 canUserResizeColumn: false
             ),
             ColumnCreator.Create<Guid, LoadOrderColumns.ModNameColumn>(
-                columnHeader: _sortableItemsProvider.ParentFactory.ParentModNameColumnHeader,
                 canUserSortColumn: false,
                 canUserResizeColumn: false
             )

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGrid/LoadOrderComponents.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGrid/LoadOrderComponents.cs
@@ -108,7 +108,7 @@ public static class LoadOrderColumns
         }
 
         // The header name should be set on column creation as it is game dependent
-        public static string GetColumnHeader() => throw new NotSupportedException();
+        public static string GetColumnHeader() => "Parent mod";
 
         public static string GetColumnTemplateResourceKey() => ColumnTemplateResourceKey;
     }

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGrid/LoadOrderComponents.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGrid/LoadOrderComponents.cs
@@ -78,11 +78,28 @@ public static class LoadOrderColumns
     }
 
     [UsedImplicitly]
-    public sealed class NameColumn : ICompositeColumnDefinition<NameColumn>
+    public sealed class DisplayNameColumn : ICompositeColumnDefinition<DisplayNameColumn>
     {
-        public const string ColumnTemplateResourceKey = nameof(LoadOrderColumns) + "_" + nameof(NameColumn);
+        public const string ColumnTemplateResourceKey = nameof(LoadOrderColumns) + "_" + nameof(DisplayNameColumn);
 
-        public static readonly ComponentKey NameComponentKey = ComponentKey.From(ColumnTemplateResourceKey + "_" + "DisplayNameComponent");
+        public static readonly ComponentKey DisplayNameComponentKey = ComponentKey.From(ColumnTemplateResourceKey + "_" + "DisplayNameComponent");
+
+        public static int Compare<TKey>(CompositeItemModel<TKey> a, CompositeItemModel<TKey> b) where TKey : notnull
+        {
+            throw new NotImplementedException();
+        }
+
+        // The header name should be set on column creation as it is game dependent
+        public static string GetColumnHeader() => throw new NotSupportedException();
+
+        public static string GetColumnTemplateResourceKey() => ColumnTemplateResourceKey;
+    }
+    
+    [UsedImplicitly]
+    public sealed class ModNameColumn : ICompositeColumnDefinition<ModNameColumn>
+    {
+        public const string ColumnTemplateResourceKey = nameof(LoadOrderColumns) + "_" + nameof(ModNameColumn);
+
         public static readonly ComponentKey ModNameComponentKey = ComponentKey.From(ColumnTemplateResourceKey + "_" + "ModNameComponent");
 
         public static int Compare<TKey>(CompositeItemModel<TKey> a, CompositeItemModel<TKey> b) where TKey : notnull

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGrid/LoadOrderDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGrid/LoadOrderDataProvider.cs
@@ -52,11 +52,11 @@ public class LoadOrderDataProvider : ILoadOrderDataProvider
         var compositeModel = new CompositeItemModel<Guid>(sortableItem.ItemId);
 
         // DisplayName
-        compositeModel.Add(LoadOrderColumns.NameColumn.NameComponentKey,
+        compositeModel.Add(LoadOrderColumns.DisplayNameColumn.DisplayNameComponentKey,
             new StringComponent(sortableItem.DisplayName, sortableItem.WhenAnyValue(item => item.DisplayName)));
 
         // ModName
-        compositeModel.Add(LoadOrderColumns.NameColumn.ModNameComponentKey,
+        compositeModel.Add(LoadOrderColumns.ModNameColumn.ModNameComponentKey,
             new StringComponent(sortableItem.ModName, sortableItem.WhenAnyValue(item => item.ModName)));
 
         // IsActive

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGridLoadOrderResources.axaml
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGridLoadOrderResources.axaml
@@ -52,14 +52,15 @@
         
     </DataTemplate>
     
-    <!-- Name Column -->
-    <DataTemplate x:Key="{x:Static local:LoadOrderColumns+NameColumn.ColumnTemplateResourceKey}">
+    <!-- DisplayName Column -->
+    <DataTemplate x:Key="{x:Static local:LoadOrderColumns+DisplayNameColumn.ColumnTemplateResourceKey}">
         <DataTemplate.DataType>
             <x:Type TypeName="controls:CompositeItemModel" x:TypeArguments="system:Guid" />
         </DataTemplate.DataType>
 
-        <StackPanel x:Name="LoadOrderItemNameColumnStack" Orientation="Horizontal" Spacing="12">
-
+        <StackPanel x:Name="LoadOrderItemNameColumnStack" Orientation="Horizontal" Spacing="{StaticResource Spacing-3}">
+            
+            <!-- Thumbnail -->
             <Border x:Name="ItemModImageBorder">
                 <icons:UnifiedIcon Value="{x:Static icons:IconValues.Nexus}" />
             </Border>
@@ -69,7 +70,7 @@
                                        Content="{CompiledBinding}">
                 <controls:ComponentControl.ComponentTemplate>
                     <controls:ComponentTemplate x:TypeArguments="controls:StringComponent"
-                                                ComponentKey="{x:Static local:LoadOrderColumns+NameColumn.NameComponentKey}">
+                                                ComponentKey="{x:Static local:LoadOrderColumns+DisplayNameColumn.DisplayNameComponentKey}">
                         <controls:ComponentTemplate.DataTemplate>
                             <DataTemplate x:DataType="controls:StringComponent" DataType="controls:StringComponent">
                                 <TextBlock x:Name="DisplayName" Text="{CompiledBinding Value.Value}" />
@@ -78,32 +79,27 @@
                     </controls:ComponentTemplate>
                 </controls:ComponentControl.ComponentTemplate>
             </controls:ComponentControl>
-            
-            <!-- Current designs no longer have vertically stacked mod and display name. The design has evolved into using extra columns which
-            we can tackle soon or find a middle ground and stack horizontally. Will decide before release. -->
-            
-            <!-- <StackPanel VerticalAlignment="Center"> -->
-            <!--      -->
-            <!--     ~1~ ModName @1@ -->
-            <!--     <controls:ComponentControl x:TypeArguments="system:Guid" -->
-            <!--                                Content="{CompiledBinding}"> -->
-            <!--         <controls:ComponentControl.ComponentTemplate> -->
-            <!--             <controls:ComponentTemplate x:TypeArguments="controls:StringComponent" -->
-            <!--                                         ComponentKey="{x:Static local:LoadOrderColumns+NameColumn.ModNameComponentKey}"> -->
-            <!--                 <controls:ComponentTemplate.DataTemplate> -->
-            <!--                     <DataTemplate x:DataType="controls:StringComponent" DataType="controls:StringComponent"> -->
-            <!--                         <TextBlock x:Name="ModName" Text="{CompiledBinding Value.Value}" /> -->
-            <!--                     </DataTemplate> -->
-            <!--                 </controls:ComponentTemplate.DataTemplate> -->
-            <!--             </controls:ComponentTemplate> -->
-            <!--         </controls:ComponentControl.ComponentTemplate> -->
-            <!--     </controls:ComponentControl> -->
-            <!--      -->
-            <!-- </StackPanel> -->
-            
         </StackPanel>
-        
     </DataTemplate>
 
+    <!-- ModName Column -->
+    <DataTemplate x:Key="{x:Static local:LoadOrderColumns+ModNameColumn.ColumnTemplateResourceKey}">
+        <DataTemplate.DataType>
+            <x:Type TypeName="controls:CompositeItemModel" x:TypeArguments="system:Guid" />
+        </DataTemplate.DataType>
+            <controls:ComponentControl x:TypeArguments="system:Guid"
+                                       Content="{CompiledBinding}">
+                <controls:ComponentControl.ComponentTemplate>
+                    <controls:ComponentTemplate x:TypeArguments="controls:StringComponent"
+                                                ComponentKey="{x:Static local:LoadOrderColumns+ModNameColumn.ModNameComponentKey}">
+                        <controls:ComponentTemplate.DataTemplate>
+                            <DataTemplate x:DataType="controls:StringComponent" DataType="controls:StringComponent">
+                                <TextBlock x:Name="ModName" Text="{CompiledBinding Value.Value}" />
+                            </DataTemplate>
+                        </controls:ComponentTemplate.DataTemplate>
+                    </controls:ComponentTemplate>
+                </controls:ComponentControl.ComponentTemplate>
+            </controls:ComponentControl>
+    </DataTemplate>
 
 </ResourceDictionary>

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/UserControls/Sorting/LoadOrderStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/UserControls/Sorting/LoadOrderStyles.axaml
@@ -109,8 +109,8 @@
                         </Style>
                     </Style>
 
-                    <!-- second column (name) -->
-                    <Style Selector="^.LoadOrderColumns_NameColumn">
+                    <!-- second column (display name) -->
+                    <Style Selector="^.LoadOrderColumns_DisplayNameColumn">
                         <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
 
                             <Style Selector="^ Border#ItemModImageBorder">
@@ -126,18 +126,22 @@
                                     <Setter Property="Size" Value="16" />
                                 </Style>
                             </Style>
-
-                            <Style Selector="^ TextBlock#ModName">
-                                <Setter Property="Theme" Value="{StaticResource BodySMNormalTheme}" />
-                                <Setter Property="Foreground" Value="{StaticResource NeutralTranslucentModerateBrush}" />
-                            </Style>
                             <Style Selector="^ TextBlock#DisplayName">
                                 <Setter Property="Theme" Value="{StaticResource BodySMNormalTheme}" />
                                 <Setter Property="Foreground" Value="{StaticResource NeutralTranslucentStrongBrush}" />
                             </Style>
                         </Style>
                     </Style>
-
+                    
+                    <!-- third column (mod name) -->
+                    <Style Selector="^.LoadOrderColumns_ModNameColumn">
+                        <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
+                            <Style Selector="^ TextBlock#ModName">
+                                <Setter Property="Theme" Value="{StaticResource BodySMNormalTheme}" />
+                                <Setter Property="Foreground" Value="{StaticResource NeutralTranslucentSubduedBrush}" />
+                            </Style>
+                        </Style>
+                    </Style>
                 </Style>
             </Style>
         </Style>


### PR DESCRIPTION
Not entirely happy with the naming, the column heading is "Parent mod" in Figma, but elsewhere in the codebase we just call it ModName, with the main Name column becoming DisplayName. I'd appreciate your thoughts.

Waiting on #3020 to be merged 