### PR TITLE
Add strongly typed GraphQl errors

### DIFF
--- a/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/CollectionDownload/CollectionDownloadViewModel.cs
@@ -359,8 +359,10 @@ public sealed class CollectionDownloadViewModel : APageViewModel<ICollectionDown
                 .ObserveOnThreadPool()
                 .SelectAwait((revision, cancellationToken) => nexusModsLibrary.GetLastPublishedRevisionNumber(revision.Collection, cancellationToken))
                 .ObserveOnUIThreadDispatcher()
-                .Subscribe(this, static (lastPublishedRevisionNumber, self) =>
+                .Subscribe(this, static (graphQlResult, self) =>
                 {
+                    // TODO: handle errors
+                    var lastPublishedRevisionNumber = graphQlResult.AssertHasData();
                     if (!lastPublishedRevisionNumber.HasValue)
                     {
                         self.IsUpdateAvailable.Value = false;

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutViewModel.cs
@@ -499,7 +499,10 @@ public class LoadoutViewModel : APageViewModel<ILoadoutViewModel>, ILoadoutViewM
 
     private async ValueTask UpdateCollectionInfo(ManagedCollectionLoadoutGroup.ReadOnly managedCollectionLoadoutGroup, CancellationToken cancellationToken)
     {
-        var lastPublishedRevisionNumber = await _nexusModsLibrary.GetLastPublishedRevisionNumber(managedCollectionLoadoutGroup.Collection, cancellationToken);
+        var graphQlResult = await _nexusModsLibrary.GetLastPublishedRevisionNumber(managedCollectionLoadoutGroup.Collection, cancellationToken);
+
+        // TODO: handle errors
+        var lastPublishedRevisionNumber = graphQlResult.AssertHasData();
 
         using var tx = _connection.BeginTransaction();
         if (lastPublishedRevisionNumber.HasValue)

--- a/src/NexusMods.Networking.NexusWebApi/Errors/CollectionDiscarded.cs
+++ b/src/NexusMods.Networking.NexusWebApi/Errors/CollectionDiscarded.cs
@@ -1,0 +1,44 @@
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using JetBrains.Annotations;
+using StrawberryShake;
+
+namespace NexusMods.Networking.NexusWebApi.Errors;
+
+/// <summary>
+/// Error returned when the queried collection was discarded.
+/// </summary>
+[PublicAPI]
+public record CollectionDiscarded : IGraphQlError<CollectionDiscarded>
+{
+    /// <inheritdoc/>
+    public required string Message { get; init; }
+
+    /// <summary>
+    /// Gets the name of the collection that was queried.
+    /// </summary>
+    public string? CollectionName { get; private set; }
+
+    /// <inheritdoc/>
+    public static ErrorCode Code { get; } = ErrorCode.From("COLLECTION_DISCARDED");
+
+    /// <inheritdoc/>
+    public static bool TryParse(IClientError clientError, [NotNullWhen(true)] out CollectionDiscarded? error)
+    {
+        Debug.Assert(Code.Equals(clientError.Code));
+        error = new CollectionDiscarded
+        {
+            Message = clientError.Message,
+        };
+
+        var extensions = clientError.Extensions;
+        if (extensions is null) return true;
+
+        if (extensions.TryGetValue("title", out var oTitle) && oTitle is string title)
+        {
+            error.CollectionName = title;
+        }
+
+        return true;
+    }
+}

--- a/src/NexusMods.Networking.NexusWebApi/Errors/CollectionRevisionDiscarded.cs
+++ b/src/NexusMods.Networking.NexusWebApi/Errors/CollectionRevisionDiscarded.cs
@@ -1,0 +1,40 @@
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using JetBrains.Annotations;
+using StrawberryShake;
+
+namespace NexusMods.Networking.NexusWebApi.Errors;
+
+/// <summary>
+/// Error returned when the queried collection revision was discarded.
+/// </summary>
+[PublicAPI]
+public record CollectionRevisionDiscarded : IGraphQlError<CollectionRevisionDiscarded>
+{
+    /// <inheritdoc/>
+    public required string Message { get; init; }
+
+    /// <inheritdoc/>
+    public static ErrorCode Code { get; } = ErrorCode.From("COLLECTION_REVISION_DISCARDED");
+
+    /// <inheritdoc/>
+    public static bool TryParse(IClientError clientError, [NotNullWhen(true)] out CollectionRevisionDiscarded? error)
+    {
+        Debug.Assert(Code.Equals(clientError.Code));
+        error = new CollectionRevisionDiscarded
+        {
+            Message = clientError.Message,
+        };
+
+        var extensions = clientError.Extensions;
+        if (extensions is null) return true;
+
+        if (extensions.TryGetValue("revision_number", out var oRevisionNumber))
+        {
+            // TODO: figure out the type
+            Debugger.Break();
+        }
+
+        return true;
+    }
+}

--- a/src/NexusMods.Networking.NexusWebApi/Errors/ErrorCode.cs
+++ b/src/NexusMods.Networking.NexusWebApi/Errors/ErrorCode.cs
@@ -1,0 +1,13 @@
+using TransparentValueObjects;
+
+namespace NexusMods.Networking.NexusWebApi.Errors;
+
+/// <summary>
+/// Represents an error code.
+/// </summary>
+[ValueObject<string>]
+public readonly partial struct ErrorCode : IAugmentWith<DefaultEqualityComparerAugment>
+{
+    /// <inheritdoc/>
+    public static IEqualityComparer<string> InnerValueDefaultEqualityComparer { get; } = StringComparer.OrdinalIgnoreCase;
+}

--- a/src/NexusMods.Networking.NexusWebApi/Errors/GraphQlResult.cs
+++ b/src/NexusMods.Networking.NexusWebApi/Errors/GraphQlResult.cs
@@ -57,7 +57,8 @@ public class GraphQlResult<TData> : IGraphQlResult<TData>
     /// <inheritdoc/>
     public TData AssertHasData()
     {
-        if (!HasData) throw new InvalidOperationException();
+        Debug.Assert(HasData, "Result should have data when this method is called, use TryGetData instead if you can't guarantee it");
+        if (!HasData) throw new InvalidOperationException($"Expected the result to contain data but it has {Errors.Count} errors instead");
         return _data.Value;
     }
 

--- a/src/NexusMods.Networking.NexusWebApi/Errors/GraphQlResult.cs
+++ b/src/NexusMods.Networking.NexusWebApi/Errors/GraphQlResult.cs
@@ -192,7 +192,11 @@ public static class GraphQlResult
     /// <summary>
     /// Tries to extract all errors.
     /// </summary>
-    public static bool TryExtractErrors<TData, TError1>(IOperationResult operationResult, [NotNullWhen(true)] out GraphQlResult<TData, TError1>? result)
+    public static bool TryExtractErrors<TOperationData, TData, TError1>(
+        this IOperationResult<TOperationData> operationResult,
+        [NotNullWhen(true)] out GraphQlResult<TData, TError1>? result,
+        [NotNullWhen(false)] out TOperationData? operationData)
+        where TOperationData : class
         where TData : notnull
         where TError1 : IGraphQlError<TError1>
     {
@@ -200,9 +204,11 @@ public static class GraphQlResult
         if (errors.Count == 0)
         {
             result = null;
+            operationData = AssertOperationData(operationResult);
             return false;
         }
 
+        operationData = null;
         if (errors.Count == 1)
         {
             var error = errors[0];
@@ -237,7 +243,11 @@ public static class GraphQlResult
     /// <summary>
     /// Tries to extract all errors.
     /// </summary>
-    public static bool TryExtractErrors<TData, TError1, TError2>(IOperationResult operationResult, [NotNullWhen(true)] out GraphQlResult<TData, TError1, TError2>? result)
+    public static bool TryExtractErrors<TOperationData, TData, TError1, TError2>(
+        this IOperationResult<TOperationData> operationResult,
+        [NotNullWhen(true)] out GraphQlResult<TData, TError1, TError2>? result,
+        [NotNullWhen(false)] out TOperationData? operationData)
+        where TOperationData : class
         where TData : notnull
         where TError1 : IGraphQlError<TError1>
         where TError2 : IGraphQlError<TError2>
@@ -246,9 +256,11 @@ public static class GraphQlResult
         if (errors.Count == 0)
         {
             result = null;
+            operationData = AssertOperationData(operationResult);
             return false;
         }
 
+        operationData = null;
         if (errors.Count == 1)
         {
             var error = errors[0];
@@ -293,7 +305,11 @@ public static class GraphQlResult
     /// <summary>
     /// Tries to extract all errors.
     /// </summary>
-    public static bool TryExtractErrors<TData, TError1, TError2, TError3>(IOperationResult operationResult, [NotNullWhen(true)] out GraphQlResult<TData, TError1, TError2, TError3>? result)
+    public static bool TryExtractErrors<TOperationData, TData, TError1, TError2, TError3>(
+        this IOperationResult<TOperationData> operationResult,
+        [NotNullWhen(true)] out GraphQlResult<TData, TError1, TError2, TError3>? result,
+        [NotNullWhen(false)] out TOperationData? operationData)
+        where TOperationData : class
         where TData : notnull
         where TError1 : IGraphQlError<TError1>
         where TError2 : IGraphQlError<TError2>
@@ -303,9 +319,11 @@ public static class GraphQlResult
         if (errors.Count == 0)
         {
             result = null;
+            operationData = AssertOperationData(operationResult);
             return false;
         }
 
+        operationData = null;
         if (errors.Count == 1)
         {
             var error = errors[0];
@@ -355,6 +373,14 @@ public static class GraphQlResult
 
         result = new GraphQlResult<TData, TError1, TError2, TError3>(parsedErrors);
         return true;
+    }
+
+    private static TOperationData AssertOperationData<TOperationData>(IOperationResult<TOperationData> operationResult)
+        where TOperationData : class
+    {
+        var operationData = operationResult.Data;
+        if (operationData is null) throw new InvalidOperationException("Expected result to contain data but found null");
+        return operationData;
     }
 
     [DoesNotReturn]

--- a/src/NexusMods.Networking.NexusWebApi/Errors/GraphQlResult.cs
+++ b/src/NexusMods.Networking.NexusWebApi/Errors/GraphQlResult.cs
@@ -1,0 +1,346 @@
+using System.Collections.Frozen;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using DynamicData.Kernel;
+using JetBrains.Annotations;
+using NexusMods.Sdk.Collections;
+using StrawberryShake;
+
+namespace NexusMods.Networking.NexusWebApi.Errors;
+
+file static class Helper
+{
+    internal static readonly IReadOnlyDictionary<ErrorCode, IGraphQlError> NoErrors = FrozenDictionary<ErrorCode, IGraphQlError>.Empty;
+
+    internal static IReadOnlyDictionary<ErrorCode, IGraphQlError> ToErrors<TError>(TError error)
+        where TError : IGraphQlError<TError>
+    {
+        return new SingleValueDictionary<ErrorCode, IGraphQlError>(new KeyValuePair<ErrorCode, IGraphQlError>(TError.Code, error));
+    }
+}
+
+/// <summary>
+/// Represents a GraphQl result.
+/// </summary>
+[PublicAPI]
+public class GraphQlResult<TData> : IGraphQlResult<TData>
+    where TData : notnull
+{
+    private readonly Optional<TData> _data;
+
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<ErrorCode, IGraphQlError> Errors { get; }
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    public GraphQlResult(TData data)
+    {
+        _data = data;
+        Errors = Helper.NoErrors;
+    }
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    public GraphQlResult(IReadOnlyDictionary<ErrorCode, IGraphQlError> errors)
+    {
+        _data = Optional<TData>.None;
+        Errors = errors;
+    }
+
+    /// <inheritdoc/>
+    public bool HasData => _data.HasValue;
+
+    /// <inheritdoc/>
+    public bool HasErrors => Errors.Count > 0;
+
+    /// <inheritdoc/>
+    public TData AssertHasData()
+    {
+        if (!HasData) throw new InvalidOperationException();
+        return _data.Value;
+    }
+
+    /// <inheritdoc/>
+    public bool TryGetData([NotNullWhen(true)] out TData? data)
+    {
+        if (!_data.HasValue)
+        {
+            data = default(TData);
+            return false;
+        }
+
+        data = _data.Value;
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public override string ToString() => $"HasData = {HasData} ({_data}) ErrorsCount = {Errors.Count}";
+}
+
+/// <inheritdoc cref="GraphQlResult{TData}"/>
+[PublicAPI]
+public class GraphQlResult<TData, TError1> : GraphQlResult<TData>, IGraphQlResult<TData, TError1>
+    where TData : notnull
+    where TError1 : IGraphQlError<TError1>
+{
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    public GraphQlResult(TData data) : base(data) { }
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    public GraphQlResult(IReadOnlyDictionary<ErrorCode, IGraphQlError> errors) : base(errors) { }
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    public GraphQlResult(TError1 error) : base(Helper.ToErrors(error)) { }
+}
+
+/// <inheritdoc cref="GraphQlResult{TData}"/>
+[PublicAPI]
+public class GraphQlResult<TData, TError1, TError2> : GraphQlResult<TData>, IGraphQlResult<TData, TError1, TError2>
+    where TData : notnull
+    where TError1 : IGraphQlError<TError1>
+    where TError2 : IGraphQlError<TError2>
+{
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    public GraphQlResult(TData data) : base(data) { }
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    public GraphQlResult(IReadOnlyDictionary<ErrorCode, IGraphQlError> errors) : base(errors) { }
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    public GraphQlResult(TError1 error) : base(Helper.ToErrors(error)) { }
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    public GraphQlResult(TError2 error) : base(Helper.ToErrors(error)) { }
+}
+
+/// <inheritdoc cref="GraphQlResult{TData}"/>
+[PublicAPI]
+public class GraphQlResult<TData, TError1, TError2, TError3> : GraphQlResult<TData>, IGraphQlResult<TData, TError1, TError2, TError3>
+    where TData : notnull
+    where TError1 : IGraphQlError<TError1>
+    where TError2 : IGraphQlError<TError2>
+    where TError3 : IGraphQlError<TError3>
+{
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    public GraphQlResult(TData data) : base(data) { }
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    public GraphQlResult(IReadOnlyDictionary<ErrorCode, IGraphQlError> errors) : base(errors) { }
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    public GraphQlResult(TError1 error) : base(Helper.ToErrors(error)) { }
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    public GraphQlResult(TError2 error) : base(Helper.ToErrors(error)) { }
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    public GraphQlResult(TError3 error) : base(Helper.ToErrors(error)) { }
+}
+
+/// <summary>
+/// Static methods
+/// </summary>
+[PublicAPI]
+public static class GraphQlResult
+{
+    /// <summary>
+    /// Tries to extract all errors.
+    /// </summary>
+    public static bool TryExtractErrors<TData, TError1>(IOperationResult operationResult, [NotNullWhen(true)] out GraphQlResult<TData, TError1>? result)
+        where TData : notnull
+        where TError1 : IGraphQlError<TError1>
+    {
+        var errors = operationResult.Errors;
+        if (errors.Count == 0)
+        {
+            result = null;
+            return false;
+        }
+
+        if (errors.Count == 1)
+        {
+            var error = errors[0];
+
+            if (TError1.Matches(error) && TError1.TryParse(error, out var error1))
+            {
+                result = new GraphQlResult<TData, TError1>(error1);
+                return true;
+            }
+
+            ThrowUnsupported(error);
+        }
+
+        var parsedErrors = new Dictionary<ErrorCode, IGraphQlError>();
+
+        foreach (var error in errors)
+        {
+            if (TError1.Matches(error) && TError1.TryParse(error, out var error1))
+            {
+                parsedErrors[TError1.Code] = error1;
+            }
+            else
+            {
+                ThrowUnsupported(error);
+            }
+        }
+
+        result = new GraphQlResult<TData, TError1>(parsedErrors);
+        return true;
+    }
+
+    /// <summary>
+    /// Tries to extract all errors.
+    /// </summary>
+    public static bool TryExtractErrors<TData, TError1, TError2>(IOperationResult operationResult, [NotNullWhen(true)] out GraphQlResult<TData, TError1, TError2>? result)
+        where TData : notnull
+        where TError1 : IGraphQlError<TError1>
+        where TError2 : IGraphQlError<TError2>
+    {
+        var errors = operationResult.Errors;
+        if (errors.Count == 0)
+        {
+            result = null;
+            return false;
+        }
+
+        if (errors.Count == 1)
+        {
+            var error = errors[0];
+
+            if (TError1.Matches(error) && TError1.TryParse(error, out var error1))
+            {
+                result = new GraphQlResult<TData, TError1, TError2>(error1);
+                return true;
+            }
+
+            if (TError2.Matches(error) && TError2.TryParse(error, out var error2))
+            {
+                result = new GraphQlResult<TData, TError1, TError2>(error2);
+                return true;
+            }
+
+            ThrowUnsupported(error);
+        }
+
+        var parsedErrors = new Dictionary<ErrorCode, IGraphQlError>();
+
+        foreach (var error in errors)
+        {
+            if (TError1.Matches(error) && TError1.TryParse(error, out var error1))
+            {
+                parsedErrors[TError1.Code] = error1;
+            }
+            else if (TError2.Matches(error) && TError2.TryParse(error, out var error2))
+            {
+                parsedErrors[TError2.Code] = error2;
+            }
+            else
+            {
+                ThrowUnsupported(error);
+            }
+        }
+
+        result = new GraphQlResult<TData, TError1, TError2>(parsedErrors);
+        return true;
+    }
+
+    /// <summary>
+    /// Tries to extract all errors.
+    /// </summary>
+    public static bool TryExtractErrors<TData, TError1, TError2, TError3>(IOperationResult operationResult, [NotNullWhen(true)] out GraphQlResult<TData, TError1, TError2, TError3>? result)
+        where TData : notnull
+        where TError1 : IGraphQlError<TError1>
+        where TError2 : IGraphQlError<TError2>
+        where TError3 : IGraphQlError<TError3>
+    {
+        var errors = operationResult.Errors;
+        if (errors.Count == 0)
+        {
+            result = null;
+            return false;
+        }
+
+        if (errors.Count == 1)
+        {
+            var error = errors[0];
+
+            if (TError1.Matches(error) && TError1.TryParse(error, out var error1))
+            {
+                result = new GraphQlResult<TData, TError1, TError2, TError3>(error1);
+                return true;
+            }
+
+            if (TError2.Matches(error) && TError2.TryParse(error, out var error2))
+            {
+                result = new GraphQlResult<TData, TError1, TError2, TError3>(error2);
+                return true;
+            }
+
+            if (TError3.Matches(error) && TError3.TryParse(error, out var error3))
+            {
+                result = new GraphQlResult<TData, TError1, TError2, TError3>(error3);
+                return true;
+            }
+
+            ThrowUnsupported(error);
+        }
+
+        var parsedErrors = new Dictionary<ErrorCode, IGraphQlError>();
+
+        foreach (var error in errors)
+        {
+            if (TError1.Matches(error) && TError1.TryParse(error, out var error1))
+            {
+                parsedErrors[TError1.Code] = error1;
+            }
+            else if (TError2.Matches(error) && TError2.TryParse(error, out var error2))
+            {
+                parsedErrors[TError2.Code] = error2;
+            }
+            else if (TError3.Matches(error) && TError3.TryParse(error, out var error3))
+            {
+                parsedErrors[TError3.Code] = error3;
+            }
+            else
+            {
+                ThrowUnsupported(error);
+            }
+        }
+
+        result = new GraphQlResult<TData, TError1, TError2, TError3>(parsedErrors);
+        return true;
+    }
+
+    [DoesNotReturn]
+    private static void ThrowUnsupported(IClientError error)
+    {
+        Debugger.Break();
+        throw new NotSupportedException($"Unknown error: `{error.Message}` Code={error.Code} Exception={error.Exception}");
+    }
+}

--- a/src/NexusMods.Networking.NexusWebApi/Errors/GraphQlResult.cs
+++ b/src/NexusMods.Networking.NexusWebApi/Errors/GraphQlResult.cs
@@ -77,6 +77,11 @@ public class GraphQlResult<TData> : IGraphQlResult<TData>
 
     /// <inheritdoc/>
     public override string ToString() => $"HasData = {HasData} ({_data}) ErrorsCount = {Errors.Count}";
+
+    /// <summary>
+    /// Implicit conversion.
+    /// </summary>
+    public static implicit operator GraphQlResult<TData>(TData data) => new(data);
 }
 
 /// <inheritdoc cref="GraphQlResult{TData}"/>
@@ -99,6 +104,11 @@ public class GraphQlResult<TData, TError1> : GraphQlResult<TData>, IGraphQlResul
     /// Constructor.
     /// </summary>
     public GraphQlResult(TError1 error) : base(Helper.ToErrors(error)) { }
+
+    /// <summary>
+    /// Implicit conversion.
+    /// </summary>
+    public static implicit operator GraphQlResult<TData, TError1>(TData data) => new(data);
 }
 
 /// <inheritdoc cref="GraphQlResult{TData}"/>
@@ -127,6 +137,11 @@ public class GraphQlResult<TData, TError1, TError2> : GraphQlResult<TData>, IGra
     /// Constructor.
     /// </summary>
     public GraphQlResult(TError2 error) : base(Helper.ToErrors(error)) { }
+
+    /// <summary>
+    /// Implicit conversion.
+    /// </summary>
+    public static implicit operator GraphQlResult<TData, TError1, TError2>(TData data) => new(data);
 }
 
 /// <inheritdoc cref="GraphQlResult{TData}"/>
@@ -161,6 +176,11 @@ public class GraphQlResult<TData, TError1, TError2, TError3> : GraphQlResult<TDa
     /// Constructor.
     /// </summary>
     public GraphQlResult(TError3 error) : base(Helper.ToErrors(error)) { }
+
+    /// <summary>
+    /// Implicit conversion.
+    /// </summary>
+    public static implicit operator GraphQlResult<TData, TError1, TError2, TError3>(TData data) => new(data);
 }
 
 /// <summary>

--- a/src/NexusMods.Networking.NexusWebApi/Errors/GraphQlResult.cs
+++ b/src/NexusMods.Networking.NexusWebApi/Errors/GraphQlResult.cs
@@ -105,6 +105,17 @@ public class GraphQlResult<TData, TError1> : GraphQlResult<TData>, IGraphQlResul
     public GraphQlResult(TError1 error) : base(Helper.ToErrors(error)) { }
 
     /// <summary>
+    /// Maps data from <typeparamref name="TData"/> to <typeparamref name="TOther"/> using provided delegate.
+    /// </summary>
+    public GraphQlResult<TOther, TError1> Map<TOther>(Func<TData, TOther> func)
+        where TOther : notnull
+    {
+        if (!HasData) return new GraphQlResult<TOther, TError1>(Errors);
+        var data = func(AssertHasData());
+        return new GraphQlResult<TOther, TError1>(data);
+    }
+
+    /// <summary>
     /// Implicit conversion.
     /// </summary>
     public static implicit operator GraphQlResult<TData, TError1>(TData data) => new(data);
@@ -136,6 +147,17 @@ public class GraphQlResult<TData, TError1, TError2> : GraphQlResult<TData>, IGra
     /// Constructor.
     /// </summary>
     public GraphQlResult(TError2 error) : base(Helper.ToErrors(error)) { }
+
+    /// <summary>
+    /// Maps data from <typeparamref name="TData"/> to <typeparamref name="TOther"/> using provided delegate.
+    /// </summary>
+    public GraphQlResult<TOther, TError1, TError2> Map<TOther>(Func<TData, TOther> func)
+        where TOther : notnull
+    {
+        if (!HasData) return new GraphQlResult<TOther, TError1, TError2>(Errors);
+        var data = func(AssertHasData());
+        return new GraphQlResult<TOther, TError1, TError2>(data);
+    }
 
     /// <summary>
     /// Implicit conversion.
@@ -175,6 +197,17 @@ public class GraphQlResult<TData, TError1, TError2, TError3> : GraphQlResult<TDa
     /// Constructor.
     /// </summary>
     public GraphQlResult(TError3 error) : base(Helper.ToErrors(error)) { }
+
+    /// <summary>
+    /// Maps data from <typeparamref name="TData"/> to <typeparamref name="TOther"/> using provided delegate.
+    /// </summary>
+    public GraphQlResult<TOther, TError1, TError2, TError3> Map<TOther>(Func<TData, TOther> func)
+        where TOther : notnull
+    {
+        if (!HasData) return new GraphQlResult<TOther, TError1, TError2, TError3>(Errors);
+        var data = func(AssertHasData());
+        return new GraphQlResult<TOther, TError1, TError2, TError3>(data);
+    }
 
     /// <summary>
     /// Implicit conversion.

--- a/src/NexusMods.Networking.NexusWebApi/Errors/IGraphQlError.cs
+++ b/src/NexusMods.Networking.NexusWebApi/Errors/IGraphQlError.cs
@@ -1,0 +1,45 @@
+using System.Diagnostics.CodeAnalysis;
+using JetBrains.Annotations;
+using StrawberryShake;
+
+namespace NexusMods.Networking.NexusWebApi.Errors;
+
+/// <summary>
+/// Represents a typed GraphQl error.
+/// </summary>
+[PublicAPI]
+public interface IGraphQlError
+{
+    /// <summary>
+    /// Gets the error code.
+    /// </summary>
+    ErrorCode Code { get; }
+
+    /// <summary>
+    /// Gets the error message.
+    /// </summary>
+    string Message { get; }
+}
+
+/// <summary>
+/// Represents a typed GraphQl error.
+/// </summary>
+[PublicAPI]
+public interface IGraphQlError<TSelf> : IGraphQlError
+    where TSelf : IGraphQlError<TSelf>
+{
+    /// <inheritdoc cref="IGraphQlError.Code"/>
+    new static abstract ErrorCode Code { get; }
+
+    ErrorCode IGraphQlError.Code => TSelf.Code;
+
+    /// <summary>
+    /// Whether the provided <see cref="IClientError"/> matches <typeparamref name="TSelf"/>.
+    /// </summary>
+    static virtual bool Matches(IClientError clientError) => clientError.Code is not null && TSelf.Code.Equals(clientError.Code);
+
+    /// <summary>
+    /// Tries to parse out the data from the <see cref="IClientError"/>.
+    /// </summary>
+    static abstract bool TryParse(IClientError clientError, [NotNullWhen(true)] out TSelf? error);
+}

--- a/src/NexusMods.Networking.NexusWebApi/Errors/IGraphQlResult.cs
+++ b/src/NexusMods.Networking.NexusWebApi/Errors/IGraphQlResult.cs
@@ -53,6 +53,9 @@ public interface IGraphQlResult<TData> : IGraphQlResult
     /// <summary>
     /// Asserts that the result has and returns it.
     /// </summary>
+    /// <remarks>
+    /// Should only be used if you called <see cref="IGraphQlResult.HasData"/> beforehand to guarantee that the result has data.
+    /// </remarks>
     /// <exception cref="InvalidOperationException">Thrown when the result doesn't have data.</exception>
     TData AssertHasData();
 

--- a/src/NexusMods.Networking.NexusWebApi/Errors/IGraphQlResult.cs
+++ b/src/NexusMods.Networking.NexusWebApi/Errors/IGraphQlResult.cs
@@ -1,0 +1,105 @@
+using System.Diagnostics.CodeAnalysis;
+using JetBrains.Annotations;
+
+namespace NexusMods.Networking.NexusWebApi.Errors;
+
+/// <summary>
+/// Represents a GraphQl result.
+/// </summary>
+[PublicAPI]
+public interface IGraphQlResult
+{
+    /// <summary>
+    /// Gets whether the query returned data.
+    /// </summary>
+    bool HasData { get; }
+
+    /// <summary>
+    /// Gets whether the query returned errors.
+    /// </summary>
+    bool HasErrors { get; }
+
+    /// <summary>
+    /// Gets all errors produced by the query.
+    /// </summary>
+    IReadOnlyDictionary<ErrorCode, IGraphQlError> Errors { get; }
+
+    /// <summary>
+    /// Tries to get a specific error.
+    /// </summary>
+    bool TryGetError<TError>([NotNullWhen(true)] out TError? error) where TError : IGraphQlError<TError>
+    {
+        if (!Errors.TryGetValue(TError.Code, out var tmp))
+        {
+            error = default(TError);
+            return false;
+        }
+
+        if (tmp is not TError errorInstance)
+            throw new NotSupportedException($"Error with code `{TError.Code}` is of type `{tmp.GetType()}` but expected `{typeof(TError)}`");
+
+        error = errorInstance;
+        return true;
+    }
+}
+
+/// <summary>
+/// Represents a GraphQl result.
+/// </summary>
+[PublicAPI]
+public interface IGraphQlResult<TData> : IGraphQlResult
+    where TData : notnull
+{
+    /// <summary>
+    /// Asserts that the result has and returns it.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when the result doesn't have data.</exception>
+    TData AssertHasData();
+
+    /// <summary>
+    /// Tries to get the data.
+    /// </summary>
+    bool TryGetData([NotNullWhen(true)] out TData? data);
+}
+
+/// <inheritdoc cref="IGraphQlResult{TData}"/>
+[PublicAPI]
+public interface IGraphQlResult<TData, TError1> : IGraphQlResult<TData>
+    where TData : notnull
+    where TError1 : IGraphQlError<TError1>
+{
+    /// <inheritdoc cref="IGraphQlResult.TryGetError{TError}"/>>
+    bool TryGetError([NotNullWhen(true)] out TError1? error) => TryGetError<TError1>(out error);
+}
+
+/// <inheritdoc cref="IGraphQlResult{TData}"/>
+[PublicAPI]
+public interface IGraphQlResult<TData, TError1, TError2> : IGraphQlResult<TData>
+    where TData : notnull
+    where TError1 : IGraphQlError<TError1>
+    where TError2 : IGraphQlError<TError2>
+{
+    /// <inheritdoc cref="IGraphQlResult.TryGetError{TError}"/>>
+    bool TryGetError([NotNullWhen(true)] out TError1? error) => TryGetError<TError1>(out error);
+
+    /// <inheritdoc cref="IGraphQlResult.TryGetError{TError}"/>>
+    bool TryGetError([NotNullWhen(true)] out TError2? error) => TryGetError<TError2>(out error);
+}
+
+/// <inheritdoc cref="IGraphQlResult{TData}"/>
+[PublicAPI]
+public interface IGraphQlResult<TData, TError1, TError2, TError3> : IGraphQlResult<TData>
+    where TData : notnull
+    where TError1 : IGraphQlError<TError1>
+    where TError2 : IGraphQlError<TError2>
+    where TError3 : IGraphQlError<TError3>
+{
+    /// <inheritdoc cref="IGraphQlResult.TryGetError{TError}"/>>
+    bool TryGetError([NotNullWhen(true)] out TError1? error) => TryGetError<TError1>(out error);
+
+    /// <inheritdoc cref="IGraphQlResult.TryGetError{TError}"/>>
+    bool TryGetError([NotNullWhen(true)] out TError2? error) => TryGetError<TError2>(out error);
+
+    /// <inheritdoc cref="IGraphQlResult.TryGetError{TError}"/>>
+    bool TryGetError([NotNullWhen(true)] out TError3? error) => TryGetError<TError3>(out error);
+}

--- a/src/NexusMods.Networking.NexusWebApi/Errors/NotFound.cs
+++ b/src/NexusMods.Networking.NexusWebApi/Errors/NotFound.cs
@@ -1,0 +1,35 @@
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using JetBrains.Annotations;
+using StrawberryShake;
+
+namespace NexusMods.Networking.NexusWebApi.Errors;
+
+/// <summary>
+/// Error returned when an entity was queried that doesn't exist. <see cref="Message"/> contains details about what entity wasn't found.
+/// </summary>
+[PublicAPI]
+public record NotFound : IGraphQlError<NotFound>
+{
+    /// <inheritdoc/>
+    public string Message { get; }
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    public NotFound(string message)
+    {
+        Message = message;
+    }
+
+    /// <inheritdoc/>
+    public static ErrorCode Code { get; } = ErrorCode.From("NOT_FOUND");
+
+    /// <inheritdoc/>
+    public static bool TryParse(IClientError clientError, [NotNullWhen(true)] out NotFound? error)
+    {
+        Debug.Assert(Code.Equals(clientError.Code));
+        error = new NotFound(clientError.Message);
+        return true;
+    }
+}

--- a/src/NexusMods.Networking.NexusWebApi/Errors/NotFound.cs
+++ b/src/NexusMods.Networking.NexusWebApi/Errors/NotFound.cs
@@ -12,15 +12,7 @@ namespace NexusMods.Networking.NexusWebApi.Errors;
 public record NotFound : IGraphQlError<NotFound>
 {
     /// <inheritdoc/>
-    public string Message { get; }
-
-    /// <summary>
-    /// Constructor.
-    /// </summary>
-    public NotFound(string message)
-    {
-        Message = message;
-    }
+    public required string Message { get; init; }
 
     /// <inheritdoc/>
     public static ErrorCode Code { get; } = ErrorCode.From("NOT_FOUND");
@@ -29,7 +21,10 @@ public record NotFound : IGraphQlError<NotFound>
     public static bool TryParse(IClientError clientError, [NotNullWhen(true)] out NotFound? error)
     {
         Debug.Assert(Code.Equals(clientError.Code));
-        error = new NotFound(clientError.Message);
+        error = new NotFound
+        {
+            Message = clientError.Message,
+        };
         return true;
     }
 }

--- a/src/NexusMods.Networking.NexusWebApi/Errors/UnknownError.cs
+++ b/src/NexusMods.Networking.NexusWebApi/Errors/UnknownError.cs
@@ -1,0 +1,23 @@
+using JetBrains.Annotations;
+
+namespace NexusMods.Networking.NexusWebApi.Errors;
+
+/// <summary>
+/// Catch-all type for all unknown not explicitly typed errors.
+/// </summary>
+[PublicAPI]
+public record UnknownError : IGraphQlError
+{
+    internal static readonly ErrorCode DefaultCode = ErrorCode.From("NMA_UNKNOWN_ERROR");
+
+    /// <inheritdoc/>
+    public required ErrorCode Code { get; init; }
+
+    /// <inheritdoc/>
+    public required string Message { get; init; }
+
+    /// <summary>
+    /// Direct error.
+    /// </summary>
+    public required StrawberryShake.IClientError ClientError { get; init; }
+}

--- a/src/NexusMods.Networking.NexusWebApi/NexusMods.Networking.NexusWebApi.csproj
+++ b/src/NexusMods.Networking.NexusWebApi/NexusMods.Networking.NexusWebApi.csproj
@@ -56,5 +56,8 @@
       <Compile Update="Errors\CollectionRevisionDiscarded.cs">
         <DependentUpon>IGraphQlError.cs</DependentUpon>
       </Compile>
+      <Compile Update="Errors\UnknownError.cs">
+        <DependentUpon>IGraphQlError.cs</DependentUpon>
+      </Compile>
     </ItemGroup>
 </Project>

--- a/src/NexusMods.Networking.NexusWebApi/NexusMods.Networking.NexusWebApi.csproj
+++ b/src/NexusMods.Networking.NexusWebApi/NexusMods.Networking.NexusWebApi.csproj
@@ -44,5 +44,8 @@
       <Compile Update="V1Interop\GameMetadata.cs">
         <DependentUpon>LocalMappingCache.cs</DependentUpon>
       </Compile>
+      <Compile Update="Errors\GraphQlResult.cs">
+        <DependentUpon>IGraphQlResult.cs</DependentUpon>
+      </Compile>
     </ItemGroup>
 </Project>

--- a/src/NexusMods.Networking.NexusWebApi/NexusMods.Networking.NexusWebApi.csproj
+++ b/src/NexusMods.Networking.NexusWebApi/NexusMods.Networking.NexusWebApi.csproj
@@ -47,5 +47,14 @@
       <Compile Update="Errors\GraphQlResult.cs">
         <DependentUpon>IGraphQlResult.cs</DependentUpon>
       </Compile>
+      <Compile Update="Errors\NotFound.cs">
+        <DependentUpon>IGraphQlError.cs</DependentUpon>
+      </Compile>
+      <Compile Update="Errors\CollectionDiscarded.cs">
+        <DependentUpon>IGraphQlError.cs</DependentUpon>
+      </Compile>
+      <Compile Update="Errors\CollectionRevisionDiscarded.cs">
+        <DependentUpon>IGraphQlError.cs</DependentUpon>
+      </Compile>
     </ItemGroup>
 </Project>

--- a/src/NexusMods.Sdk/Collections/SingleValueDictionary.cs
+++ b/src/NexusMods.Sdk/Collections/SingleValueDictionary.cs
@@ -1,0 +1,58 @@
+using System.Collections;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using JetBrains.Annotations;
+
+namespace NexusMods.Sdk.Collections;
+
+/// <summary>
+/// Read-only dictionary for a single value.
+/// </summary>
+[PublicAPI]
+[DebuggerDisplay("Key = {_kv.Key} Value = {_kv.Value}")]
+public class SingleValueDictionary<TKey, TValue> : IReadOnlyDictionary<TKey, TValue>
+{
+    private readonly KeyValuePair<TKey, TValue> _kv;
+    private readonly IEqualityComparer<TKey> _keyEqualityComparer;
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    public SingleValueDictionary(KeyValuePair<TKey, TValue> kv, IEqualityComparer<TKey>? keyEqualityComparer = null)
+    { 
+        _kv = kv;
+        _keyEqualityComparer = keyEqualityComparer ?? EqualityComparer<TKey>.Default;
+    }
+
+    /// <inheritdoc/>
+    public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() => new SingleValueEnumerator<KeyValuePair<TKey, TValue>>(_kv);
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    /// <inheritdoc/>
+    public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
+    {
+        if (!_keyEqualityComparer.Equals(key, _kv.Key))
+        {
+            value = default(TValue);
+            return false;
+        }
+
+        value = _kv.Value;
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public int Count => 1;
+
+    /// <inheritdoc/>
+    public bool ContainsKey(TKey key) => _keyEqualityComparer.Equals(key, _kv.Key);
+
+    /// <inheritdoc/>
+    public TValue this[TKey key] => _keyEqualityComparer.Equals(key, _kv.Key) ? _kv.Value : throw new IndexOutOfRangeException();
+
+    /// <inheritdoc/>
+    public IEnumerable<TKey> Keys => new SingleValueEnumerable<TKey>(_kv.Key);
+
+    /// <inheritdoc/>
+    public IEnumerable<TValue> Values => new SingleValueEnumerable<TValue>(_kv.Value);
+}

--- a/src/NexusMods.Sdk/Collections/SingleValueEnumerable.cs
+++ b/src/NexusMods.Sdk/Collections/SingleValueEnumerable.cs
@@ -1,0 +1,27 @@
+using System.Collections;
+using System.Diagnostics;
+using JetBrains.Annotations;
+
+namespace NexusMods.Sdk.Collections;
+
+/// <summary>
+/// Implements <see cref="IEnumerable{T}"/> for a single value.
+/// </summary>
+[PublicAPI]
+[DebuggerDisplay("Value = {_value}")]
+public sealed class SingleValueEnumerable<TValue> : IEnumerable<TValue>
+{
+    private readonly TValue _value;
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    public SingleValueEnumerable(TValue value)
+    {
+        _value = value;
+    }
+
+    /// <inheritdoc/>
+    public IEnumerator<TValue> GetEnumerator() => new SingleValueEnumerator<TValue>(_value);
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/src/NexusMods.Sdk/Collections/SingleValueEnumerator.cs
+++ b/src/NexusMods.Sdk/Collections/SingleValueEnumerator.cs
@@ -1,0 +1,44 @@
+using System.Collections;
+using System.Diagnostics;
+using JetBrains.Annotations;
+
+namespace NexusMods.Sdk.Collections;
+
+/// <summary>
+/// Implements <see cref="IEnumerator{T}"/> for a single value.
+/// </summary>
+[PublicAPI]
+[DebuggerDisplay("Value = {Current} Accessed={_didAccess}")]
+public sealed class SingleValueEnumerator<TValue> : IEnumerator<TValue>
+{
+    private bool _didAccess;
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    public SingleValueEnumerator(TValue value)
+    {
+        Current = value;
+    }
+
+    /// <inheritdoc/>
+    public bool MoveNext()
+    {
+        if (_didAccess) return false;
+        _didAccess = true;
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public void Reset()
+    {
+        _didAccess = false;
+    }
+
+    /// <inheritdoc/>
+    public TValue Current { get; }
+    object? IEnumerator.Current => Current;
+
+    /// <inheritdoc/>
+    public void Dispose() { }
+}


### PR DESCRIPTION
The GraphQl calls the app is doing can return errors, keeping #2912 in mind we want to forward these errors and deal with them explicitly instead of just assuming it works and throwing a meaningless exception if it doesn't.

This PR adds some new types to help with that. I've also updated one API call already on how to use the new types as an example.