### PR TITLE
Add managed ZIP extractor

### DIFF
--- a/src/ArchiveManagement/NexusMods.FileExtractor/Extractors/ManagedZipExtractor.cs
+++ b/src/ArchiveManagement/NexusMods.FileExtractor/Extractors/ManagedZipExtractor.cs
@@ -13,26 +13,40 @@ internal class ManagedZipExtractor : IExtractor
     public async Task ExtractAllAsync(IStreamFactory source, AbsolutePath destination, CancellationToken cancellationToken = default)
     {
         await using var stream = await source.GetStreamAsync().ConfigureAwait(false);
-
         using var archive = new ZipArchive(stream, mode: ZipArchiveMode.Read, leaveOpen: false, entryNameEncoding: null);
-        foreach (var entry in archive.Entries)
+
+        var directoryMapping = new Dictionary<string, RelativePath>(StringComparer.Ordinal);
+        foreach (var directoryEntry in archive.Entries.Where(IsDirectoryEntry))
         {
-            if (entry.FullName.EndsWith('/') || entry.FullName.EndsWith('\\')) continue;
+            var relativeDirectoryPath = RelativePath.FromUnsanitizedInput(PathsHelper.FixDirectoryName(directoryEntry.FullName));
+            directoryMapping.Add(directoryEntry.FullName, relativeDirectoryPath);
 
-            var fileName = RelativePath.FromUnsanitizedInput(PathsHelper.FixFileName(entry.FullName));
-            var outputPath = destination.Combine(fileName);
+            var directoryPath = destination.Combine(relativeDirectoryPath);
+            if (!directoryPath.DirectoryExists()) directoryPath.CreateDirectory();
+        }
 
-            var parent = outputPath.Parent;
-            if (!parent.DirectoryExists()) parent.CreateDirectory();
+        foreach (var fileEntry in archive.Entries.Where(IsFileEntry))
+        {
+            var fileName = RelativePath.FromUnsanitizedInput(PathsHelper.FixFileName(fileEntry.Name));
+            var directory = directoryMapping
+                .Where(kv => fileEntry.FullName.StartsWith(kv.Key, StringComparison.Ordinal))
+                .OrderByDescending(kv => kv.Key, StringComparer.Ordinal)
+                .First();
+
+            var relativePath = directory.Value.Join(fileName);
+            var outputPath = destination.Combine(relativePath);
 
             await using var outputStream = outputPath.Open(mode: FileMode.Create, access: FileAccess.ReadWrite, share: FileShare.Read);
-            outputStream.SetLength(entry.Length);
+            outputStream.SetLength(fileEntry.Length);
 
-            await using var inputStream = entry.Open();
+            await using var inputStream = fileEntry.Open();
 
-            await inputStream.CopyToAsync(outputStream, cancellationToken: cancellationToken);
+            await inputStream.CopyToAsync(outputStream, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
     }
+
+    private static bool IsDirectoryEntry(ZipArchiveEntry entry) => entry.Name.Length == 0;
+    private static bool IsFileEntry(ZipArchiveEntry entry) => entry.Name.Length != 0;
 
     public Priority DeterminePriority(IEnumerable<FileType> signatures)
     {

--- a/src/ArchiveManagement/NexusMods.FileExtractor/Extractors/ManagedZipExtractor.cs
+++ b/src/ArchiveManagement/NexusMods.FileExtractor/Extractors/ManagedZipExtractor.cs
@@ -1,0 +1,46 @@
+using System.IO.Compression;
+using NexusMods.Abstractions.FileExtractor;
+using NexusMods.Abstractions.IO;
+using NexusMods.Paths;
+
+namespace NexusMods.FileExtractor.Extractors;
+
+internal class ManagedZipExtractor : IExtractor
+{
+    public FileType[] SupportedSignatures { get; } = [FileType.ZIP];
+    public Extension[] SupportedExtensions { get; } = [new(".zip")];
+
+    public async Task ExtractAllAsync(IStreamFactory source, AbsolutePath destination, CancellationToken cancellationToken = default)
+    {
+        await using var stream = await source.GetStreamAsync().ConfigureAwait(false);
+
+        using var archive = new ZipArchive(stream, mode: ZipArchiveMode.Read, leaveOpen: false, entryNameEncoding: null);
+        foreach (var entry in archive.Entries)
+        {
+            if (entry.FullName.EndsWith('/') || entry.FullName.EndsWith('\\')) continue;
+
+            var fileName = RelativePath.FromUnsanitizedInput(PathsHelper.FixFileName(entry.FullName));
+            var outputPath = destination.Combine(fileName);
+
+            var parent = outputPath.Parent;
+            if (!parent.DirectoryExists()) parent.CreateDirectory();
+
+            await using var outputStream = outputPath.Open(mode: FileMode.Create, access: FileAccess.ReadWrite, share: FileShare.Read);
+            outputStream.SetLength(entry.Length);
+
+            await using var inputStream = entry.Open();
+
+            await inputStream.CopyToAsync(outputStream, cancellationToken: cancellationToken);
+        }
+    }
+
+    public Priority DeterminePriority(IEnumerable<FileType> signatures)
+    {
+        foreach (var signature in signatures)
+        {
+            if (signature == FileType.ZIP) return Priority.Highest;
+        }
+
+        return Priority.None;
+    }
+}

--- a/src/ArchiveManagement/NexusMods.FileExtractor/Extractors/SevenZipExtractor.cs
+++ b/src/ArchiveManagement/NexusMods.FileExtractor/Extractors/SevenZipExtractor.cs
@@ -107,8 +107,8 @@ public class SevenZipExtractor : IExtractor
                 fileNameOnDisk = fileName;
             }
 
-            var fixedFileName = FixFileName(fileName);
-            Debug.Assert(fixedFileName.All(c => !IsInvalidChar(c)), message: $"`{fixedFileName}` should be fixed");
+            var fixedFileName = PathsHelper.FixFileName(fileName);
+            Debug.Assert(fixedFileName.All(c => !PathsHelper.IsInvalidChar(c)), message: $"`{fixedFileName}` should be fixed");
 
             var source = System.IO.Path.Combine(nativePath, fileNameOnDisk);
             var destination = System.IO.Path.Combine(nativePath, fixedFileName);
@@ -156,16 +156,6 @@ public class SevenZipExtractor : IExtractor
         }
     }
 
