### PR TITLE
Cleanup sortable provider disposables

### DIFF
--- a/src/NexusMods.Abstractions.Games/SortOrder/ASortableItemProviderFactory.cs
+++ b/src/NexusMods.Abstractions.Games/SortOrder/ASortableItemProviderFactory.cs
@@ -117,25 +117,26 @@ public abstract class ASortableItemProviderFactory<TItem, TKey> : ISortableItemP
     private bool _isDisposed;
     
     /// <inheritdoc />
-    public virtual void Dispose()
+    public void Dispose()
     {
         Dispose(true);
+        System.GC.SuppressFinalize(this);
     }
-    
+
     protected virtual void Dispose(bool disposing)
     {
         if (_isDisposed) return;
-        
+
         if (disposing)
         {
             foreach (var provider in _providers.Values)
             {
                 provider.Dispose();
-                _providers.Clear();
             }
+
+            _providers.Clear();
         }
-        
+
         _isDisposed = true;
     }
-
 }

--- a/src/NexusMods.Games.RedEngine/Cyberpunk2077/SortOrder/RedMod/RedModSortableItemProvider.cs
+++ b/src/NexusMods.Games.RedEngine/Cyberpunk2077/SortOrder/RedMod/RedModSortableItemProvider.cs
@@ -10,6 +10,7 @@ using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.MnemonicDB.Abstractions.TxFunctions;
 using NexusMods.Paths;
 using NexusMods.Sdk;
+using NexusMods.Sdk.Threading;
 using R3;
 
 
@@ -118,46 +119,35 @@ public class RedModSortableItemProvider : ASortableItemProvider<RedModSortableIt
 
     public override async Task<IReadOnlyList<RedModSortableItem>> RefreshSortOrder(CancellationToken token, IDb? loadoutDb = null)
     {
-        var hasEntered = await Semaphore.WaitAsync(SemaphoreTimeout, token);
-        if (!hasEntered) throw new TimeoutException($"Timed out waiting for semaphore in RefreshSortOrder");
-        
-        try
-        {
-            var dbToUse = loadoutDb ?? _connection.Db;
-            
-            var redModsGroups = RedModLoadoutGroup.All(dbToUse)
-                .Where(g => g.AsLoadoutItemGroup().AsLoadoutItem().LoadoutId == LoadoutId)
-                .Select(g => new RedModWithState(g, g.RedModFolder(), g.IsEnabled()))
-                .ToList();
-                
-            var oldOrder = OrderCache.Items.OrderBy(item => item.SortIndex).ToList();
-            
-            if (token.IsCancellationRequested) return [];
-            
-            // Update the order
-            var stagingList = SynchronizeSortingToItems(redModsGroups, oldOrder, this);
-            
-            if (token.IsCancellationRequested) return [];
+        using var disposableSemaphore = await Semaphore.WaitAsyncDisposable(SemaphoreTimeout, token);
+        if (!disposableSemaphore.HasEntered) throw new TimeoutException($"Timed out waiting for semaphore in SetRelativePosition");
 
-            // Update the database
-            await PersistSortOrder(stagingList, SortOrderEntityId, token);
-            
-            if (token.IsCancellationRequested) return [];
+        var dbToUse = loadoutDb ?? _connection.Db;
 
-            // Update the cache
-            OrderCache.Edit(innerCache =>
-                {
-                    innerCache.Clear();
-                    innerCache.AddOrUpdate(stagingList);
-                }
-            );
-            
-            return stagingList;
-        }
-        finally
+        var redModsGroups = RedModLoadoutGroup.All(dbToUse)
+            .Where(g => g.AsLoadoutItemGroup().AsLoadoutItem().LoadoutId == LoadoutId)
+            .Select(g => new RedModWithState(g, g.RedModFolder(), g.IsEnabled()))
+            .ToList();
+
+        var oldOrder = OrderCache.Items.OrderBy(item => item.SortIndex).ToList();
+        if (token.IsCancellationRequested) return [];
+
+        // Update the order
+        var stagingList = SynchronizeSortingToItems(redModsGroups, oldOrder, this);
+        if (token.IsCancellationRequested) return [];
+
+        // Update the database
+        await PersistSortOrder(stagingList, SortOrderEntityId, token);
+        if (token.IsCancellationRequested) return [];
+
+        // Update the cache
+        OrderCache.Edit(innerCache =>
         {
-            Semaphore.Release();
-        }
+            innerCache.Clear();
+            innerCache.AddOrUpdate(stagingList);
+        });
+   
+        return stagingList;
     }
 
     /// <summary>
@@ -360,6 +350,7 @@ public class RedModSortableItemProvider : ASortableItemProvider<RedModSortableIt
 
     protected override void Dispose(bool disposing)
     {
+        base.Dispose(disposing);
         if (_isDisposed) return;
 
         if (disposing)
@@ -368,8 +359,5 @@ public class RedModSortableItemProvider : ASortableItemProvider<RedModSortableIt
         }
 
         _isDisposed = true;
-        
-        base.Dispose(disposing);
     }
-
 }

--- a/src/NexusMods.Sdk/Threading/Extensions.cs
+++ b/src/NexusMods.Sdk/Threading/Extensions.cs
@@ -30,4 +30,27 @@ public static class SemaphoreSlimExtensions
         semaphoreSlim.Wait(cancellationToken);
         return new DisposableSemaphoreSlim(semaphoreSlim, entered: true);
     }
+
+    /// <summary>
+    /// Wait using <see cref="DisposableSemaphoreSlim"/>.
+    /// </summary>
+    public static async Task<DisposableSemaphoreSlim> WaitAsyncDisposable(
+        this SemaphoreSlim semaphoreSlim,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+    {
+        var hasEntered = await semaphoreSlim.WaitAsync(timeout, cancellationToken: cancellationToken);
+        return new DisposableSemaphoreSlim(semaphoreSlim, entered: hasEntered);
+    }
+
+    /// <summary>
+    /// Wait infinitely using <see cref="DisposableSemaphoreSlim"/>.
+    /// </summary>
+    public static async Task<DisposableSemaphoreSlim> WaitAsyncDisposable(
+        this SemaphoreSlim semaphoreSlim,
+        CancellationToken cancellationToken = default)
+    {
+        await semaphoreSlim.WaitAsync(cancellationToken: cancellationToken);
+        return new DisposableSemaphoreSlim(semaphoreSlim, entered: true);
+    }
 }


### PR DESCRIPTION
- Moves `Clear` outside for loop
- Uses `DisposableSemaphoreSlim` instead of manual `try/final`

I don't think this will solve our shutdown issue just yet.