### PR TITLE
Add diagnostics for configuring Cyberpunk 2077 on Linux for Steam

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -137,7 +137,7 @@
     <PackageVersion Include="BitFaster.Caching" Version="2.5.2" />
     <PackageVersion Include="CliWrap" Version="3.6.7" />
     <PackageVersion Include="DynamicData" Version="9.1.2" />
-    <PackageVersion Include="GameFinder" Version="4.6.0" />
+    <PackageVersion Include="GameFinder" Version="4.6.1" />
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="ini-parser-netstandard" Version="2.5.2" />
     <PackageVersion Include="Mutagen.Bethesda.Skyrim" Version="0.44.0" />

--- a/src/Abstractions/NexusMods.Abstractions.GameLocators/Stores/Steam/SteamLocatorResultMetadata.cs
+++ b/src/Abstractions/NexusMods.Abstractions.GameLocators/Stores/Steam/SteamLocatorResultMetadata.cs
@@ -26,4 +26,6 @@ public record SteamLocatorResultMetadata : IGameLocatorResultMetadata
     
     /// <inheritdoc />
     public IEnumerable<LocatorId> ToLocatorIds() => ManifestIds.Select(m => LocatorId.From(m.ToString()));
+
+    public Func<string?>? GetLaunchOptions { get; init; }
 }

--- a/src/Abstractions/NexusMods.Abstractions.GameLocators/Stores/Steam/SteamLocatorResultMetadata.cs
+++ b/src/Abstractions/NexusMods.Abstractions.GameLocators/Stores/Steam/SteamLocatorResultMetadata.cs
@@ -27,5 +27,7 @@ public record SteamLocatorResultMetadata : IGameLocatorResultMetadata
     /// <inheritdoc />
     public IEnumerable<LocatorId> ToLocatorIds() => ManifestIds.Select(m => LocatorId.From(m.ToString()));
 
+    public AbsolutePath? ProtonPrefixDirectory { get; init; }
+
     public Func<string?>? GetLaunchOptions { get; init; }
 }

--- a/src/Abstractions/NexusMods.Abstractions.GameLocators/WineParser.cs
+++ b/src/Abstractions/NexusMods.Abstractions.GameLocators/WineParser.cs
@@ -1,0 +1,123 @@
+using JetBrains.Annotations;
+
+namespace NexusMods.Abstractions.GameLocators;
+
+/// <summary>
+/// Parser for WINE.
+/// </summary>
+public static class WineParser
+{
+    public const string EnvironmentVariableName = "WINEDLLOVERRIDES";
+
+    /// <summary>
+    /// Parses the <see cref="EnvironmentVariableName"/>.
+    /// </summary>
+    public static IReadOnlyList<WineDllOverride> ParseEnvironmentVariable(ReadOnlySpan<char> environmentVariableValue)
+    {
+        var results = new List<WineDllOverride>();
+
+        // https://gitlab.winehq.org/wine/wine/-/wikis/Wine-User's-Guide#winedlloverrides-dll-overrides
+        var span = GetWineDllOverridesSection(environmentVariableValue);
+
+        // NOTE(erri120): DLLs are separated with a semicolon
+        var splitEnumerator = span.Split(';');
+        foreach (var splitRange in splitEnumerator)
+        {
+            var section = span[splitRange];
+
+            var index = section.LastIndexOf('=');
+            var namesSpan = section[..index];
+
+            var dllNamesEnumerator = namesSpan.Split(',');
+            var dllOverrideTypes = GetOverrideTypes(section);
+
+            foreach (var range in dllNamesEnumerator)
+            {
+                var name = FixDllName(namesSpan[range]).ToString();
+                results.Add(new WineDllOverride(name, dllOverrideTypes));
+            }
+        }
+
+        return results;
+    }
+
+    private static ReadOnlySpan<char> FixDllName(ReadOnlySpan<char> input)
+    {
+        return input.TrimEnd(".dll");
+    }
+
+    private static WineDllOverrideType[] GetOverrideTypes(ReadOnlySpan<char> section)
+    {
+        var index = section.LastIndexOf('=');
+        if (index == section.Length - 1) return WineDllOverride.Disabled;
+
+        var typesSpan = section[(index + 1)..];
+
+        var numTypes = typesSpan.Count(',') + 1;
+        Span<WineDllOverrideType> overrideTypesSpan = stackalloc WineDllOverrideType[numTypes];
+
+        var typesIndex = 0;
+        var typesEnumerator = typesSpan.Split(',');
+        foreach (var splitRange in typesEnumerator)
+        {
+            var typeSpan = typesSpan[splitRange];
+            if (typeSpan.Length != 1) continue;
+
+            var c = typeSpan[0];
+            if (c is 'n') overrideTypesSpan[typesIndex++] = WineDllOverrideType.Native;
+            if (c is 'b') overrideTypesSpan[typesIndex++] = WineDllOverrideType.BuiltIn;
+        }
+
+        return overrideTypesSpan[..typesIndex].ToArray();
+    }
+
+    private static ReadOnlySpan<char> GetWineDllOverridesSection(ReadOnlySpan<char> input)
+    {
+        const string prefix = "WINEDLLOVERRIDES=";
+
+        var span = input;
+        if (!span.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) return span;
+
+        span = span[prefix.Length..];
+        if (!span.StartsWith('"')) return span;
+
+        span = span[1..];
+        var index = span.IndexOf('"');
+        span = span[..index];
+
+        return span;
+    }
+}
+
+public record WineDllOverride(string DllName, WineDllOverrideType[] OverrideTypes)
+{
+    /// <summary>
+    /// Gets whether the DLL is disabled.
+    /// </summary>
+    public bool IsDisabled => OverrideTypes is [WineDllOverrideType.Disabled];
+
+    internal static readonly WineDllOverrideType[] Disabled = [WineDllOverrideType.Disabled];
+}
+
+/// <summary>
+/// DLL override types for Wine.
+/// </summary>
+[PublicAPI]
+public enum WineDllOverrideType
+{
+    /// <summary>
+    /// The dll is disabled.
+    /// </summary>
+    Disabled = 0,
+
+    /// <summary>
+    /// The built-in version should be loaded.
+    /// </summary>
+    BuiltIn = 1,
+
+    /// <summary>
+    /// The native version should be loaded.
+    /// </summary>
+    Native = 2,
+}
+

