### PR TITLE
Fix the redmod deploy order

### DIFF
--- a/src/NexusMods.Abstractions.Games/RunGameTool.cs
+++ b/src/NexusMods.Abstractions.Games/RunGameTool.cs
@@ -103,7 +103,7 @@ public class RunGameTool<T> : IRunGameTool
         }
         else
         {
-            _ = await RunCommand(cancellationToken, program);
+            _ = await RunCommand(cancellationToken, commandLineArgs, program);
         }
 
         // Check if the process has spawned any new processes that we need to wait for (e.g. Launcher -> Game)
@@ -127,9 +127,10 @@ public class RunGameTool<T> : IRunGameTool
         
     }
 
-    private async Task<CommandResult> RunCommand(CancellationToken cancellationToken, AbsolutePath program)
+    private async Task<CommandResult> RunCommand(CancellationToken cancellationToken, string[] arguments, AbsolutePath program)
     {
         var command = new Command(program.ToString())
+            .WithArguments(arguments)
             .WithWorkingDirectory(program.Parent.ToString());
 
         var result = await _processFactory.ExecuteAsync(command, cancellationToken: cancellationToken);

--- a/src/NexusMods.Abstractions.Loadouts/Models/DiskStateExtensions.cs
+++ b/src/NexusMods.Abstractions.Loadouts/Models/DiskStateExtensions.cs
@@ -45,8 +45,6 @@ public static class DiskStateExtensions
         // Get the attributes for the entries in the disk state
 
         var ret = DiskStateEntry.FindByGame(asOfDb, metadata.Id);
-        //asOfDb.BulkCache(ret.EntityIds);
-        
         return ret;
     }
     

--- a/src/NexusMods.Abstractions.Loadouts/Models/DiskStateExtensions.cs
+++ b/src/NexusMods.Abstractions.Loadouts/Models/DiskStateExtensions.cs
@@ -45,7 +45,7 @@ public static class DiskStateExtensions
         // Get the attributes for the entries in the disk state
 
         var ret = DiskStateEntry.FindByGame(asOfDb, metadata.Id);
-        asOfDb.BulkCache(ret.EntityIds);
+        //asOfDb.BulkCache(ret.EntityIds);
         
         return ret;
     }

--- a/src/NexusMods.Games.RedEngine/Cyberpunk2077/RunCyberpunk2077Game.cs
+++ b/src/NexusMods.Games.RedEngine/Cyberpunk2077/RunCyberpunk2077Game.cs
@@ -1,0 +1,20 @@
+using NexusMods.Abstractions.Games;
+using NexusMods.Abstractions.Loadouts;
+
+namespace NexusMods.Games.RedEngine.Cyberpunk2077;
+
+public class RunCyberpunk2077Game(IServiceProvider provider, Cyberpunk2077Game game) : RunGameTool<Cyberpunk2077Game>(provider, game)
+{
+    public override Task Execute(Loadout.ReadOnly loadout, CancellationToken cancellationToken, string[]? commandLineArgs)
+    {
+        if (commandLineArgs == null)
+        {
+            commandLineArgs = ["-modded"];
+        }
+        else
+        {
+            commandLineArgs = commandLineArgs.Append("-modded").ToArray();
+        }
+        return base.Execute(loadout, cancellationToken, commandLineArgs);
+    }
+}

--- a/src/NexusMods.Games.RedEngine/Resources/Cyberpunk2077/deploy_redmod.bat
+++ b/src/NexusMods.Games.RedEngine/Resources/Cyberpunk2077/deploy_redmod.bat
@@ -31,4 +31,4 @@ if not exist "redMod.exe" (
 )
 
 echo Launching redMod.exe with deploy parameter...
-redMod.exe deploy
+redMod.exe %*

--- a/src/NexusMods.Games.RedEngine/Services.cs
+++ b/src/NexusMods.Games.RedEngine/Services.cs
@@ -17,7 +17,7 @@ public static class Services
             .AddRedModSortOrderModel()
             .AddRedModLoadoutGroupModel()
             .AddRedModSortableEntryModel()
-            .AddSingleton<ITool, RunGameTool<Cyberpunk2077Game>>()
+            .AddSingleton<ITool, RunCyberpunk2077Game>()
             .AddSingleton<ITool, RedModDeployTool>()
             .AddSingleton<RedModSortableItemProviderFactory>()
 


### PR DESCRIPTION
This does a few things:

* adds `-modded` to Cyberpunk when launching (always adds it)
* makes sure we provide the proper CLI commands to `redmod.exe` when we run it
* use `-modlist` instead of `--modlist` when calling redmod
* use `-force` so it always redeploys
* update the redmod `.bat` file so we can pass in arguments to the script 

NOTE: this also removes the `BulkCache` call from the app during the synchronizer runs. This was an optimization from the past that was breaking some things in the app. It's a long story, but with the recent bloom filter changes to MnemonicDB the bulk cache function would sometimes load partial entities, resulting in the `Missing attribute` errors we've been seeing. The loading features of MnemonicDB are so much faster now (and will get faster in the future) that we no longer need this functionality. 
