### PR TITLE
More http download fixes

### DIFF
--- a/src/NexusMods.Collections/CollectionDownloader.cs
+++ b/src/NexusMods.Collections/CollectionDownloader.cs
@@ -15,6 +15,7 @@ using NexusMods.Abstractions.NexusModsLibrary.Models;
 using NexusMods.Abstractions.NexusWebApi;
 using NexusMods.Abstractions.NexusWebApi.Types;
 using NexusMods.Abstractions.NexusWebApi.Types.V2;
+using NexusMods.Abstractions.Settings;
 using NexusMods.Abstractions.Telemetry;
 using NexusMods.CrossPlatform.Process;
 using NexusMods.Extensions.BCL;
@@ -256,7 +257,6 @@ public class CollectionDownloader
         CollectionRevisionMetadata.ReadOnly revisionMetadata,
         ItemType itemType,
         IDb db,
-        int maxDegreeOfParallelism = -1,
         CancellationToken cancellationToken = default)
     {
         var job = new DownloadCollectionJob
@@ -266,7 +266,7 @@ public class CollectionDownloader
             RevisionMetadata = revisionMetadata,
             Db = db,
             ItemType = itemType,
-            MaxDegreeOfParallelism = maxDegreeOfParallelism,
+            MaxDegreeOfParallelism = _serviceProvider.GetRequiredService<ISettingsManager>().Get<DownloadSettings>().MaxParallelDownloads,
         };
 
         await _jobMonitor.Begin<DownloadCollectionJob, R3.Unit>(job);

--- a/src/NexusMods.Collections/DownloadCollectionJob.cs
+++ b/src/NexusMods.Collections/DownloadCollectionJob.cs
@@ -12,7 +12,7 @@ public class DownloadCollectionJob : IJobDefinitionWithStart<DownloadCollectionJ
     public required CollectionDownloader.ItemType ItemType { get; init; }
     public required CollectionDownloader Downloader { get; init; }
     public required IDb Db { get; init; }
-    public int MaxDegreeOfParallelism { get; init; } = -1;
+    public required int MaxDegreeOfParallelism { get; init; }
 
     public async ValueTask<R3.Unit> StartAsync(IJobContext<DownloadCollectionJob> context)
     {

--- a/src/NexusMods.Collections/DownloadSettings.cs
+++ b/src/NexusMods.Collections/DownloadSettings.cs
@@ -1,0 +1,24 @@
+using NexusMods.Abstractions.Settings;
+
+namespace NexusMods.Collections;
+
+public class DownloadSettings : ISettings
+{
+    public int MaxParallelDownloads { get; set; } = Environment.ProcessorCount;
+
+    public static ISettingsBuilder Configure(ISettingsBuilder settingsBuilder)
+    {
+        return settingsBuilder.AddToUI<DownloadSettings>(builder => builder
+            .AddPropertyToUI(x => x.MaxParallelDownloads, propertyBuilder => propertyBuilder
+                .AddToSection(Sections.General)
+                .WithDisplayName("Max Parallel Downloads")
+                .WithDescription("Set the maximum number of downloads that can happen in parallel when downloading collections")
+                .UseSingleValueMultipleChoiceContainer(
+                    valueComparer: EqualityComparer<int>.Default,
+                    allowedValues: Enumerable.Range(start: 1, Environment.ProcessorCount).ToArray(),
+                    valueToDisplayString: static i => i.ToString()
+                )
+            )
+        );
+    }
+}

--- a/src/NexusMods.Collections/Services.cs
+++ b/src/NexusMods.Collections/Services.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.Collections;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.NexusModsLibrary;
+using NexusMods.Abstractions.Settings;
 
 namespace NexusMods.Collections;
 
@@ -16,6 +17,7 @@ public static class Services
             .AddNexusCollectionItemLoadoutGroupModel()
             .AddNexusCollectionReplicatedLoadoutGroupModel()
             .AddCollectionVerbs()
-            .AddSingleton<CollectionDownloader>();
+            .AddSingleton<CollectionDownloader>()
+            .AddSettings<DownloadSettings>();
     }
 }

--- a/src/NexusMods.Networking.HttpDownloader/Services.cs
+++ b/src/NexusMods.Networking.HttpDownloader/Services.cs
@@ -23,7 +23,13 @@ public static class Services
     private static HttpClient BuildClient()
     {
         var pipeline = new ResiliencePipelineBuilder<HttpResponseMessage>()
-            .AddRetry(new HttpRetryStrategyOptions())
+            .AddRetry(new HttpRetryStrategyOptions
+            {
+                BackoffType = DelayBackoffType.Exponential,
+                MaxRetryAttempts = 3,
+                Delay = TimeSpan.FromSeconds(3),
+                UseJitter = true,
+            })
             .Build();
 
         HttpMessageHandler handler = new ResilienceHandler(pipeline)

--- a/src/NexusMods.Networking.NexusWebApi/ExternalDownloadJob.cs
+++ b/src/NexusMods.Networking.NexusWebApi/ExternalDownloadJob.cs
@@ -51,6 +51,7 @@ public record ExternalDownloadJob : HttpDownloadJob
             DownloadPageUri = uri,
             Destination = tempFileManager.CreateFile(),
             Uri = uri,
+            Client = provider.GetRequiredService<HttpClient>(),
         };
 
         return monitor.Begin<ExternalDownloadJob, AbsolutePath>(job);


### PR DESCRIPTION
- Use default HTTP client config
- Add retry on network exceptions
- Add setting to control max parallel download count for collections