### PR TITLE
Expanded Statusbar control

### DIFF
--- a/src/NexusMods.App.UI/Controls/Divider.cs
+++ b/src/NexusMods.App.UI/Controls/Divider.cs
@@ -1,0 +1,10 @@
+using Avalonia.Controls.Primitives;
+
+namespace NexusMods.App.UI.Controls;
+
+/// <summary>
+/// A divider control.
+/// </summary>
+public class Divider : TemplatedControl
+{
+}

--- a/src/NexusMods.Themes.NexusFluentDark/Resources/ControlThemes/DividerControlTheme.axaml
+++ b/src/NexusMods.Themes.NexusFluentDark/Resources/ControlThemes/DividerControlTheme.axaml
@@ -1,0 +1,40 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:controls="clr-namespace:NexusMods.App.UI.Controls;assembly=NexusMods.App.UI"
+                    xmlns:icons="clr-namespace:NexusMods.Icons;assembly=NexusMods.Icons">
+    
+    <Design.PreviewWith>
+        <controls:Statusbar Classes="Primary">
+            <StackPanel>
+                <controls:StandardButton Text="Button 3" Fill="Weak"
+                                         Size="ExtraSmall"
+                                         ShowLabel="False"
+                                         ShowIcon="Left"
+                                         LeftIcon="{x:Static icons:IconValues.MoreVertical}" />
+                <controls:StandardButton Text="Button 3" Fill="Weak"
+                                         Size="ExtraSmall" />
+            </StackPanel>
+            <TextBlock Text="1 of 9 required mods" />
+            <controls:Divider />
+            <TextBlock Text="1 of 9 required mods" />
+        </controls:Statusbar>
+    </Design.PreviewWith>
+
+    <ControlTheme x:Key="{x:Type controls:Divider}" TargetType="controls:Divider">
+        <Setter Property="Background" Value="{StaticResource StrokeTranslucentModerateBrush}" />
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="Height" Value="4" />
+        <Setter Property="Width" Value="4" />
+        <Setter Property="Margin" Value="0" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Ellipse
+                        Height="{TemplateBinding Height}"
+                        Width="{TemplateBinding Width}"
+                        HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                        VerticalAlignment="{TemplateBinding VerticalAlignment}"
+                        Fill="{TemplateBinding Background}" />
+            </ControlTemplate>
+        </Setter>
+    </ControlTheme>
+</ResourceDictionary>

--- a/src/NexusMods.Themes.NexusFluentDark/Resources/ControlThemes/StatusbarControlTheme.axaml
+++ b/src/NexusMods.Themes.NexusFluentDark/Resources/ControlThemes/StatusbarControlTheme.axaml
@@ -61,6 +61,18 @@
                     </StackPanel>
                     <TextBlock Text="1 of 9 required mods" />
                 </controls:Statusbar>
+                <controls:Statusbar Classes="Warning">
+                    <StackPanel>
+                        <controls:StandardButton Text="Button 3" Fill="Weak"
+                                                 Size="ExtraSmall"
+                                                 ShowLabel="False"
+                                                 ShowIcon="Left"
+                                                 LeftIcon="{x:Static icons:IconValues.MoreVertical}" />
+                        <controls:StandardButton Text="Button 3" Fill="Weak"
+                                                 Size="ExtraSmall" />
+                    </StackPanel>
+                    <TextBlock Text="1 of 9 required mods" />
+                </controls:Statusbar>
             </StackPanel>
         </Border>
     </Design.PreviewWith>
@@ -74,22 +86,23 @@
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="BorderBrush" Value="{StaticResource StrokeTranslucentWeakBrush}" />
         <Setter Property="Padding" Value="24, 12,24,0" />
-        <Setter Property="CornerRadius" Value="{StaticResource Rounded}" />
+        <Setter Property="CornerRadius" Value="{StaticResource Rounded-lg}" />
         <Setter Property="Template">
             <ControlTemplate>
                 <Border
-                        MinHeight="{TemplateBinding MinHeight}"
-                        HorizontalAlignment="Stretch"
-                        VerticalAlignment="{TemplateBinding VerticalAlignment}"
-                        Background="{StaticResource SurfaceLowBrush}"
-                        Padding="{TemplateBinding Padding}">
+                    MinHeight="{TemplateBinding MinHeight}"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="{TemplateBinding VerticalAlignment}"
+                    Background="{StaticResource SurfaceLowBrush}"
+                    Padding="{TemplateBinding Padding}">
                     <Border Name="ButtonContainer"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
                             CornerRadius="{TemplateBinding CornerRadius}"
                             Background="{TemplateBinding Background}"
                             Padding="8"
-                            HorizontalAlignment="Stretch">
+                            HorizontalAlignment="Stretch"
+                            BackgroundSizing="OuterBorderEdge">
                         <StackPanel Orientation="Horizontal">
                             <ItemsPresenter Name="PART_ItemsPresenter"
                                             ItemsPanel="{TemplateBinding ItemsPanel}" />
@@ -102,9 +115,14 @@
         <Style Selector="^.Info">
             <Setter Property="Background" Value="#331D4ED8" />
         </Style>
-        
+
         <Style Selector="^.Primary">
             <Setter Property="Background" Value="#33FB923C" />