--- a/src/Abstractions/NexusMods.Abstractions.GameLocators/WineParser.cs
+++ b/src/Abstractions/NexusMods.Abstractions.GameLocators/WineParser.cs
@@ -14,6 +14,8 @@ public static class WineParser
     /// </summary>
     public static IReadOnlyList<WineDllOverride> ParseEnvironmentVariable(ReadOnlySpan<char> environmentVariableValue)
     {
+        if (environmentVariableValue.Length == 0) return [];
+
         var results = new List<WineDllOverride>();
 
         // https://gitlab.winehq.org/wine/wine/-/wikis/Wine-User's-Guide#winedlloverrides-dll-overrides
@@ -97,6 +99,20 @@ public record WineDllOverride(string DllName, WineDllOverrideType[] OverrideType
     public bool IsDisabled => OverrideTypes is [WineDllOverrideType.Disabled];
 
     internal static readonly WineDllOverrideType[] Disabled = [WineDllOverrideType.Disabled];
+
+    /// <inheritdoc/>
+    public override string ToString()
+    {
+        var typesString = OverrideTypes.Select(ToString).Aggregate((a, b) => $"{a},{b}");
+        return $"{DllName}={typesString}";
+    }
+
+    private static string ToString(WineDllOverrideType overrideType) => overrideType switch
+    {
+        WineDllOverrideType.BuiltIn => "b",
+        WineDllOverrideType.Native => "n",
+        _ => "",
+    };
 }
 
 /// <summary>

--- a/src/Games/NexusMods.Games.Generic/NexusMods.Games.Generic.csproj
+++ b/src/Games/NexusMods.Games.Generic/NexusMods.Games.Generic.csproj
@@ -5,13 +5,11 @@
     </ItemGroup>
 
     <ItemGroup>
-      <Folder Include="Entities\" />
-    </ItemGroup>
-
-    <ItemGroup>
       <ProjectReference Include="..\..\Abstractions\NexusMods.Abstractions.FileExtractor\NexusMods.Abstractions.FileExtractor.csproj" />
+      <ProjectReference Include="..\..\Abstractions\NexusMods.Abstractions.Games.Diagnostics\NexusMods.Abstractions.Games.Diagnostics.csproj" />
       <ProjectReference Include="..\..\Abstractions\NexusMods.Abstractions.Games\NexusMods.Abstractions.Games.csproj" />
       <ProjectReference Include="..\..\Abstractions\NexusMods.Abstractions.IO\NexusMods.Abstractions.IO.csproj" />
       <ProjectReference Include="..\..\Abstractions\NexusMods.Abstractions.Serialization\NexusMods.Abstractions.Serialization.csproj" />
+        <ProjectReference Include="..\..\NexusMods.App.Generators.Diagnostics\NexusMods.App.Generators.Diagnostics\NexusMods.App.Generators.Diagnostics.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 </Project>

--- a/src/Games/NexusMods.Games.Generic/WineDiagnosticHelper.cs
+++ b/src/Games/NexusMods.Games.Generic/WineDiagnosticHelper.cs
@@ -1,0 +1,54 @@
+using System.Text;
+using NexusMods.Abstractions.GameLocators;
+using NexusMods.Abstractions.GameLocators.Stores.Steam;
+using NexusMods.Extensions.BCL;
+
+namespace NexusMods.Games.Generic;
+
+public static class WineDiagnosticHelper
+{
+    public static string? GetWineDllOverridesUpdateInstructions(GameInstallation gameInstallation, WineDllOverride[] requiredOverrides)
+    {
+        if (gameInstallation.LocatorResultMetadata is not SteamLocatorResultMetadata steamLocatorResultMetadata) return null;
+
+        var launchOptions = steamLocatorResultMetadata.GetLaunchOptions?.Invoke();
+        if (launchOptions is null) return null;
+
+        var existingOverrides = WineParser.ParseEnvironmentVariable(launchOptions);
+
+        var overridesToAdd = new List<WineDllOverride>();
+        var overridesToUpdate = new List<(WineDllOverride From, WineDllOverride To)>();
+
+        foreach (var requiredOverride in requiredOverrides)
+        {
+            if (existingOverrides.TryGetFirst(dllOverride => dllOverride.DllName.Equals(requiredOverride.DllName, StringComparison.OrdinalIgnoreCase), out var found))
+            {
+                if (found.OverrideTypes.SequenceEqual(requiredOverride.OverrideTypes)) continue;
+                overridesToUpdate.Add((From: found, To: requiredOverride));
+            }
+            else
+            {
+                overridesToAdd.Add(requiredOverride);
+            }
+        }
+
+        if (overridesToAdd.Count == 0 && overridesToUpdate.Count == 0) return null;
+
+        var sb = new StringBuilder();
+
+        var dllOverridesString = requiredOverrides.Select(x => x.ToString()).Aggregate((a, b) => $"{a};{b}");
+        sb.AppendLine($"""
+- Open Steam
+- Right-click the game
+- Click on "Properties..."
+- Open the "General" section
+- Update "Launch Options" to be the following:
+
+```
+WINEDLLOVERRIDES="{dllOverridesString}" %command%
+```                  
+""");
+        
+        return sb.ToString();
+    }
+}

--- a/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/Cyberpunk2077Game.cs
+++ b/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/Cyberpunk2077Game.cs
@@ -95,6 +95,7 @@ public class Cyberpunk2077Game : AGame, ISteamGame, IGogGame, IEpicGame
         new PatternBasedDependencyEmitter(PatternDefinitions.Definitions, _serviceProvider),
         new MissingProtontricksForRedModEmitter(_serviceProvider),
         new MissingRedModEmitter(),
+        new WinePrefixRequirementsEmitter(),
     ];
 
     public override ISortableItemProviderFactory[] SortableItemProviderFactories => _sortableItemProviderFactories;

