### PR TITLE
Fixes UI issue with Row spacing when dragging/dropping 

### DIFF
--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/TreeDataGridBaseStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/TreeDataGridBaseStyles.axaml
@@ -8,7 +8,7 @@
         xmlns:system="clr-namespace:System;assembly=System.Runtime">
     <!-- NOTE(Al12rs): Keep: `xmlns:system="clr-namespace:System;assembly=System.Runtime"` even if marked as unused -->
     <!-- See false positive error and note for CompositeItemModel later down the file -->
-    
+
     <Design.PreviewWith>
         <Border Classes="Low" Padding="16">
             <TreeDataGrid Width="400" Height="200" />
@@ -27,25 +27,28 @@
         <SolidColorBrush x:Key="TreeDataGridHeaderForegroundPointerOverBrush" Color="White" />
         <SolidColorBrush x:Key="TreeDataGridHeaderForegroundPressedBrush" Color="White" />
         <SolidColorBrush x:Key="TreeDataGridSelectedCellBackgroundBrush" Color="White" Opacity="0.4" />
-        
+
         <!-- needs to be a resource and not set by a style so we can add Clasess based on DataContext -->
         <!-- NOTE(Al12rs): CompositeItemModel with new x:TypeArguments syntax works fine, but Rider doesn't like it. -->
         <ControlTemplate x:Key="LoadOrderItemTreeRowTemplate"
                          TargetType="TreeDataGridRow"
                          x:DataType="{x:Type controls:CompositeItemModel, x:TypeArguments=system:Guid}">
-            <Border x:Name="RowBorder"
-                    Background="{TemplateBinding Background}"
-                    BorderBrush="{TemplateBinding BorderBrush}"
-                    BorderThickness="{TemplateBinding BorderThickness}"
-                    CornerRadius="{TemplateBinding CornerRadius}"
-                    Classes.IsActive="{CompiledBinding StyleFlags,
+            <Border x:Name="RowOuterBorder"
+                    Background="{StaticResource SurfaceTransparentBrush}">
+                <Border x:Name="RowBorder"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        CornerRadius="{TemplateBinding CornerRadius}"
+                        Classes.IsActive="{CompiledBinding StyleFlags,
                         Converter={x:Static converters:CompositeStyleFlagConverter.Instance},
                         ConverterParameter=IsActive}">
-                <TreeDataGridCellsPresenter Name="PART_CellsPresenter"
-                                            CornerRadius="{TemplateBinding CornerRadius}"
-                                            ElementFactory="{TemplateBinding ElementFactory}"
-                                            Items="{TemplateBinding Columns}"
-                                            Rows="{TemplateBinding Rows}" />
+                    <TreeDataGridCellsPresenter Name="PART_CellsPresenter"
+                                                CornerRadius="{TemplateBinding CornerRadius}"
+                                                ElementFactory="{TemplateBinding ElementFactory}"
+                                                Items="{TemplateBinding Columns}"
+                                                Rows="{TemplateBinding Rows}" />
+                </Border>
             </Border>
         </ControlTemplate>
 

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/TreeDataGridSortOrderStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/TreeDataGridSortOrderStyles.axaml
@@ -176,7 +176,7 @@
             <Setter Property="Margin" Value="0" />
 
             <!-- templated bindings (passed down to Border#RowBorder) -->
-            <Setter Property="Background" Value="{StaticResource SurfaceLowBrush}" />
+            <Setter Property="Background" Value="{StaticResource SurfaceMidBrush}" />
             <Setter Property="BorderBrush" Value="{StaticResource SurfaceTransparentBrush}" />
             <Setter Property="BorderThickness" Value="0" />
             <Setter Property="CornerRadius" Value="8" />

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/TreeDataGridSortOrderStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/TreeDataGridSortOrderStyles.axaml
@@ -171,16 +171,20 @@
             <Setter Property="Template" Value="{DynamicResource LoadOrderItemTreeRowTemplate}" />
 
             <Setter Property="Opacity" Value="1" />
-            <Setter Property="Height" Value="48" />
-            <Setter Property="MinHeight" Value="48" />
-            <Setter Property="Margin" Value="0,4,0,0" />
+            <Setter Property="Height" Value="52" />
+            <Setter Property="MinHeight" Value="52" />
+            <Setter Property="Margin" Value="0" />
 
             <!-- templated bindings (passed down to Border#RowBorder) -->
-            <Setter Property="Background" Value="{StaticResource SurfaceMidBrush}" />
+            <Setter Property="Background" Value="{StaticResource SurfaceLowBrush}" />
             <Setter Property="BorderBrush" Value="{StaticResource SurfaceTransparentBrush}" />
             <Setter Property="BorderThickness" Value="0" />
             <Setter Property="CornerRadius" Value="8" />
 
+            <Style Selector="^ Border#RowOuterBorder">
+                <Setter Property="Padding" Value="0,2,0,2" />
+            </Style>
+            
             <!-- this can't be bound the same as the above template bindings as TreeDataGridRow doesn't have the property -->
             <Style Selector="^ Border#RowBorder">
                 <Setter Property="BoxShadow" Value="{StaticResource DropShadowXS}" />


### PR DESCRIPTION
- Part of #2276

Adds an extra Border so we can have a visual gap between rows but the load order drag and drop treats it as no gaps.

https://github.com/user-attachments/assets/eacdb5ed-afbe-49e2-8f79-6fd12cb03ad0
