### PR TITLE
Added: Job Cancellation Basics, including Advanced Installer Handler

### DIFF
--- a/src/NexusMods.Abstractions.Jobs/IJob.cs
+++ b/src/NexusMods.Abstractions.Jobs/IJob.cs
@@ -55,6 +55,16 @@ public interface IJob
     /// Get the definition of the job
     /// </summary>
     public IJobDefinition Definition { get; }
+    
+    /// <summary>
+    /// Cancels this job
+    /// </summary>
+    void Cancel();
+    
+    /// <summary>
+    /// Gets whether this job can be cancelled
+    /// </summary>
+    bool CanBeCancelled { get; }
 }
 
 /// <summary>

--- a/src/NexusMods.Abstractions.Jobs/IJobContext.cs
+++ b/src/NexusMods.Abstractions.Jobs/IJobContext.cs
@@ -44,6 +44,13 @@ public interface IJobContext : IAsyncDisposable, IDisposable
     /// Set the progress of the job as a rate of units per second
     /// </summary>
     void SetRateOfProgress(double rate);
+
+    /// <summary>
+    /// Explicitly cancel this job with a message. This will cancel the job and throw an <see cref="OperationCanceledException"/>.
+    /// </summary>
+    /// <param name="message">The cancellation message</param>
+    /// <returns>This method never returns - it always throws</returns>
+    void CancelAndThrow(string message);
 }
 
 /// <summary>

--- a/src/NexusMods.Abstractions.Jobs/IJobGroup.cs
+++ b/src/NexusMods.Abstractions.Jobs/IJobGroup.cs
@@ -6,4 +6,19 @@ namespace NexusMods.Abstractions.Jobs;
 public interface IJobGroup : IReadOnlyCollection<IJob>
 {
     public CancellationToken CancellationToken { get; }
+    
+    /// <summary>
+    /// Cancels all jobs in this group
+    /// </summary>
+    void Cancel();
+    
+    /// <summary>
+    /// Gets whether this job group has been cancelled
+    /// </summary>
+    bool IsCancelled { get; }
+    
+    /// <summary>
+    /// Adds a job to this group
+    /// </summary>
+    void Attach(IJob job);
 }

--- a/src/NexusMods.Abstractions.Jobs/IJobMonitor.cs
+++ b/src/NexusMods.Abstractions.Jobs/IJobMonitor.cs
@@ -32,4 +32,19 @@ public interface IJobMonitor
     /// All the jobs the monitor knows about
     /// </summary>
     ReadOnlyObservableCollection<IJob> Jobs { get; }
+    
+    /// <summary>
+    /// Cancels a specific job by its ID
+    /// </summary>
+    void Cancel(JobId jobId);
+    
+    /// <summary>
+    /// Cancels all jobs in the specified group
+    /// </summary>
+    void CancelGroup(IJobGroup group);
+    
+    /// <summary>
+    /// Cancels all active jobs
+    /// </summary>
+    void CancelAll();
 }

--- a/src/NexusMods.App.UI/Pages/LibraryPage/LibraryViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LibraryPage/LibraryViewModel.cs
@@ -4,6 +4,8 @@ using Avalonia.Controls.Models.TreeDataGrid;
 using Avalonia.Platform.Storage;
 using DynamicData;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NexusMods.App.UI.Overlays.Generic.MessageBox.Ok;
 using NexusMods.Abstractions.Library;
 using NexusMods.Abstractions.Library.Installers;
 using NexusMods.Abstractions.Library.Models;
@@ -461,7 +463,16 @@ After asking design, we're choosing to simply open the mod page for now.
         CancellationToken cancellationToken,
         bool useAdvancedInstaller = false)
     {
-        await _libraryService.InstallItem(libraryItem, loadout, parent: targetLoadoutGroup, installer: useAdvancedInstaller ? _advancedInstaller : null);
+        try
+        {
+            await _libraryService.InstallItem(libraryItem, loadout, parent: targetLoadoutGroup, installer: useAdvancedInstaller ? _advancedInstaller : null);
+        }
+        catch (OperationCanceledException)
+        {
+            // User cancelled the installation - this is expected behavior, don't show error
+            var logger = _serviceProvider.GetRequiredService<ILogger<LibraryViewModel>>();
+            logger.LogInformation("Installation of {LibraryItem} was cancelled by user", libraryItem.Name);
+        }
     }
 
     private async ValueTask RemoveSelectedItems(CancellationToken cancellationToken)

