### PR TITLE
Fix R3 error logging

### DIFF
--- a/src/NexusMods.App/Startup.cs
+++ b/src/NexusMods.App/Startup.cs
@@ -94,10 +94,9 @@ public class Startup
 
     public static AppBuilder BuildAvaloniaApp(IServiceProvider serviceProvider)
     {
-        ReactiveUiExtensions.DefaultLogger = serviceProvider.GetRequiredService<ILogger<Startup>>();
-
-        IconProvider.Current
-            .Register<MaterialDesignIconProvider>();
+        var logger = serviceProvider.GetRequiredService<ILogger<Startup>>();
+        ReactiveUiExtensions.DefaultLogger = logger;
+        IconProvider.Current.Register<MaterialDesignIconProvider>();
 
         var app = AppBuilder
             .Configure(serviceProvider.GetRequiredService<App>)
@@ -115,7 +114,10 @@ public class Startup
                 UseOpacitySaveLayer = true,
             })
             .LogToTrace()
-            .UseR3()
+            .UseR3(unhandledExceptionHandler: exception =>
+            {
+                LogMessages.R3UnhandledException(logger, exception);
+            })
             .UseReactiveUI();
 
         Locator.CurrentMutable.UnregisterCurrent(typeof(IViewLocator));
@@ -123,11 +125,7 @@ public class Startup
         
         Locator.CurrentMutable.RegisterConstant<IBindingTypeConverter>(new SizeToStringTypeConverter());
         
-        var logger = serviceProvider.GetRequiredService<ILogger<Startup>>();
-        ObservableSystem.RegisterUnhandledExceptionHandler(exception =>
-        {
-            LogMessages.R3UnhandledException(logger, exception);
-        });
+
 
         return app;
     }


### PR DESCRIPTION
We were actually never logging unhandled exceptions in R3 observables because we set the handler and then it gets overwritten by `UseR3()`.