### PR TITLE
Simplify getting linux compatibility data

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.GameLocators/IGameLocatorResultMetadata.cs
+++ b/src/Abstractions/NexusMods.Abstractions.GameLocators/IGameLocatorResultMetadata.cs
@@ -12,4 +12,9 @@ public interface IGameLocatorResultMetadata
     /// Converts this metadata to a format that the game locator and file hash db can use to reference a specific build, version, etc.
     /// </summary>
     public IEnumerable<LocatorId> ToLocatorIds();
+
+    /// <summary>
+    /// Gets the linux compatibility data provider instance.
+    /// </summary>
+    public ILinuxCompatibilityDataProvider? LinuxCompatibilityDataProvider { get; }
 }

--- a/src/Abstractions/NexusMods.Abstractions.GameLocators/ILinuxCompatibilityDataProvider.cs
+++ b/src/Abstractions/NexusMods.Abstractions.GameLocators/ILinuxCompatibilityDataProvider.cs
@@ -1,0 +1,26 @@
+using JetBrains.Annotations;
+using NexusMods.Paths;
+
+namespace NexusMods.Abstractions.GameLocators;
+
+/// <summary>
+/// Linux compatibility data provider.
+/// </summary>
+[PublicAPI]
+public interface ILinuxCompatibilityDataProvider
+{
+    /// <summary>
+    /// Path to the WINE prefix directory.
+    /// </summary>
+    public AbsolutePath WinePrefixDirectoryPath { get; }
+
+    /// <summary>
+    /// Gets all WINE DLL overrides.
+    /// </summary>
+    public ValueTask<WineDllOverride[]> GetWineDllOverrides(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets all installed winetricks components.
+    /// </summary>
+    public ValueTask<IReadOnlySet<string>> GetInstalledWinetricksComponents(CancellationToken cancellationToken);
+}

--- a/src/Abstractions/NexusMods.Abstractions.GameLocators/Stores/EADesktop/EADesktopLocatorResultMetadata.cs
+++ b/src/Abstractions/NexusMods.Abstractions.GameLocators/Stores/EADesktop/EADesktopLocatorResultMetadata.cs
@@ -13,6 +13,9 @@ public record EADesktopLocatorResultMetadata : IGameLocatorResultMetadata
     /// </summary>
     public required string SoftwareId { get; init; }
 
+    /// <inheritdoc/>
+    public ILinuxCompatibilityDataProvider? LinuxCompatibilityDataProvider { get; init; }
+
     /// <inheritdoc />
     public IEnumerable<LocatorId> ToLocatorIds() => [LocatorId.From(SoftwareId)];
 }

--- a/src/Abstractions/NexusMods.Abstractions.GameLocators/Stores/EGS/EpicLocatorResultMetadata.cs
+++ b/src/Abstractions/NexusMods.Abstractions.GameLocators/Stores/EGS/EpicLocatorResultMetadata.cs
@@ -13,6 +13,9 @@ public record EpicLocatorResultMetadata : IGameLocatorResultMetadata
     /// </summary>
     public required string CatalogItemId { get; init; }
 
+    /// <inheritdoc/>
+    public ILinuxCompatibilityDataProvider? LinuxCompatibilityDataProvider { get; init; }
+
     /// <inheritdoc />
     public IEnumerable<LocatorId> ToLocatorIds() => [LocatorId.From(CatalogItemId)];
 }

--- a/src/Abstractions/NexusMods.Abstractions.GameLocators/Stores/GOG/GOGLocatorResultMetadata.cs
+++ b/src/Abstractions/NexusMods.Abstractions.GameLocators/Stores/GOG/GOGLocatorResultMetadata.cs
@@ -18,6 +18,9 @@ public record GOGLocatorResultMetadata : IGameLocatorResultMetadata
     /// </summary>
     public required string BuildId { get; init; }
     
+    /// <inheritdoc/>
+    public ILinuxCompatibilityDataProvider? LinuxCompatibilityDataProvider { get; init; }
+
     /// <inheritdoc />
     public IEnumerable<LocatorId> ToLocatorIds() => [LocatorId.From(BuildId)];
 }

