### PR TITLE
Add validation to settings

### DIFF
--- a/src/NexusMods.Abstractions.Settings/ConfigurablePathsContainer.cs
+++ b/src/NexusMods.Abstractions.Settings/ConfigurablePathsContainer.cs
@@ -8,10 +8,10 @@ namespace NexusMods.Abstractions.Settings;
 [PublicAPI]
 public class ConfigurablePathsContainer : APropertyValueContainer<ConfigurablePath[]>
 {
-    public ConfigurablePathsContainer(ConfigurablePath[] value, ConfigurablePath[] defaultValue, Action<ISettingsManager, ConfigurablePath[]> updaterFunc, IEqualityComparer<ConfigurablePath[]>? equalityComparer = null) 
-        : base(value, defaultValue, updaterFunc,
-        equalityComparer
-    )
-    {
-    }
+    public ConfigurablePathsContainer(
+            ConfigurablePath[] value,
+            ConfigurablePath[] defaultValue,
+            Action<ISettingsManager, ConfigurablePath[]> updaterFunc,
+            IEqualityComparer<ConfigurablePath[]>? equalityComparer = null)
+        : base(value, defaultValue, updaterFunc, equalityComparer: equalityComparer) { }
 }

--- a/src/NexusMods.Abstractions.Settings/IValueContainer.cs
+++ b/src/NexusMods.Abstractions.Settings/IValueContainer.cs
@@ -19,6 +19,11 @@ public interface IValueContainer
     bool HasChanged { get; }
 
     /// <summary>
+    /// Gets the validation result.
+    /// </summary>
+    ValidationResult ValidationResult { get; }
+
+    /// <summary>
     /// Updates the value in the settings manager.
     /// </summary>
     void Update(ISettingsManager settingsManager);

--- a/src/NexusMods.Abstractions.Settings/SettingsBuilder/IPropertyUIBuilder.cs
+++ b/src/NexusMods.Abstractions.Settings/SettingsBuilder/IPropertyUIBuilder.cs
@@ -42,14 +42,21 @@ public interface IPropertyUIBuilder<TSettings, TProperty>
         /// <remarks>
         /// This property allows for Markdown.
         /// </remarks>
-        IWithLinkStep WithDescription(string description);
+        IOptionalStep WithDescription(string description);
 
-        IWithLinkStep WithDescription(Func<TProperty, string> descriptionFactory);
+        IOptionalStep WithDescription(Func<TProperty, string> descriptionFactory);
+    }
+
+    public interface IOptionalStep : IValidationStep, IWithLinkStep;
+
+    public interface IValidationStep : IConfigureValueContainerStep
+    {
+        IOptionalStep WithValidation(Func<TProperty, ValidationResult> validator);
     }
 
     public interface IWithLinkStep : IConfigureValueContainerStep
     {
-        IConfigureValueContainerStep WithLink(Uri link);
+        IOptionalStep WithLink(Uri link);
     }
 
     [PublicAPI]

--- a/src/NexusMods.Abstractions.Settings/SingleValueMultipleChoiceContainer.cs
+++ b/src/NexusMods.Abstractions.Settings/SingleValueMultipleChoiceContainer.cs
@@ -20,7 +20,7 @@ public sealed class SingleValueMultipleChoiceContainer : APropertyValueContainer
         Action<ISettingsManager, object> updaterFunc,
         IEqualityComparer<object> valueComparer,
         object[] allowedValues,
-        Func<object, string> valueToTranslation) : base(value, defaultValue, updaterFunc, valueComparer)
+        Func<object, string> valueToTranslation) : base(value, defaultValue, updaterFunc, equalityComparer: valueComparer)
     {
         _allowedValues = allowedValues;
         _valueToTranslation = valueToTranslation;

--- a/src/NexusMods.Settings/SettingsUIBuilder.cs
+++ b/src/NexusMods.Settings/SettingsUIBuilder.cs
@@ -42,7 +42,7 @@ internal class PropertyUIBuilder<TSettings, TProperty> :
     IPropertyUIBuilder<TSettings, TProperty>,
     IPropertyUIBuilder<TSettings, TProperty>.IWithDisplayNameStep,
     IPropertyUIBuilder<TSettings, TProperty>.IWithDescriptionStep,
-    IPropertyUIBuilder<TSettings, TProperty>.IWithLinkStep,
+    IPropertyUIBuilder<TSettings, TProperty>.IOptionalStep,
     IPropertyUIBuilder<TSettings, TProperty>.IRequiresRestartStep
     where TSettings : class, ISettings, new()
     where TProperty : notnull
@@ -50,6 +50,7 @@ internal class PropertyUIBuilder<TSettings, TProperty> :
     private SectionId _sectionId = SectionId.DefaultValue;
     private string _displayName = string.Empty;
     private Func<TProperty, string> _descriptionFactory = _ => string.Empty;
+    private Func<TProperty, ValidationResult>? _validator;
     private Uri? _link = null;
     private bool _requiresRestart;
     private string? _restartMessage;
@@ -66,6 +67,7 @@ internal class PropertyUIBuilder<TSettings, TProperty> :
         _requiresRestart,
         _restartMessage,
         _factory!,
+        _validator,
         selectorFunc,
         propertySetterDelegate
     );
@@ -82,21 +84,27 @@ internal class PropertyUIBuilder<TSettings, TProperty> :
         return this;
     }
 
-    public IPropertyUIBuilder<TSettings, TProperty>.IWithLinkStep WithDescription(string description)
+    public IPropertyUIBuilder<TSettings, TProperty>.IOptionalStep WithDescription(string description)
     {
         _descriptionFactory = _ => description;
         return this;
     }
 
-    public IPropertyUIBuilder<TSettings, TProperty>.IWithLinkStep WithDescription(Func<TProperty, string> descriptionFactory)
+    public IPropertyUIBuilder<TSettings, TProperty>.IOptionalStep WithDescription(Func<TProperty, string> descriptionFactory)
     {
         _descriptionFactory = descriptionFactory;
         return this;
     }
 
-    public IPropertyUIBuilder<TSettings, TProperty>.IConfigureValueContainerStep WithLink(Uri link)
+    public IPropertyUIBuilder<TSettings, TProperty>.IOptionalStep WithLink(Uri link)
     {
         _link = link;
+        return this;
+    }
+
+    public IPropertyUIBuilder<TSettings, TProperty>.IOptionalStep WithValidation(Func<TProperty, ValidationResult> validator)
+    {
+        _validator = validator;
         return this;
     }
 
@@ -150,7 +158,7 @@ internal class PropertyUIBuilder<TSettings, TProperty> :
 
         return this;
     }
-    
+
     private class ConfigurablePathsContainerFactory : ISettingsPropertyValueContainerFactory
     {
         public SettingsPropertyValueContainer Create(object currentValue, object defaultValue, IPropertyBuilderOutput propertyBuilderOutput)


### PR DESCRIPTION
This was supposed to be part of the system initially since we never had a user for it until now, it didn't got added. With this we can validate user provided inputs, like paths, in the settings to make sure they don't choose weird paths.