### PR TITLE
Update not supported reasons for installers

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Library.Installers/InstallerResult.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Library.Installers/InstallerResult.cs
@@ -56,4 +56,11 @@ public record struct Success;
 /// The input is not supported by the installer.
 /// </summary>
 [PublicAPI]
-public record struct NotSupported(string? Reason = null);
+public record struct NotSupported(string Reason)
+{
+    /// <summary>
+    /// Default constructor.
+    /// </summary>
+    [Obsolete("All installers should return a reason with the not supported result")]
+    public NotSupported() : this(Reason: string.Empty) { }
+}

--- a/src/Games/NexusMods.Games.Generic/Installers/GenericPatternMatchInstaller.cs
+++ b/src/Games/NexusMods.Games.Generic/Installers/GenericPatternMatchInstaller.cs
@@ -41,13 +41,13 @@ public class GenericPatternMatchInstaller : ALibraryArchiveInstaller
     {
         var installDataTuple = (loadoutGroup, transaction, loadout);
         if (InstallFolderTargets.Length == 0)
-            return ValueTask.FromResult<InstallerResult>(new NotSupported());
+            return ValueTask.FromResult<InstallerResult>(new NotSupported(Reason: "Found no targets to match against"));
 
         var tree = libraryArchive.GetTree();
 
         return InstallFolderTargets.Any(target => TryInstallForTarget(target, tree, installDataTuple))
             ? ValueTask.FromResult<InstallerResult>(new Success())
-            : ValueTask.FromResult<InstallerResult>(new NotSupported());
+            : ValueTask.FromResult<InstallerResult>(new NotSupported(Reason: "Found no matching targets"));
     }
 
     private bool TryInstallForTarget(InstallFolderTarget target, KeyedBox<RelativePath, LibraryArchiveTree> tree, InstallDataTuple installDataTuple)

--- a/src/Games/NexusMods.Games.MountAndBlade2Bannerlord/Installers/BLSEInstaller.cs
+++ b/src/Games/NexusMods.Games.MountAndBlade2Bannerlord/Installers/BLSEInstaller.cs
@@ -45,13 +45,15 @@ public class BLSEInstaller : ALibraryArchiveInstaller
     public override ValueTask<InstallerResult> ExecuteAsync(
         LibraryArchive.ReadOnly libraryArchive, LoadoutItemGroup.New loadoutGroup, ITransaction transaction, Loadout.ReadOnly loadout, CancellationToken cancellationToken)
     {
+        const string launcherFileName = "Bannerlord.BLSE.Launcher.exe";
+        
         var store = loadout.InstallationInstance.Store;
         var installDir = store == GameStore.XboxGamePass ? (RelativePath)"bin/Gaming.Desktop.x64_Shipping_Client" : (RelativePath)"bin/Win64_Shipping_Client";
 
         // Check if we are BLSE, we'll do a simple file check to determine this.
-        var hasBlseLauncher = libraryArchive.Children.Any(x => x.Path.StartsWith(installDir/"Bannerlord.BLSE.Launcher.exe"));
-        if (!hasBlseLauncher) return ValueTask.FromResult((InstallerResult)(new NotSupported()));
-        
+        var hasBlseLauncher = libraryArchive.Children.Any(x => x.Path.StartsWith(installDir / launcherFileName));
+        if (!hasBlseLauncher) return ValueTask.FromResult((InstallerResult)(new NotSupported(Reason: $"Archive doesn't contain a file named `{launcherFileName}`")));
+
         // This is the group which contains the files for BLSE.
         var modGroup = new LoadoutItemGroup.New(transaction, out var modGroupEntityId)
         {

--- a/src/Games/NexusMods.Games.MountAndBlade2Bannerlord/Installers/BannerlordModInstaller.cs
+++ b/src/Games/NexusMods.Games.MountAndBlade2Bannerlord/Installers/BannerlordModInstaller.cs
@@ -35,7 +35,7 @@ public sealed class BannerlordModInstaller : ALibraryArchiveInstaller
     public override async ValueTask<InstallerResult> ExecuteAsync(LibraryArchive.ReadOnly libraryArchive, LoadoutItemGroup.New loadoutGroup, ITransaction transaction, Loadout.ReadOnly loadout, CancellationToken cancellationToken)
     {
         var moduleInfoFileTuples = await GetModuleInfoFiles(libraryArchive, cancellationToken);
-        if (moduleInfoFileTuples.Count == 0) return new NotSupported(); // TODO: Will it install in root folder the content?
+        if (moduleInfoFileTuples.Count == 0) return new NotSupported(Reason: "Found no module info files in the archive"); // TODO: Will it install in root folder the content?
 
         var launcherManager = _launcherManagerFactory.Get(loadout.Installation);
         var store = loadout.Installation.Store;

--- a/src/Games/NexusMods.Games.RedEngine/ModInstallers/AppearancePresetInstaller.cs
+++ b/src/Games/NexusMods.Games.RedEngine/ModInstallers/AppearancePresetInstaller.cs
@@ -50,7 +50,7 @@ public class AppearancePresetInstaller : ALibraryArchiveInstaller
             ))).ToArray();
 
         return modFiles.Length == 0