-    /// <summary>
-    /// Fixes a file name from the archive to work on all platforms properly and consistently.
-    /// </summary>
-    internal static string FixFileName(ReadOnlySpan<char> input)
-    {
-        const string charsToTrim = " .";
-        var output = input.TrimEnd(charsToTrim);
-        return output.ToString();
-    }
-
     internal static void To7ZipWindowsExtractionPath(Span<char> input)
     {
         // https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file
@@ -179,13 +169,11 @@ public class SevenZipExtractor : IExtractor
         for (var i = input.Length - 1; i >= 0; i--)
         {
             var current = input[i];
-            if (!IsInvalidChar(current)) break;
+            if (!PathsHelper.IsInvalidChar(current)) break;
 
             input[i] = '_';
         }
     }
-
-    private static bool IsInvalidChar(char c) => c is '.' or ' ';
 
     /// <summary>
     /// Returns a list of all paths in the archive that need to be trimmed.
@@ -234,7 +222,7 @@ public class SevenZipExtractor : IExtractor
         if (fileNameSlice.Length == 2 && fileNameSlice[0] == '.' && fileNameSlice[1] == '.') return false;
 
         var lastChar = fileNameSlice[^1];
-        if (!IsInvalidChar(lastChar)) return false;
+        if (!PathsHelper.IsInvalidChar(lastChar)) return false;
 
         fileName = fileNameSlice.ToString();
         return true;

--- a/src/ArchiveManagement/NexusMods.FileExtractor/PathsHelper.cs
+++ b/src/ArchiveManagement/NexusMods.FileExtractor/PathsHelper.cs
@@ -1,0 +1,16 @@
+namespace NexusMods.FileExtractor;
+
+internal static class PathsHelper
+{
+    internal static bool IsInvalidChar(char c) => c is '.' or ' ';
+
+    /// <summary>
+    /// Fixes a file name from the archive to work on all platforms properly and consistently.
+    /// </summary>
+    internal static string FixFileName(ReadOnlySpan<char> input)
+    {
+        const string charsToTrim = " .";
+        var output = input.TrimEnd(charsToTrim);
+        return output.ToString();
+    }
+}

--- a/src/ArchiveManagement/NexusMods.FileExtractor/PathsHelper.cs
+++ b/src/ArchiveManagement/NexusMods.FileExtractor/PathsHelper.cs
@@ -2,15 +2,23 @@ namespace NexusMods.FileExtractor;
 
 internal static class PathsHelper
 {
+    private const string CharsToTrim = " .";
+
     internal static bool IsInvalidChar(char c) => c is '.' or ' ';
+
+    internal static string FixDirectoryName(ReadOnlySpan<char> input)
+    {
+        const string directorySeparators = "/\\";
+        var trimmed = input.TrimEnd(directorySeparators);
+        return FixFileName(trimmed);
+    }
 
     /// <summary>
     /// Fixes a file name from the archive to work on all platforms properly and consistently.
     /// </summary>
     internal static string FixFileName(ReadOnlySpan<char> input)
     {
-        const string charsToTrim = " .";
-        var output = input.TrimEnd(charsToTrim);
+        var output = input.TrimEnd(CharsToTrim);
         return output.ToString();
     }
 }

