### PR TITLE
Don't validate exit code by default

### DIFF
--- a/src/ArchiveManagement/NexusMods.FileExtractor/Extractors/SevenZipExtractor.cs
+++ b/src/ArchiveManagement/NexusMods.FileExtractor/Extractors/SevenZipExtractor.cs
@@ -192,7 +192,7 @@ public class SevenZipExtractor : IExtractor
                 pathsWithInvalidCharacters.Add((fileName, isDirectory));
             }));
 
-        await _processFactory.ExecuteAsync(process, cancellationToken: cancellationToken);
+        await _processFactory.ExecuteAsync(process, validateExitCode: true, cancellationToken: cancellationToken);
         return pathsWithInvalidCharacters;
     }
 
@@ -251,7 +251,7 @@ public class SevenZipExtractor : IExtractor
                 _ = TryParseExtractCommandOutput(line, out var percentage);
             }));
 
-        await _processFactory.ExecuteAsync(process, cancellationToken: cancellationToken);
+        await _processFactory.ExecuteAsync(process, validateExitCode: true, cancellationToken: cancellationToken);
     }
 
     private static bool TryParseExtractCommandOutput(ReadOnlySpan<char> line, out int percentage)

--- a/src/Games/NexusMods.Games.Generic/GameToolRunner.cs
+++ b/src/Games/NexusMods.Games.Generic/GameToolRunner.cs
@@ -41,7 +41,7 @@ public class GameToolRunner
     {
         var isLinux = FileSystem.Shared.OS.IsLinux;
         if (!isLinux)
-            return await _processFactory.ExecuteAsync(command, logProcessOutput, cancellationToken);
+            return await _processFactory.ExecuteAsync(command, logProcessOutput, cancellationToken: cancellationToken);
         
         // For Linux, if the user is managing the game via Steam, we can use proton (via protontricks)
         var install = loadout.InstallationInstance;
@@ -50,9 +50,9 @@ public class GameToolRunner
         {
             var appId = steamLocatorResultMetadata.AppId;
             command = await _protontricks.MakeLaunchCommand(command, appId);
-            return await _processFactory.ExecuteAsync(command, logProcessOutput, cancellationToken);
+            return await _processFactory.ExecuteAsync(command, logProcessOutput, cancellationToken: cancellationToken);
         }
 
-        return await _processFactory.ExecuteAsync(command, logProcessOutput, cancellationToken);
+        return await _processFactory.ExecuteAsync(command, logProcessOutput, cancellationToken: cancellationToken);
     }
 }

--- a/src/NexusMods.CrossPlatform/Process/FakeProcessFactory.cs
+++ b/src/NexusMods.CrossPlatform/Process/FakeProcessFactory.cs
@@ -22,6 +22,7 @@ internal class FakeProcessFactory : IProcessFactory
     public async Task<CommandResult> ExecuteAsync(
         Command command,
         bool logProcessOutput = true,
+        bool validateExitCode = false,
         CancellationToken cancellationToken = default)
     {
         Callback?.Invoke(command);

--- a/src/NexusMods.CrossPlatform/Process/IProcessFactory.cs
+++ b/src/NexusMods.CrossPlatform/Process/IProcessFactory.cs
@@ -12,8 +12,9 @@ public interface IProcessFactory
     /// </summary>
     /// <param name="command"></param>
     /// <param name="logProcessOutput"></param>
+    /// <param name="validateExitCode"></param>
     /// <param name="cancellationToken">Allows you to cancel the task, killing the process prematurely.</param>
-    Task<CommandResult> ExecuteAsync(Command command, bool logProcessOutput = true, CancellationToken cancellationToken = default);
+    Task<CommandResult> ExecuteAsync(Command command, bool logProcessOutput = true, bool validateExitCode = false, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Executes the gives process asynchronously.

--- a/src/NexusMods.CrossPlatform/Process/OSInteropWindows.cs
+++ b/src/NexusMods.CrossPlatform/Process/OSInteropWindows.cs
@@ -41,10 +41,8 @@ internal class OSInteropWindows : AOSInterop
         var path = filePath.ToNativeSeparators(_fileSystem.OS);
 
         // reference: https://ss64.com/nt/explorer.html
-        var command = Cli.Wrap("explorer.exe").WithArguments($@"/select,""{path}""")
-            // NOTE(Al12rs): Apparently explorer.exe returns 1 on success here, so we need to ignore non-zero return values during validation
-            .WithValidation(CommandResultValidation.None);
-        
+        var command = Cli.Wrap("explorer.exe").WithArguments($@"/select,""{path}""");
+
         try
         {
             var task = _processFactory.ExecuteAsync(command, logProcessOutput: logOutput, cancellationToken: cancellationToken);

--- a/src/NexusMods.CrossPlatform/Process/ProcessFactory.cs
+++ b/src/NexusMods.CrossPlatform/Process/ProcessFactory.cs
@@ -71,8 +71,11 @@ internal class ProcessFactory : IProcessFactory
     public async Task<CommandResult> ExecuteAsync(
         Command command,
         bool logProcessOutput = true,
+        bool validateExitCode = false,
         CancellationToken cancellationToken = default)
     {
+        command = command.WithValidation(validateExitCode ? CommandResultValidation.ZeroExitCode : CommandResultValidation.None);
+
         if (!logProcessOutput)
         {
             // We require a non-null pipe here, for more details, see:

--- a/src/NexusMods.CrossPlatform/Process/XDGSettingsDependency.cs
+++ b/src/NexusMods.CrossPlatform/Process/XDGSettingsDependency.cs
@@ -17,8 +17,7 @@ internal class XDGSettingsDependency : ExecutableRuntimeDependency
     {
         var command = Cli
             .Wrap("xdg-settings")
-            .WithArguments($"set default-url-scheme-handler {uriScheme} {desktopFile}")
-            .WithValidation(CommandResultValidation.None);
+            .WithArguments($"set default-url-scheme-handler {uriScheme} {desktopFile}");
 
         return command;
     }

--- a/tests/NexusMods.CrossPlatform.Tests/OSInteropTests.cs
+++ b/tests/NexusMods.CrossPlatform.Tests/OSInteropTests.cs
@@ -56,6 +56,7 @@ public class OSInteropTests
                     command.TargetFilePath == targetFilePath &&
                     command.Arguments == arguments),
                 Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult(new CommandResult(0, DateTimeOffset.Now, DateTimeOffset.Now)));
@@ -67,6 +68,7 @@ public class OSInteropTests
             .Received(1)
             .ExecuteAsync(
                 Arg.Any<Command>(),
+                Arg.Any<bool>(),
                 Arg.Any<bool>(),
                 Arg.Any<CancellationToken>()
             );


### PR DESCRIPTION
Exit code validation is questionable at best and unreasonable to have as a default set to true. This PR changes the default behavior to not have exit code validation. Any consumer of the API that cares about non-zero exit codes can set the option to have validation.

Resolves #3087.