### PR TITLE
Fix exeption when resizing to full-screen with 4 panels

### DIFF
--- a/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/IPanelResizerViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/IPanelResizerViewModel.cs
@@ -24,9 +24,11 @@ public interface IPanelResizerViewModel : IViewModelInterface
     /// X=0.5 and Y=0.5 will be in the center of the workspace.
     /// </remarks>
     public Point LogicalEndPoint { get; set; }
-
-    public Point ActualStartPoint { get; set; }
-    public Point ActualEndPoint { get; set; }
+    
+    /// <summary>
+    /// The actual start and end points of the resizer in the workspace.
+    /// </summary>
+    public (Point ActualStartPoint, Point ActualEndPoint) ActualPoints { get; set; }
 
     /// <summary>
     /// Gets whether the resizer is horizontally aligned.

--- a/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerView.axaml.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerView.axaml.cs
@@ -44,9 +44,7 @@ public partial class PanelResizerView : ReactiveUserControl<IPanelResizerViewMod
                 .Subscribe()
                 .DisposeWith(disposables);
 
-            this.WhenAnyValue(
-                    view => view.ViewModel!.ActualStartPoint,
-                    view => view.ViewModel!.ActualEndPoint)
+            this.WhenAnyValue(view => view.ViewModel!.ActualPoints)
                 .SubscribeWithErrorLogging(tuple =>
                 {
                     if (ViewModel is null) return;

--- a/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerViewModel.cs
+++ b/src/NexusMods.App.UI/WorkspaceSystem/PanelResizer/PanelResizerViewModel.cs
@@ -11,9 +11,7 @@ public class PanelResizerViewModel : AViewModel<IPanelResizerViewModel>, IPanelR
 {
     [Reactive] public Point LogicalStartPoint { get; set; }
     [Reactive] public Point LogicalEndPoint { get; set; }
-
-    [Reactive] public Point ActualStartPoint { get; set; }
-    [Reactive] public Point ActualEndPoint { get; set; }
+    [Reactive] public (Point ActualStartPoint, Point ActualEndPoint) ActualPoints { get; set; }
 
     public bool IsHorizontal { get; }
 
@@ -46,8 +44,7 @@ public class PanelResizerViewModel : AViewModel<IPanelResizerViewModel>, IPanelR
     {
         var matrix = Matrix.CreateScale(_workspaceSize.Width, _workspaceSize.Height);
 
-        ActualStartPoint = LogicalStartPoint.Transform(matrix);
-        ActualEndPoint = LogicalEndPoint.Transform(matrix);
+        ActualPoints = (LogicalStartPoint.Transform(matrix), LogicalEndPoint.Transform(matrix));
     }
 
     public void Arrange(Size workspaceSize)


### PR DESCRIPTION
- Fixes #3137

View was reacting to changes to `ActualStartPoint` before `ActualEndPoint` was set, causing inconsistent state