--- a/src/Abstractions/NexusMods.Abstractions.GameLocators/Stores/Origin/OriginLocatorResultMetadata.cs
+++ b/src/Abstractions/NexusMods.Abstractions.GameLocators/Stores/Origin/OriginLocatorResultMetadata.cs
@@ -13,6 +13,9 @@ public record OriginLocatorResultMetadata : IGameLocatorResultMetadata
     /// </summary>
     public required string Id { get; init; }
 
+    /// <inheritdoc/>
+    public ILinuxCompatibilityDataProvider? LinuxCompatibilityDataProvider { get; init; }
+
     /// <inheritdoc />
     public IEnumerable<LocatorId> ToLocatorIds() => [LocatorId.From(Id)];
 }

--- a/src/Abstractions/NexusMods.Abstractions.GameLocators/Stores/Steam/SteamLocatorResultMetadata.cs
+++ b/src/Abstractions/NexusMods.Abstractions.GameLocators/Stores/Steam/SteamLocatorResultMetadata.cs
@@ -23,20 +23,10 @@ public record SteamLocatorResultMetadata : IGameLocatorResultMetadata
     /// The `manifestIds` of the installed depots for a found game, according to Steam's associated `appmanifest` file
     /// </summary>
     public ulong[] ManifestIds { get; set; } = [];
-    
+
+    /// <inheritdoc/>
+    public ILinuxCompatibilityDataProvider? LinuxCompatibilityDataProvider { get; init; }
+
     /// <inheritdoc />
     public IEnumerable<LocatorId> ToLocatorIds() => ManifestIds.Select(m => LocatorId.From(m.ToString()));
-
-    /// <summary>
-    /// Path to the proton prefix directory.
-    /// </summary>
-    /// <remarks>
-    /// To get the WINE prefix directory, combine this path with `pfx`.
-    /// </remarks>
-    public AbsolutePath? ProtonPrefixDirectory { get; init; }
-
-    /// <summary>
-    /// Anonymous function that returns the current launch options of the game or null.
-    /// </summary>
-    public Func<string?>? GetLaunchOptions { get; init; }
 }

--- a/src/Abstractions/NexusMods.Abstractions.GameLocators/Stores/Xbox/XboxLocatorResultMetadata.cs
+++ b/src/Abstractions/NexusMods.Abstractions.GameLocators/Stores/Xbox/XboxLocatorResultMetadata.cs
@@ -13,6 +13,9 @@ public record XboxLocatorResultMetadata : IGameLocatorResultMetadata
     /// </summary>
     public required string Id { get; init; }
 
+    /// <inheritdoc/>
+    public ILinuxCompatibilityDataProvider? LinuxCompatibilityDataProvider { get; init; }
+
     /// <inheritdoc />
     public IEnumerable<LocatorId> ToLocatorIds() => [LocatorId.From(Id)];
 }

--- a/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/Emitters/WinePrefixRequirementsEmitter.cs
+++ b/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/Emitters/WinePrefixRequirementsEmitter.cs
@@ -27,10 +27,10 @@ public class WinePrefixRequirementsEmitter : ILoadoutDiagnosticEmitter
     {
         await Task.Yield();
 
-        var dllOverridesInstructions = WineDiagnosticHelper.GetWineDllOverridesUpdateInstructions(loadout.InstallationInstance, RequiredOverrides);
+        var dllOverridesInstructions = await WineDiagnosticHelper.GetWineDllOverridesUpdateInstructions(loadout.InstallationInstance, RequiredOverrides, cancellationToken: cancellationToken);
         if (dllOverridesInstructions is not null) yield return Diagnostics.CreateRequiredWineDllOverrides(dllOverridesInstructions);
 
-        var winetricksInstructions = WineDiagnosticHelper.GetWinetricksInstructions(loadout.InstallationInstance, RequiredWinetricksPackages);
+        var winetricksInstructions = await WineDiagnosticHelper.GetWinetricksInstructions(loadout.InstallationInstance, RequiredWinetricksPackages, cancellationToken: cancellationToken);
         if (winetricksInstructions is not null) yield return Diagnostics.CreateRequiredWinetricksPackages(winetricksInstructions);
     }
 }

