### PR TITLE
Improved: Hiding of Updates when No Updates Are Available

### DIFF
--- a/src/NexusMods.App.UI/Pages/ILibraryDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/ILibraryDataProvider.cs
@@ -136,13 +136,14 @@ public static class LibraryDataProviderHelper
 
     public static void AddHideUpdatesActionComponent(
         CompositeItemModel<EntityId> itemModel,
-        bool isEnabled = true)
+        bool isEnabled = true,
+        bool isVisible = true)
     {
         // Default the observables to simple static values for now
         var isHiddenObservable = R3.Observable.Return(false);
         var itemCountObservable = R3.Observable.Return(1);
         
-        itemModel.Add(LibraryColumns.Actions.HideUpdatesComponentKey, new LibraryComponents.HideUpdatesAction(isHiddenObservable, itemCountObservable, Observable.Return(isEnabled)));
+        itemModel.Add(LibraryColumns.Actions.HideUpdatesComponentKey, new LibraryComponents.HideUpdatesAction(isHiddenObservable, itemCountObservable, Observable.Return(isEnabled), Observable.Return(isVisible)));
     }
 
     public static void AddHideUpdatesActionComponent(
@@ -182,7 +183,9 @@ public static class LibraryDataProviderHelper
             .Select(optional => optional.HasValue)
             .ToObservable();
 
-        itemModel.Add(LibraryColumns.Actions.HideUpdatesComponentKey, new LibraryComponents.HideUpdatesAction(isHiddenObservable, itemCountObservable, isEnabledObservable));
+        var isVisibleObservable = Observable.Return(true);
+
+        itemModel.Add(LibraryColumns.Actions.HideUpdatesComponentKey, new LibraryComponents.HideUpdatesAction(isHiddenObservable, itemCountObservable, isEnabledObservable, isVisibleObservable));
     }
 
     private record struct FileUpdateDetails(int NumUpdatesHidden, int NumUpdatesShown);
@@ -242,6 +245,7 @@ public static class LibraryDataProviderHelper
             .Select(optional => optional.HasValue && optional.Value.HasAnyUpdates)
             .ToObservable();
         
-        itemModel.Add(LibraryColumns.Actions.HideUpdatesComponentKey, new LibraryComponents.HideUpdatesAction(isHiddenObservable, itemCountObservable, isEnabledObservable));
+        var isVisibleObservable = Observable.Return(true);
+        itemModel.Add(LibraryColumns.Actions.HideUpdatesComponentKey, new LibraryComponents.HideUpdatesAction(isHiddenObservable, itemCountObservable, isEnabledObservable, isVisibleObservable));
     }
 }

--- a/src/NexusMods.App.UI/Pages/ILibraryDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/ILibraryDataProvider.cs
@@ -149,7 +149,8 @@ public static class LibraryDataProviderHelper
     public static void AddHideUpdatesActionComponent(
         CompositeItemModel<EntityId> itemModel,
         IObservable<Optional<ModUpdateOnPage>> unfilteredFileUpdateObservable,
-        IModUpdateFilterService filterService)
+        IModUpdateFilterService filterService,
+        Observable<bool> isVisibleObservable)
     {
         // Note(sewer):
         // Determine if the current file is hidden by checking if any of the newer
@@ -183,8 +184,6 @@ public static class LibraryDataProviderHelper
             .Select(optional => optional.HasValue)
             .ToObservable();
 
-        var isVisibleObservable = Observable.Return(true);
-
         itemModel.Add(LibraryColumns.Actions.HideUpdatesComponentKey, new LibraryComponents.HideUpdatesAction(isHiddenObservable, itemCountObservable, isEnabledObservable, isVisibleObservable));
     }
 
@@ -192,7 +191,8 @@ public static class LibraryDataProviderHelper
     public static void AddHideUpdatesActionComponent(
         CompositeItemModel<EntityId> itemModel,
         IObservable<Optional<ModUpdatesOnModPage>> unfilteredUpdatedOnModPage,
-        IModUpdateFilterService modUpdateFilterService)
+        IModUpdateFilterService modUpdateFilterService,
+        Observable<bool> isVisibleObservable)
     {
         // Note(sewer):
         //
@@ -245,7 +245,6 @@ public static class LibraryDataProviderHelper
             .Select(optional => optional.HasValue && optional.Value.HasAnyUpdates)
             .ToObservable();
         
-        var isVisibleObservable = Observable.Return(true);
         itemModel.Add(LibraryColumns.Actions.HideUpdatesComponentKey, new LibraryComponents.HideUpdatesAction(isHiddenObservable, itemCountObservable, isEnabledObservable, isVisibleObservable));
     }
 }

