### PR TITLE
Fixes for the loadout group page

### DIFF
--- a/src/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -1083,6 +1083,16 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
                 };
                 diffs.Add(KeyValuePair.Create(path, entry));
             }
+            else if (actions.HasFlag(Actions.WarnOfUnableToExtract))
+            {
+                entry = new DiskDiffEntry
+                {
+                    Hash = node.Loadout.Hash,
+                    Size = node.Loadout.Size,
+                    ChangeType = FileChangeType.Added,
+                    GamePath = path,
+                };
+            }
             else if (actions.HasFlag(Actions.ExtractToDisk))
             {
                 entry = new DiskDiffEntry

--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/FileEntryComponent.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/FileEntryComponent.cs
@@ -1,0 +1,21 @@
+using NexusMods.Abstractions.UI;
+
+namespace NexusMods.App.UI.Controls;
+
+public class FileEntryComponent : ReactiveR3Object, IItemModelComponent<FileEntryComponent>, IComparable<FileEntryComponent>, IComparable
+{
+    public StringComponent Name { get; }
+    public ValueComponent<bool> IsDeleted { get; }
+    
+    public FileEntryComponent(
+        StringComponent name,
+        ValueComponent<bool> isDeleted)
+    {
+        Name = name;
+        IsDeleted = isDeleted;
+    }
+    
+    public int CompareTo(FileEntryComponent? other) => Name.CompareTo(other?.Name);
+
+    public int CompareTo(object? obj) =>  obj is FileEntryComponent other ? CompareTo(other) : 1;
+}

--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/SharedColumns.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/SharedColumns.cs
@@ -65,13 +65,13 @@ public static class SharedColumns
     {
         public static int Compare<TKey>(CompositeItemModel<TKey> a, CompositeItemModel<TKey> b) where TKey : notnull
         {
-            var aValue = a.GetOptional<StringComponent>(StringComponentKey);
-            var bValue = b.GetOptional<StringComponent>(StringComponentKey);
+            var aValue = a.GetOptional<FileEntryComponent>(FileEntryComponentKey);
+            var bValue = b.GetOptional<FileEntryComponent>(FileEntryComponentKey);
             return aValue.Compare(bValue);
         }
 
         public const string ColumnTemplateResourceKey = Prefix + "NameWithFileIcon";
-        public static readonly ComponentKey StringComponentKey = ComponentKey.From(ColumnTemplateResourceKey + "_" + nameof(StringComponent));
+        public static readonly ComponentKey FileEntryComponentKey = ComponentKey.From(ColumnTemplateResourceKey + "_" + nameof(FileEntryComponent));
         public static readonly ComponentKey IconComponentKey = ComponentKey.From(ColumnTemplateResourceKey + "_" + nameof(UnifiedIconComponent));
 
         public static string GetColumnHeader() => "Name";

--- a/src/NexusMods.App.UI/Pages/LoadoutGroupFilesPage/LoadoutGroupFilesProvider.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutGroupFilesPage/LoadoutGroupFilesProvider.cs
@@ -81,14 +81,18 @@ public class LoadoutGroupFilesProvider
         var itemUpdates = LoadoutItemWithTargetPath.Observe(_connection, modFile.Id);
         var nameUpdates = itemUpdates.Select(x => useFullFilePaths ? FileToFilePath(x) : FileToFileName(x));
         var iconUpdates = itemUpdates.Select(FileToIconValue);
-        var sizeUpdates = itemUpdates.Select(x => LoadoutFile.Size.TryGetValue(x, out var size) ? size : Size.Zero);
-        
-        fileItemModel.Add(SharedColumns.NameWithFileIcon.StringComponentKey, new StringComponent(initialValue: FileToFileName(modFile), valueObservable: nameUpdates));
+        var sizeUpdates = itemUpdates.Select(x => LoadoutFile.Size.TryGetValue(x, out var sizeVal) ? sizeVal : Size.Zero);
+
+        fileItemModel.Add(SharedColumns.NameWithFileIcon.FileEntryComponentKey,
+            new FileEntryComponent(
+                new StringComponent(initialValue: FileToFileName(modFile), valueObservable: nameUpdates),
+                new ValueComponent<bool>(modFile.IsDeletedFile())
+            ));
         fileItemModel.Add(SharedColumns.NameWithFileIcon.IconComponentKey, new UnifiedIconComponent(initialValue: FileToIconValue(modFile), valueObservable: iconUpdates));
         fileItemModel.Add(SharedColumns.ItemSizeOverGamePath.ComponentKey, new SizeComponent(initialValue: LoadoutFile.Size.TryGetValue(modFile, out var size) ? size : Size.Zero, valueObservable: sizeUpdates));
         // Note(sewer): File Count omitted to avoid rendering a '1' for every file for cleanliness.
         //              Will see how this goes once the columns are actually there.
-
+        
         return fileItemModel;
     }
 }
