### PR TITLE
Fix Applying indicator and jobMonitor notifications

### DIFF
--- a/src/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -1444,7 +1444,7 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
                 if (!GameInstallMetadata.LastSyncedLoadout.TryGetValue(remappedLoadout.Installation, out var lastSyncedLoadoutId))
                 {
                     await _synchronizerService.Synchronize(remappedLoadout.LoadoutId);
-                    remappedLoadout.Rebase();
+                    remappedLoadout = remappedLoadout.Rebase();
                 }
                 else
                 {
@@ -1453,7 +1453,7 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
                     if (!lastSyncedLoadout.IsValid())
                     {
                         await _synchronizerService.Synchronize(remappedLoadout.LoadoutId);
-                        remappedLoadout.Rebase();
+                        remappedLoadout = remappedLoadout.Rebase();
                     }
                 }
                 return remappedLoadout;

--- a/src/NexusMods.Abstractions.Loadouts.Synchronizers/ILoadoutSynchronizer.cs
+++ b/src/NexusMods.Abstractions.Loadouts.Synchronizers/ILoadoutSynchronizer.cs
@@ -49,6 +49,11 @@ public interface ILoadoutSynchronizer
     /// Rescan the files in the folders this game requires. This is used to bring the local cache up to date with the
     /// whatever is on disk.
     /// </summary>
+    /// <param name="gameInstallation">The game installation to rescan.</param>
+    /// <param name="ignoreModifiedDate">
+    /// If false, files that have unchanged modified date since the last scan will be skipped.
+    /// If true, all files will be rehashed.
+    /// </param>
     Task<GameInstallMetadata.ReadOnly> RescanFiles(GameInstallation gameInstallation, bool ignoreModifiedDate = false);
     
     #endregion

--- a/src/NexusMods.Abstractions.Loadouts.Synchronizers/Jobs/SynchronizeLoadoutJob.cs
+++ b/src/NexusMods.Abstractions.Loadouts.Synchronizers/Jobs/SynchronizeLoadoutJob.cs
@@ -1,0 +1,13 @@
+using NexusMods.Abstractions.Jobs;
+using R3;
+
+namespace NexusMods.Abstractions.Loadouts.Synchronizers;
+
+/// <summary>
+/// Synchronize the loadout with the game folder,
+/// any changes in the game folder will be added to the loadout,
+/// and any new changes in the loadout will be applied to the game folder.
+/// </summary>
+/// <param name="LoadoutId"></param>
+public record SynchronizeLoadoutJob(LoadoutId LoadoutId) : IJobDefinition<Unit>;
+    

--- a/src/NexusMods.App.UI/LeftMenu/Items/ApplyControl/ApplyControlView.axaml.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Items/ApplyControl/ApplyControlView.axaml.cs
@@ -26,6 +26,9 @@ public partial class ApplyControlView : ReactiveUserControl<IApplyControlViewMod
                 
                 this.OneWayBind(ViewModel, vm => vm.IsProcessing, v => v.ProcessingChangesStackPanel.IsVisible)
                     .DisposeWith(disposables);
+                
+                this.OneWayBind(ViewModel, vm => vm.IsApplying, v => v.ProgressBarControl.IsVisible)
+                    .DisposeWith(disposables);
 
                 this.WhenAnyObservable(view => view.ViewModel!.ApplyCommand.CanExecute)
                     .OnUI()
@@ -35,11 +38,6 @@ public partial class ApplyControlView : ReactiveUserControl<IApplyControlViewMod
                             PreviewChangesButton.IsVisible = canApply;
                         }
                     )
-                    .DisposeWith(disposables);
-
-                this.WhenAnyObservable(view => view.ViewModel!.ApplyCommand.IsExecuting)
-                    .OnUI()
-                    .Subscribe(isApplying => { ProgressBarControl.IsVisible = isApplying; })
                     .DisposeWith(disposables);
 
                 this.OneWayBind(ViewModel, vm => vm.ApplyButtonText, v => v.ApplyButtonTextBlock.Text)

--- a/src/NexusMods.App.UI/LeftMenu/Items/ApplyControl/ApplyControlViewModel.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Items/ApplyControl/ApplyControlViewModel.cs
@@ -116,10 +116,12 @@ public class ApplyControlViewModel : AViewModel<IApplyControlViewModel>, IApplyC
                                                 && !running
                                                 && gameStatus != GameSynchronizerState.Busy
                                                 && ldStatus == LoadoutSynchronizerState.Current;
+                        
                     })
                     .DisposeWith(disposables);
 
                 _jobMonitor.HasActiveJob<SynchronizeLoadoutJob>(job => job.LoadoutId == loadoutId)
+                    .Prepend(_jobMonitor.Jobs.Any(job => job.Definition is SynchronizeLoadoutJob sJob && sJob.LoadoutId == loadoutId))
                     .OnUI()
                     .Subscribe(isApplying => IsApplying = isApplying)
                     .DisposeWith(disposables);

