### PR TITLE
Fixes workspace panel corner issues

### DIFF
--- a/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelView.axaml
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelView.axaml
@@ -28,7 +28,18 @@
     The best solution I've found so far is to have a Panel and two child Borders. Using Panel as a parent means both 
     children are drawn over the same area and not stacked, this allows us to layer. One Border is the clipping border which 
     contains the nested content and the other has the BorderBrush that is drawn over the top of everything. 
-     --> 
+    
+    <Panel>
+      <Border x:Name="PanelClippingBorder">
+        <WhateverContent />
+          <NestedContent />
+        <MoreContent />
+      </Border>
+      <Border x:Name="PanelBorder" />
+    </Panel>
+    
+    Borders by default stretch h and v to fill their parent. So these two Borders will always be the same size. One is clipping the content (and so PanelBorder has CornerRadius set). The other one, as it's drawn after, it's drawing an outline with a transparent background over all of it. (edited) 
+     -->
     <Panel>
         <Border x:Name="PanelClipBorder">
             <Grid RowDefinitions="Auto, *">
@@ -146,7 +157,7 @@
                 </ItemsControl>
             </Grid>
         </Border>
-        <Border x:Name="PanelBorder"/>
+        <Border x:Name="PanelBorder" />
     </Panel>
 
 </reactive:ReactiveUserControl>

--- a/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelView.axaml
+++ b/src/NexusMods.App.UI/WorkspaceSystem/Panel/PanelView.axaml
@@ -11,122 +11,142 @@
     mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="200"
     x:Class="NexusMods.App.UI.WorkspaceSystem.PanelView">
 
+    <!-- NOTE (insomnious): We have an ongoing Avalonia issue in how Backgrounds/CornerRadius/BorderBrush work together. It's not a bug
+    but more just needing to know what happens and the best way to work with it so it feels right.
     
-    <Border x:Name="PanelBorder">
-        <Grid RowDefinitions="Auto, *">
-            <Border Grid.Row="0" x:Name="TabHeaderBorder">
-                <Grid ColumnDefinitions="*, Auto">
-                    <Grid Grid.Column="0" ColumnDefinitions="Auto, *, Auto">
-                        <Border Grid.Column="0" x:Name="ScrollLeftButtonBorder">
-                            <controls:StandardButton x:Name="ScrollLeftButton"
-                                                     Size="Medium"
-                                 ShowIcon="IconOnly"
-                                 LeftIcon="{x:Static icons:IconValues.ChevronLeft}"
-                                 Fill="None"
-                                 Margin="8,0,8,0"/>
-                        </Border>
+    Child elements are drawn after the parent and so if the parent has a rounded border, and ClipToBounds is set to true,
+    the child background (which is a default rectangle the size of the bounds) corners are clipped by the parent. 
+    If the parent has a BorderBrush (which is an inner border), then the child background is drawn over the parent border 
+    as this border is drawn before and within the bounds.
+    
+    A background is going to be drawn rectangular unless the specific control has a CornerRadius value set and so if we 
+    wanted to solve the problem of the child background being drawn over the parent border, we need to set each child 
+    control to have a matching corner radius. This isn't acceptable as it means we need to set the same value in multiple 
+    places and do lots of work based on what child and where it is and will involve a lot of work to maintain and reduce 
+    reusability.    
+     
+    The best solution I've found so far is to have a Panel and two child Borders. Using Panel as a parent means both 
+    children are drawn over the same area and not stacked, this allows us to layer. One Border is the clipping border which 
+    contains the nested content and the other has the BorderBrush that is drawn over the top of everything. 
+     --> 
+    <Panel>
+        <Border x:Name="PanelClipBorder">
+            <Grid RowDefinitions="Auto, *">
+                <Border Grid.Row="0" x:Name="TabHeaderBorder">
+                    <Grid ColumnDefinitions="*, Auto">
+                        <Grid Grid.Column="0" ColumnDefinitions="Auto, *, Auto">
+                            <Border Grid.Column="0" x:Name="ScrollLeftButtonBorder">
+                                <controls:StandardButton x:Name="ScrollLeftButton"
+                                                         Size="Medium"
+                                                         ShowIcon="IconOnly"
+                                                         LeftIcon="{x:Static icons:IconValues.ChevronLeft}"
+                                                         Fill="None"
+                                                         Margin="8,0,8,0" />
+                            </Border>
 
