### PR TITLE
Updated: Collection and Library Strings are now Localizable

### DIFF
--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionComponents.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionComponents.cs
@@ -7,6 +7,7 @@ using NexusMods.Abstractions.UI.Extensions;
 using NexusMods.App.UI.Controls;
 using NexusMods.App.UI.Extensions;
 using NexusMods.App.UI.Pages.LibraryPage;
+using NexusMods.App.UI.Resources;
 using NexusMods.MnemonicDB.Abstractions.Models;
 using R3;
 
@@ -104,8 +105,8 @@ public static class CollectionComponents
 
         protected virtual string GetButtonText(bool isDownloading, bool isDownloaded)
         {
-            if (isDownloaded) return "Downloaded";
-            return isDownloading ? "Downloading" : "Download";
+            if (isDownloaded) return Language.CollectionComponents_DownloadAction_ButtonText_Downloaded;
+            return isDownloading ? Language.CollectionComponents_DownloadAction_ButtonText_Downloading : Language.CollectionComponents_DownloadAction_ButtonText_Download;
         }
 
         private bool _isDisposed;
@@ -144,7 +145,7 @@ public static class CollectionComponents
         protected override string GetButtonText(bool isDownloading, bool isDownloaded)
         {
             if (isDownloading || isDownloaded) return base.GetButtonText(isDownloading, isDownloaded);
-            return "Third-party download";
+            return Language.CollectionComponents_ExternalDownloadAction_ButtonText_ThirdPartyDownload;
         }
     }
 
@@ -173,7 +174,7 @@ public static class CollectionComponents
 
         public ReactiveCommand<Unit, CollectionDownloadExternal.ReadOnly> CommandOpenModal { get; }
 
-        private static string GetButtonText(bool isDownloaded) => isDownloaded ? "Downloaded" : "Manual download";
+        private static string GetButtonText(bool isDownloaded) => isDownloaded ? Language.CollectionComponents_DownloadAction_ButtonText_Downloaded : Language.CollectionComponents_ManualDownloadAction_ButtonText_ManualDownload;
 
         private bool _isDisposed;
 

--- a/src/NexusMods.App.UI/Pages/LibraryPage/LibraryComponents.cs
+++ b/src/NexusMods.App.UI/Pages/LibraryPage/LibraryComponents.cs
@@ -7,6 +7,7 @@ using NexusMods.Abstractions.UI;
 using NexusMods.Abstractions.UI.Extensions;
 using NexusMods.App.UI.Controls;
 using NexusMods.App.UI.Extensions;
+using NexusMods.App.UI.Resources;
 using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.Networking.NexusWebApi;
 using ObservableCollections;
@@ -227,7 +228,9 @@ public static class LibraryComponents
             _idsObservable = childrenItemIdsObservable.SubscribeWithErrorLogging(changeSet => _ids.AsT0.ApplyChanges(changeSet));
         }
 
-        internal static string GetButtonText(bool isInstalled) => isInstalled ? "Installed" : "Install";
+        internal static string GetButtonText(bool isInstalled) => isInstalled
+            ? Language.LibraryComponents_InstallAction_ButtonText_Installed // "Installed"
+            : Language.LibraryComponents_InstallAction_ButtonText_Install; // "Install"
 
         [SuppressMessage("ReSharper", "RedundantIfElseBlock")]
         [SuppressMessage("ReSharper", "ConvertIfStatementToReturnStatement")]
@@ -239,18 +242,18 @@ public static class LibraryComponents
             {
                 if (numInstalled == numTotal)
                 {
-                    return "Installed";
+                    return Language.LibraryComponents_InstallAction_ButtonText_Installed;
                 } else {
-                    return $"Installed {numInstalled}/{numTotal}";
+                    return $"{Language.LibraryComponents_InstallAction_ButtonText_Installed} {numInstalled}/{numTotal}";
                 }
             }
             else
             {
                 if (!isExpanded && numTotal == 1)
                 {
-                    return "Install";
+                    return Language.LibraryComponents_InstallAction_ButtonText_Install;
                 } else {
-                    return $"Install ({numTotal})";
+                    return $"{Language.LibraryComponents_InstallAction_ButtonText_Install} {numTotal}";
                 }
             }
         }

