### PR TITLE
Open correct workspace when adding a collection

### DIFF
--- a/src/NexusMods.App.UI/Windows/MainWindowViewModel.cs
+++ b/src/NexusMods.App.UI/Windows/MainWindowViewModel.cs
@@ -182,7 +182,7 @@ public class MainWindowViewModel : AViewModel<IMainWindowViewModel>, IMainWindow
         if (!loadoutId.HasValue) return Optional<(LoadoutId, WorkspaceId)>.None;
 
         var workspaceViewModel = workspaceController.ChangeOrCreateWorkspaceByContext(
-            predicate: loadoutContext => IsCorrectLoadoutForGame(loadoutContext.LoadoutId, gameId),
+            predicate: loadoutContext => loadoutContext.LoadoutId.Equals(loadoutId.Value),
             getPageData: () => Optional<PageData>.None,
             getWorkspaceContext: () => new LoadoutContext
             {


### PR DESCRIPTION
We want to open the workspace of the active loadout for the game instead of the first workspace of the game.

Fixes #3188.