### PR TITLE
Support adding/removing games with CLI without installation required

### DIFF
--- a/docs/developers/Contributing.md
+++ b/docs/developers/Contributing.md
@@ -21,6 +21,27 @@ helping you make things like new 'Windows' and 'Controls' easier.
 
 Make sure to follow our [Development Guidelines](./development-guidelines/UICodingGuidelines.md).
 
+### Debugging the App
+This app is designed to be used with [games](../users/games/index.md) that are currently supported. It is recommended to
+have a supported game installed on your system to debug the app with full functionality.
+
+If you want to contribute to the app without a supported game installed, you can continue
+doing so by manually adding a supported game. However, supported games that are manually added and not installed properly for 
+testing purposes may not be playable. You can still use the app to test the UI and other features, 
+but some features may not work as expected. To add a supported game manually:
+
+1. Have a directory ready and copy its path for the game you want to add to store its mods.
+2. After building the project, go to your terminal and change the directory to the `src/NexusMods.App/bin/Debug/net9.0` folder.
+3. Enter the following CLI command and replace the arguments: 
+   ```bash
+   NexusMods.App as-main add-game -g "Game Name" -v [Version] -p "Path"
+   ```
+4. Save the `EntityID` provided and run the app to check if the game is listed in the "My Games" section.
+5. Later on, you can remove the game by running the following CLI command:
+   ```bash
+   NexusMods.App as-main remove-game -g "Game Name" -id "EntityID"
+   ```
+
 ## Translations
 
 Translations are currently handled via the IDE. See [this issue](https://github.com/Nexus-Mods/NexusMods.App/issues/598) for more details.

--- a/src/NexusMods.App.Cli/OptionParsers/GameParser.cs
+++ b/src/NexusMods.App.Cli/OptionParsers/GameParser.cs
@@ -11,11 +11,33 @@ internal class GameParser(IGameRegistry gameRegistry) : IOptionParser<IGame>
 {
     public bool TryParse(string toParse, out IGame value, out string error)
     {
-        var install = gameRegistry.Installations.Values.FirstOrDefault(g => g.Game.GameId.ToString() == toParse) ??
-                    gameRegistry.Installations.Values.FirstOrDefault(g => g.Game.Name.Equals(toParse, StringComparison.CurrentCultureIgnoreCase))!;
-
-        value = (IGame)install.Game;
-        error = string.Empty;
-        return true;
+        try
+        {
+            var install = gameRegistry.Installations.Values.FirstOrDefault(g => g.Game.GameId.ToString() == toParse) ??
+                          gameRegistry.Installations.Values.FirstOrDefault(g => g.Game.Name.Equals(toParse, StringComparison.CurrentCultureIgnoreCase)) ??
+                          GameInstallation.Empty;
+            if (install.Equals(GameInstallation.Empty))
+            {
+                throw new NullReferenceException();
+            }
+            value = (IGame)install.Game;
+            error = string.Empty;
+            return true;
+        }
+        catch (NullReferenceException)
+        {
+            // Recheck if current game parse is supported
+            var install = gameRegistry.SupportedGames.FirstOrDefault(g => g.GameId.ToString() == toParse) ??
+                       gameRegistry.SupportedGames.FirstOrDefault(g => g.Name.Equals(toParse, StringComparison.CurrentCultureIgnoreCase))!;
+            if (install == null!)
+            {
+                value = null!;
+                error = $"Game '{toParse}' is not found or supported.";
+                return false;
+            }
+            value = (IGame)install;
+            error = $"Warning: Game '{toParse}' is supported but not installed. Please install it properly for full functionality.";
+            return true;
+        }
     }
 }

--- a/src/NexusMods.StandardGameLocators/CliVerbs.cs
+++ b/src/NexusMods.StandardGameLocators/CliVerbs.cs
@@ -2,6 +2,8 @@ using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.Cli;
 using NexusMods.Abstractions.GameLocators;
 using NexusMods.Abstractions.Games;
+using NexusMods.Abstractions.Loadouts;
+using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.Paths;
 using NexusMods.ProxyConsole.Abstractions;
 using NexusMods.ProxyConsole.Abstractions.VerbDefinitions;
@@ -15,6 +17,7 @@ internal static class CliVerbs
 {
     internal static IServiceCollection AddGameLocatorCliVerbs(this IServiceCollection services) =>
         services.AddVerb(() => AddGame)
+            .AddVerb(() => RemoveGame)
             .AddVerb(() => ListGames);
 
     [Verb("add-game", "Manually register a game in the database")]
@@ -25,8 +28,36 @@ internal static class CliVerbs
         [Option("p", "path", "The path where the game can be found")] AbsolutePath path)
     {
         var locator = locators.OfType<ManuallyAddedLocator>().First();
-        await locator.Add(game, version, path);
-        await renderer.Text("Game added successfully");
+        var manualInfo = await locator.Add(game, version, path);
+        await renderer.Text("Game added successfully. Save this ID somewhere for future reference: {0}", manualInfo.Item1);
+        return 0;
+    }
+
+    [Verb("remove-game", "Manually unregister a manually-added game from the database")]
+    private static async Task<int> RemoveGame(
+        [Injected] IEnumerable<IGameLocator> locators,
+        [Injected] IRenderer renderer,
+        [Injected] IConnection conn,
+        [Option("g", "game", "The game to unregister")] IGame game,
+        [Option("id", "entityID", "The EntityId of the game to remove")]
+        string id)
+    {
+        var locator = locators.OfType<ManuallyAddedLocator>().First();
+        var entId = EntityId.From(Convert.ToUInt64(id, 16));
+        var db = conn.Db;
+        // Removes loadouts associated with this game first
+        var managedInstallations = Loadout.All(db)
+            .Select(loadout => loadout.InstallationInstance)
+            .Distinct();
+        foreach (var installation in managedInstallations)
+        {
+            if (installation.Locator != locator || installation.Game != game) continue;
+            var synchronizer = installation.GetGame().Synchronizer;
+            await synchronizer.UnManage(installation, false);
+        }
+        // Remove the game from the database
+        await locator.Remove(entId);
+        await renderer.Text("Game removed successfully.");
         return 0;
     }
 


### PR DESCRIPTION
Fixes #3143 

This PR refactors the game parsing behavior for `add-game` CLI to allow access for future developers/contributors to add supported games without having the game installed in their PC. The output is updated to provide the EntityID for deletion purposes. 

This also adds a new CLI command `NexusMods.App remove-game -g <game> -id <EntityID>` which will remove the game from the app’s database and the loadouts associated with the game. The game parameter is required to remove loadouts while the `EntityID` is used to remove the game from the app’s database.

I included more documentation in the Contributing docs to emphasize the requirement of a supported game for full functionality and steps to contribute without a supported game installed.

_Note: I am not sure how to return the boolean value of True with warning message to the developer in at the end of `GameParser.cs` so I just left it there as a note._