--- a/src/NexusMods.Games.AdvancedInstaller.UI/AdvancedManualInstallerUI.cs
+++ b/src/NexusMods.Games.AdvancedInstaller.UI/AdvancedManualInstallerUI.cs
@@ -46,7 +46,7 @@ public class AdvancedManualInstallerUI : ALibraryArchiveInstaller, IAdvancedInst
         var tree = LibraryArchiveTree.Create(libraryArchive);
         var (shouldInstall, deploymentData) = await GetDeploymentDataAsync(loadoutGroup.GetLoadoutItem(transaction).Name, tree, loadout);
 
-        if (!shouldInstall) return new NotSupported(Reason: "The user chose to abort the installation");
+        if (!shouldInstall) throw new OperationCanceledException("The user chose to abort the installation");
 
         deploymentData.CreateLoadoutItems(tree, loadout, loadoutGroup, transaction);
         return new Success();

--- a/src/NexusMods.Games.AdvancedInstaller.UI/AdvancedManualInstallerUI.cs
+++ b/src/NexusMods.Games.AdvancedInstaller.UI/AdvancedManualInstallerUI.cs
@@ -46,6 +46,15 @@ public class AdvancedManualInstallerUI : ALibraryArchiveInstaller, IAdvancedInst
         var tree = LibraryArchiveTree.Create(libraryArchive);
         var (shouldInstall, deploymentData) = await GetDeploymentDataAsync(loadoutGroup.GetLoadoutItem(transaction).Name, tree, loadout);
 
+        // Note(sewer): Normally cancellation flows through CancellationTokenSource.Cancel() -> CancellationToken -> OperationCanceledException.
+        //              Here we only have the CancellationToken (not the source), and the UI action itself is the cancellation signal.
+        //
+        //              The user closing the dialog IS the cancellation event in this context, so we throw directly rather than
+        //              waiting for an external token source to signal cancellation.
+        //
+        //              Note: Because this is an installer, the caller will catch this OperationCanceledException and call
+        //              context.CancelAndThrow() to properly handle the cancellation through the job framework. So for consistency,
+        //              the token will be correctly signaled as canceled.
         if (!shouldInstall) throw new OperationCanceledException("The user chose to abort the installation");
 
         deploymentData.CreateLoadoutItems(tree, loadout, loadoutGroup, transaction);

--- a/src/NexusMods.Jobs/JobContext.cs
+++ b/src/NexusMods.Jobs/JobContext.cs
@@ -43,6 +43,11 @@ public sealed class JobContext<TJobDefinition, TJobResult> : IJobWithResult<TJob
             SetStatus(JobStatus.Completed);
             _tcs.TrySetResult(_result.Value);
         }
