### PR TITLE
Fix for the app never exiting

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,10 +16,10 @@
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.4.0" />
     <PackageVersion Include="Nerdbank.FullDuplexStream" Version="1.1.12" />
     <PackageVersion Include="Nerdbank.Streams" Version="2.11.79" />
-    <PackageVersion Include="NexusMods.Cascade" Version="0.11.0" />
-    <PackageVersion Include="NexusMods.Cascade.SourceGenerator" Version="0.11.0" />
-    <PackageVersion Include="NexusMods.MnemonicDB" Version="0.12.0" />
-    <PackageVersion Include="NexusMods.MnemonicDB.Abstractions" Version="0.12.0" />
+    <PackageVersion Include="NexusMods.Cascade" Version="0.12.0" />
+    <PackageVersion Include="NexusMods.Cascade.SourceGenerator" Version="0.12.0" />
+    <PackageVersion Include="NexusMods.MnemonicDB" Version="0.13.0" />
+    <PackageVersion Include="NexusMods.MnemonicDB.Abstractions" Version="0.13.0" />
     <PackageVersion Include="NexusMods.Hashing.xxHash3.Paths" Version="3.0.3" />
     <PackageVersion Include="NexusMods.Hashing.xxHash3" Version="3.0.3" />
     <PackageVersion Include="NexusMods.Archives.Nx" Version="0.6.4" />
@@ -149,7 +149,7 @@
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="ini-parser-netstandard" Version="2.5.2" />
     <PackageVersion Include="Mutagen.Bethesda.Skyrim" Version="0.44.0" />
-    <PackageVersion Include="NexusMods.MnemonicDB.SourceGenerator" Version="0.12.0" />
+    <PackageVersion Include="NexusMods.MnemonicDB.SourceGenerator" Version="0.13.0" />
     <PackageVersion Include="NLog.Extensions.Logging" Version="5.3.14" />
     <PackageVersion Include="OneOf" Version="3.0.271" />
     <PackageVersion Include="ReactiveUI.Fody" Version="19.5.41" />

--- a/src/NexusMods.App/Program.cs
+++ b/src/NexusMods.App/Program.cs
@@ -139,7 +139,9 @@ public class Program
         }
         finally
         {
-            host.StopAsync().Wait(timeout: TimeSpan.FromSeconds(5));
+            // Wait for 15 seconds for the host to stop, otherwise kill the process
+            if (!host.StopAsync().Wait(timeout: TimeSpan.FromSeconds(15)))
+                Environment.Exit(0);
         }
     }
 

--- a/src/NexusMods.DataModel/Synchronizer/SynchronizerService.cs
+++ b/src/NexusMods.DataModel/Synchronizer/SynchronizerService.cs
@@ -71,7 +71,7 @@ public class SynchronizerService : ISynchronizerService
                 var metaData = GameInstallMetadata.Load(db, loadout.InstallationInstance.GameMetadataId);
                 var hasPreviousLoadout = GameInstallMetadata.LastSyncedLoadoutTransaction.TryGetValue(metaData, out var lastId);
 
-                var lastScannedDiskState = metaData.DiskStateAsOf(metaData.LastScannedDiskStateTransaction);
+                var lastScannedDiskState = metaData.DiskStateEntries;
                 var previousDiskState = hasPreviousLoadout ? metaData.DiskStateAsOf(Transaction.Load(db, lastId)) : lastScannedDiskState;
         
                 return ValueTask.FromResult(synchronizer.ShouldSynchronize(loadout, previousDiskState, lastScannedDiskState));


### PR DESCRIPTION
Updates to the newest version of MnemonicDB which reworks how the application exits. Hard-exits the app after 15 seconds if it doesn't properly shutdown. Fix a but with crashing if the last scanned transaction datom wasn't set, we don't need it anyways, so we just use `.DiskEntries` on the game object instead