-                        <ScrollViewer Grid.Column="1"
-                                      x:Name="TabHeaderScrollViewer"
-                                      VerticalScrollBarVisibility="Disabled"
-                                      HorizontalScrollBarVisibility="Auto">
-                            <Grid ColumnDefinitions="Auto, Auto, *">
-                                <StackPanel Grid.Column="0" Orientation="Horizontal">
-                                    <ItemsControl x:Name="TabHeaders" Height="36">
-                                        <ItemsControl.ItemsPanel>
-                                            <ItemsPanelTemplate>
-                                                <StackPanel Classes="Spacing-none" 
-                                                    Orientation="Horizontal" />
-                                            </ItemsPanelTemplate>
-                                        </ItemsControl.ItemsPanel>
+                            <ScrollViewer Grid.Column="1"
+                                          x:Name="TabHeaderScrollViewer"
+                                          VerticalScrollBarVisibility="Disabled"
+                                          HorizontalScrollBarVisibility="Auto">
+                                <Grid ColumnDefinitions="Auto, Auto, *">
+                                    <StackPanel Grid.Column="0" Orientation="Horizontal">
+                                        <ItemsControl x:Name="TabHeaders" Height="36">
+                                            <ItemsControl.ItemsPanel>
+                                                <ItemsPanelTemplate>
+                                                    <StackPanel Classes="Spacing-none"
+                                                                Orientation="Horizontal" />
+                                                </ItemsPanelTemplate>
+                                            </ItemsControl.ItemsPanel>
 
-                                        <ItemsControl.ItemTemplate>
-                                            <DataTemplate DataType="{x:Type workspace:IPanelTabViewModel}">
-                                                <reactive:ViewModelViewHost ViewModel="{CompiledBinding Header}" />
-                                            </DataTemplate>
-                                        </ItemsControl.ItemTemplate>
-                                    </ItemsControl>
-                                </StackPanel>
-                                
-                                <Separator x:Name="OneTabLine" Grid.Column="1" Margin="4,0,0,0"/>
-                                
-                                <Border Grid.Column="2" x:Name="AddTabButton1Container"
-                                        HorizontalAlignment="Stretch">
-                                    
-                                    <controls:StandardButton x:Name="AddTabButton1"
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate DataType="{x:Type workspace:IPanelTabViewModel}">
+                                                    <reactive:ViewModelViewHost ViewModel="{CompiledBinding Header}" />
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </StackPanel>
+
+                                    <Separator x:Name="OneTabLine" Grid.Column="1" Margin="4,0,0,0" />
+
+                                    <Border Grid.Column="2" x:Name="AddTabButton1Container"
+                                            HorizontalAlignment="Stretch">
+
+                                        <controls:StandardButton x:Name="AddTabButton1"
+                                                                 Size="Medium"
+                                                                 ShowIcon="IconOnly"
+                                                                 LeftIcon="{x:Static icons:IconValues.Add}"
+                                                                 Fill="None"
+                                                                 Margin="8,0,0,0" />
+
+                                    </Border>
+                                    <ToolTip.Tip>
+                                        <TextBlock Text="{x:Static resources:Language.Panel_Add_tab_ToolTip}" />
+                                    </ToolTip.Tip>
+                                </Grid>
+
+                            </ScrollViewer>
+
+                            <Border Grid.Column="2" x:Name="TabHeaderAddAndScrollBorder">
+                                <StackPanel Orientation="Horizontal" Spacing="{StaticResource Spacing-1}">
+
+                                    <controls:StandardButton x:Name="AddTabButton2"
                                                              Size="Medium"
                                                              ShowIcon="IconOnly"
                                                              LeftIcon="{x:Static icons:IconValues.Add}"
                                                              Fill="None"
-                                                             Margin="8,0,0,0"/>
-                                    
+                                                             Margin="8,0,0,0" />
+
+                                    <controls:StandardButton x:Name="ScrollRightButton"
+                                                             Size="Medium"
+                                                             ShowIcon="IconOnly"
+                                                             LeftIcon="{x:Static icons:IconValues.ChevronRight}"
+                                                             Fill="None" />
+                                </StackPanel>
+                            </Border>
+                        </Grid>
+
+                        <Border Grid.Column="1" x:Name="TabHeaderSideAreaBorder">
+                            <StackPanel
+                                x:Name="TabHeaderSideArea"
+                                Orientation="Horizontal"
+                                Classes="Spacing-3"
+                                Margin="6, 0, 8, 0">
+                                <!-- NOTE(insomnious): needs an extra 2 on the right margin to account for the 2px border -->
+
+                                <!-- TODO: Remove this hiding Border when PoppedOut panels are implemented -->
+                                <Border IsVisible="False">
+                                    <Button x:Name="PopOutPanelButton"
+                                            Classes="PanelTitlebar OpenInWindow" />
                                 </Border>
