### PR TITLE
Load Order: add support for thumbnail images

### DIFF
--- a/src/Abstractions/NexusMods.Abstractions.Games/ISortableItem.cs
+++ b/src/Abstractions/NexusMods.Abstractions.Games/ISortableItem.cs
@@ -1,4 +1,7 @@
 
+using DynamicData.Kernel;
+using NexusMods.Abstractions.Loadouts;
+
 namespace NexusMods.Abstractions.Games;
 
 /// <summary>
@@ -29,6 +32,12 @@ public interface ISortableItem
     /// The name of the winning mod containing the item
     /// </summary>
     public string ModName { get; set; }
+    
+    /// <summary>
+    /// The optional loadout group id of the mod containing the item.
+    /// Optional since some items my not be part of a loadout group.
+    /// </summary>
+    public Optional<LoadoutItemGroupId> ModGroupId { get; set; }
     
     /// <summary>
     /// Represents whether the item is active in the sort order or not

--- a/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/SortOrder/RedMod/RedModSortableItem.cs
+++ b/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/SortOrder/RedMod/RedModSortableItem.cs
@@ -1,4 +1,6 @@
+using DynamicData.Kernel;
 using NexusMods.Abstractions.Games;
+using NexusMods.Abstractions.Loadouts;
 using NexusMods.Paths;
 
 namespace NexusMods.Games.RedEngine.Cyberpunk2077.SortOrder;
@@ -24,5 +26,6 @@ public class RedModSortableItem : ISortableItem<RedModSortableItem, SortItemKey<
     public int SortIndex { get; set; }
     public string DisplayName { get; }
     public string ModName { get; set; }
+    public Optional<LoadoutItemGroupId> ModGroupId { get; set; }
     public bool IsActive { get; set; }
 }

--- a/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/SortOrder/RedMod/RedModSortableItemProvider.cs
+++ b/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/SortOrder/RedMod/RedModSortableItemProvider.cs
@@ -240,6 +240,7 @@ public class RedModSortableItemProvider : ASortableItemProvider<RedModSortableIt
 
             item.IsActive = redModMatch.IsEnabled;
             item.ModName = redModMatch.RedMod.AsLoadoutItemGroup().AsLoadoutItem().Parent.AsLoadoutItem().Name;
+            item.ModGroupId = redModMatch.RedMod.AsLoadoutItemGroup().LoadoutItemGroupId;
         }
 
         return stagingList;

--- a/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/SortOrder/RedMod/RedModSortableItemProvider.cs
+++ b/src/Games/NexusMods.Games.RedEngine/Cyberpunk2077/SortOrder/RedMod/RedModSortableItemProvider.cs
@@ -240,7 +240,7 @@ public class RedModSortableItemProvider : ASortableItemProvider<RedModSortableIt
 
             item.IsActive = redModMatch.IsEnabled;
             item.ModName = redModMatch.RedMod.AsLoadoutItemGroup().AsLoadoutItem().Parent.AsLoadoutItem().Name;
-            item.ModGroupId = redModMatch.RedMod.AsLoadoutItemGroup().LoadoutItemGroupId;
+            item.ModGroupId = redModMatch.RedMod.AsLoadoutItemGroup().AsLoadoutItem().Parent.LoadoutItemGroupId;
         }
 
         return stagingList;

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGrid/LoadOrderComponents.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGrid/LoadOrderComponents.cs
@@ -83,7 +83,8 @@ public static class LoadOrderColumns
         public const string ColumnTemplateResourceKey = nameof(LoadOrderColumns) + "_" + nameof(DisplayNameColumn);
 
         public static readonly ComponentKey DisplayNameComponentKey = ComponentKey.From(ColumnTemplateResourceKey + "_" + "DisplayNameComponent");
