### PR TITLE
Fix duplicate collection downloads on upload

### DIFF
--- a/src/NexusMods.Networking.NexusWebApi/NexusModsLibrary.Collections.cs
+++ b/src/NexusMods.Networking.NexusWebApi/NexusModsLibrary.Collections.cs
@@ -13,6 +13,9 @@ using NexusMods.Abstractions.NexusWebApi.Types;
 using NexusMods.Abstractions.NexusWebApi.Types.V2;
 using NexusMods.Abstractions.NexusWebApi.Types.V2.Uid;
 using NexusMods.MnemonicDB.Abstractions;
+using NexusMods.MnemonicDB.Abstractions.Query;
+using NexusMods.MnemonicDB.Abstractions.Query.SliceDescriptors;
+using NexusMods.MnemonicDB.Abstractions.TxFunctions;
 using NexusMods.Networking.NexusWebApi.Extensions;
 using NexusMods.Paths;
 using NexusMods.Sdk;
@@ -440,6 +443,19 @@ public partial class NexusModsLibrary
         GameIdCache gameIds,
         ResolvedEntitiesLookup resolvedEntitiesLookup)
     {
+        // NOTE(erri120): This exists because we can't replace downloads, there is no consistent identity generator for them.
+        // Usually, revisions don't get added twice; they are immutable once published. However, it's possible to add draft
+        // revisions to the app, which is what we do when uploading collections.
+        var existingDownloads = CollectionDownload.FindByCollectionRevision(db, collectionRevisionEntityId);
+        foreach (var entity in existingDownloads)
+        {
+            tx.Delete(entity, recursive: false);
+
+            // TODO: figure out what we want to do here
+            var references = db.Datoms(new ReferencesSlice(entity));
+            if (references.Count > 0) throw new NotImplementedException($"Collection download `{entity.Name}` (index={entity.ArrayIndex}) for collection `{collectionRoot.Info.Name}`/`{revisionInfo.RevisionNumber}` can't be deleted because it gets referenced by `{references.Count}` datoms, likely because it got installed");
+        }
+
         for (var i = 0; i < collectionRoot.Mods.Length; i++)
         {
             var collectionMod = collectionRoot.Mods[i];


### PR DESCRIPTION
When uploading a collection revision, we can either create a new revision or update an existing revision. The latter causes issues in our data model because we previously assumed that revisions are mutable.

This "fix" is more of a hack and will remove all the previous downloads before adding the new ones. It will throw an exception if any of the previous download entities are referenced by anything.

Part of #3118.