### PR TITLE
Fix for no apply button

### DIFF
--- a/src/NexusMods.Abstractions.Loadouts.Synchronizers/ILoadoutSynchronizer.cs
+++ b/src/NexusMods.Abstractions.Loadouts.Synchronizers/ILoadoutSynchronizer.cs
@@ -49,7 +49,7 @@ public interface ILoadoutSynchronizer
     /// Rescan the files in the folders this game requires. This is used to bring the local cache up to date with the
     /// whatever is on disk.
     /// </summary>
-    Task<GameInstallMetadata.ReadOnly> RescanFiles(GameInstallation gameInstallation);
+    Task<GameInstallMetadata.ReadOnly> RescanFiles(GameInstallation gameInstallation, bool ignoreModifiedDate = false);
     
     #endregion
     

--- a/src/NexusMods.Abstractions.Loadouts.Synchronizers/Rules/ActionMapping.cs
+++ b/src/NexusMods.Abstractions.Loadouts.Synchronizers/Rules/ActionMapping.cs
@@ -73,7 +73,7 @@ public class ActionMapping
             AAx_XXx_i => DeleteFromDisk,
             AAx_xxx_I => BackupFile | DeleteFromDisk,
             AAx_XXx_I => DeleteFromDisk,
-            AAA_xxx_i => BackupFile,
+            AAA_xxx_i => DoNothing,
             AAA_XXX_i => DoNothing,
             AAA_xxx_I => DoNothing,
             AAA_XXX_I => DoNothing,

--- a/src/NexusMods.DataModel/CommandLine/Verbs/LoadoutManagementVerbs.cs
+++ b/src/NexusMods.DataModel/CommandLine/Verbs/LoadoutManagementVerbs.cs
@@ -40,6 +40,7 @@ public static class LoadoutManagementVerbs
             .AddVerb(() => SetVersion)
             .AddVerb(() => Synchronize)
             .AddVerb(() => InstallMod)
+            .AddVerb(() => Reindex)
             .AddVerb(() => ListLoadouts)
             .AddVerb(() => BackupFiles)
             .AddVerb(() => ListGroupContents)
@@ -136,6 +137,17 @@ public static class LoadoutManagementVerbs
             await libraryService.InstallItem(localFile.AsLibraryFile().AsLibraryItem(), loadout);
             return 0;
         });
+    }
+    
+    [Verb("loadout reindex", "Re-indexes the on-disk state of the loadout")]
+    private static async Task<int> Reindex([Injected] IRenderer renderer,
+        [Option("l", "loadout", "loadout to add the mod to")] Loadout.ReadOnly loadout,
+        [Injected] CancellationToken token)
+    {
+        await renderer.Text("Reindexing {0}", loadout.Name);
+        var synchronizer = loadout.InstallationInstance.GetGame().Synchronizer;
+        await synchronizer.RescanFiles(loadout.InstallationInstance, true);
+        return 0;
     }
 
 

--- a/src/NexusMods.DataModel/Synchronizer/SynchronizerService.cs
+++ b/src/NexusMods.DataModel/Synchronizer/SynchronizerService.cs
@@ -198,8 +198,7 @@ public class SynchronizerService : ISynchronizerService
         var isBusy = loadoutState.ObservePropertyChanged(l => l.Busy);
 
         var lastApplied = LastAppliedRevisionFor(loadout.InstallationInstance)
-            .ToObservable()
-            .Where(last => last != default(LoadoutWithTxId));
+            .ToObservable();
 
         var revisions = Loadout.RevisionsWithChildUpdates(_conn, loadoutId)
             .ToObservable()
@@ -227,7 +226,7 @@ public class SynchronizerService : ISynchronizerService
                     if (busy)
                         return LoadoutSynchronizerState.Pending;
 
-                    if (last.Id != loadoutId)
+                    if (last.Id != loadoutId && last != default(LoadoutWithTxId))
                         return LoadoutSynchronizerState.OtherLoadoutSynced;
 
                     // Last DB revision is the same in the applied loadout


### PR DESCRIPTION
If a loadout has never been applied (and neither has the game), then there's no "previously applied state" and the loadout/tx state is set to `default` we later on in the synchronizer filter out any default states. 

TL;DR - in some rare cases where a user has *only* ever installed a collection, they may not see an apply button, this fixes that issue.

--

This also does the following: 

* Handles a case in Cyberpunk where there's two files that collide on the minimal hash. If we detect one or more possible hash files for a given minimal hash we bail out and hash the slow way
* Changes a broken mapping that was backing up files for no reason (leftover from when we had ignore paths)
* Adds a verb for manually reindexing a loadout's disk state, for testing