+        </Style>
+
+        <Style Selector="^.Warning">
+            <Setter Property="Background" Value="#1AFEF08A" />
+            <Setter Property="Foreground" Value="{StaticResource WarningStrongBrush}" />
         </Style>
     </ControlTheme>
 

--- a/src/NexusMods.Themes.NexusFluentDark/Resources/ResourceIndex.axaml
+++ b/src/NexusMods.Themes.NexusFluentDark/Resources/ResourceIndex.axaml
@@ -34,6 +34,7 @@
         <MergeResourceInclude Source="/Resources/ControlThemes/StandardButton.axaml"/>
         
         <!-- control themes for other controls/components -->
+        <MergeResourceInclude Source="/Resources/ControlThemes/DividerControlTheme.axaml"/>
         <MergeResourceInclude Source="/Resources/ControlThemes/UnifiedIconControlTheme.axaml"/>
         <MergeResourceInclude Source="/Resources/ControlThemes/EmptyStateControlTheme.axaml"/>
         <MergeResourceInclude Source="/Resources/ControlThemes/AlertControlTheme.axaml"/>

--- a/src/NexusMods.Themes.NexusFluentDark/Styles/UserControls/Statusbar/StatusbarStyles.axaml
+++ b/src/NexusMods.Themes.NexusFluentDark/Styles/UserControls/Statusbar/StatusbarStyles.axaml
@@ -3,6 +3,11 @@
         xmlns:controls="clr-namespace:NexusMods.App.UI.Controls;assembly=NexusMods.App.UI"
         xmlns:icons="clr-namespace:NexusMods.Icons;assembly=NexusMods.Icons">
 
+    <!-- This file is used for expected child controls such as Buttons, Seperators etc.
+    The ControlTheme in src/NexusMods.Themes.NexusFluentDark/Resources/ControlThemes/StatusbarControlTheme.axaml
+    is used for the actual parent control template and styles.
+     -->
+
     <Design.PreviewWith>
         <Border Width="800">
             <StackPanel>
@@ -35,7 +40,17 @@
                         <controls:StandardButton Text="Button 3" Fill="Weak"
                                                  Size="ExtraSmall" />
                     </StackPanel>
-                    <TextBlock Text="1 of 9 required mods" />
+                    <StackPanel>
+                        <icons:UnifiedIcon Value="{x:Static icons:IconValues.Check}"
+                                           Foreground="{StaticResource SuccessModerateBrush}"/>
+                        <TextBlock Text="1 of 9 required mods" />
+                    </StackPanel>
+                    <controls:Divider />
+                    <StackPanel>
+                        <icons:UnifiedIcon Value="{x:Static icons:IconValues.Check}"
+                                           Foreground="{StaticResource SuccessModerateBrush}" />
+                        <TextBlock Text="1 of 9 required mods" />
+                    </StackPanel>
                 </controls:Statusbar>
                 <controls:Statusbar Classes="Info">
                     <StackPanel>
@@ -61,6 +76,26 @@
                     </StackPanel>
                     <TextBlock Text="1 of 9 required mods" />
                 </controls:Statusbar>
+                <controls:Statusbar Classes="Warning">
+                    <StackPanel>
+                        <controls:StandardButton Text="Button 3" Fill="Weak"
+                                                 Size="ExtraSmall"
+                                                 ShowLabel="False"
+                                                 ShowIcon="Left"
+                                                 LeftIcon="{x:Static icons:IconValues.MoreVertical}" />
+                        <controls:StandardButton Text="Button 3" Fill="Weak"
+                                                 Size="ExtraSmall" />
+                    </StackPanel>
+                    <StackPanel>
+                        <icons:UnifiedIcon Value="{x:Static icons:IconValues.WarningAmber}" />
+                        <TextBlock Text="1 of 9 required mods" />
+                    </StackPanel>
+                    <controls:Divider />
+                    <StackPanel>
+                        <icons:UnifiedIcon Value="{x:Static icons:IconValues.WarningAmber}" />
+                        <TextBlock Text="1 of 9 required mods" />
+                    </StackPanel>
+                </controls:Statusbar>
             </StackPanel>
         </Border>
     </Design.PreviewWith>
@@ -75,14 +110,19 @@
             <Setter Property="Width" Value="1" />
         </Style>
 
-        <!-- button group -->
+        <!-- button group/control group -->
         <Style Selector="^ > StackPanel">
+            <Setter Property="VerticalAlignment" Value="Center" />
             <Setter Property="Orientation" Value="Horizontal" />
             <Setter Property="Spacing" Value="{StaticResource Spacing-1}" />
         </Style>
-
-        <Style Selector="^ > TextBlock">
+        
+        <Style Selector="^ TextBlock">
             <Setter Property="VerticalAlignment" Value="Center" />
+        </Style>
+        
+        <Style Selector="^ icons|UnifiedIcon">
+            <Setter Property="Size" Value="16" />
         </Style>
     </Style>
 </Styles>


### PR DESCRIPTION
Closes #3130 

- Created simple `<Divider />` control (a bit like Separator) as it's used in loads of places and visually like a bullet point.
- Reworked styles to match Figma 

![image](https://github.com/user-attachments/assets/1140c4c2-23b4-4138-afcc-e3d655077b21)