--- a/src/NexusMods.App.UI/LeftMenu/Items/ApplyControl/ApplyControlViewModel.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Items/ApplyControl/ApplyControlViewModel.cs
@@ -31,6 +31,7 @@ public class ApplyControlViewModel : AViewModel<IApplyControlViewModel>, IApplyC
     private readonly IServiceProvider _serviceProvider;
     private readonly GameInstallMetadataId _gameMetadataId;
     [Reactive] private bool CanApply { get; set; } = true;
+    [Reactive] public bool IsApplying { get; private set; }
 
     public ReactiveCommand<Unit, Unit> ApplyCommand { get; }
     public ReactiveCommand<NavigationInformation, Unit> ShowApplyDiffCommand { get; }
@@ -115,6 +116,12 @@ public class ApplyControlViewModel : AViewModel<IApplyControlViewModel>, IApplyC
                                                 && ldStatus == LoadoutSynchronizerState.Current;
                     })
                     .DisposeWith(disposables);
+
+                _jobMonitor.HasActiveJob<SynchronizeLoadoutJob>(job => job.LoadoutId.Value == loadoutId.Value)
+                    .OnUI()
+                    .Subscribe(isApplying => IsApplying = isApplying)
+                    .DisposeWith(disposables);
+                
             }
         );
     }

--- a/src/NexusMods.App.UI/LeftMenu/Items/ApplyControl/ApplyControlViewModel.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Items/ApplyControl/ApplyControlViewModel.cs
@@ -3,6 +3,7 @@ using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using DynamicData;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.Jobs;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.UI;
@@ -98,7 +99,8 @@ public class ApplyControlViewModel : AViewModel<IApplyControlViewModel>, IApplyC
                 //     - This is done in 'Synchronize' method.
                 // - They're running a tool from within the App.
                 //     - Check running jobs.
-                loadoutStatuses.CombineLatest(isProcessingObservable, gameStatuses, gameRunningTracker.GetWithCurrentStateAsStarting(), (loadout, isProcessing, game, running) => (loadout, isProcessing, game, running))
+                loadoutStatuses.CombineLatest(isProcessingObservable, gameStatuses, gameRunningTracker.GetWithCurrentStateAsStarting(), 
+                        (loadout, isProcessing, game, running) => (loadout, isProcessing, game, running))
                     .OnUI()
                     .Subscribe(status =>
                     {
@@ -117,7 +119,7 @@ public class ApplyControlViewModel : AViewModel<IApplyControlViewModel>, IApplyC
                     })
                     .DisposeWith(disposables);
 
-                _jobMonitor.HasActiveJob<SynchronizeLoadoutJob>(job => job.LoadoutId.Value == loadoutId.Value)
+                _jobMonitor.HasActiveJob<SynchronizeLoadoutJob>(job => job.LoadoutId == loadoutId)
                     .OnUI()
                     .Subscribe(isApplying => IsApplying = isApplying)
                     .DisposeWith(disposables);

--- a/src/NexusMods.App.UI/LeftMenu/Items/ApplyControl/IApplyControlViewModel.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Items/ApplyControl/IApplyControlViewModel.cs
@@ -17,5 +17,7 @@ public interface IApplyControlViewModel : IViewModelInterface
     
     bool IsProcessing { get; }
     
+    bool IsApplying { get; }
+    
     string ApplyButtonText { get; }
 }

--- a/src/NexusMods.Jobs/JobContext.cs
+++ b/src/NexusMods.Jobs/JobContext.cs
@@ -8,7 +8,7 @@ namespace NexusMods.Jobs;
 public sealed class JobContext<TJobDefinition, TJobResult> : IJobWithResult<TJobResult>, IJobContext<TJobDefinition> 
     where TJobDefinition : IJobDefinition<TJobResult> where TJobResult : notnull
 {
-    private readonly Subject<JobStatus> _status;
+    private readonly BehaviorSubject<JobStatus> _status;
     private readonly Subject<Optional<Percent>> _progress;
     private readonly Subject<Optional<double>> _rateOfProgress;
     private readonly TJobDefinition _definition;
@@ -25,7 +25,7 @@ public sealed class JobContext<TJobDefinition, TJobResult> : IJobWithResult<TJob
         _action = action;
         _definition = definition;
         Monitor = monitor;
-        _status = new Subject<JobStatus>();
+        _status = new BehaviorSubject<JobStatus>(JobStatus.Created);
         _progress = new Subject<Optional<Percent>>();
         _rateOfProgress = new Subject<Optional<double>>();
         


### PR DESCRIPTION
Makes the Applying indicator in the left menu accurately show when there is an apply operation in process, such as when managing the game for the first time.

- Added a job for the Synchronize operation so we can track it
- Fixed a bug with the HasActiveJob method not returning notifications due to missing initial State values 
- Fixed a bug with a rare path in create loadout that was applying the wrong lodout
- Use the SynchronizerService Synchronize method inside CreateLoadout to have tracking
- Some comments and readability cleanup