--- a/src/NexusMods.App.UI/Resources/Language.Designer.cs
+++ b/src/NexusMods.App.UI/Resources/Language.Designer.cs
@@ -2809,5 +2809,47 @@ namespace NexusMods.App.UI.Resources {
                 return ResourceManager.GetString("ViewModInfoPage_Title", resourceCulture);
             }
         }
+        
+        public static string LibraryComponents_InstallAction_ButtonText_Installed {
+            get {
+                return ResourceManager.GetString("LibraryComponents_InstallAction_ButtonText_Installed", resourceCulture);
+            }
+        }
+        
+        public static string LibraryComponents_InstallAction_ButtonText_Install {
+            get {
+                return ResourceManager.GetString("LibraryComponents_InstallAction_ButtonText_Install", resourceCulture);
+            }
+        }
+        
+        public static string CollectionComponents_DownloadAction_ButtonText_Downloaded {
+            get {
+                return ResourceManager.GetString("CollectionComponents_DownloadAction_ButtonText_Downloaded", resourceCulture);
+            }
+        }
+        
+        public static string CollectionComponents_DownloadAction_ButtonText_Downloading {
+            get {
+                return ResourceManager.GetString("CollectionComponents_DownloadAction_ButtonText_Downloading", resourceCulture);
+            }
+        }
+        
+        public static string CollectionComponents_DownloadAction_ButtonText_Download {
+            get {
+                return ResourceManager.GetString("CollectionComponents_DownloadAction_ButtonText_Download", resourceCulture);
+            }
+        }
+        
+        public static string CollectionComponents_ExternalDownloadAction_ButtonText_ThirdPartyDownload {
+            get {
+                return ResourceManager.GetString("CollectionComponents_ExternalDownloadAction_ButtonText_ThirdPartyDownload", resourceCulture);
+            }
+        }
+        
+        public static string CollectionComponents_ManualDownloadAction_ButtonText_ManualDownload {
+            get {
+                return ResourceManager.GetString("CollectionComponents_ManualDownloadAction_ButtonText_ManualDownload", resourceCulture);
+            }
+        }
     }
 }

--- a/src/NexusMods.App.UI/Resources/Language.resx
+++ b/src/NexusMods.App.UI/Resources/Language.resx
@@ -990,4 +990,25 @@ To apply changes or launch the game again, please close the game first.</value>
     <data name="UpgradeToPremiumView_UpgradeButton" xml:space="preserve">
         <value>Upgrade to Premium</value>
     </data>
+    <data name="LibraryComponents_InstallAction_ButtonText_Installed" xml:space="preserve">
+        <value>Installed</value>
+    </data>
+    <data name="LibraryComponents_InstallAction_ButtonText_Install" xml:space="preserve">
+        <value>Install</value>
+    </data>
+    <data name="CollectionComponents_DownloadAction_ButtonText_Downloaded" xml:space="preserve">
+        <value>Downloaded</value>
+    </data>
+    <data name="CollectionComponents_DownloadAction_ButtonText_Downloading" xml:space="preserve">
+        <value>Downloading</value>
+    </data>
+    <data name="CollectionComponents_DownloadAction_ButtonText_Download" xml:space="preserve">
+        <value>Download</value>
+    </data>
+    <data name="CollectionComponents_ExternalDownloadAction_ButtonText_ThirdPartyDownload" xml:space="preserve">
+        <value>Third-party download</value>
+    </data>
+    <data name="CollectionComponents_ManualDownloadAction_ButtonText_ManualDownload" xml:space="preserve">
+        <value>Manual download</value>
+    </data>
 </root>


### PR DESCRIPTION
Lifted out of a work-in-progress branch of mine; just to avoid unnecessary merge conflicts.
This makes the strings for the `Library` and `Collections` section localizable; nothing more, nothing less.