### PR TITLE
Enable collection creation and add events

### DIFF
--- a/src/NexusMods.Abstractions.Loadouts/Models/Loadout.cs
+++ b/src/NexusMods.Abstractions.Loadouts/Models/Loadout.cs
@@ -75,6 +75,8 @@ public partial class Loadout : IModelDefinition
 
     public partial struct ReadOnly
     {
+        public ILocatableGame LocatableGame => InstallationInstance.Game;
+
         /// <summary>
         /// Get the game installation for this loadout.
         /// </summary>

--- a/src/NexusMods.App.UI/LeftMenu/Loadout/LoadoutLeftMenuView.axaml.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Loadout/LoadoutLeftMenuView.axaml.cs
@@ -15,8 +15,6 @@ public partial class LoadoutLeftMenuView : ReactiveUserControl<ILoadoutLeftMenuV
     {
         InitializeComponent();
 
-        NewCollection.IsVisible = CollectionCreator.IsFeatureEnabled;
-
         this.WhenActivated(disposables =>
         {
             this.OneWayBind(ViewModel, vm => vm.ApplyControlViewModel, view => view.ApplyControlViewHost.ViewModel)

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/ILoadoutViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/ILoadoutViewModel.cs
@@ -41,4 +41,7 @@ public interface ILoadoutViewModel : IPageViewModelInterface
     ReactiveCommand<Unit> CommandOpenRevisionUrl { get; }
     ReactiveCommand<Unit> CommandCopyRevisionUrl { get; }
     ReactiveCommand<Unit> CommandChangeVisibility { get; }
+
+    // TODO: remove for GA
+    bool EnableCollectionSharing { get; }
 }

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutView.axaml.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutView.axaml.cs
@@ -38,11 +38,12 @@ public partial class LoadoutView : R3UserControl<ILoadoutViewModel>
                         view.RulesTabItem.IsVisible = vm?.HasRulesSection ?? false;
 
                         var isCollection = vm?.IsCollection ?? true;
+                        var enableCollectionSharing = vm?.EnableCollectionSharing ?? false;
 
                         view.AllPageHeader.IsVisible = !isCollection;
-                        view.Statusbar.IsVisible = isCollection;
+                        view.Statusbar.IsVisible = isCollection && enableCollectionSharing;
 
-                        view.ButtonShareCollection.IsVisible = isCollection && CollectionCreator.IsFeatureEnabled;
+                        view.ButtonShareCollection.IsVisible = isCollection;
                         view.WritableCollectionPageHeader.IsVisible = isCollection;
 
                         var selectedSubTab = vm?.SelectedSubTab;

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/LoadoutViewModel.cs
@@ -15,6 +15,7 @@ using NexusMods.Abstractions.Loadouts.Extensions;
 using NexusMods.Abstractions.NexusModsLibrary.Models;
 using NexusMods.Abstractions.NexusWebApi;
 using NexusMods.Abstractions.NexusWebApi.Types;
+using NexusMods.Abstractions.Settings;
 using NexusMods.Abstractions.Telemetry;
 using NexusMods.App.UI.Controls;
 using NexusMods.App.UI.Controls.Navigation;
@@ -27,6 +28,7 @@ using NexusMods.App.UI.Pages.LoadoutPage.Dialogs.CollectionPublished;
 using NexusMods.App.UI.Pages.LoadoutPage.Dialogs.ShareCollection;
 using NexusMods.App.UI.Pages.Sorting;
 using NexusMods.App.UI.Resources;
+using NexusMods.App.UI.Settings;
 using NexusMods.App.UI.Windows;
 using NexusMods.App.UI.WorkspaceSystem;
 using NexusMods.Collections;
@@ -89,6 +91,8 @@ public class LoadoutViewModel : APageViewModel<ILoadoutViewModel>, ILoadoutViewM
     public ReactiveCommand<Unit> CommandCopyRevisionUrl { get; }
     public ReactiveCommand<Unit> CommandChangeVisibility { get; }
 
+    public bool EnableCollectionSharing { get; }
+
     private readonly IServiceProvider _serviceProvider;
     private readonly NexusModsLibrary _nexusModsLibrary;
     private readonly IConnection _connection;
@@ -106,6 +110,9 @@ public class LoadoutViewModel : APageViewModel<ILoadoutViewModel>, ILoadoutViewM
         _connection = serviceProvider.GetRequiredService<IConnection>();
         _nexusModsLibrary = serviceProvider.GetRequiredService<NexusModsLibrary>();
         _avaloniaInterop = serviceProvider.GetRequiredService<IAvaloniaInterop>();
+
+        var settingsManager = serviceProvider.GetRequiredService<ISettingsManager>();
+        EnableCollectionSharing = settingsManager.Get<ExperimentalSettings>().EnableCollectionSharing;
 
         var loadoutFilter = new LoadoutFilter
         {

--- a/src/NexusMods.App.UI/Pages/MyGames/MyGamesViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/MyGames/MyGamesViewModel.cs
@@ -36,6 +36,7 @@ using NexusMods.App.UI.Extensions;
 using NexusMods.App.UI.Overlays;
 using NexusMods.App.UI.Overlays.ManageGameWarning;
 using NexusMods.App.UI.Pages.LibraryPage;
+using NexusMods.App.UI.Settings;
 using NexusMods.Collections;
 using NexusMods.CrossPlatform.Process;
 using NexusMods.Paths;

--- a/src/NexusMods.App.UI/Settings/ExperimentalSettings.cs
+++ b/src/NexusMods.App.UI/Settings/ExperimentalSettings.cs
@@ -4,7 +4,7 @@ using NexusMods.Abstractions.NexusWebApi.Types.V2;
 using NexusMods.Abstractions.Settings;
 using NexusMods.Sdk;
 
-namespace NexusMods.App.UI;
+namespace NexusMods.App.UI.Settings;
 
 /// <summary>
 /// Settings that give access to experimental features in the UI.
@@ -15,6 +15,9 @@ public record ExperimentalSettings : ISettings
     /// Enables games that are not enabled by default.
     /// </summary>
     public bool EnableAllGames { get; [UsedImplicitly] set; } = ApplicationConstants.IsDebug;
+
+    // TODO: remove for GA
+    public bool EnableCollectionSharing { get; [UsedImplicitly] set; }
 
     [JsonIgnore]
     public readonly GameId[] SupportedGames =
@@ -34,6 +37,12 @@ public record ExperimentalSettings : ISettings
                     .WithDescription("Allows you to manage unsupported games.")
                     .UseBooleanContainer()
                     .RequiresRestart()
+                )
+                .AddPropertyToUI(x => x.EnableCollectionSharing, b => b
+                    .AddToSection(Sections.Experimental)
+                    .WithDisplayName("Enable sharing collections")
+                    .WithDescription("Allows uploading of collections")
+                    .UseBooleanContainer()
                 )
             );
     }

--- a/src/NexusMods.App/Program.cs
+++ b/src/NexusMods.App/Program.cs
@@ -12,6 +12,7 @@ using NexusMods.Abstractions.Serialization;
 using NexusMods.Abstractions.Settings;
 using NexusMods.Abstractions.Telemetry;
 using NexusMods.App.UI;
+using NexusMods.App.UI.Settings;
 using NexusMods.CrossPlatform;
 using NexusMods.CrossPlatform.Process;
 using NexusMods.DataModel;

--- a/src/NexusMods.App/Services.cs
+++ b/src/NexusMods.App/Services.cs
@@ -8,6 +8,7 @@ using NexusMods.Abstractions.Settings;
 using NexusMods.Abstractions.Telemetry;
 using NexusMods.App.Commandline;
 using NexusMods.App.UI;
+using NexusMods.App.UI.Settings;
 using NexusMods.CLI;
 using NexusMods.Collections;
 using NexusMods.CrossPlatform;

--- a/src/NexusMods.Collections/CollectionCreator.cs
+++ b/src/NexusMods.Collections/CollectionCreator.cs
@@ -28,9 +28,6 @@ namespace NexusMods.Collections;
 
 public static class CollectionCreator
 {
-    // TODO: remove for GA
-    public static bool IsFeatureEnabled => ApplicationConstants.IsDebug;
-
     public static bool IsCollectionUploaded(IConnection connection, CollectionGroupId groupId, out CollectionMetadata.ReadOnly collection)
     {
         var group = ManagedCollectionLoadoutGroup.Load(connection.Db, groupId);

--- a/src/NexusMods.Collections/NexusMods.Collections.csproj
+++ b/src/NexusMods.Collections/NexusMods.Collections.csproj
@@ -9,6 +9,7 @@
       <ProjectReference Include="..\NexusMods.Abstractions.Library\NexusMods.Abstractions.Library.csproj" />
       <ProjectReference Include="..\NexusMods.FileExtractor\NexusMods.FileExtractor.csproj" />
       <ProjectReference Include="..\NexusMods.Games.FOMOD\NexusMods.Games.FOMOD.csproj" />
+      <ProjectReference Include="..\NexusMods.Telemetry\NexusMods.Telemetry.csproj" />
       <ProjectReference Include="..\\NexusMods.Networking.NexusWebApi\NexusMods.Networking.NexusWebApi.csproj" />
       <PackageReference Include="NexusMods.MnemonicDB.SourceGenerator" PrivateAssets="all" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>

--- a/src/NexusMods.Telemetry/EventMetadata.cs
+++ b/src/NexusMods.Telemetry/EventMetadata.cs
@@ -50,7 +50,9 @@ public readonly struct EventMetadata
     /// <summary>
     /// Constructor.
     /// </summary>
-    public EventMetadata(string? name, Optional<double> value = default, TimeProvider? timeProvider = null)
+    public EventMetadata(string? name, TimeProvider? timeProvider = null) : this(name, value: Optional<double>.None, timeProvider: timeProvider) { }
+
+    private EventMetadata(string? name, Optional<double> value = default, TimeProvider? timeProvider = null)
     {
         Name = name;
         Value = value;

--- a/src/NexusMods.Telemetry/Events.cs
+++ b/src/NexusMods.Telemetry/Events.cs
@@ -30,6 +30,14 @@ public static class Events
         private const string Category = "Library";
     }
 
+    public static class Collections
+    {
+        private const string Category = "Collections";
+        public static readonly EventDefinition CreateLocalCollection = new(Category, Action: "Create local collection");
+        public static readonly EventDefinition ShareCollection = new(Category, Action: "Share collection");
+        public static readonly EventDefinition UploadRevision = new(Category, Action: "Upload revision");
+    }
+
     public static class HealthCheck
     {
         private const string Category = "Health check";


### PR DESCRIPTION
Enables collection creation for everyone, but collection sharing is now locked behind a setting. Also adds tracking events so we know how many people are using this feature.