### PR TITLE
Fix app crashing on disposed bitmaps in the guided installer

### DIFF
--- a/src/NexusMods.App/Startup.cs
+++ b/src/NexusMods.App/Startup.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.ReactiveUI;
@@ -59,6 +60,7 @@ public class Startup
         }
         catch (Exception e)
         {
+            Debugger.Break();
             logger.LogCritical(e, "Exception crashed the application!");
         }
     }


### PR DESCRIPTION
Fixes #3056.

The issue came from our use of the scoped cache and the interaction between disposed lifetimes and bitmaps. Removing the scoped cache and having better handling of disposing the image fixes the issue.