--- a/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/Diagnostics.cs
+++ b/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/Diagnostics.cs
@@ -172,4 +172,22 @@ Please install the {RedmodLink} and start the game at least once.
             .AddValue<NamedLink>("RedmodLink")
         )
         .Finish();
+
+    [DiagnosticTemplate]
+    [UsedImplicitly]
+    internal static IDiagnosticTemplate RequiredWineDllOverrides = DiagnosticTemplateBuilder
+        .Start()
+        .WithId(new DiagnosticId(Source, number: 5))
+        .WithTitle("Update WINE dll overrides to mod on Linux")
+        .WithSeverity(DiagnosticSeverity.Critical)
+        .WithSummary("These changes are required for Linux")
+        .WithDetails("""
+Modding Cyberpunk 2077 on Linux requires you to configure WINE.
+
+{Instructions}
+""")
+        .WithMessageData(messageBuilder => messageBuilder
+            .AddValue<string>("Instructions")
+        )
+        .Finish();
 }

--- a/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/Diagnostics.cs
+++ b/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/Diagnostics.cs
@@ -190,4 +190,22 @@ Modding Cyberpunk 2077 on Linux requires you to configure WINE.
             .AddValue<string>("Instructions")
         )
         .Finish();
+
+    [DiagnosticTemplate]
+    [UsedImplicitly]
+    internal static IDiagnosticTemplate RequiredWinetricksPackages = DiagnosticTemplateBuilder
+        .Start()
+        .WithId(new DiagnosticId(Source, number: 6))
+        .WithTitle("Install required winetricks packages")
+        .WithSeverity(DiagnosticSeverity.Critical)
+        .WithSummary("These packages are required or Linux")
+        .WithDetails("""
+Modding Cyberpunk 2077 on Linux requires packages to be installed in your WINE prefix.
+
+{Instructions}  
+""")
+        .WithMessageData(messageBuilder => messageBuilder
+            .AddValue<string>("Instructions")
+        )
+        .Finish();
 }

