### PR TITLE
Fix all parts of a path when extracting ZIP files

### DIFF
--- a/src/ArchiveManagement/NexusMods.FileExtractor/PathsHelper.cs
+++ b/src/ArchiveManagement/NexusMods.FileExtractor/PathsHelper.cs
@@ -5,6 +5,42 @@ internal static class PathsHelper
     private const string CharsToTrim = " .";
 
     internal static bool IsInvalidChar(char c) => c is '.' or ' ';
+    internal static bool IsDirectorySeparator(char c) => c is '/' or '\\';
+
+    /// <summary>
+    /// Removes all invalid characters from all parts of the path.
+    /// </summary>
+    internal static string FixPath(ReadOnlySpan<char> input)
+    {
+        const string directorySeparators = "/\\";
+
+        Span<char> result = stackalloc char[input.Length];
+        var resultIndex = 0;
+
+        var shouldCheck = true;
+        for (var inputIndex = input.Length - 1; inputIndex >= 0; inputIndex--)
+        {
+            var current = input[inputIndex];
+            if (IsDirectorySeparator(current))
+            {
+                shouldCheck = true;
+                result[resultIndex++] = current;
+                continue;
+            }
+
+            var isInvalidChar = IsInvalidChar(current);
+            if (!isInvalidChar) shouldCheck = false;
+            else if (shouldCheck) continue;
+
+            result[resultIndex++] = current;
+        }
+
+        var resultSlice = result[..resultIndex];
+        resultSlice.Reverse();
+
+        var trimmed = resultSlice.TrimEnd(directorySeparators);
+        return trimmed.Length == 0 ? string.Empty : trimmed.ToString();
+    }
 
     internal static string FixDirectoryName(ReadOnlySpan<char> input)
     {

--- a/tests/NexusMods.FileExtractor.Tests/PathsHelperTests.cs
+++ b/tests/NexusMods.FileExtractor.Tests/PathsHelperTests.cs
@@ -5,6 +5,19 @@ namespace NexusMods.FileExtractor.Tests;
 public class PathsHelperTests
 {
     [Theory]
+    [InlineData("foo/bar", "foo/bar")]
+    [InlineData("foo/bar/", "foo/bar")]
+    [InlineData("foo\\bar\\", "foo\\bar")]
+    [InlineData("foo /bar ", "foo/bar")]
+    [InlineData("foo./bar.", "foo/bar")]
+    [InlineData("foo.\\bar.", "foo\\bar")]
+    public void Test_FixPath(string input, string expected)
+    {
+        var actual = PathsHelper.FixPath(input);
+        actual.Should().Be(expected);
+    }
+
+    [Theory]
     [InlineData("foo/bar.baz", "foo/bar.baz")]
     [InlineData("foo bar.baz", "foo bar.baz")]
     [InlineData("foo.bar.", "foo.bar")]


### PR DESCRIPTION
Instead of being fancy by first fixing the directories and then the files, this just fixes all paths in one pass.

Should resolve issues we've seen with the new ZIP extractor.