### PR TITLE
Reverse targets in Library selector

### DIFF
--- a/src/NexusMods.App.UI/Pages/LibraryPage/LibraryViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LibraryPage/LibraryViewModel.cs
@@ -221,7 +221,7 @@ public class LibraryViewModel : APageViewModel<ILibraryViewModel>, ILibraryViewM
                     return new InstallationTarget(group.CollectionGroupId, group.AsLoadoutItemGroup().AsLoadoutItem().Name);
                 })
                 .AddKey(x => x.Id)
-                .SortAndBind(out _installationTargets, Comparer<InstallationTarget>.Create((a,b) => a.Id.Value.CompareTo(b.Id.Value)))
+                .SortAndBind(out _installationTargets, Comparer<InstallationTarget>.Create((a, b) => b.Id.Value.CompareTo(a.Id.Value)))
                 .Subscribe()
                 .AddTo(disposables);
 


### PR DESCRIPTION
Puts the last created collection at the top instead of the bottom.