--- a/src/NexusMods.StandardGameLocators/BaseLinuxCompatibilityDataProvider.cs
+++ b/src/NexusMods.StandardGameLocators/BaseLinuxCompatibilityDataProvider.cs
@@ -1,0 +1,39 @@
+using NexusMods.Abstractions.GameLocators;
+using NexusMods.Paths;
+
+namespace NexusMods.StandardGameLocators;
+
+/// <summary>
+/// Base implementation of <see cref="ILinuxCompatibilityDataProvider"/>.
+/// </summary>
+public class BaseLinuxCompatibilityDataProvider : ILinuxCompatibilityDataProvider
+{
+    /// <inheritdoc/>
+    public AbsolutePath WinePrefixDirectoryPath { get; }
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    public BaseLinuxCompatibilityDataProvider(AbsolutePath winePrefixDirectoryPath)
+    {
+        WinePrefixDirectoryPath = winePrefixDirectoryPath;
+    }
+
+    /// <inheritdoc/>
+    public virtual ValueTask<WineDllOverride[]> GetWineDllOverrides(CancellationToken cancellationToken)
+    {
+        return ValueTask.FromResult<WineDllOverride[]>([]);
+    }
+
+    /// <inheritdoc/>
+    public virtual async ValueTask<IReadOnlySet<string>> GetInstalledWinetricksComponents(CancellationToken cancellationToken)
+    {
+        var winetricksFilePath = WinePrefixDirectoryPath.Combine("winetricks.log");
+        if (!winetricksFilePath.FileExists) return new HashSet<string>();
+
+        await using var stream = winetricksFilePath.Read();
+        var result = WineParser.ParseWinetricksLogFile(stream);
+
+        return result;
+    }
+}

--- a/src/NexusMods.StandardGameLocators/HeroicGogLocator.cs
+++ b/src/NexusMods.StandardGameLocators/HeroicGogLocator.cs
@@ -48,13 +48,18 @@ public class HeroicGogLocator : IGameLocator
             var fs = found.Path.FileSystem;
             var gamePath = found.Path;
 
+            ILinuxCompatibilityDataProvider? linuxCompatibilityDataProvider = null;
+
             if (found is HeroicGOGGame heroicGOGGame)
             {
                 var wineData = heroicGOGGame.WineData;
                 if (wineData is not null)
                 {
                     if (wineData.WinePrefixPath.DirectoryExists())
+                    {
                         fs = heroicGOGGame.GetWinePrefix()!.CreateOverlayFileSystem(fs);
+                        linuxCompatibilityDataProvider = new BaseLinuxCompatibilityDataProvider(wineData.WinePrefixPath);
+                    }
                 }
 
                 // NOTE(erri120): GOG builds for Linux are whack, the installer Heroic uses is whack,
@@ -68,6 +73,7 @@ public class HeroicGogLocator : IGameLocator
             {
                 Id = id,
                 BuildId = found.BuildId,
+                LinuxCompatibilityDataProvider = linuxCompatibilityDataProvider,
             });
         }
     }

--- a/src/NexusMods.StandardGameLocators/ManuallyAddedGame.cs
+++ b/src/NexusMods.StandardGameLocators/ManuallyAddedGame.cs
@@ -33,5 +33,8 @@ public partial class ManuallyAddedGame : IModelDefinition
     {
         /// <inheritdoc />
         public IEnumerable<LocatorId> ToLocatorIds() => [LocatorId.From("NONE")];
+
+        /// <inheritdoc/>
+        public ILinuxCompatibilityDataProvider? LinuxCompatibilityDataProvider => null;
     }
 }

--- a/src/NexusMods.StandardGameLocators/Unknown/UnknownLocatorResultMetadata.cs
+++ b/src/NexusMods.StandardGameLocators/Unknown/UnknownLocatorResultMetadata.cs
@@ -10,4 +10,7 @@ namespace NexusMods.StandardGameLocators.Unknown;
 public record UnknownLocatorResultMetadata(LocatorId[] LocatorIds) : IGameLocatorResultMetadata
 {
     public IEnumerable<LocatorId> ToLocatorIds() => LocatorIds;
+
+    /// <inheritdoc/>
+    public ILinuxCompatibilityDataProvider? LinuxCompatibilityDataProvider { get; init; }
 }


### PR DESCRIPTION
Moves some code around to unify how we can get Linux compatibility data for a game locator result.

Required for #3066.

Fixes #3079.