### PR TITLE
Fetch collection status on page load and use R3 bindings

### DIFF
--- a/src/NexusMods.Abstractions.Collections/ManagedCollectionLoadoutGroup.cs
+++ b/src/NexusMods.Abstractions.Collections/ManagedCollectionLoadoutGroup.cs
@@ -1,6 +1,8 @@
+using DynamicData.Kernel;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.NexusModsLibrary.Attributes;
 using NexusMods.Abstractions.NexusModsLibrary.Models;
+using NexusMods.Abstractions.NexusWebApi.Types;
 using NexusMods.MnemonicDB.Abstractions.Attributes;
 using NexusMods.MnemonicDB.Abstractions.Models;
 
@@ -28,4 +30,19 @@ public partial class ManagedCollectionLoadoutGroup : IModelDefinition
     /// The current revision number.
     /// </summary>
     public static readonly RevisionNumberAttribute CurrentRevisionNumber = new(Namespace, nameof(CurrentRevisionNumber));
+
+    /// <summary>
+    /// Creates a <see cref="RevisionStatus"/>.
+    /// </summary>
+    public static RevisionStatus ToStatus(RevisionNumber currentRevisionNumber, Optional<RevisionNumber> lastPublishedRevision)
+    {
+        if (!lastPublishedRevision.HasValue) return RevisionStatus.Draft;
+        return lastPublishedRevision.Value == currentRevisionNumber ? RevisionStatus.Published : RevisionStatus.Draft;
+    }
+
+    public partial struct ReadOnly
+    {
+        /// <inheritdoc cref="ManagedCollectionLoadoutGroup.ToStatus"/>
+        public RevisionStatus ToStatus() => ManagedCollectionLoadoutGroup.ToStatus(CurrentRevisionNumber, LastPublishedRevisionNumber);
+    }
 }

--- a/src/NexusMods.Abstractions.Collections/ManagedCollectionLoadoutGroup.cs
+++ b/src/NexusMods.Abstractions.Collections/ManagedCollectionLoadoutGroup.cs
@@ -1,4 +1,5 @@
 using NexusMods.Abstractions.Loadouts;
+using NexusMods.Abstractions.NexusModsLibrary.Attributes;
 using NexusMods.Abstractions.NexusModsLibrary.Models;
 using NexusMods.MnemonicDB.Abstractions.Attributes;
 using NexusMods.MnemonicDB.Abstractions.Models;
@@ -17,4 +18,14 @@ public partial class ManagedCollectionLoadoutGroup : IModelDefinition
     /// The collection.
     /// </summary>
     public static readonly ReferenceAttribute<CollectionMetadata> Collection = new(Namespace, nameof(Collection)) { IsIndexed = true };
+
+    /// <summary>
+    /// The revision number of the last published revision.
+    /// </summary>
+    public static readonly RevisionNumberAttribute LastPublishedRevisionNumber = new(Namespace, nameof(LastPublishedRevisionNumber)) { IsOptional = true };
+
+    /// <summary>
+    /// The current revision number.
+    /// </summary>
+    public static readonly RevisionNumberAttribute CurrentRevisionNumber = new(Namespace, nameof(CurrentRevisionNumber));
 }

--- a/src/NexusMods.App.UI/Controls/Spine/SpineViewModel.cs
+++ b/src/NexusMods.App.UI/Controls/Spine/SpineViewModel.cs
@@ -256,7 +256,7 @@ public class SpineViewModel : AViewModel<ISpineViewModel>, ISpineViewModel
                 Context = new LoadoutPageContext
                 {
                     LoadoutId = loadoutId,
-                    GroupScope = Optional<LoadoutItemGroupId>.None,
+                    GroupScope = Optional<CollectionGroupId>.None,
                 }
             },
             () => new LoadoutContext

--- a/src/NexusMods.App.UI/LeftMenu/Items/NewCollectionViewModel.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Items/NewCollectionViewModel.cs
@@ -43,7 +43,7 @@ public class NewCollectionViewModel : LeftMenuItemViewModel
                 Context = new LoadoutPageContext
                 {
                     LoadoutId = loadoutId,
-                    GroupScope = collectionGroup.AsLoadoutItemGroup().LoadoutItemGroupId,
+                    GroupScope = collectionGroup.CollectionGroupId,
                 },
             };
 

--- a/src/NexusMods.App.UI/LeftMenu/Loadout/LoadoutLeftMenuViewModel.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Loadout/LoadoutLeftMenuViewModel.cs
@@ -109,7 +109,7 @@ public class LoadoutLeftMenuViewModel : AViewModel<ILoadoutLeftMenuViewModel>, I
                 Context = new LoadoutPageContext
                 {
                     LoadoutId = loadoutContext.LoadoutId,
-                    GroupScope = Optional<LoadoutItemGroupId>.None,
+                    GroupScope = Optional<CollectionGroupId>.None,
                 },
             }
         )
@@ -182,7 +182,7 @@ public class LoadoutLeftMenuViewModel : AViewModel<ILoadoutLeftMenuViewModel>, I
                         Context = new LoadoutPageContext
                         {
                             LoadoutId = loadout,
-                            GroupScope = collection.AsLoadoutItemGroup().LoadoutItemGroupId,
+                            GroupScope = collection.CollectionGroupId,
                         },
                     };
 

