### PR TITLE
Fix app backing up entire game when DLC list changes

### DIFF
--- a/src/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -509,11 +509,8 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
         var locatorsToAdd = newLocatorIds.Except(loadout.LocatorIds).ToArray();
         var locatorsToRemove = loadout.LocatorIds.Except(newLocatorIds).ToArray();
         
-        var locatorAdditions = locatorsToAdd.Length;
-        var locatorRemovals = locatorsToRemove.Length;
-
         // No reason to change the loadout if the version is the same
-        if (locatorRemovals == 0 && locatorAdditions == 0)
+        if (locatorsToAdd.Length == 0 && locatorsToRemove.Length == 0)
             return loadout;
 
         // Make a lookup set of the new files

--- a/src/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -505,9 +505,12 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
         
         if (newLocatorIds.Length != metadataLocatorIds.Length)
             Logger.LogWarning("Found duplicate locator IDs `{LocatorIds}` on gameLocatorResult for game `{Game}` while reprocessing game updates", metadataLocatorIds, loadout.InstallationInstance.Game.Name);
-
-        var locatorAdditions = loadout.LocatorIds.Except(newLocatorIds).Count();
-        var locatorRemovals = newLocatorIds.Except(loadout.LocatorIds).Count();
+        
+        var locatorsToAdd = newLocatorIds.Except(loadout.LocatorIds).ToArray();
+        var locatorsToRemove = loadout.LocatorIds.Except(newLocatorIds).ToArray();
+        
+        var locatorAdditions = locatorsToAdd.Length;
+        var locatorRemovals = locatorsToRemove.Length;
 
         // No reason to change the loadout if the version is the same
         if (locatorRemovals == 0 && locatorAdditions == 0)
@@ -561,8 +564,7 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
         
         loadout = loadout.Rebase();
         
-        var locatorsToRemove = loadout.LocatorIds.Except(newLocatorIds).ToArray();
-        var locatorsToAdd = newLocatorIds.Except(loadout.LocatorIds).ToArray();
+
         
         foreach (var id in locatorsToRemove) 
             tx.Retract(loadout, Loadout.LocatorIds, id);

--- a/src/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -560,7 +560,7 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
         }
         
         loadout = loadout.Rebase();
-ix         
+        
         var locatorsToRemove = loadout.LocatorIds.Except(newLocatorIds).ToArray();
         var locatorsToAdd = newLocatorIds.Except(loadout.LocatorIds).ToArray();
         

--- a/src/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -560,9 +560,13 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
         }
         
         loadout = loadout.Rebase();
-        foreach (var id in loadout.LocatorIds) 
+ix         
+        var locatorsToRemove = loadout.LocatorIds.Except(newLocatorIds).ToArray();
+        var locatorsToAdd = newLocatorIds.Except(loadout.LocatorIds).ToArray();
+        
+        foreach (var id in locatorsToRemove) 
             tx.Retract(loadout, Loadout.LocatorIds, id);
-        foreach (var id in newLocatorIds)
+        foreach (var id in locatorsToAdd)
             tx.Add(loadout, Loadout.LocatorIds, id);
         
         var result = await tx.Commit();


### PR DESCRIPTION
- Fixes #3417 

Retracting and Adding LocatorIds was resulting in no addition, manning that the game locator Id would be removed from the loadout, resulting in the entire game being put in External Changes and being backed up.
