### PR TITLE
Remove WIP from Load Order tab name

### DIFF
--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrdersWIPPage.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrdersWIPPage.cs
@@ -53,7 +53,7 @@ public class LoadOrdersWIPPageFactory : APageFactory<ILoadOrdersWIPPageViewModel
         yield return new PageDiscoveryDetails
         {
             SectionName = "Mods",
-            ItemName = "Load Orders (WIP)",
+            ItemName = "Load Orders",
             Icon = IconValues.Swap,
             PageData = new PageData
             {

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrdersWipPageViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrdersWipPageViewModel.cs
@@ -18,7 +18,7 @@ public class LoadOrdersWipPageViewModel : APageViewModel<ILoadOrdersWIPPageViewM
 
         SortingSelectionViewModel = new SortingSelectionViewModel(serviceProvider, _loadoutId, iosInterop);
         
-        TabTitle = "Load Orders (WIP)";
+        TabTitle = "Load Orders";
     }
 
 }


### PR DESCRIPTION
The actual files are still called WIP since the load order view will still eventually be moved to some other place instead of the dedicated page.