@@ -118,9 +122,9 @@ public class LoadoutGroupFilesTreeFolderModelInitializer : IFolderModelInitializ
         GeneratedFolder<GamePathTreeItemWithPath, TFolderModelInitializer> folder)
         where TFolderModelInitializer : IFolderModelInitializer<GamePathTreeItemWithPath>
     {
-        model.Add(SharedColumns.NameWithFileIcon.StringComponentKey,
-            new StringComponent(initialValue: folder.FolderName.ToString(), valueObservable: R3.Observable.Return(folder.FolderName.ToString()))
-        );
+       // Add name
+        model.Add(SharedColumns.NameWithFileIcon.FileEntryComponentKey, 
+            new FileEntryComponent(new StringComponent(folder.FolderName.ToString()), isDeleted: new ValueComponent<bool>(false)));
 
         // Add the icon for the folder, making it flip on 'IsExpanded'.
         var iconStream = model.ObservePropertyChanged(m => m.IsExpanded)

--- a/src/NexusMods.App.UI/Pages/LoadoutGroupFilesPage/LoadoutGroupFilesProvider.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutGroupFilesPage/LoadoutGroupFilesProvider.cs
@@ -33,9 +33,9 @@ public class LoadoutGroupFilesProvider
         _connection = serviceProvider.GetRequiredService<IConnection>();
     }
 
