### PR TITLE
Fix "No game installed with active loadout" error when downloading collections

### DIFF
--- a/src/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -1408,9 +1408,18 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
                 var remappedLoadout = result.Remap(loadout);
 
                 // If there is no currently synced loadout, then we can ingest the game folder
-                if (!remappedLoadout.Installation.Contains(GameInstallMetadata.LastSyncedLoadout))
+                if (!GameInstallMetadata.LastSyncedLoadout.TryGetValue(remappedLoadout.Installation, out var lastSyncedLoadoutId))
                 {
                     remappedLoadout = await Synchronize(remappedLoadout);
+                }
+                else
+                {
+                    // check if the last synced loadout is valid (can apparently happen if the user unmanaged the game and manages it again)
+                    var lastSyncedLoadout = Loadout.Load(remappedLoadout.Db, lastSyncedLoadoutId);
+                    if (!lastSyncedLoadout.IsValid())
+                    {
+                        remappedLoadout = await Synchronize(lastSyncedLoadout);
+                    }
                 }
                 return remappedLoadout;
             }

--- a/src/NexusMods.App.Cli/Types/IpcHandlers/NxmIpcProtocolHandler.cs
+++ b/src/NexusMods.App.Cli/Types/IpcHandlers/NxmIpcProtocolHandler.cs
@@ -123,6 +123,15 @@ public class NxmIpcProtocolHandler : IIpcProtocolHandler
                     game = installedGame;
                     break;
                 }
+
+                var activeLoadouts = Loadout.All(connection.Db)
+                    .Where(ld => ld.InstallationInstance.Game.GameId == installedGame.Game.GameId);
+                
+                if (activeLoadouts.Any())
+                {
+                    game = installedGame;
+                    break;
+                }
             }
         }
         if (game is null)


### PR DESCRIPTION
- Fix #3113
Support installing collections in cases where there is no last applied loadout