-
+        public static readonly ComponentKey ImageComponentKey = ComponentKey.From(ColumnTemplateResourceKey + "_" + nameof(ImageComponent));
+        
         public static int Compare<TKey>(CompositeItemModel<TKey> a, CompositeItemModel<TKey> b) where TKey : notnull
         {
             throw new NotImplementedException();
@@ -101,7 +102,7 @@ public static class LoadOrderColumns
         public const string ColumnTemplateResourceKey = nameof(LoadOrderColumns) + "_" + nameof(ModNameColumn);
 
         public static readonly ComponentKey ModNameComponentKey = ComponentKey.From(ColumnTemplateResourceKey + "_" + "ModNameComponent");
-
+        
         public static int Compare<TKey>(CompositeItemModel<TKey> a, CompositeItemModel<TKey> b) where TKey : notnull
         {
             throw new NotImplementedException();

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGridLoadOrderResources.axaml
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGridLoadOrderResources.axaml
@@ -11,21 +11,21 @@
         <DataTemplate.DataType>
             <x:Type TypeName="controls:CompositeItemModel" x:TypeArguments="games:ISortItemKey" />
         </DataTemplate.DataType>
-        
+
         <!-- IndexComponent -->
-        <controls:ComponentControl x:TypeArguments="games:ISortItemKey" 
+        <controls:ComponentControl x:TypeArguments="games:ISortItemKey"
                                    Content="{CompiledBinding}">
             <controls:ComponentControl.ComponentTemplate>
                 <controls:ComponentTemplate x:TypeArguments="local:LoadOrderComponents+IndexComponent"
-                                   ComponentKey="{x:Static local:LoadOrderColumns+IndexColumn.IndexComponentKey}">
+                                            ComponentKey="{x:Static local:LoadOrderColumns+IndexColumn.IndexComponentKey}">
                     <controls:ComponentTemplate.DataTemplate>
                         <DataTemplate x:DataType="local:LoadOrderComponents+IndexComponent">
-                            
+
                             <StackPanel x:Name="LoadOrderItemIndexColumnStack">
-                                
+
                                 <!-- Drag indicator -->
                                 <Border x:Name="ItemModDragBorder">
-                                    <icons:UnifiedIcon Value="{x:Static icons:IconValues.DragVerticalDots}"/>
+                                    <icons:UnifiedIcon Value="{x:Static icons:IconValues.DragVerticalDots}" />
                                 </Border>
 
                                 <controls:StandardButton x:Name="UpButton"
@@ -49,15 +49,15 @@
                                                          Fill="None" />
                                 <Border x:Name="ItemIndexSeparator" />
                             </StackPanel>
-                            
+
                         </DataTemplate>
                     </controls:ComponentTemplate.DataTemplate>
-                    </controls:ComponentTemplate>
+                </controls:ComponentTemplate>
             </controls:ComponentControl.ComponentTemplate>
         </controls:ComponentControl>
-        
+
     </DataTemplate>
-    
+
     <!-- DisplayName Column -->
     <DataTemplate x:Key="{x:Static local:LoadOrderColumns+DisplayNameColumn.ColumnTemplateResourceKey}">
         <DataTemplate.DataType>
@@ -65,7 +65,7 @@
         </DataTemplate.DataType>
 
         <StackPanel x:Name="LoadOrderItemNameColumnStack" Orientation="Horizontal" Spacing="{StaticResource Spacing-3}">
-            
+
             <!-- Thumbnail -->
             <Border x:Name="ItemModImageBorder">
                 <controls:ComponentControl x:TypeArguments="games:ISortItemKey" Content="{CompiledBinding}">
@@ -74,12 +74,8 @@
                                                     ComponentKey="{x:Static local:LoadOrderColumns+DisplayNameColumn.ImageComponentKey}">
                             <controls:ComponentTemplate.DataTemplate>
                                 <DataTemplate DataType="{x:Type controls:ImageComponent}">
-                                    <Panel>
-                                        <!-- The below image is drawn after the icon and covers the icon if a thumbnail is present. --> 
-                                        <!-- If no thumbnail, then the below Image is null\transparent and so the icon is seen -->
-                                        <icons:UnifiedIcon Value="{x:Static icons:IconValues.Nexus}" />
-                                        <Image Source="{CompiledBinding Value.Value}" />
-                                    </Panel>
+                                    <Image x:Name="ImageThumbnail"
+                                           Source="{CompiledBinding Value.Value}" />
                                 </DataTemplate>
                             </controls:ComponentTemplate.DataTemplate>
 
@@ -87,11 +83,12 @@
                     </controls:ComponentControl.ComponentTemplate>
 
                     <controls:ComponentControl.Fallback>
-                        <icons:UnifiedIcon Value="{x:Static icons:IconValues.Nexus}" />
+                        <icons:UnifiedIcon x:Name="FallbackIcon" 
+                                           Value="{x:Static icons:IconValues.Nexus}" />
                     </controls:ComponentControl.Fallback>
                 </controls:ComponentControl>
             </Border>
-            
+
             <!-- DisplayName -->
             <controls:ComponentControl x:TypeArguments="games:ISortItemKey"
                                        Content="{CompiledBinding}">
@@ -114,19 +111,19 @@
         <DataTemplate.DataType>
             <x:Type TypeName="controls:CompositeItemModel" x:TypeArguments="games:ISortItemKey" />
         </DataTemplate.DataType>
-            <controls:ComponentControl x:TypeArguments="games:ISortItemKey"
-                                       Content="{CompiledBinding}">
-                <controls:ComponentControl.ComponentTemplate>
-                    <controls:ComponentTemplate x:TypeArguments="controls:StringComponent"
-                                                ComponentKey="{x:Static local:LoadOrderColumns+ModNameColumn.ModNameComponentKey}">
-                        <controls:ComponentTemplate.DataTemplate>
-                            <DataTemplate x:DataType="controls:StringComponent" DataType="controls:StringComponent">
-                                <TextBlock x:Name="ModName" Text="{CompiledBinding Value.Value}" />
-                            </DataTemplate>
-                        </controls:ComponentTemplate.DataTemplate>
-                    </controls:ComponentTemplate>
-                </controls:ComponentControl.ComponentTemplate>
-            </controls:ComponentControl>
+        <controls:ComponentControl x:TypeArguments="games:ISortItemKey"
+                                   Content="{CompiledBinding}">
+            <controls:ComponentControl.ComponentTemplate>
+                <controls:ComponentTemplate x:TypeArguments="controls:StringComponent"
+                                            ComponentKey="{x:Static local:LoadOrderColumns+ModNameColumn.ModNameComponentKey}">
+                    <controls:ComponentTemplate.DataTemplate>
+                        <DataTemplate x:DataType="controls:StringComponent" DataType="controls:StringComponent">
+                            <TextBlock x:Name="ModName" Text="{CompiledBinding Value.Value}" />
+                        </DataTemplate>
+                    </controls:ComponentTemplate.DataTemplate>
+                </controls:ComponentTemplate>
+            </controls:ComponentControl.ComponentTemplate>
+        </controls:ComponentControl>
     </DataTemplate>
 
 </ResourceDictionary>

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGridLoadOrderResources.axaml
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGridLoadOrderResources.axaml
@@ -75,6 +75,9 @@
                             <controls:ComponentTemplate.DataTemplate>
                                 <DataTemplate DataType="{x:Type controls:ImageComponent}">
                                     <Panel>
+                                        <!-- The below image is drawn after the icon and covers the icon if a thumbnail is present. --> 
+                                        <!-- If no thumbnail, then the below Image is null\transparent and so the icon is seen -->
+                                        <icons:UnifiedIcon Value="{x:Static icons:IconValues.Nexus}" />
                                         <Image Source="{CompiledBinding Value.Value}" />
                                     </Panel>
                                 </DataTemplate>

--- a/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGridLoadOrderResources.axaml
+++ b/src/NexusMods.App.UI/Pages/Sorting/LoadOrder/TreeDataGridLoadOrderResources.axaml
@@ -68,7 +68,25 @@
             
             <!-- Thumbnail -->
             <Border x:Name="ItemModImageBorder">
-                <icons:UnifiedIcon Value="{x:Static icons:IconValues.Nexus}" />
+                <controls:ComponentControl x:TypeArguments="games:ISortItemKey" Content="{CompiledBinding}">
+                    <controls:ComponentControl.ComponentTemplate>
+                        <controls:ComponentTemplate x:TypeArguments="controls:ImageComponent"
+                                                    ComponentKey="{x:Static local:LoadOrderColumns+DisplayNameColumn.ImageComponentKey}">
+                            <controls:ComponentTemplate.DataTemplate>
+                                <DataTemplate DataType="{x:Type controls:ImageComponent}">
+                                    <Panel>
+                                        <Image Source="{CompiledBinding Value.Value}" />
+                                    </Panel>
+                                </DataTemplate>
+                            </controls:ComponentTemplate.DataTemplate>
+
+                        </controls:ComponentTemplate>
+                    </controls:ComponentControl.ComponentTemplate>
+
+                    <controls:ComponentControl.Fallback>
+                        <icons:UnifiedIcon Value="{x:Static icons:IconValues.Nexus}" />
+                    </controls:ComponentControl.Fallback>
+                </controls:ComponentControl>
             </Border>
             
             <!-- DisplayName -->

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/UserControls/Sorting/LoadOrderStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/UserControls/Sorting/LoadOrderStyles.axaml
@@ -119,23 +119,36 @@
                         </Style>
                     </Style>
 
-                    <!-- second column (display name) -->
+                    <!-- second column (thumbnail and display name) -->
                     <Style Selector="^.LoadOrderColumns_DisplayNameColumn">
                         <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
-
-                            <Style Selector="^ Border#ItemModImageBorder">
+                            
+                            <!-- thumbnail -->
+                            <Style Selector="^ Border.LoadOrderColumns_DisplayNameColumn_ImageComponent">
                                 <Setter Property="Background" Value="{StaticResource SurfaceTranslucentMidBrush}" />
-                                <Setter Property="BorderThickness" Value="1" />
-                                <Setter Property="BorderBrush" Value="{StaticResource SurfaceTranslucentLowBrush}" />
+                                <Setter Property="BorderThickness" Value="0" />
                                 <Setter Property="CornerRadius" Value="{StaticResource Rounded}" />
                                 <Setter Property="Width" Value="45" />
                                 <Setter Property="Height" Value="28" />
-
-                                <Style Selector="^ > icons|UnifiedIcon">
-                                    <Setter Property="Foreground" Value="{StaticResource NeutralWeakBrush}" />
+                                <!-- easy way to get the rounded corner to mask the image below -->
+                                <Setter Property="ClipToBounds" Value="True" />
+                                <!-- allows the border to be drawn over the background -->
+                                <Setter Property="BackgroundSizing" Value="OuterBorderEdge"/>
+                        
+                                <!-- hidden for now as some thumbnails have transparency and I don't think
+                                there is a time anymore that a mod won't have a thumbnail -->
+                                <Style Selector="^ > Panel > icons|UnifiedIcon">
+                                    <Setter Property="IsVisible" Value="False"/>
+                                    <Setter Property="Foreground" Value="{StaticResource NeutralSubduedBrush}" />
                                     <Setter Property="Size" Value="16" />
                                 </Style>
+                        
+                                <Style Selector="^ > Panel > Image">
+                                    <Setter Property="Stretch" Value="UniformToFill" />
+                                </Style>
                             </Style>
+                            
+                            <!-- display name -->
                             <Style Selector="^ TextBlock#DisplayName">
                                 <Setter Property="Theme" Value="{StaticResource BodySMNormalTheme}" />
                                 <Setter Property="Foreground" Value="{StaticResource NeutralTranslucentStrongBrush}" />

--- a/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/UserControls/Sorting/LoadOrderStyles.axaml
+++ b/src/Themes/NexusMods.Themes.NexusFluentDark/Styles/UserControls/Sorting/LoadOrderStyles.axaml
@@ -122,36 +122,35 @@
                     <!-- second column (thumbnail and display name) -->
                     <Style Selector="^.LoadOrderColumns_DisplayNameColumn">
                         <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
-                            
-                            <!-- thumbnail -->
-                            <Style Selector="^ Border.LoadOrderColumns_DisplayNameColumn_ImageComponent">
+
+                            <!-- thumbnail parent -->
+                            <Style Selector="^ Border#ItemModImageBorder">
                                 <Setter Property="Background" Value="{StaticResource SurfaceTranslucentMidBrush}" />
-                                <Setter Property="BorderThickness" Value="0" />
                                 <Setter Property="CornerRadius" Value="{StaticResource Rounded}" />
                                 <Setter Property="Width" Value="45" />
                                 <Setter Property="Height" Value="28" />
                                 <!-- easy way to get the rounded corner to mask the image below -->
                                 <Setter Property="ClipToBounds" Value="True" />
                                 <!-- allows the border to be drawn over the background -->
-                                <Setter Property="BackgroundSizing" Value="OuterBorderEdge"/>
-                        
-                                <!-- hidden for now as some thumbnails have transparency and I don't think
-                                there is a time anymore that a mod won't have a thumbnail -->
-                                <Style Selector="^ > Panel > icons|UnifiedIcon">
-                                    <Setter Property="IsVisible" Value="False"/>
+                                <Setter Property="BackgroundSizing" Value="OuterBorderEdge" />
+
+                                <!-- thumbnail -->
+                                <Style Selector="^ Border.LoadOrderColumns_DisplayNameColumn_ImageComponent Image#ImageThumbnail">
+                                    <Setter Property="Stretch" Value="UniformToFill" />
+                                </Style>
+
+                                <!-- fallback icon -->
+                                <Style Selector="^ icons|UnifiedIcon#FallbackIcon">
                                     <Setter Property="Foreground" Value="{StaticResource NeutralSubduedBrush}" />
                                     <Setter Property="Size" Value="16" />
                                 </Style>
-                        
-                                <Style Selector="^ > Panel > Image">
-                                    <Setter Property="Stretch" Value="UniformToFill" />
-                                </Style>
                             </Style>
-                            
+
                             <!-- display name -->
                             <Style Selector="^ TextBlock#DisplayName">
                                 <Setter Property="Theme" Value="{StaticResource BodySMNormalTheme}" />
                                 <Setter Property="Foreground" Value="{StaticResource NeutralTranslucentStrongBrush}" />
+                                <Setter Property="TextTrimming" Value="CharacterEllipsis" />
                             </Style>
                         </Style>
                     </Style>
@@ -184,7 +183,7 @@
                         </Style>
                     </Style>
                 </Style>
-                
+
                 <!-- pointerover -->
                 <Style Selector="^ TreeDataGridRow:pointerover">
 


### PR DESCRIPTION
- Closes #3096
- Closes #2277 

![image](https://github.com/user-attachments/assets/2728e663-6a5b-4ad1-9124-e2ea2cf76b45)


## Details:
- [x] Add thumbnail support to Load Order backend
- [x] Implement RedMod Load Order thumbnails backend
- [x] Add thumbnail support to Load Order UI
- [x] Fix styling for images

Please wait for @insomnious to fix some styling for the images before merging