-            ? ValueTask.FromResult<InstallerResult>(new NotSupported())
+            ? ValueTask.FromResult<InstallerResult>(new NotSupported(Reason: $"Archive contains no files that have the `{extensionPreset}` extension"))
             : ValueTask.FromResult<InstallerResult>(new Success());
     }
 }

--- a/src/Games/NexusMods.Games.RedEngine/ModInstallers/FolderlessModInstaller.cs
+++ b/src/Games/NexusMods.Games.RedEngine/ModInstallers/FolderlessModInstaller.cs
@@ -45,7 +45,7 @@ public class FolderlessModInstaller : ALibraryArchiveInstaller
             .ToArray();
 
         return modFiles.Length == 0
-            ? ValueTask.FromResult<InstallerResult>(new NotSupported())
+            ? ValueTask.FromResult<InstallerResult>(new NotSupported(Reason: "Archive contains no matching files"))
             : ValueTask.FromResult<InstallerResult>(new Success());
     }
 }

--- a/src/Games/NexusMods.Games.RedEngine/ModInstallers/RedModInstaller.cs
+++ b/src/Games/NexusMods.Games.RedEngine/ModInstallers/RedModInstaller.cs
@@ -69,10 +69,8 @@ public class RedModInstaller : ALibraryArchiveInstaller
                 infosList.Add((f, infoJson));
         }
         
-        if (infosList.Count == 0)
-            return new NotSupported();
-        
-        
+        if (infosList.Count == 0) return new NotSupported(Reason: $"Archive contains no valid redmod files named `{InfoJson}`");
+
         foreach (var (file, infoJson) in infosList.OrderBy(x => x.InfoJson.Name))
         {
             var modFolder = file.Parent();

--- a/src/Games/NexusMods.Games.RedEngine/ModInstallers/SimpleOverlayModInstaller.cs
+++ b/src/Games/NexusMods.Games.RedEngine/ModInstallers/SimpleOverlayModInstaller.cs
@@ -44,7 +44,7 @@ public class SimpleOverlayModInstaller : ALibraryArchiveInstaller
             .OrderBy(node => node.Depth())
             .ToArray();
 
-        if (roots.Length == 0) return ValueTask.FromResult<InstallerResult>(new NotSupported());
+        if (roots.Length == 0) return ValueTask.FromResult<InstallerResult>(new NotSupported(Reason: "Archive contains no valid roots"));
 
         var highestRoot = roots.First();
 
@@ -57,7 +57,7 @@ public class SimpleOverlayModInstaller : ALibraryArchiveInstaller
             var fullPath = file.Item.Path; // all the way up to root
             var relativePath = fullPath.DropFirst(node.Depth() - 1); // get relative path
 
-            var _ = new LoadoutFile.New(tx, out var id)
+            _ = new LoadoutFile.New(tx, out var id)
             {
                 LoadoutItemWithTargetPath = new LoadoutItemWithTargetPath.New(tx, id)
                 {
@@ -76,7 +76,7 @@ public class SimpleOverlayModInstaller : ALibraryArchiveInstaller
         }
 
         return newFiles == 0
-            ? ValueTask.FromResult<InstallerResult>(new NotSupported())
+            ? ValueTask.FromResult<InstallerResult>(new NotSupported(Reason: "Found no matching files in the archive"))
             : ValueTask.FromResult<InstallerResult>(new Success());
     }
 }

--- a/src/NexusMods.Library/InstallLoadoutItemJob.cs
+++ b/src/NexusMods.Library/InstallLoadoutItemJob.cs
@@ -111,7 +111,7 @@ internal class InstallLoadoutItemJob : IJobDefinitionWithStart<InstallLoadoutIte
             var result = await installer.ExecuteAsync(LibraryItem, loadoutGroup, transaction, loadout, context.CancellationToken);
             if (result.IsNotSupported(out var reason))
             {
-                if (reason is not null && Logger.IsEnabled(LogLevel.Trace))
+                if (Logger.IsEnabled(LogLevel.Trace) && !string.IsNullOrEmpty(reason))
                 {
                     Logger.LogTrace("Installer doesn't support library item `{LibraryItem}` because \"{Reason}\"", LibraryItem.Name, reason);
                 }

--- a/tests/NexusMods.StandardGameLocators.TestHelpers/StubbedGames/StubbedGameInstaller.cs
+++ b/tests/NexusMods.StandardGameLocators.TestHelpers/StubbedGames/StubbedGameInstaller.cs
@@ -41,7 +41,7 @@ public class StubbedGameInstaller : ALibraryArchiveInstaller
             .ToArray();
 
         return modFiles.Length == 0
-            ? ValueTask.FromResult<InstallerResult>(new NotSupported())
+            ? ValueTask.FromResult<InstallerResult>(new NotSupported(Reason: "Archive contains no files"))
             : ValueTask.FromResult<InstallerResult>(new Success());
     }
 }


### PR DESCRIPTION
Makes it obsolete to not provide a reason when an installer returns `NotSupported`. I've also updated all existing installers to return a reason.