--- a/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/Emitters/WinePrefixRequirementsEmitter.cs
+++ b/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/Emitters/WinePrefixRequirementsEmitter.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 using NexusMods.Abstractions.Diagnostics;
 using NexusMods.Abstractions.Diagnostics.Emitters;
@@ -16,13 +17,20 @@ public class WinePrefixRequirementsEmitter : ILoadoutDiagnosticEmitter
         new("version", [WineDllOverrideType.Native, WineDllOverrideType.BuiltIn]),
     ];
 
+    private static readonly ImmutableHashSet<string> RequiredWinetricksPackages =
+    [
+        "d3dcompiler_47",
+        "vcrun2022",
+    ];
+
     public async IAsyncEnumerable<Diagnostic> Diagnose(Loadout.ReadOnly loadout, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         await Task.Yield();
 
-        var instructions = WineDiagnosticHelper.GetWineDllOverridesUpdateInstructions(loadout.InstallationInstance, RequiredOverrides);
-        if (instructions is null) yield break;
+        var dllOverridesInstructions = WineDiagnosticHelper.GetWineDllOverridesUpdateInstructions(loadout.InstallationInstance, RequiredOverrides);
+        if (dllOverridesInstructions is not null) yield return Diagnostics.CreateRequiredWineDllOverrides(dllOverridesInstructions);
 
-        yield return Diagnostics.CreateRequiredWineDllOverrides(instructions);
+        var winetricksInstructions = WineDiagnosticHelper.GetWinetricksInstructions(loadout.InstallationInstance, RequiredWinetricksPackages);
+        if (winetricksInstructions is not null) yield return Diagnostics.CreateRequiredWinetricksPackages(winetricksInstructions);
     }
 }