-    private IObservable<IChangeSet<LoadoutFile.ReadOnly, GamePath>> FilteredModFiles(ModFilesFilter filesFilter)
+    private IObservable<IChangeSet<LoadoutItemWithTargetPath.ReadOnly, GamePath>> FilteredModFiles(ModFilesFilter filesFilter)
     {
-        return LoadoutFile
+        return LoadoutItemWithTargetPath
             .ObserveAll(_connection)
             .Filter(x => LoadoutFilesObservableExtensions.FilterEntityId(_connection, filesFilter, x.Id))
             .ChangeKey(FileToGamePath);
@@ -49,7 +49,7 @@ public class LoadoutGroupFilesProvider
     public IObservable<IChangeSet<CompositeItemModel<GamePath>, GamePath>> ObserveModFiles(ModFilesFilter filesFilter, bool useFullFilePaths)
     {
         var filesObservable = FilteredModFiles(filesFilter)
-            .Transform(x => ToModFileItemModel(new LoadoutFile.ReadOnly(x.Db, x.EntitySegment, x.Id), useFullFilePaths));
+            .Transform(x => ToModFileItemModel(new LoadoutItemWithTargetPath.ReadOnly(x.Db, x.EntitySegment, x.Id), useFullFilePaths));
 
         // If we are requesting a flat view, we can skip folder generation.
         if (useFullFilePaths)
@@ -62,7 +62,7 @@ public class LoadoutGroupFilesProvider
         return wrapper; // Use `SimplifiedObservableRoots` to match previous behaviour pre-CompositeItemModels.
     }
 
-    private CompositeItemModel<GamePath> ToModFileItemModel(LoadoutFile.ReadOnly modFile, bool useFullFilePaths)
+    private CompositeItemModel<GamePath> ToModFileItemModel(LoadoutItemWithTargetPath.ReadOnly modFile, bool useFullFilePaths)
     {
         // Files don't have children.
         // We inject the relevant folders at the listener level, i.e. whatever calls `ObserveModFiles`
@@ -78,14 +78,14 @@ public class LoadoutGroupFilesProvider
         //              And we check if a value is the same as before when we assign the inner
         //              BindableReactiveProperty from the component, so actually, not filtering
         //              might be better. Food for thought.
-        var itemUpdates = LoadoutFile.Observe(_connection, modFile.Id);
+        var itemUpdates = LoadoutItemWithTargetPath.Observe(_connection, modFile.Id);
         var nameUpdates = itemUpdates.Select(x => useFullFilePaths ? FileToFilePath(x) : FileToFileName(x));
         var iconUpdates = itemUpdates.Select(FileToIconValue);
-        var sizeUpdates = itemUpdates.Select(x => x.Size);
+        var sizeUpdates = itemUpdates.Select(x => LoadoutFile.Size.TryGetValue(x, out var size) ? size : Size.Zero);
         
         fileItemModel.Add(SharedColumns.NameWithFileIcon.StringComponentKey, new StringComponent(initialValue: FileToFileName(modFile), valueObservable: nameUpdates));
         fileItemModel.Add(SharedColumns.NameWithFileIcon.IconComponentKey, new UnifiedIconComponent(initialValue: FileToIconValue(modFile), valueObservable: iconUpdates));
-        fileItemModel.Add(SharedColumns.ItemSizeOverGamePath.ComponentKey, new SizeComponent(initialValue: modFile.Size, valueObservable: sizeUpdates));
+        fileItemModel.Add(SharedColumns.ItemSizeOverGamePath.ComponentKey, new SizeComponent(initialValue: LoadoutFile.Size.TryGetValue(modFile, out var size) ? size : Size.Zero, valueObservable: sizeUpdates));
         // Note(sewer): File Count omitted to avoid rendering a '1' for every file for cleanliness.
         //              Will see how this goes once the columns are actually there.
 
@@ -176,14 +176,14 @@ public class LoadoutGroupFilesTreeFolderModelInitializer : IFolderModelInitializ
 
 internal static class PathHelpers
 {
-    internal static GamePath FileToGamePath(LoadoutFile.ReadOnly modFile)
+    internal static GamePath FileToGamePath(LoadoutItemWithTargetPath.ReadOnly modFile)
     {
-        var path = modFile.AsLoadoutItemWithTargetPath().TargetPath;
+        var path = modFile.TargetPath;
         return new GamePath(path.Item2, path.Item3);
     }
-    internal static string FileToFilePath(LoadoutFile.ReadOnly modFile) => modFile.AsLoadoutItemWithTargetPath().TargetPath.Item3;
-    internal static IconValue FileToIconValue(LoadoutFile.ReadOnly modFile) => ((RelativePath)FileToFileName(modFile)).Extension.GetIconType().GetIconValue();
-    internal static string FileToFileName(LoadoutFile.ReadOnly modFile) => ((RelativePath)FileToFilePath(modFile)).FileName;
+    internal static string FileToFilePath(LoadoutItemWithTargetPath.ReadOnly modFile) => modFile.TargetPath.Item3;
+    internal static IconValue FileToIconValue(LoadoutItemWithTargetPath.ReadOnly modFile) => ((RelativePath)FileToFileName(modFile)).Extension.GetIconType().GetIconValue();
+    internal static string FileToFileName(LoadoutItemWithTargetPath.ReadOnly modFile) => ((RelativePath)FileToFilePath(modFile)).FileName;
 }
 
 internal static class LoadoutFilesObservableExtensions
@@ -193,7 +193,7 @@ internal static class LoadoutFilesObservableExtensions
         IConnection connection,
         ModFilesFilter modFilesFilter)
     {
-        return source.ChangeKey(x => FileToGamePath(new LoadoutFile.ReadOnly(connection.Db, x.E)))
+        return source.ChangeKey(x => FileToGamePath(new LoadoutItemWithTargetPath.ReadOnly(connection.Db, x.E)))
               .Filter(datom => FilterEntityId(connection, modFilesFilter, datom.E));
     }
 

--- a/src/NexusMods.App.UI/Pages/LoadoutGroupFilesPage/LoadoutGroupFilesViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutGroupFilesPage/LoadoutGroupFilesViewModel.cs
@@ -60,25 +60,29 @@ public class LoadoutGroupFilesViewModel : APageViewModel<ILoadoutGroupFilesViewM
                         return false;
 
                     var gamePath = item.Key;
-                    var file = LoadoutItemGroupHelpers.FindMatchingFile
+                    var itemWithPath = LoadoutItemGroupHelpers.FindMatchingFile
                         (state.connection, state.Item1.Context!.GroupIds, gamePath, false);
-
-                    // If we can't find a file, then it's a directory, which we can't open an editor for.
-                    return file.HasValue;
+                    
+                    // Don't open the editor if no file is found (it's a directory),
+                    // or if it is not a LoadoutFile (it's a DeletedFile).
+                    return itemWithPath.HasValue && itemWithPath.Value.IsLoadoutFile();
                 }
             )
             .ToReactiveCommand<NavigationInformation>(info =>
             {
                 // Note(sewer): Is it possible to avoid a double entity load here?
                 var gamePath = SelectedItem!.Key;
-                var file = LoadoutItemGroupHelpers.FindMatchingFile(connection, Context!.GroupIds, gamePath);
-                
+                var itemWithPath = LoadoutItemGroupHelpers.FindMatchingFile(connection, Context!.GroupIds, gamePath);
+
+                if (!itemWithPath.HasValue || !itemWithPath.Value.TryGetAsLoadoutFile(out var loadoutItem)) 
+                    return;
+
                 var pageData = new PageData
                 {
                     FactoryId = TextEditorPageFactory.StaticId,
                     Context = new TextEditorPageContext
                     {
-                        FileId = (LoadoutFileId) file!.Value.Id, // not null because command was executable
+                        FileId = loadoutItem.LoadoutFileId, // not null because command was executable
                         FilePath = gamePath.Path,
                         IsReadOnly = Context!.IsReadOnly,
                     },

--- a/src/NexusMods.App.UI/Pages/LoadoutGroupFilesPage/LoadoutItemGroupHelpers.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutGroupFilesPage/LoadoutItemGroupHelpers.cs
@@ -80,7 +80,7 @@ public static class LoadoutItemGroupHelpers
     }
 
     /// <summary>
-    /// Finds a loadout file matching the specified game path within the given loadout item groups.
+    /// Finds a LoadoutItemWithTargetPath matching the specified game path within the given loadout item groups.
     /// </summary>
     /// <param name="connection">The connection used to MnemonicDB.</param>
     /// <param name="groupIds">The <see cref="LoadoutItemGroup"/> IDs (usually mod) to search within.</param>
@@ -88,7 +88,7 @@ public static class LoadoutItemGroupHelpers
     /// <param name="requireAllGroups">If true, throws <see cref="InvalidOperationException"/> when any group is missing. If false, continues with available groups.</param>
     /// <returns>The matching <see cref="LoadoutItemWithTargetPath.ReadOnly"/> if found; otherwise, null.</returns>
     /// <exception cref="InvalidOperationException">Thrown when requireAllGroups is true and any group is missing.</exception>
-    public static LoadoutFile.ReadOnly? FindMatchingFile(IConnection connection, LoadoutItemGroupId[] groupIds, GamePath gamePath, bool requireAllGroups = true)
+    public static LoadoutItemWithTargetPath.ReadOnly? FindMatchingFile(IConnection connection, LoadoutItemGroupId[] groupIds, GamePath gamePath, bool requireAllGroups = true)
     {
         var (validGroups, _) = LoadAllGroups(connection, groupIds, requireAllGroups);
         
@@ -100,7 +100,7 @@ public static class LoadoutItemGroupHelpers
             foreach (var item in group.Children.OfTypeLoadoutItemWithTargetPath())
             {
                 if (item.TargetPath == gamePath)
-                    return item.ToLoadoutFile();
+                    return item;
             }
         }
         

--- a/src/NexusMods.App.UI/Pages/TreeDataGridSharedResources.axaml
+++ b/src/NexusMods.App.UI/Pages/TreeDataGridSharedResources.axaml
@@ -116,11 +116,12 @@
             <!-- File Name -->
             <controls:ComponentControl Grid.Column="1" x:TypeArguments="gameLocators:GamePath" Content="{CompiledBinding}">
                 <controls:ComponentControl.ComponentTemplate>
-                    <controls:ComponentTemplate x:TypeArguments="controls:StringComponent"
-                                                ComponentKey="{x:Static controls:SharedColumns+NameWithFileIcon.StringComponentKey}">
+                    <controls:ComponentTemplate x:TypeArguments="controls:FileEntryComponent"
+                                                ComponentKey="{x:Static controls:SharedColumns+NameWithFileIcon.FileEntryComponentKey}">
                         <controls:ComponentTemplate.DataTemplate>
-                            <DataTemplate DataType="{x:Type controls:StringComponent}">
-                                <TextBlock Text="{CompiledBinding Value.Value}" Classes="FileNameTextBlock" />
+                            <DataTemplate DataType="{x:Type controls:FileEntryComponent}">
+                                <TextBlock Text="{CompiledBinding Name.Value.Value}" Classes="FileNameTextBlock"
+                                           Classes.StrikeThrough="{CompiledBinding IsDeleted.Value.Value}"/>
                             </DataTemplate>
                         </controls:ComponentTemplate.DataTemplate>
                     </controls:ComponentTemplate>

--- a/src/NexusMods.Themes.NexusFluentDark/Styles/Controls/TextBlock/TextBlockStyles.axaml
+++ b/src/NexusMods.Themes.NexusFluentDark/Styles/Controls/TextBlock/TextBlockStyles.axaml
@@ -33,5 +33,10 @@
         <Style Selector="^.Success">
             <Setter Property="Foreground" Value="{StaticResource SuccessStrongBrush}" />
         </Style>
+        
+        <!-- Decoration TextBlock styles -->
+        <Style Selector="^.StrikeThrough">
+            <Setter Property="TextDecorations" Value="StrikeThrough" />
+        </Style>
     </Style>
 </Styles>


### PR DESCRIPTION
The recent updates to the LoadoutGroup page didn't take deleted files into account. This change fixes this issue by changing `LoadoutFile` to `LoadoutItemWithTargetedPath` and conditionally loading `Size`. It also updates the `Pending Changes` page to show `WarnOfUnableToExtract`, so we actually see deleted files even if we don't have a source for them. 

## To test:

* Create a game loadout
* Add a mod
* Go to the game folder and delete a game file
* Apply changes
* Verify that there is a `0` sized entry in the `External Changes` pane
* Delete the `0` sized file
* Verify that a warning appears in Health Check about a file not being found for the base game
* Verify that the file deleted shows up as a green entry in the `Pending Changes` dialog

We can improve this UX in the future, but at least for now we can see these issuse instead of the problems being invisible. 