-                                <ToolTip.Tip>
-                                    <TextBlock Text="{x:Static resources:Language.Panel_Add_tab_ToolTip}" />
-                                </ToolTip.Tip>
-                            </Grid>
 
-                        </ScrollViewer>
-
-                        <Border Grid.Column="2" x:Name="TabHeaderAddAndScrollBorder">
-                            <StackPanel Orientation="Horizontal" Spacing="{StaticResource Spacing-1}">
-                                
-                                <controls:StandardButton x:Name="AddTabButton2"
+                                <controls:StandardButton x:Name="ClosePanelButton"
                                                          Size="Medium"
                                                          ShowIcon="IconOnly"
-                                                         LeftIcon="{x:Static icons:IconValues.Add}"
-                                                         Fill="None"
-                                                         Margin="8,0,0,0" />
-                                
-                                <controls:StandardButton x:Name="ScrollRightButton"
-                                                         Size="Medium"
-                                                         ShowIcon="IconOnly"
-                                                         LeftIcon="{x:Static icons:IconValues.ChevronRight}"
+                                                         LeftIcon="{x:Static icons:IconValues.Close}"
                                                          Fill="None" />
                             </StackPanel>
                         </Border>
                     </Grid>
+                </Border>
 
-                    <Border Grid.Column="1" x:Name="TabHeaderSideAreaBorder">
-                        <StackPanel
-                            x:Name="TabHeaderSideArea"
-                            Orientation="Horizontal"
-                            Classes="Spacing-3"
-                            Margin="6, 0, 8, 0">
-                            <!-- NOTE(insomnious): needs an extra 2 on the right margin to account for the 2px border -->
-                            
-                            <!-- TODO: Remove this hiding Border when PoppedOut panels are implemented -->
-                            <Border IsVisible="False">
-                                <Button x:Name="PopOutPanelButton"
-                                        Classes="PanelTitlebar OpenInWindow" />
-                            </Border>
+                <ItemsControl Grid.Row="1" x:Name="TabContents">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <Grid RowDefinitions="*" ColumnDefinitions="*" />
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
 
-                            <controls:StandardButton x:Name="ClosePanelButton"
-                                                     Size="Medium"
-                                                     ShowIcon="IconOnly"
-                                                     LeftIcon="{x:Static icons:IconValues.Close}"
-                                                     Fill="None" />
-                        </StackPanel>
-                    </Border>
-                </Grid>
-            </Border>
-
-            <ItemsControl Grid.Row="1" x:Name="TabContents">
-                <ItemsControl.ItemsPanel>
-                    <ItemsPanelTemplate>
-                        <Grid RowDefinitions="*" ColumnDefinitions="*" />
-                    </ItemsPanelTemplate>
-                </ItemsControl.ItemsPanel>
-
-                <ItemsControl.ItemTemplate>
-                    <DataTemplate DataType="{x:Type workspace:IPanelTabViewModel}">
-                        <reactive:ViewModelViewHost x:Name="ViewModelViewHost"
-                                                    IsVisible="{CompiledBinding IsVisible, Mode=OneWay}"
-                                                    ViewModel="{CompiledBinding Contents.ViewModel, Mode=OneWay}" />
-                    </DataTemplate>
-                </ItemsControl.ItemTemplate>
-            </ItemsControl>
-        </Grid>
-    </Border>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate DataType="{x:Type workspace:IPanelTabViewModel}">
+                            <reactive:ViewModelViewHost x:Name="ViewModelViewHost"
+                                                        IsVisible="{CompiledBinding IsVisible, Mode=OneWay}"
+                                                        ViewModel="{CompiledBinding Contents.ViewModel, Mode=OneWay}" />
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </Grid>
+        </Border>
+        <Border x:Name="PanelBorder"/>
+    </Panel>
 
 </reactive:ReactiveUserControl>

--- a/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerView.axaml
+++ b/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerView.axaml
@@ -13,6 +13,9 @@
     HorizontalContentAlignment="Center"
     VerticalContentAlignment="Center">
 
-    <icons:UnifiedIcon x:Name="Icon" Size="30" IsVisible="False" />
+    <icons:UnifiedIcon x:Name="Icon" 
+                       Size="24" 
+                       Foreground="{StaticResource NeutralSubduedBrush}"
+                       IsVisible="False"  />
 
 </reactive:ReactiveUserControl>

--- a/src/NexusMods.Themes.NexusFluentDark/Styles/UserControls/WorkspaceSystem/PanelViewStyles.axaml
+++ b/src/NexusMods.Themes.NexusFluentDark/Styles/UserControls/WorkspaceSystem/PanelViewStyles.axaml
@@ -8,13 +8,27 @@
         </Border>
     </Design.PreviewWith>
     