--- a/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/Emitters/WinePrefixRequirementsEmitter.cs
+++ b/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/Emitters/WinePrefixRequirementsEmitter.cs
@@ -1,0 +1,28 @@
+using System.Runtime.CompilerServices;
+using NexusMods.Abstractions.Diagnostics;
+using NexusMods.Abstractions.Diagnostics.Emitters;
+using NexusMods.Abstractions.GameLocators;
+using NexusMods.Abstractions.Loadouts;
+using NexusMods.Games.Generic;
+
+namespace NexusMods.Games.RedEngine.Cyberpunk2077.Emitters;
+
+public class WinePrefixRequirementsEmitter : ILoadoutDiagnosticEmitter
+{
+    // https://wiki.redmodding.org/cyberpunk-2077-modding/for-mod-users/users-modding-cyberpunk-2077/modding-on-linux
+    private static readonly WineDllOverride[] RequiredOverrides =
+    [
+        new("winmm", [WineDllOverrideType.Native, WineDllOverrideType.BuiltIn]),
+        new("version", [WineDllOverrideType.Native, WineDllOverrideType.BuiltIn]),
+    ];
+
+    public async IAsyncEnumerable<Diagnostic> Diagnose(Loadout.ReadOnly loadout, [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        await Task.Yield();
+
+        var instructions = WineDiagnosticHelper.GetWineDllOverridesUpdateInstructions(loadout.InstallationInstance, RequiredOverrides);
+        if (instructions is null) yield break;
+
+        yield return Diagnostics.CreateRequiredWineDllOverrides(instructions);
+    }
+}

--- a/src/NexusMods.StandardGameLocators/AGameLocator.cs
+++ b/src/NexusMods.StandardGameLocators/AGameLocator.cs
@@ -28,7 +28,7 @@ public abstract class AGameLocator<TGameType, TId, TGame, TParent> : IGameLocato
     where TGameType : class, GameFinder.Common.IGame
     where TId : notnull
 {
-    private readonly ILogger _logger;
+    protected readonly ILogger Logger;
 
     private readonly AHandler<TGameType, TId>? _handler;
     private IReadOnlyDictionary<TId, TGameType>? _cachedGames;
@@ -39,7 +39,7 @@ public abstract class AGameLocator<TGameType, TId, TGame, TParent> : IGameLocato
     /// <param name="provider"></param>
     protected AGameLocator(IServiceProvider provider)
     {
-        _logger = provider.GetRequiredService<ILogger<TParent>>();
+        Logger = provider.GetRequiredService<ILogger<TParent>>();
         _handler = provider.GetService<AHandler<TGameType, TId>>();
     }
 
@@ -65,7 +65,7 @@ public abstract class AGameLocator<TGameType, TId, TGame, TParent> : IGameLocato
             if (errors.Any())
             {
                 foreach (var error in errors)
-                    _logger.LogError("While looking for games: {Error}", error);
+                    Logger.LogError("While looking for games: {Error}", error);
             }
 
 #if DEBUG
@@ -75,22 +75,22 @@ public abstract class AGameLocator<TGameType, TId, TGame, TParent> : IGameLocato
                 switch (cachedGame.Value)
                 {
                     case XboxGame xb:
-                        _logger.LogDebug($"Found Xbox Game: {xb.Id}, {xb.DisplayName}");
+                        Logger.LogDebug($"Found Xbox Game: {xb.Id}, {xb.DisplayName}");
                         break;
                     case SteamGame st:
-                        _logger.LogDebug($"Found Steam Game: {st.AppId}, {st.Name}");
+                        Logger.LogDebug($"Found Steam Game: {st.AppId}, {st.Name}");
                         break;
                     case EGSGame eg:
-                        _logger.LogDebug($"Found Epic Game: {eg.CatalogItemId}, {eg.DisplayName}");
+                        Logger.LogDebug($"Found Epic Game: {eg.CatalogItemId}, {eg.DisplayName}");
                         break;
                     case GOGGame gog:
-                        _logger.LogDebug($"Found GOG Galaxy Game: {gog.Id}, {gog.Name}");
+                        Logger.LogDebug($"Found GOG Galaxy Game: {gog.Id}, {gog.Name}");
                         break;
                     case OriginGame og:
-                        _logger.LogDebug($"Found Origin Game: {og.Id}, {og.InstallPath}");
+                        Logger.LogDebug($"Found Origin Game: {og.Id}, {og.InstallPath}");
                         break;
                     case EADesktopGame ea:
-                        _logger.LogDebug($"Found EA Desktop Game: {ea.EADesktopGameId}, {ea.BaseInstallPath}");
+                        Logger.LogDebug($"Found EA Desktop Game: {ea.EADesktopGameId}, {ea.BaseInstallPath}");
                         break;
                 }
             }

--- a/src/NexusMods.StandardGameLocators/SteamLocator.cs
+++ b/src/NexusMods.StandardGameLocators/SteamLocator.cs
@@ -1,5 +1,7 @@
 using GameFinder.StoreHandlers.Steam;
 using GameFinder.StoreHandlers.Steam.Models.ValueTypes;
+using GameFinder.StoreHandlers.Steam.Services;
+using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.GameLocators;
 using NexusMods.Abstractions.GameLocators.Stores.Steam;
 using NexusMods.Abstractions.Games;
@@ -46,6 +48,20 @@ public class SteamLocator : AGameLocator<SteamGame, AppId, ISteamGame, SteamLoca
             AppId = game.AppId.Value,
             ManifestIds = game.AppManifest.InstalledDepots.Select(x => x.Value.ManifestId.Value).ToArray(),
             CloudSavesDirectory = game.GetCloudSavesDirectoryPath(),
+            GetLaunchOptions = () =>
+            {
+                var localConfigPath = SteamLocationFinder.GetUserDataDirectoryPath(game.SteamPath, game.AppManifest.LastOwner).Combine("config").Combine("localconfig.vdf");
+                var parserResult = LocalUserConfigParser.ParseConfigFile(game.AppManifest.LastOwner, localConfigPath);
+                if (parserResult.IsFailed)
+                {
+                    Logger.LogWarning("Error while parsing local user config at `{Path}`: `{Error}`", localConfigPath, parserResult.Errors);
+                    return null;
+                }
+
+                if (!parserResult.Value.LocalAppData.TryGetValue(game.AppId, out var localAppData)) return null;
+                var launchOptions = localAppData.LaunchOptions;
+                return launchOptions;
+            },
         };
     }
 }