+        catch (OperationCanceledException)
+        {
+            SetStatus(JobStatus.Cancelled);
+            _tcs.TrySetCanceled();
+        }
         catch (Exception ex)
         {
             SetStatus(JobStatus.Failed);
@@ -64,9 +69,11 @@ public sealed class JobContext<TJobDefinition, TJobResult> : IJobWithResult<TJob
     public IObservable<Optional<Percent>> ObservableProgress => _progress;
     public Optional<double> RateOfProgress { get; private set; }
     public IObservable<Optional<double>> ObservableRateOfProgress => _rateOfProgress;
+    public bool CanBeCancelled => Status.IsActive();
 
     public Task YieldAsync()
     {
+        CancellationToken.ThrowIfCancellationRequested();
         return Task.CompletedTask;
     }
 
@@ -118,6 +125,8 @@ public sealed class JobContext<TJobDefinition, TJobResult> : IJobWithResult<TJob
     {
         return _tcs.Task;
     }
+    
+    public void Cancel() => Group.Cancel();
 
     public async ValueTask DisposeAsync()
     {

--- a/src/NexusMods.Jobs/JobContext.cs
+++ b/src/NexusMods.Jobs/JobContext.cs
@@ -99,6 +99,12 @@ public sealed class JobContext<TJobDefinition, TJobResult> : IJobWithResult<TJob
         _rateOfProgress.OnNext(rate);
     }
 
+    public void CancelAndThrow(string message)
+    {
+        Cancel();
+        throw new OperationCanceledException(message);
+    }
+
     public Task WaitAsync(CancellationToken cancellationToken = default)
     {
         return _tcs.Task;

--- a/src/NexusMods.Jobs/JobGroup.cs
+++ b/src/NexusMods.Jobs/JobGroup.cs
@@ -8,6 +8,8 @@ public class JobGroup : IJobGroup
 {
     private readonly CancellationTokenSource _token;
     private readonly JobMonitor _monitor;
+    public bool IsCancelled => _token.Token.IsCancellationRequested;
+    
     public JobGroup(JobMonitor monitor)
     {
         _token = new CancellationTokenSource();
@@ -32,4 +34,5 @@ public class JobGroup : IJobGroup
 
     public int Count => Jobs.Count;
     public CancellationToken CancellationToken => _token.Token;
+    public void Cancel() => _token.Cancel();
 }

--- a/src/NexusMods.Jobs/JobMonitor.cs
+++ b/src/NexusMods.Jobs/JobMonitor.cs
@@ -93,4 +93,22 @@ public sealed class JobMonitor : IJobMonitor, IDisposable
         );
         return new JobTask<TJobType, TResultType>(ctx);
     }
+    
+    public void Cancel(JobId jobId)
+    {
+        var job = _allJobs.Lookup(jobId);
+        if (job.HasValue)
+            job.Value.Cancel();
+    }
+    
+    public void CancelGroup(IJobGroup group) => group.Cancel();
+
+    public void CancelAll()
+    {
+        foreach (var job in _allJobs.Items)
+        {
+            if (job.Status.IsActive())
+                job.Cancel();
+        }
+    }
 }

--- a/src/NexusMods.Library/InstallLoadoutItemJob.cs
+++ b/src/NexusMods.Library/InstallLoadoutItemJob.cs
@@ -80,7 +80,7 @@ internal class InstallLoadoutItemJob : IJobDefinitionWithStart<InstallLoadoutIte
         if (result == null)
         {
             if (Installer is AdvancedManualInstaller)
-                throw new OperationCanceledException($"Advanced installer was cancelled by user for `{LibraryItem.Name}` (`{LibraryItem.Id}`)");
+                throw new InvalidOperationException($"Advanced installer did not succeed for `{LibraryItem.Name}` (`{LibraryItem.Id}`)");
 
             var fallbackInstaller = FallbackInstaller ?? AdvancedManualInstaller.Create(ServiceProvider);
             result = await ExecuteInstallersAsync([fallbackInstaller], loadout, context);

--- a/src/NexusMods.Library/InstallLoadoutItemJob.cs
+++ b/src/NexusMods.Library/InstallLoadoutItemJob.cs
@@ -80,7 +80,7 @@ internal class InstallLoadoutItemJob : IJobDefinitionWithStart<InstallLoadoutIte
         if (result == null)
         {
             if (Installer is AdvancedManualInstaller)
-                throw new InvalidOperationException($"Advanced installer did not succeed for `{LibraryItem.Name}` (`{LibraryItem.Id}`)");
+                throw new OperationCanceledException($"Advanced installer was cancelled by user for `{LibraryItem.Name}` (`{LibraryItem.Id}`)");
 
             var fallbackInstaller = FallbackInstaller ?? AdvancedManualInstaller.Create(ServiceProvider);
             result = await ExecuteInstallersAsync([fallbackInstaller], loadout, context);


### PR DESCRIPTION
This adds the basic primitives for cancelling jobs, including handling for the special case of the Advanced Installer in a graceful (enough) way.

By request, I split this into just a small PR with the code.
I also wrote some docs, and found some things to patch up, those will be a separate PR later.

Related:
- #2727

fixes #2727
fixes #2723