### PR TITLE
Fix wine overrides section parser

### DIFF
--- a/src/NexusMods.Abstractions.GameLocators/WineParser.cs
+++ b/src/NexusMods.Abstractions.GameLocators/WineParser.cs
@@ -123,9 +123,14 @@ public static class WineParser
 
         var span = input[(index + prefix.Length)..];
 
-        span = span[1..];
-        index = span.IndexOf('"');
-        span = span[..index];
+        var whitespaceIndex = span.IndexOf(' ');
+        if (whitespaceIndex != -1)
+            span = span[..whitespaceIndex];
+
+        if (span.StartsWith('"'))
+            span = span[1..];
+        if (span.EndsWith('"'))
+            span = span[..^1];
 
         return span;
     }

--- a/tests/NexusMods.StandardGameLocators.Tests/WineParserTests.cs
+++ b/tests/NexusMods.StandardGameLocators.Tests/WineParserTests.cs
@@ -10,6 +10,8 @@ public class WineParserTests
     [InlineData("foo bar baz", "")]
     [InlineData("WINEDLLOVERRIDES=\"foo,bar,baz\" foo bar baz", "foo,bar,baz")]
     [InlineData("FOO BAR BAZ WINEDLLOVERRIDES=\"foo,bar,baz\" foo bar baz", "foo,bar,baz")]
+    [InlineData("WINEDLLOVERRIDES=foo,bar,baz=n,b %command% \"hello world\"", "foo,bar,baz=n,b")]
+    [InlineData("WINEDLLOVERRIDES=foo,bar,baz=n,b %command%", "foo,bar,baz=n,b")]
     public void Test_GetWineDllOverridesSection(string input, string expected)
     {
         var actual = WineParser.GetWineDllOverridesSection(input).ToString();


### PR DESCRIPTION
Properly parses the section even if there are no quotes.

Fixes #3334.