--- a/src/NexusMods.App.UI/Pages/LibraryPage/LibraryComponents.cs
+++ b/src/NexusMods.App.UI/Pages/LibraryPage/LibraryComponents.cs
@@ -436,6 +436,7 @@ public static class LibraryComponents
         public ReactiveCommand<Unit> CommandHideUpdates { get; } = new();
         public BindableReactiveProperty<bool> IsEnabled { get; }
         public BindableReactiveProperty<bool> IsHidden { get; }
+        public BindableReactiveProperty<bool> IsVisible { get; }
         public BindableReactiveProperty<string> ButtonText { get; }
         public BindableReactiveProperty<IconValue> Icon { get; }
 
@@ -445,10 +446,11 @@ public static class LibraryComponents
             return 0; // All hide updates actions are considered equal for sorting
         }
 
-        public HideUpdatesAction(Observable<bool> isHiddenObservable, Observable<int> itemCount, Observable<bool> isEnabled)
+        public HideUpdatesAction(Observable<bool> isHiddenObservable, Observable<int> itemCount, Observable<bool> isEnabled, Observable<bool> isVisible)
         {
             IsHidden = isHiddenObservable.ToBindableReactiveProperty();
             IsEnabled = isEnabled.ToBindableReactiveProperty();
+            IsVisible = isVisible.ToBindableReactiveProperty();
             
             // Button text changes based on hidden state and item count
             // We use BindableReactiveProperty on ButtonText field as UI elements bind to this.
@@ -469,7 +471,7 @@ public static class LibraryComponents
             if (!_isDisposed)
             {
                 if (disposing)
-                    Disposable.Dispose(CommandHideUpdates, IsEnabled, IsHidden, ButtonText, Icon);
+                    Disposable.Dispose(CommandHideUpdates, IsEnabled, IsHidden, IsVisible, ButtonText, Icon);
 
                 _isDisposed = true;
             }

--- a/src/NexusMods.App.UI/Pages/LibraryPage/TreeDataGridLibraryResources.axaml
+++ b/src/NexusMods.App.UI/Pages/LibraryPage/TreeDataGridLibraryResources.axaml
@@ -173,7 +173,8 @@
                                         <DataTemplate DataType="{x:Type local:LibraryComponents+HideUpdatesAction}">
                                             <MenuItem Header="{CompiledBinding ButtonText.Value}"
                                                       Command="{CompiledBinding CommandHideUpdates}"
-                                                      IsEnabled="{CompiledBinding IsEnabled.Value}">
+                                                      IsEnabled="{CompiledBinding IsEnabled.Value}"
+                                                      IsVisible="{CompiledBinding IsVisible.Value}">
                                                 <MenuItem.Icon>
                                                     <icons:UnifiedIcon Value="{CompiledBinding Icon.Value}" />
                                                 </MenuItem.Icon>

--- a/src/NexusMods.App.UI/Pages/LocalFileDataProvider.cs
+++ b/src/NexusMods.App.UI/Pages/LocalFileDataProvider.cs
@@ -89,7 +89,7 @@ internal class LocalFileDataProvider : ILibraryDataProvider, ILoadoutDataProvide
         LibraryDataProviderHelper.AddInstallActionComponent(itemModel, localFile.AsLibraryFile().AsLibraryItem(), linkedLoadoutItemsObservable);
         LibraryDataProviderHelper.AddViewChangelogActionComponent(itemModel, isEnabled: false);
         LibraryDataProviderHelper.AddViewModPageActionComponent(itemModel, isEnabled: false);
-        LibraryDataProviderHelper.AddHideUpdatesActionComponent(itemModel, isEnabled: false);
+        LibraryDataProviderHelper.AddHideUpdatesActionComponent(itemModel, isEnabled: false, isVisible: false);
     }
 
     private IObservable<IChangeSet<LocalFile.ReadOnly, EntityId>> FilterLoadoutItems(LoadoutFilter loadoutFilter)


### PR DESCRIPTION
This addresses:
- #3494

- Local Files: Always have the `Hide Update` button hidden.
- Nexus Files: The `Hide Update` button is hidden if the latest update is already in the library.