### PR TITLE
Fix exception when writing empty RedMod loadorder file

### DIFF
--- a/src/NexusMods.Games.RedEngine/RedModDeployTool.cs
+++ b/src/NexusMods.Games.RedEngine/RedModDeployTool.cs
@@ -94,7 +94,8 @@ public class RedModDeployTool : ITool
 
         // NOTE(erri120): redmod only accepts CRLR line breaks, everything else breaks the program
         // and results in getting errors like `Non-existant mod selected`
-        var output = order.Aggregate((a, b) => $"{a}\r\n{b}");
+        var output = order.Count > 0 ? string.Join("\r\n", order) : string.Empty;
+
         await loadorderFilePath.WriteAllTextAsync(output);
     }
     public string Name => "RedMod Deploy";


### PR DESCRIPTION
Replaces Aggregate with string.Join to handle empty collections gracefully.

Previously, calling Aggregate on an empty collection would throw an exception, causing the Synchronizer to fail when no redmods were enabled.

I wasn't able to test this, so if someone wants to check please do.

## Steps for testing:
- Ensure you have RedMod DLC installed
- Install a redmod mod but disable it (you should have no other enabled remods)
- Apply
- No exceptions should happen