### PR TITLE
Fix cache instance not available in service provider

### DIFF
--- a/src/NexusMods.Networking.NexusWebApi/Services.cs
+++ b/src/NexusMods.Networking.NexusWebApi/Services.cs
@@ -45,13 +45,10 @@ public static class Services
         collection.AddIgnoreFileUpdateModel();
 
         collection.AddGameDomainToGameIdMappingModel();
+        collection.AddSingleton<GameDomainToGameIdMappingCache>();
         collection.AddSingleton<IGameDomainToGameIdMappingCache>(serviceProvider =>
         {
-            var fallbackCache = new GameDomainToGameIdMappingCache(
-                conn: serviceProvider.GetRequiredService<IConnection>(),
-                gqlClient: serviceProvider.GetRequiredService<INexusGraphQLClient>(),
-                logger: serviceProvider.GetRequiredService<ILogger<GameDomainToGameIdMappingCache>>()
-            );
+            var fallbackCache = serviceProvider.GetRequiredService<GameDomainToGameIdMappingCache>();
 
             if (!LocalMappingCache.TryParseJsonFile(out var gameIdToDomain, out var gameDomainToId))
             {


### PR DESCRIPTION
The tests gets the instance from the service provider not the interface. Only the interface was registered which is why network tests were failing.