--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadViewModel.cs
@@ -357,12 +357,22 @@ public sealed class CollectionDownloadViewModel : APageViewModel<ICollectionDown
 
             R3.Observable.Return(_revision)
                 .ObserveOnThreadPool()
-                .SelectAwait((revision, cancellationToken) => nexusModsLibrary.GetNewerRevisionNumbers(revision, cancellationToken))
+                .SelectAwait((revision, cancellationToken) => nexusModsLibrary.GetLastPublishedRevisionNumber(revision.Collection, cancellationToken))
                 .ObserveOnUIThreadDispatcher()
-                .Subscribe(this, static (newerRevisions, self) =>
+                .Subscribe(this, static (lastPublishedRevisionNumber, self) =>
                 {
-                    self.IsUpdateAvailable.Value = newerRevisions.Length > 0;
-                    self.NewestRevisionNumber.Value = newerRevisions.FirstOrOptional(_ => true);
+                    if (!lastPublishedRevisionNumber.HasValue)
+                    {
+                        self.IsUpdateAvailable.Value = false;
+                        self.NewestRevisionNumber.Value = Optional<RevisionNumber>.None;
+                    }
+                    else
+                    {
+                        var isUpdateAvailable = lastPublishedRevisionNumber.Value > self._revision.RevisionNumber;
+
+                        self.IsUpdateAvailable.Value = isUpdateAvailable;
+                        self.NewestRevisionNumber.Value = isUpdateAvailable ? lastPublishedRevisionNumber : Optional<RevisionNumber>.None;
+                    }
                 }).AddTo(disposables);
 
             R3.Observable.Return(collectionJsonFile)

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/ILoadoutViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/ILoadoutViewModel.cs
@@ -10,8 +10,8 @@ public interface ILoadoutViewModel : IPageViewModelInterface
     string EmptyStateTitleText { get; }
 
     LoadoutTreeDataGridAdapter Adapter { get; }
-    int ItemCount { get; }
-    int SelectionCount { get; } 
+    IReadOnlyBindableReactiveProperty<int> ItemCount { get; }
+    IReadOnlyBindableReactiveProperty<int> SelectionCount { get; } 
 
     LoadoutPageSubTabs SelectedSubTab { get; }
     bool HasRulesSection { get; }

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/ILoadoutViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/ILoadoutViewModel.cs
@@ -7,38 +7,27 @@ namespace NexusMods.App.UI.Pages.LoadoutPage;
 
 public interface ILoadoutViewModel : IPageViewModelInterface
 {
-    LoadoutTreeDataGridAdapter Adapter { get; }
-
-    ReactiveCommand<NavigationInformation> ViewLibraryCommand { get; }
-    
     string EmptyStateTitleText { get; }
 
-    ReactiveCommand<NavigationInformation> ViewFilesCommand { get; }
+    LoadoutTreeDataGridAdapter Adapter { get; }
+    int ItemCount { get; }
+    int SelectionCount { get; } 
 
-    ReactiveCommand<Unit> RemoveItemCommand { get; }
-    
-    ReactiveCommand<Unit> CollectionToggleCommand { get; }
-    ReactiveCommand<Unit> DeselectItemsCommand { get; }
-    
-    public int SelectionCount { get; } 
-    
-    bool IsCollection { get; }
-    
-    bool IsCollectionEnabled { get; }
-    bool IsCollectionUploaded { get; }
-    
-    string CollectionName { get; } 
-    
+    LoadoutPageSubTabs SelectedSubTab { get; }
+    bool HasRulesSection { get; }
     ISortingSelectionViewModel RulesSectionViewModel { get; }
-    
-    public int ItemCount { get; }
-    
-    public bool HasRulesSection { get; }
-    
-    public LoadoutPageSubTabs SelectedSubTab { get; }
+
+    bool IsCollection { get; }
+    bool IsCollectionUploaded { get; }
+    string CollectionName { get; } 
+
+    ReactiveCommand<NavigationInformation> CommandOpenLibraryPage { get; }
+    ReactiveCommand<NavigationInformation> CommandOpenFilesPage { get; }
+
+    ReactiveCommand<Unit> CommandRemoveItem { get; }
+    ReactiveCommand<Unit> CommandDeselectItems { get; }
 
     ReactiveCommand<Unit> CommandUploadRevision { get; }
     ReactiveCommand<Unit> CommandOpenRevisionUrl { get; }
-
     ReactiveCommand<Unit> CommandRenameGroup { get; }
 }

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/ILoadoutViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/ILoadoutViewModel.cs
@@ -1,3 +1,5 @@
+using NexusMods.Abstractions.NexusModsLibrary.Models;
+using NexusMods.Abstractions.NexusWebApi.Types;
 using NexusMods.App.UI.Controls.Navigation;
 using NexusMods.App.UI.Pages.Sorting;
 using NexusMods.App.UI.WorkspaceSystem;
@@ -20,6 +22,9 @@ public interface ILoadoutViewModel : IPageViewModelInterface
     bool IsCollection { get; }
     IReadOnlyBindableReactiveProperty<bool> IsCollectionUploaded { get; }
     IReadOnlyBindableReactiveProperty<string> CollectionName { get; } 
+    IReadOnlyBindableReactiveProperty<CollectionStatus> CollectionStatus { get; }
+    IReadOnlyBindableReactiveProperty<RevisionStatus> RevisionStatus { get; }
+    IReadOnlyBindableReactiveProperty<RevisionNumber> RevisionNumber { get; }
 
     ReactiveCommand<NavigationInformation> CommandOpenLibraryPage { get; }
     ReactiveCommand<NavigationInformation> CommandOpenFilesPage { get; }

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/ILoadoutViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/ILoadoutViewModel.cs
@@ -25,6 +25,7 @@ public interface ILoadoutViewModel : IPageViewModelInterface
     IReadOnlyBindableReactiveProperty<CollectionStatus> CollectionStatus { get; }
     IReadOnlyBindableReactiveProperty<RevisionStatus> RevisionStatus { get; }
     IReadOnlyBindableReactiveProperty<RevisionNumber> RevisionNumber { get; }
+    IReadOnlyBindableReactiveProperty<bool> HasOutstandingChanges { get; }
 
     ReactiveCommand<NavigationInformation> CommandOpenLibraryPage { get; }
     ReactiveCommand<NavigationInformation> CommandOpenFilesPage { get; }

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/ILoadoutViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/ILoadoutViewModel.cs
@@ -18,8 +18,8 @@ public interface ILoadoutViewModel : IPageViewModelInterface
     ISortingSelectionViewModel RulesSectionViewModel { get; }
 
     bool IsCollection { get; }
-    bool IsCollectionUploaded { get; }
-    string CollectionName { get; } 
+    IReadOnlyBindableReactiveProperty<bool> IsCollectionUploaded { get; }
+    IReadOnlyBindableReactiveProperty<string> CollectionName { get; } 
 
     ReactiveCommand<NavigationInformation> CommandOpenLibraryPage { get; }
     ReactiveCommand<NavigationInformation> CommandOpenFilesPage { get; }

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutPage.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutPage.cs
@@ -21,7 +21,7 @@ public record LoadoutPageContext : IPageFactoryContext
     /// <summary>
     /// If provided, will limit the scope of items shown to the group with the given ID.
     /// </summary>
-    public required Optional<LoadoutItemGroupId> GroupScope { get; init; }
+    public required Optional<CollectionGroupId> GroupScope { get; init; }
 
     /// <summary>
     /// If provided, will create the page with the given sub-tab selected.
@@ -71,7 +71,7 @@ public class LoadoutPageFactory : APageFactory<ILoadoutViewModel, LoadoutPageCon
                 Context = new LoadoutPageContext
                 {
                     LoadoutId = loadoutContext.LoadoutId,
-                    GroupScope = Optional<LoadoutItemGroupId>.None,
+                    GroupScope = Optional<CollectionGroupId>.None,
                 },
             },
         };

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutTreeDataGridAdapter.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutTreeDataGridAdapter.cs
@@ -1,0 +1,125 @@
+using System.ComponentModel;
+using Avalonia.Controls.Models.TreeDataGrid;
+using DynamicData;
+using Microsoft.Extensions.DependencyInjection;
+using NexusMods.Abstractions.Loadouts;
+using NexusMods.App.UI.Controls;
+using NexusMods.App.UI.Controls.Navigation;
+using NexusMods.MnemonicDB.Abstractions;
+using OneOf;
+using R3;
+
+namespace NexusMods.App.UI.Pages.LoadoutPage;
+
+public readonly record struct ToggleEnableStateMessage(LoadoutItemId[] Ids);
+
+public readonly record struct OpenCollectionMessage(LoadoutItemId[] Ids, NavigationInformation NavigationInformation);
+
+public class LoadoutTreeDataGridAdapter :
+    TreeDataGridAdapter<CompositeItemModel<EntityId>, EntityId>,
+    ITreeDataGirdMessageAdapter<OneOf<ToggleEnableStateMessage, OpenCollectionMessage>>
+{
+    public Subject<OneOf<ToggleEnableStateMessage, OpenCollectionMessage>> MessageSubject { get; } = new();
+
+    private readonly ILoadoutDataProvider[] _loadoutDataProviders;
+    private readonly LoadoutFilter _loadoutFilter;
+
+    public LoadoutTreeDataGridAdapter(IServiceProvider serviceProvider, LoadoutFilter loadoutFilter)
+    {
+        _loadoutDataProviders = serviceProvider.GetServices<ILoadoutDataProvider>().ToArray();
+        _loadoutFilter = loadoutFilter;
+    }
+
+    protected override IObservable<IChangeSet<CompositeItemModel<EntityId>, EntityId>> GetRootsObservable(bool viewHierarchical)
+    {
+        return _loadoutDataProviders.Select(x => x.ObserveLoadoutItems(_loadoutFilter)).MergeChangeSets();
+    }
+
+    protected override void BeforeModelActivationHook(CompositeItemModel<EntityId> model)
+    {
+        base.BeforeModelActivationHook(model);
+
+        model.SubscribeToComponentAndTrack<LoadoutComponents.EnabledStateToggle, LoadoutTreeDataGridAdapter>(
+            key: LoadoutColumns.EnabledState.EnabledStateToggleComponentKey,
+            state: this,
+            factory: static (self, itemModel, component) => component.CommandToggle.Subscribe((self, itemModel, component), static (_, tuple) =>
+                {
+                    var (self, itemModel, _) = tuple;
+                    var ids = GetLoadoutItemIds(itemModel).ToArray();
+
+                    self.MessageSubject.OnNext(new ToggleEnableStateMessage(ids));
+                }
+            )
+        );
+
+        model.SubscribeToComponentAndTrack<LoadoutComponents.ParentCollectionDisabled, LoadoutTreeDataGridAdapter>(
+            key: LoadoutColumns.EnabledState.ParentCollectionDisabledComponentKey,
+            state: this,
+            factory: static (self, itemModel, component) => component.ButtonCommand.Subscribe((self, itemModel, component), static (navInfo, tuple) =>
+                {
+                    var (self, itemModel, _) = tuple;
+                    var ids = GetLoadoutItemIds(itemModel).ToArray();
+
+                    self.MessageSubject.OnNext(new OpenCollectionMessage(ids, navInfo));
+                }
+            )
+        );
+
+        model.SubscribeToComponentAndTrack<LoadoutComponents.LockedEnabledState, LoadoutTreeDataGridAdapter>(
+            key: LoadoutColumns.EnabledState.LockedEnabledStateComponentKey,
+            state: this,
+            factory: static (self, itemModel, component) => component.ButtonCommand.Subscribe((self, itemModel, component), static (navInfo, tuple) =>
+                {
+                    var (self, itemModel, _) = tuple;
+                    var ids = GetLoadoutItemIds(itemModel).ToArray();
+
+                    self.MessageSubject.OnNext(new OpenCollectionMessage(ids, navInfo));
+                }
+            )
+        );
+
+        model.SubscribeToComponentAndTrack<LoadoutComponents.MixLockedAndParentDisabled, LoadoutTreeDataGridAdapter>(
+            key: LoadoutColumns.EnabledState.MixLockedAndParentDisabledComponentKey,
+            state: this,
+            factory: static (self, itemModel, component) => component.ButtonCommand.Subscribe((self, itemModel, component), static (navInfo, tuple) =>
+                {
+                    var (self, itemModel, _) = tuple;
+                    var ids = GetLoadoutItemIds(itemModel).ToArray();
+
+                    self.MessageSubject.OnNext(new OpenCollectionMessage(ids, navInfo));
+                }
+            )
+        );
+    }
+
+    private static IEnumerable<LoadoutItemId> GetLoadoutItemIds(CompositeItemModel<EntityId> itemModel)
+    {
+        return itemModel.Get<LoadoutComponents.LoadoutItemIds>(LoadoutColumns.EnabledState.LoadoutItemIdsComponentKey).ItemIds;
+    }
+
+    protected override IColumn<CompositeItemModel<EntityId>>[] CreateColumns(bool viewHierarchical)
+    {
+        var nameColumn = ColumnCreator.Create<EntityId, SharedColumns.Name>();
+
+        return
+        [
+            viewHierarchical ? ITreeDataGridItemModel<CompositeItemModel<EntityId>, EntityId>.CreateExpanderColumn(nameColumn) : nameColumn,
+            ColumnCreator.Create<EntityId, SharedColumns.InstalledDate>(sortDirection: ListSortDirection.Descending),
+            ColumnCreator.Create<EntityId, LoadoutColumns.Collections>(),
+            ColumnCreator.Create<EntityId, LoadoutColumns.EnabledState>(),
+        ];
+    }
+
+    private bool _isDisposed;
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && !_isDisposed)
+        {
+            MessageSubject.Dispose();
+            _isDisposed = true;
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutView.axaml
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutView.axaml
@@ -48,7 +48,7 @@
 
                     <!-- STATUSBAR -->
 
-                    <controls:Statusbar Grid.Row="0">
+                    <controls:Statusbar Grid.Row="0" x:Name="Statusbar">
                         <StackPanel>
                                 
                             <controls:StandardButton Size="Toolbar"

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutView.axaml.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutView.axaml.cs
@@ -31,9 +31,10 @@ public partial class LoadoutView : R3UserControl<ILoadoutViewModel>
                 view.RulesTabItem.IsVisible = vm?.HasRulesSection ?? false;
 
                 var isCollection = vm?.IsCollection ?? false;
+                view.AllPageHeader.IsVisible = !isCollection;
+                view.Statusbar.IsVisible = isCollection;
                 view.ButtonUploadCollectionRevision.IsVisible = isCollection && CollectionCreator.IsFeatureEnabled;
                 view.WritableCollectionPageHeader.IsVisible = isCollection;
-                view.AllPageHeader.IsVisible = !isCollection;
 
                 var selectedSubTab = vm?.SelectedSubTab;
                 if (selectedSubTab is not null)
@@ -86,7 +87,7 @@ public partial class LoadoutView : R3UserControl<ILoadoutViewModel>
                     self.StatusText.Text = isCollectionUploaded ? "Uploaded" : "Not Uploaded";
                     self.ButtonUploadCollectionRevision.Text = isCollectionUploaded ? "Upload update" : "Share";
                     self.ButtonUploadCollectionRevision.ShowIcon = isCollectionUploaded ? StandardButton.ShowIconOptions.None : StandardButton.ShowIconOptions.Left;
-                    self. ButtonOpenRevisionUrl.IsVisible = isCollectionUploaded;
+                    self.ButtonOpenRevisionUrl.IsVisible = isCollectionUploaded;
 
                     if (isCollectionUploaded)
                     {

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutView.axaml.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutView.axaml.cs
@@ -25,13 +25,13 @@ public partial class LoadoutView : ReactiveUserControl<ILoadoutViewModel>
             // initially hidden
             ContextControlGroup.IsVisible = false;
             
-            this.BindCommand(ViewModel, vm => vm.ViewFilesCommand, view => view.ViewFilesButton)
+            this.BindCommand(ViewModel, vm => vm.CommandOpenFilesPage, view => view.ViewFilesButton)
                 .AddTo(disposables);
             
-            this.BindCommand(ViewModel, vm => vm.ViewLibraryCommand, view => view.ViewLibraryButton)
+            this.BindCommand(ViewModel, vm => vm.CommandOpenLibraryPage, view => view.ViewLibraryButton)
                 .AddTo(disposables);
 
-            this.BindCommand(ViewModel, vm => vm.RemoveItemCommand, view => view.DeleteButton)
+            this.BindCommand(ViewModel, vm => vm.CommandRemoveItem, view => view.DeleteButton)
                 .AddTo(disposables);
 
             this.OneWayBind(ViewModel, vm => vm.Adapter.Source.Value, view => view.TreeDataGrid.Source)
@@ -58,7 +58,7 @@ public partial class LoadoutView : ReactiveUserControl<ILoadoutViewModel>
             this.OneWayBind(ViewModel, vm => vm.HasRulesSection, view => view.RulesTabItem.IsVisible)
                 .AddTo(disposables);
             
-            this.BindCommand(ViewModel, vm => vm.DeselectItemsCommand, view => view.DeselectItemsButton)
+            this.BindCommand(ViewModel, vm => vm.CommandDeselectItems, view => view.DeselectItemsButton)
                 .AddTo(disposables);
 
             this.BindCommand(ViewModel, vm => vm.CommandUploadRevision, view => view.ButtonUploadCollectionRevision)
@@ -70,9 +70,6 @@ public partial class LoadoutView : ReactiveUserControl<ILoadoutViewModel>
             this.BindCommand(ViewModel, vm => vm.CommandRenameGroup, view => view.MenuItemRenameCollection)
                 .AddTo(disposables);
 
-            this.BindCommand(ViewModel, vm => vm.DeselectItemsCommand, view => view.DeselectItemsButton)
-                .AddTo(disposables);
-            
             this.WhenAnyValue(view => view.ViewModel!.IsCollection)
                 .WhereNotNull()
                 .SubscribeWithErrorLogging(isCollection =>

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutViewModel.cs
@@ -62,6 +62,8 @@ public class LoadoutViewModel : APageViewModel<ILoadoutViewModel>, ILoadoutViewM
     IReadOnlyBindableReactiveProperty<RevisionStatus> ILoadoutViewModel.RevisionStatus => RevisionStatus;
     private BindableReactiveProperty<RevisionNumber> RevisionNumber { get; }
     IReadOnlyBindableReactiveProperty<RevisionNumber> ILoadoutViewModel.RevisionNumber => RevisionNumber;
+    private BindableReactiveProperty<bool> HasOutstandingChanges { get; } = new(value: true); // TODO: implement this
+    IReadOnlyBindableReactiveProperty<bool> ILoadoutViewModel.HasOutstandingChanges => HasOutstandingChanges;
 
     public ReactiveCommand<NavigationInformation> CommandOpenLibraryPage { get; }
     public ReactiveCommand<NavigationInformation> CommandOpenFilesPage { get; }

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutViewModel.cs
@@ -71,7 +71,7 @@ public class LoadoutViewModel : APageViewModel<ILoadoutViewModel>, ILoadoutViewM
         IWindowManager windowManager,
         IServiceProvider serviceProvider,
         LoadoutId loadoutId,
-        Optional<LoadoutItemGroupId> collectionGroupId = default,
+        Optional<CollectionGroupId> collectionGroupId = default,
         Optional<LoadoutPageSubTabs> selectedSubTab = default) : base(windowManager)
     {
         _serviceProvider = serviceProvider;
@@ -79,7 +79,7 @@ public class LoadoutViewModel : APageViewModel<ILoadoutViewModel>, ILoadoutViewM
         var loadoutFilter = new LoadoutFilter
         {
             LoadoutId = loadoutId,
-            CollectionGroupId = collectionGroupId,
+            CollectionGroupId = collectionGroupId.Convert(x => (LoadoutItemGroupId)x.Value),
         };
 
         Adapter = new LoadoutTreeDataGridAdapter(serviceProvider, loadoutFilter);
@@ -434,7 +434,7 @@ public class LoadoutViewModel : APageViewModel<ILoadoutViewModel>, ILoadoutViewM
             Context = new LoadoutPageContext
             {
                 LoadoutId = loadoutId,
-                GroupScope = collectionGroup.AsLoadoutItemGroup().LoadoutItemGroupId,
+                GroupScope = collectionGroup.CollectionGroupId,
             },
         };
 

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutViewModel.cs
@@ -30,7 +30,6 @@ using NexusMods.Networking.NexusWebApi;
 using ObservableCollections;
 using R3;
 using ReactiveUI;
-using ReactiveUI.Fody.Helpers;
 using ReactiveCommand = R3.ReactiveCommand;
 
 namespace NexusMods.App.UI.Pages.LoadoutPage;
@@ -49,9 +48,11 @@ public class LoadoutViewModel : APageViewModel<ILoadoutViewModel>, ILoadoutViewM
     public bool HasRulesSection { get; }
     public ISortingSelectionViewModel RulesSectionViewModel { get; }
 
-    [Reactive] public bool IsCollection { get; private set; }
-    [Reactive] public bool IsCollectionUploaded { get; private set; }
-    [Reactive] public string CollectionName { get; private set; }
+    public bool IsCollection { get; }
+    private BindableReactiveProperty<string> CollectionName { get; }
+    IReadOnlyBindableReactiveProperty<string> ILoadoutViewModel.CollectionName => CollectionName;
+    private BindableReactiveProperty<bool> IsCollectionUploaded { get; }
+    IReadOnlyBindableReactiveProperty<bool> ILoadoutViewModel.IsCollectionUploaded => IsCollectionUploaded;
 
     public ReactiveCommand<NavigationInformation> CommandOpenLibraryPage { get; }
     public ReactiveCommand<NavigationInformation> CommandOpenFilesPage { get; }
@@ -75,6 +76,9 @@ public class LoadoutViewModel : APageViewModel<ILoadoutViewModel>, ILoadoutViewM
         Optional<LoadoutPageSubTabs> selectedSubTab = default) : base(windowManager)
     {
         _serviceProvider = serviceProvider;
+        var libraryService = serviceProvider.GetRequiredService<ILibraryService>();
+        _connection = serviceProvider.GetRequiredService<IConnection>();
+        _nexusModsLibrary = serviceProvider.GetRequiredService<NexusModsLibrary>();
 
         var loadoutFilter = new LoadoutFilter
         {
@@ -84,18 +88,15 @@ public class LoadoutViewModel : APageViewModel<ILoadoutViewModel>, ILoadoutViewM
 
         Adapter = new LoadoutTreeDataGridAdapter(serviceProvider, loadoutFilter);
 
-        var libraryService = serviceProvider.GetRequiredService<ILibraryService>();
-        _connection = serviceProvider.GetRequiredService<IConnection>();
-        _nexusModsLibrary = serviceProvider.GetRequiredService<NexusModsLibrary>();
-
         if (collectionGroupId.HasValue)
         {
             var collectionGroup = LoadoutItem.Load(_connection.Db, collectionGroupId.Value);
-            CollectionName = collectionGroup.Name;
+            IsCollection = true;
             TabTitle = collectionGroup.Name;
             TabIcon = IconValues.CollectionsOutline;
-            IsCollection = true;
-            IsCollectionUploaded = CollectionCreator.IsCollectionUploaded(_connection, collectionGroupId.Value, out _);
+
+            CollectionName = new BindableReactiveProperty<string>(value: collectionGroup.Name);
+            IsCollectionUploaded = new BindableReactiveProperty<bool>(value: CollectionCreator.IsCollectionUploaded(_connection, collectionGroupId.Value, out _));
 
             // If there are no other collections in the loadout, this is the `My Mods` collection and `All` view is hidden,
             // so we show the `sorting views here` view here instead
@@ -109,23 +110,23 @@ public class LoadoutViewModel : APageViewModel<ILoadoutViewModel>, ILoadoutViewM
 
             CommandUploadRevision = new ReactiveCommand<Unit>(async (unit, cancellationToken) =>
             {
-                var shareDialog = IsCollectionUploaded ? LoadoutDialogs.UpdateCollection(CollectionName) : LoadoutDialogs.ShareCollection(CollectionName);
+                var shareDialog = IsCollectionUploaded.Value ? LoadoutDialogs.UpdateCollection(CollectionName.Value) : LoadoutDialogs.ShareCollection(CollectionName.Value);
                 var shareDialogResult = await windowManager.ShowDialog(shareDialog, DialogWindowType.Modal);
                 if (shareDialogResult.ButtonId != ButtonDefinitionId.From("share")) return;
 
                 var collection = await CollectionCreator.UploadDraftRevision(serviceProvider, collectionGroupId.Value, cancellationToken);
-                var successDialog = IsCollectionUploaded ? LoadoutDialogs.UpdateCollectionSuccess(CollectionName) : LoadoutDialogs.ShareCollectionSuccess(CollectionName);
+                var successDialog = IsCollectionUploaded.Value ? LoadoutDialogs.UpdateCollectionSuccess(CollectionName.Value) : LoadoutDialogs.ShareCollectionSuccess(CollectionName.Value);
 
                 var successDialogResult = await windowManager.ShowDialog(successDialog, DialogWindowType.Modal);
 
-                IsCollectionUploaded = CollectionCreator.IsCollectionUploaded(_connection, collectionGroupId.Value, out _);
+                IsCollectionUploaded.Value = CollectionCreator.IsCollectionUploaded(_connection, collectionGroupId.Value, out _);
                 if (successDialogResult.ButtonId != ButtonDefinitionId.From("view-page")) return;
 
                 var uri = GetCollectionUri(collection);
                 await serviceProvider.GetRequiredService<IOSInterop>().OpenUrl(uri, cancellationToken: cancellationToken);
             }, maxSequential: 1, configureAwait: false);
 
-            CommandOpenRevisionUrl = this.WhenAnyValue(vm => vm.IsCollectionUploaded).ToObservable().ToReactiveCommand<Unit>(async (_, cancellationToken) =>
+            CommandOpenRevisionUrl = IsCollectionUploaded.ToReactiveCommand<Unit>(async (_, cancellationToken) =>
             {
                 var managedCollectionLoadoutGroup = ManagedCollectionLoadoutGroup.Load(_connection.Db, collectionGroupId.Value);
                 if (!managedCollectionLoadoutGroup.IsValid()) return;
@@ -133,10 +134,10 @@ public class LoadoutViewModel : APageViewModel<ILoadoutViewModel>, ILoadoutViewM
                 var uri = GetCollectionUri(managedCollectionLoadoutGroup.Collection);
                 await serviceProvider.GetRequiredService<IOSInterop>().OpenUrl(uri, cancellationToken: cancellationToken);
             }, configureAwait: false);
-            
+
             CommandRenameGroup = new ReactiveCommand<Unit>(async (_, cancellationToken) =>
             {
-                var dialog = LoadoutDialogs.RenameCollection(CollectionName);
+                var dialog = LoadoutDialogs.RenameCollection(CollectionName.Value);
                 var result = await windowManager.ShowDialog(dialog, DialogWindowType.Modal);
                 if (result.ButtonId != ButtonDefinitionId.From("rename")) return;
 
@@ -152,13 +153,15 @@ public class LoadoutViewModel : APageViewModel<ILoadoutViewModel>, ILoadoutViewM
                 tx.Add(collectionGroupId.Value, LoadoutItem.Name, newName);
                 await tx.Commit();
 
-                CollectionName = newName;
-                TabTitle = CollectionName;
+                CollectionName.Value = newName;
+                TabTitle = newName;
             });
         }
         else
         {
-            CollectionName = string.Empty;
+            CollectionName = new BindableReactiveProperty<string>(value: string.Empty);
+            IsCollectionUploaded = new BindableReactiveProperty<bool>(value: false);
+
             TabTitle = Language.LoadoutViewPageTitle;
             TabIcon = IconValues.FormatAlignJustify;
             RulesSectionViewModel = new SortingSelectionViewModel(serviceProvider, windowManager, loadoutId, Optional<Observable<bool>>.None);
@@ -338,8 +341,7 @@ public class LoadoutViewModel : APageViewModel<ILoadoutViewModel>, ILoadoutViewM
 
             if (collectionGroupId.HasValue)
             {
-                this.WhenAnyValue(x => x.IsCollectionUploaded)
-                    .ToObservable()
+                IsCollectionUploaded
                     .Where(isUploaded => isUploaded)
                     .ObserveOnThreadPool()
                     .Select((_connection, collectionGroupId.Value), static (_, state) => ManagedCollectionLoadoutGroup.Load(state._connection.Db, state.Value))

--- a/src/NexusMods.App.UI/Pages/MyLoadouts/GameLoadoutsSectionEntry/GameLoadoutsSectionEntryViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/MyLoadouts/GameLoadoutsSectionEntry/GameLoadoutsSectionEntryViewModel.cs
@@ -110,7 +110,7 @@ public class GameLoadoutsSectionEntryViewModel : AViewModel<IGameLoadoutsSection
                         Context = new LoadoutPageContext
                         {
                             LoadoutId = loadoutId,
-                            GroupScope = Optional<LoadoutItemGroupId>.None,
+                            GroupScope = Optional<CollectionGroupId>.None,
                         },
                     },
                     () => new LoadoutContext

--- a/src/NexusMods.App.UI/Pages/Sorting/SortingSelection/SortingSelectionViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/Sorting/SortingSelection/SortingSelectionViewModel.cs
@@ -48,7 +48,7 @@ public class SortingSelectionViewModel : AViewModel<ISortingSelectionViewModel>,
                     Context = new LoadoutPageContext()
                     {
                         LoadoutId = loadoutId,
-                        GroupScope = Optional<LoadoutItemGroupId>.None,
+                        GroupScope = Optional<CollectionGroupId>.None,
                         SelectedSubTab = LoadoutPageSubTabs.Rules,
                     },
                 };

--- a/src/NexusMods.Collections/CollectionCreator.cs
+++ b/src/NexusMods.Collections/CollectionCreator.cs
@@ -127,12 +127,14 @@ public static class CollectionCreator
         if (group.TryGetAsManagedCollectionLoadoutGroup(out var managedCollectionLoadoutGroup))
         {
             collection = managedCollectionLoadoutGroup.Collection;
-            await nexusModsLibrary.UploadDraftRevision(collection, streamFactory, collectionManifest, cancellationToken);
+            var revisionNumber = await nexusModsLibrary.UploadDraftRevision(collection, streamFactory, collectionManifest, cancellationToken);
+            tx.Add(groupId, ManagedCollectionLoadoutGroup.CurrentRevisionNumber, revisionNumber);
         }
         else
         {
             collection = await nexusModsLibrary.CreateCollection(streamFactory, collectionManifest, cancellationToken);
             tx.Add(groupId, ManagedCollectionLoadoutGroup.Collection, collection);
+            tx.Add(groupId, ManagedCollectionLoadoutGroup.CurrentRevisionNumber, RevisionNumber.From(1));
         }
 
         await tx.Commit();

--- a/src/NexusMods.Collections/CollectionCreator.cs
+++ b/src/NexusMods.Collections/CollectionCreator.cs
@@ -6,7 +6,6 @@ using DynamicData.Kernel;
 using Microsoft.Extensions.DependencyInjection;
 using NexusMods.Abstractions.Collections;
 using NexusMods.Abstractions.Collections.Json;
-using NexusMods.Abstractions.Library;
 using NexusMods.Abstractions.Library.Models;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.NexusModsLibrary;
@@ -31,7 +30,7 @@ public static class CollectionCreator
     // TODO: remove for GA
     public static bool IsFeatureEnabled => ApplicationConstants.IsDebug;
     
-    public static bool IsCollectionUploaded(IConnection connection, LoadoutItemGroupId groupId, out CollectionMetadata.ReadOnly collection)
+    public static bool IsCollectionUploaded(IConnection connection, CollectionGroupId groupId, out CollectionMetadata.ReadOnly collection)
     {
         var group = ManagedCollectionLoadoutGroup.Load(connection.Db, groupId);
         if (!group.IsValid())
@@ -93,7 +92,7 @@ public static class CollectionCreator
 
     public static async ValueTask<CollectionMetadata.ReadOnly> UploadDraftRevision(
         IServiceProvider serviceProvider,
-        LoadoutItemGroupId groupId,
+        CollectionGroupId groupId,
         CancellationToken cancellationToken)
     {
         var connection = serviceProvider.GetRequiredService<IConnection>();

--- a/src/NexusMods.Networking.NexusWebApi/GraphQL/CollectionRevisionNumbers.graphql
+++ b/src/NexusMods.Networking.NexusWebApi/GraphQL/CollectionRevisionNumbers.graphql
@@ -7,7 +7,8 @@ query CollectionRevisionNumbers($slug: String!, $domainName: String!, $viewAdult
 
         revisions {
             id,
-            revisionNumber
+            revisionNumber,
+            ...CollectionRevisionStatusFragment
         }
     }
 }

--- a/src/NexusMods.Networking.NexusWebApi/GraphQL/CommonFragments.graphql
+++ b/src/NexusMods.Networking.NexusWebApi/GraphQL/CommonFragments.graphql
@@ -28,6 +28,11 @@ fragment ModFragment on Mod {
     uid
 }
 
+fragment CollectionRevisionStatusFragment on CollectionRevision {
+    status,
+    revisionStatus
+}
+
 fragment CollectionRevisionFragment on CollectionRevision {
     id
     assetsSizeBytes
@@ -37,8 +42,7 @@ fragment CollectionRevisionFragment on CollectionRevision {
     overallRating
     overallRatingCount
     modCount
-    status
-    revisionStatus
+    ...CollectionRevisionStatusFragment
 
     modFiles {
         id,

--- a/tests/NexusMods.DataModel.SchemaVersions.Tests/Schema.verified.md
+++ b/tests/NexusMods.DataModel.SchemaVersions.Tests/Schema.verified.md
@@ -3,8 +3,8 @@ This schema is written to a markdown file for both documentation and validation 
 models in the app, then validate the tests to update this file. 
 
 ## Statistics
-   - Fingerprint: 0xD7B048D3EFE21816
-   - Total attributes: 219
+   - Fingerprint: 0x2F39E452AF165FA1
+   - Total attributes: 221
    - Total namespaces: 73
    
 ## Attributes
@@ -118,6 +118,8 @@ models in the app, then validate the tests to update this file.
 | NexusMods.Loadouts.SortableEntry/ParentSortOrder                                   | Reference               | True    | False | False     | 
 | NexusMods.Loadouts.SortableEntry/SortIndex                                         | Int32                   | False   | False | False     | 
 | NexusMods.ManagedCollectionLoadoutGroup/Collection                                 | Reference               | True    | False | False     | 
+| NexusMods.ManagedCollectionLoadoutGroup/CurrentRevisionNumber                      | UInt64                  | False   | False | False     | 
+| NexusMods.ManagedCollectionLoadoutGroup/LastPublishedRevisionNumber                | UInt64                  | False   | False | False     | 
 | NexusMods.MnemonicDB.DatomStore/Cardinality                                        | UInt8                   | False   | False | False     | 
 | NexusMods.MnemonicDB.DatomStore/Documentation                                      | Utf8                    | False   | False | False     | 
 | NexusMods.MnemonicDB.DatomStore/Indexed                                            | UInt8                   | False   | False | False     | 


### PR DESCRIPTION
Requires #3502, part of #3493.

Cleans up `ILoadoutViewModel` to move to R3 bindings instead of ReactiveUI.

Fetches the current collection status from Nexus Mods on page loads and exposes the data in the VM. UI updates to follow soon :tm:.