+    <Styles.Resources>
+        <StaticResource x:Key="PanelViewCornerRadius" ResourceKey="Rounded-lg"/>
+        <SolidColorBrush x:Key="PanelBorderBrushUnselected" Color="Transparent"/>
+        <StaticResource x:Key="PanelBorderBrushSelected" ResourceKey="BrandNeutral600"/>
+    </Styles.Resources>
+    
     <Style Selector="ui|PanelView">
         
-        <Style Selector="^ Border#PanelBorder">
+        <!-- Both Border's below need CornerRadius as one is clipping the content below, and the other is drawing the 
+        border and needs setting specifically -->
+        
+        <Style Selector="^ Border#PanelClipBorder">
+            <Setter Property="ClipToBounds" Value="True" />
             <Setter Property="Background" Value="{StaticResource SurfaceLowBrush}" />
-            <Setter Property="CornerRadius" Value="8" />
+            <Setter Property="CornerRadius" Value="{StaticResource PanelViewCornerRadius}" />
+        </Style>
+        
+        <Style Selector="^ Border#PanelBorder">
+            <Setter Property="CornerRadius" Value="{StaticResource PanelViewCornerRadius}" />
             <Setter Property="BorderThickness" Value="2" />
-            <Setter Property="BorderBrush" Value="Transparent" />
+            <Setter Property="BorderBrush" Value="{StaticResource PanelBorderBrushUnselected}" />
         </Style>
     
         <Style Selector="^ ItemsControl#TabContents">
@@ -38,7 +52,7 @@
         <Style Selector="^:alone">
             <Style Selector="^ Border#PanelBorder">
                 <Setter Property="BorderThickness" Value="2" />
-                <Setter Property="BorderBrush" Value="Transparent" />
+                <Setter Property="BorderBrush" Value="{StaticResource PanelBorderBrushUnselected}" />
             </Style>
         </Style>
 
@@ -49,7 +63,7 @@
             <Style Selector="^:selected">
                 <Style Selector="^ Border#PanelBorder">
                     <Setter Property="BorderThickness" Value="2" />
-                    <Setter Property="BorderBrush" Value="{StaticResource BrandNeutral600}" />
+                    <Setter Property="BorderBrush" Value="{StaticResource PanelBorderBrushSelected}" />
                 </Style>
             </Style>
 
@@ -57,7 +71,7 @@
             <Style Selector="^:not(:selected)">
                 <Style Selector="^ Border#PanelBorder">
                     <Setter Property="BorderThickness" Value="2" />
-                    <Setter Property="BorderBrush" Value="Transparent" />
+                    <Setter Property="BorderBrush" Value="{StaticResource PanelBorderBrushUnselected}" />
                 </Style>
             </Style>
         </Style>


### PR DESCRIPTION
We have an ongoing UI thing in Avalonia with how Backgrounds/CornerRadius/BorderBrush work together. It's not a bug but more just needing to know what happens and the best way to work with it so it feels intuitive.

Child elements are drawn after the parent and so if the parent has a rounded border, and ClipToBounds is set to true, the child background (which is a default rectangle the size of the bounds) corners are clipped by the parent. If the parent has a  BorderBrush (which is an inner border), then the child background is drawn over the parent border as this border is drawn before and within the bounds.

A background is going to be drawn rectangular unless the specific control has a CornerRadius value set and so if we wanted to solve the problem of the child background being drawn over the parent border, we need to set each child control to have a matching corner radius. This isn't acceptable as it means we need to set the same value in multiple places and do lots of work based on what child and where it is and will involve a lot of work to maintain and reduce reusability.   

The best solution I've found so far is to have a Panel and two child Borders. Using Panel as a parent means both children are drawn over the same area and not stacked, this allows us to layer. One Border is the clipping border which contains the nested content and the other has the BorderBrush that is drawn over the top of everything.

```
<Panel>
  <Border x:Name="PanelClippingBorder">
    <!-- whatever content goes here -->
  </Border>
  <Border x:Name="PanelBorder" />
</Panel>
```
Borders by default stretch h and v to fill their parent. So these two Borders will always be the same size. One is clipping the content (and so PanelBorder has CornerRadius set). The other one, as it's drawn after, it's drawing an outline with a transparent background over all of it. (edited) 

Before and After

![image](https://github.com/user-attachments/assets/6fbcfb1a-7676-4773-97e5-a2a5223a1a0b)
![image](https://github.com/user-attachments/assets/bcce36f9-2812-4ad1-b375-4a6944bea2c5)
