### PR TITLE
Close tabs on middle click

### DIFF
--- a/src/NexusMods.App.UI/WorkspaceSystem/PanelTabHeader/PanelTabHeaderView.axaml.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/PanelTabHeader/PanelTabHeaderView.axaml.cs
@@ -4,7 +4,6 @@ using System.Reactive.Linq;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.ReactiveUI;
-using DynamicData.Kernel;
 using JetBrains.Annotations;
 using NexusMods.App.UI.Extensions;
 using ReactiveUI;

--- a/src/NexusMods.App.UI/WorkspaceSystem/PanelTabHeader/PanelTabHeaderView.axaml.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/PanelTabHeader/PanelTabHeaderView.axaml.cs
@@ -59,15 +59,14 @@ public partial class PanelTabHeaderView : ReactiveUserControl<IPanelTabHeaderVie
                 .BindToView(this, view => view.ViewModel!.IsSelected)
                 .DisposeWith(disposables);
                 
-            Observable.FromEventPattern<PointerReleasedEventArgs>(
-                addHandler => Container.PointerReleased += addHandler,
-                removeHandler => Container.PointerReleased -= removeHandler
-                ).Where(eventPattern => eventPattern.EventArgs.InitialPressMouseButton == MouseButton.Middle && 
-                                        Bounds.Contains(eventPattern.EventArgs.GetPosition(this)) && 
-                                        eventPattern.EventArgs.GetIntermediatePoints(this).FirstOrOptional(_ => true)
-                                            .Convert(point => Bounds.Contains(point.Position)) 
-                                            .ValueOr(false)
+            Observable
+                .FromEventPattern<PointerReleasedEventArgs>(
+                    addHandler => Container.PointerReleased += addHandler,
+                    removeHandler => Container.PointerReleased -= removeHandler
                 )
+                .Select(static eventPattern => eventPattern.EventArgs)
+                .Where(eventArgs => eventArgs.InitialPressMouseButton != MouseButton.Middle &&
+                                    Bounds.Contains(eventArgs.GetPosition(this)))
                 .Select(_ => Unit.Default)
                 .InvokeReactiveCommand(this, view => view.ViewModel!.CloseTabCommand)
                 .DisposeWith(disposables);


### PR DESCRIPTION
Repost of #3122 to add changes

- Closes #1755.

This only closes tabs if the pointer is inside the bounds of the tab header at the time of both pressing and releasing, similar to how it works in popular web browsers.

Credits to @JonathanFeenstra 