### PR TITLE
Fix for mod deletes not triggering an apply

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,10 +16,10 @@
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.4.0" />
     <PackageVersion Include="Nerdbank.FullDuplexStream" Version="1.1.12" />
     <PackageVersion Include="Nerdbank.Streams" Version="2.11.79" />
-    <PackageVersion Include="NexusMods.Cascade" Version="0.13.0" />
-    <PackageVersion Include="NexusMods.Cascade.SourceGenerator" Version="0.13.0" />
-    <PackageVersion Include="NexusMods.MnemonicDB" Version="0.13.3" />
-    <PackageVersion Include="NexusMods.MnemonicDB.Abstractions" Version="0.13.3" />
+    <PackageVersion Include="NexusMods.Cascade" Version="0.15.0" />
+    <PackageVersion Include="NexusMods.Cascade.SourceGenerator" Version="0.15.0" />
+    <PackageVersion Include="NexusMods.MnemonicDB" Version="0.15.0" />
+    <PackageVersion Include="NexusMods.MnemonicDB.Abstractions" Version="0.15.0" />
     <PackageVersion Include="NexusMods.Hashing.xxHash3.Paths" Version="3.0.4" />
     <PackageVersion Include="NexusMods.Hashing.xxHash3" Version="3.0.4" />
     <PackageVersion Include="NexusMods.Archives.Nx" Version="0.6.4" />
@@ -149,13 +149,13 @@
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="ini-parser-netstandard" Version="2.5.2" />
     <PackageVersion Include="Mutagen.Bethesda.Skyrim" Version="0.44.0" />
-    <PackageVersion Include="NexusMods.MnemonicDB.SourceGenerator" Version="0.13.3" />
+    <PackageVersion Include="NexusMods.MnemonicDB.SourceGenerator" Version="0.15.0" />
     <PackageVersion Include="NLog.Extensions.Logging" Version="5.3.14" />
     <PackageVersion Include="OneOf" Version="3.0.271" />
     <PackageVersion Include="ReactiveUI.Fody" Version="19.5.41" />
     <PackageVersion Include="Sewer56.BitStream" Version="1.3.0" />
     <PackageVersion Include="Splat.Microsoft.Extensions.Logging" Version="15.2.22" />
     <PackageVersion Include="TransparentValueObjects" Version="1.1.0" />
-      <PackageVersion Include="TransparentValueObjects.Abstractions" Version="1.1.0" />
+    <PackageVersion Include="TransparentValueObjects.Abstractions" Version="1.1.0" />
   </ItemGroup>
 </Project>

--- a/src/NexusMods.Abstractions.Loadouts/Models/LoadoutObservables.cs
+++ b/src/NexusMods.Abstractions.Loadouts/Models/LoadoutObservables.cs
@@ -43,12 +43,13 @@ public partial class Loadout
     /// But this means that the row updates whenever any of the tracked entities are updated, meaning we can simply watch this row or the specific
     /// cell on the row to know whenever something modifies the loadout.
     /// </summary>
-    public static readonly Flow<MostRecentTxForLoadoutRow.Active> MostRecentTxForLoadout =
+    public static readonly Flow<MostRecentTxForLoadoutRow> MostRecentTxForLoadout =
         Pattern.Create()
             .Match(LoadoutAssociatedEntities, out var loadout, out var entity)
             .DbLatestTx(entity, out var maxTx)
-            .ReturnMostRecentTxForLoadoutRow(loadout, maxTx.Max())
-            .ToActive();
+            // Track the count as well, so that we know when items are removed. Removing an item
+            // may not change the max TxId, but removal will change the count of items being tracked
+            .ReturnMostRecentTxForLoadoutRow(loadout, maxTx.Max(), entity.Count());
     
     
     /// <summary>
@@ -58,7 +59,7 @@ public partial class Loadout
     {
         // A bit wordy, to have to specify all the generic types here, eventually we'll add a simpler method via Cascade to do this. 
         return connection.Topology
-            .ObserveCell<MostRecentTxForLoadoutRow.Active, MostRecentTxForLoadoutRow, EntityId, EntityId>(MostRecentTxForLoadout, id, x => x.TxId)
+            .Observe(MostRecentTxForLoadout.Where(row => row.LoadoutId == id.Value))
             .Select(_ => Loadout.Load(connection.Db, id));
     }
 }

--- a/src/NexusMods.Abstractions.Loadouts/Rows/MostRecentTxForLoadoutRow.cs
+++ b/src/NexusMods.Abstractions.Loadouts/Rows/MostRecentTxForLoadoutRow.cs
@@ -3,4 +3,4 @@ using NexusMods.MnemonicDB.Abstractions;
 
 namespace NexusMods.Abstractions.Loadouts.Rows;
 
-public readonly partial record struct MostRecentTxForLoadoutRow(EntityId LoadoutId, EntityId TxId) : IRowDefinition;
+public readonly partial record struct MostRecentTxForLoadoutRow(EntityId LoadoutId, EntityId TxId, int ItemCount) : IRowDefinition;

--- a/src/NexusMods.Library/InstallLoadoutItemJob.cs
+++ b/src/NexusMods.Library/InstallLoadoutItemJob.cs
@@ -20,6 +20,7 @@ internal class InstallLoadoutItemJob : IJobDefinitionWithStart<InstallLoadoutIte
     public LibraryItem.ReadOnly LibraryItem { get; init; }
     public LoadoutItemGroupId ParentGroupId { get; init; }
     public LoadoutId LoadoutId { get; init; }
+    
     public required ITransaction Transaction { get; init; }
     required internal IConnection Connection { get; init; }
     required internal IServiceProvider ServiceProvider { get; init; }
@@ -89,9 +90,9 @@ internal class InstallLoadoutItemJob : IJobDefinitionWithStart<InstallLoadoutIte
             LibraryItemId = LibraryItem,
         };
         
-        if (OwnsTransaction)
+        if (OwnsTransaction && Transaction is IMainTransaction mainTransaction)
         {
-            var transactionResult = await Transaction.Commit();
+            var transactionResult = await mainTransaction.Commit();
             Transaction.Dispose();
             return new InstallLoadoutItemJobResult(transactionResult.Remap(loadoutGroup));
         }


### PR DESCRIPTION
A few bugs were addressed here:

* Just tracking the TxId wasn't enough, as when mods are deleted they may not change the max TxId (for example if a older mod was removed, so now we also track the count of entities being tracked, one or the other of those two values will always change
* There was a bug in the TxId tracking in MnemonicDB where it wouldn't recognize when an entity was completely deleted, and remove the TxId tracking for that entity. Essentially entities would never "die" according to the max TxId tracker query, this is fixed in MnemonicDB
* Updates to the latest version of MnemonicDB as well