--- a/src/NexusMods.StandardGameLocators/SteamLocator.cs
+++ b/src/NexusMods.StandardGameLocators/SteamLocator.cs
@@ -48,6 +48,7 @@ public class SteamLocator : AGameLocator<SteamGame, AppId, ISteamGame, SteamLoca
             AppId = game.AppId.Value,
             ManifestIds = game.AppManifest.InstalledDepots.Select(x => x.Value.ManifestId.Value).ToArray(),
             CloudSavesDirectory = game.GetCloudSavesDirectoryPath(),
+            ProtonPrefixDirectory = game.GetProtonPrefix()?.ProtonDirectory,
             GetLaunchOptions = () =>
             {
                 var localConfigPath = SteamLocationFinder.GetUserDataDirectoryPath(game.SteamPath, game.AppManifest.LastOwner).Combine("config").Combine("localconfig.vdf");

--- a/tests/NexusMods.StandardGameLocators.Tests/WineParserTests.cs
+++ b/tests/NexusMods.StandardGameLocators.Tests/WineParserTests.cs
@@ -1,0 +1,55 @@
+using FluentAssertions;
+using NexusMods.Abstractions.GameLocators;
+
+namespace NexusMods.StandardGameLocators.Tests;
+
+public class WineParserTests
+{
+    [Theory]
+    [MemberData(nameof(TestData))]
+    public void Test_Parse(string input, List<WineDllOverride> expected)
+    {
+        var actual = WineParser.ParseEnvironmentVariable(input);
+        actual.Should().HaveSameCount(expected);
+
+        for (var i = 0; i < actual.Count; i++)
+        {
+            var a = actual[i];
+            var b = expected[i];
+
+            a.DllName.Should().Be(b.DllName);
+            a.OverrideTypes.Should().Equal(b.OverrideTypes);
+            a.IsDisabled.Should().Be(b.IsDisabled);
+        }
+    }
+
+    public static TheoryData<string, List<WineDllOverride>> TestData()
+    {
+        return new TheoryData<string, List<WineDllOverride>>
+        {
+            {
+                "WINEDLLOVERRIDES=\"comdlg32,shell32=n,b\" wine program_name",
+                [
+                    new WineDllOverride("comdlg32", [WineDllOverrideType.Native, WineDllOverrideType.BuiltIn]),
+                    new WineDllOverride("shell32", [WineDllOverrideType.Native, WineDllOverrideType.BuiltIn]),
+                ]
+            },
+            {
+                "WINEDLLOVERRIDES=\"comdlg32,shell32=n\" wine program_name",
+                [
+                    new WineDllOverride("comdlg32", [WineDllOverrideType.Native]),
+                    new WineDllOverride("shell32", [WineDllOverrideType.Native]),
+                ]
+            },
+            {
+                "WINEDLLOVERRIDES=\"comdlg32=b,n;shell32=b;comctl32=n;oleaut32=\" wine program_name",
+                [
+                    new WineDllOverride("comdlg32", [WineDllOverrideType.BuiltIn, WineDllOverrideType.Native]),
+                    new WineDllOverride("shell32", [WineDllOverrideType.BuiltIn]),
+                    new WineDllOverride("comctl32", [WineDllOverrideType.Native]),
+                    new WineDllOverride("oleaut32", [WineDllOverrideType.Disabled]),
+                ]
+            },
+        };
+    }
+}

--- a/tests/NexusMods.StandardGameLocators.Tests/WineParserTests.cs
+++ b/tests/NexusMods.StandardGameLocators.Tests/WineParserTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using FluentAssertions;
 using NexusMods.Abstractions.GameLocators;
 
@@ -6,8 +7,8 @@ namespace NexusMods.StandardGameLocators.Tests;
 public class WineParserTests
 {
     [Theory]
-    [MemberData(nameof(TestData))]
-    public void Test_Parse(string input, List<WineDllOverride> expected)
+    [MemberData(nameof(TestData_ParseEnvironmentVariable))]
+    public void Test_ParseEnvironmentVariable(string input, List<WineDllOverride> expected)
     {
         var actual = WineParser.ParseEnvironmentVariable(input);
         actual.Should().HaveSameCount(expected);
@@ -24,6 +25,17 @@ public class WineParserTests
     }
 
     [Theory]
+    [MemberData(nameof(TestData_ParseWinetricksLogFile))]
+    public void Test_ParseWinetricksLogFile(string fileContents, HashSet<string> expected)
+    {
+        var bytes = Encoding.UTF8.GetBytes(fileContents);
+        using var ms = new MemoryStream(bytes, writable: false);
+
+        var result = WineParser.ParseWinetricksLogFile(ms);
+        result.Should().Equal(expected);
+    }
+
+    [Theory]
     [MemberData(nameof(TestData_ToString))]
     public void Test_ToString(WineDllOverride input, string expected)
     {
@@ -31,6 +43,17 @@ public class WineParserTests
         actual.Should().Be(expected);
     }
 
+    public static TheoryData<string, HashSet<string>> TestData_ParseWinetricksLogFile()
+    {
+        return new TheoryData<string, HashSet<string>>
+        {
+            {
+                "d3dcompiler_47\nvcrun2022",
+                ["d3dcompiler_47", "vcrun2022"]
+            },
+        };
+    }
+    
     public static TheoryData<WineDllOverride, string> TestData_ToString()
     {
         return new TheoryData<WineDllOverride, string>
@@ -54,7 +77,7 @@ public class WineParserTests
         };
     }
 
-    public static TheoryData<string, List<WineDllOverride>> TestData()
+    public static TheoryData<string, List<WineDllOverride>> TestData_ParseEnvironmentVariable()
     {
         return new TheoryData<string, List<WineDllOverride>>
         {

--- a/tests/NexusMods.StandardGameLocators.Tests/WineParserTests.cs
+++ b/tests/NexusMods.StandardGameLocators.Tests/WineParserTests.cs
@@ -23,6 +23,37 @@ public class WineParserTests
         }
     }
 
+    [Theory]
+    [MemberData(nameof(TestData_ToString))]
+    public void Test_ToString(WineDllOverride input, string expected)
+    {
+        var actual = input.ToString();
+        actual.Should().Be(expected);
+    }
+
+    public static TheoryData<WineDllOverride, string> TestData_ToString()
+    {
+        return new TheoryData<WineDllOverride, string>
+        {
+            {
+                new WineDllOverride("comdlg32", [WineDllOverrideType.Native, WineDllOverrideType.BuiltIn]),
+                "comdlg32=n,b"
+            },
+            {
+                new WineDllOverride("shell32", [WineDllOverrideType.BuiltIn]),
+                "shell32=b"
+            },
+            {
+                new WineDllOverride("comctl32", [WineDllOverrideType.Native]),
+                "comctl32=n"
+            },
+            {
+                new WineDllOverride("oleaut32", [WineDllOverrideType.Disabled]),
+                "oleaut32="
+            },
+        };
+    }
+
     public static TheoryData<string, List<WineDllOverride>> TestData()
     {
         return new TheoryData<string, List<WineDllOverride>>


### PR DESCRIPTION
Resolves #2171.

- Adds utilities for parsing `WINEDLLOVERRIDES` and `winetricks.log` files
- Adds two new critical diagnostics for Cyberpunk 2077