--- a/src/ArchiveManagement/NexusMods.FileExtractor/Services.cs
+++ b/src/ArchiveManagement/NexusMods.FileExtractor/Services.cs
@@ -21,6 +21,7 @@ public static class Services
         coll.AddFileExtractorVerbs();
         coll.AddSingleton<IFileExtractor, FileExtractor>();
         coll.AddSingleton<IExtractor, SevenZipExtractor>();
+        coll.AddSingleton<IExtractor, ManagedZipExtractor>();
         coll.TryAddSingleton<TemporaryFileManager, TemporaryFileManagerEx>();
         return coll;
     }

--- a/tests/NexusMods.FileExtractor.Tests/PathsHelperTests.cs
+++ b/tests/NexusMods.FileExtractor.Tests/PathsHelperTests.cs
@@ -1,0 +1,28 @@
+using FluentAssertions;
+
+namespace NexusMods.FileExtractor.Tests;
+
+public class PathsHelperTests
+{
+    [Theory]
+    [InlineData("foo/bar.baz", "foo/bar.baz")]
+    [InlineData("foo bar.baz", "foo bar.baz")]
+    [InlineData("foo.bar.", "foo.bar")]
+    [InlineData("foo/bar ", "foo/bar")]
+    [InlineData("foo/bar .", "foo/bar")]
+    [InlineData("foo/bar. ", "foo/bar")]
+    public void Test_FixFileName(string input, string expected)
+    {
+        var actual = PathsHelper.FixFileName(input);
+        actual.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("foo/bar /", "foo/bar")]
+    [InlineData("foo/bar. /", "foo/bar")]
+    public void Test_FixDirectoryName(string input, string expected)
+    {
+        var actual = PathsHelper.FixDirectoryName(input);
+        actual.Should().Be(expected);
+    }
+}

--- a/tests/NexusMods.FileExtractor.Tests/SevenZipExtractionTests.cs
+++ b/tests/NexusMods.FileExtractor.Tests/SevenZipExtractionTests.cs
@@ -66,19 +66,6 @@ public class SevenZipExtractionTests
     }
 
     [Theory]
-    [InlineData("foo/bar.baz", "foo/bar.baz")]
-    [InlineData("foo bar.baz", "foo bar.baz")]
-    [InlineData("foo.bar.", "foo.bar")]
-    [InlineData("foo/bar ", "foo/bar")]
-    [InlineData("foo/bar .", "foo/bar")]
-    [InlineData("foo/bar. ", "foo/bar")]
-    public void Test_FixFileName(string input, string expected)
-    {
-        var actual = PathsHelper.FixFileName(input);
-        actual.Should().Be(expected);
-    }
-
-    [Theory]
     [InlineData("2024-04-16 06:10:44 D....            0            0  .", false, null, true)]
     [InlineData("2024-04-16 06:10:44 D....            0            0  ..", false, null, true)]
     [InlineData("2024-04-16 06:10:44 D....            0            0  foo ", true, "foo ", true)]

--- a/tests/NexusMods.FileExtractor.Tests/SevenZipExtractionTests.cs
+++ b/tests/NexusMods.FileExtractor.Tests/SevenZipExtractionTests.cs
@@ -74,7 +74,7 @@ public class SevenZipExtractionTests
     [InlineData("foo/bar. ", "foo/bar")]
     public void Test_FixFileName(string input, string expected)
     {
-        var actual = SevenZipExtractor.FixFileName(input);
+        var actual = PathsHelper.FixFileName(input);
         actual.Should().Be(expected);
     }
 


### PR DESCRIPTION
Adds a new extractor using `System.IO.Compression.ZipArchive` to extract ZIP archives instead of using 7zip. Some quick benchmarks show a 29-36% performance increase when using the new extractor over 7z:

https://www.nexusmods.com/Core/Libs/Common/Widgets/DownloadPopUp?id=21567&game_id=3333

- SevenZip: 21198 ms
- ManagedZip: 13642 ms

https://www.nexusmods.com/Core/Libs/Common/Widgets/DownloadPopUp?id=32406&game_id=3333

- SevenZip: 19671 ms
- ManagedZip: 13995 ms
