### PR TITLE
Fix collection rating parsing

### DIFF
--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadViewModel.cs
@@ -442,7 +442,7 @@ public sealed class CollectionDownloadViewModel : APageViewModel<ICollectionDown
     public ulong TotalDownloads => _collection.TotalDownloads.ValueOr(0ul);
     public string Category => _collection.Category.Name;
     public Size TotalSize => _revision.TotalSize.ValueOr(Size.Zero);
-    public Percent OverallRating => Percent.CreateClamped(_revision.Collection.RecentRating.ValueOr(0));
+    public Percent OverallRating => Percent.Create(_revision.Collection.RecentRating.ValueOr(0), maximum: 100);
 
     public string AuthorName => _collection.Author.Name;
     public bool IsAdult => _revision.IsAdult.ValueOr(false);

--- a/src/NexusMods.App.UI/Pages/LibraryPage/Collections/CollectionCardViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LibraryPage/Collections/CollectionCardViewModel.cs
@@ -85,7 +85,7 @@ public class CollectionCardViewModel : AViewModel<ICollectionCardViewModel>, ICo
     public ulong EndorsementCount => _collection.Endorsements.ValueOr(0ul);
     public ulong TotalDownloads => _collection.TotalDownloads.ValueOr(0ul);
     public Size TotalSize => _revision.TotalSize.ValueOr(Size.Zero);
-    public Percent OverallRating => Percent.CreateClamped(_revision.Collection.RecentRating.ValueOr(0));
+    public Percent OverallRating => Percent.Create(_revision.Collection.RecentRating.ValueOr(0), maximum: 100);
 
     public bool IsAdult => _revision.IsAdult.ValueOr(false);
     public string AuthorName => _collection.Author.Name;


### PR DESCRIPTION
Some API endpoints return values between 0 and 100, others between 0 and 1. We previously used the latter which didn't work when switching to the former that resulted in always showing 100%.

Resolves #2370.