### PR TITLE
Various Small Fixes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -147,7 +147,7 @@
     <PackageVersion Include="BitFaster.Caching" Version="2.5.2" />
     <PackageVersion Include="CliWrap" Version="3.6.7" />
     <PackageVersion Include="DynamicData" Version="9.3.2" />
-    <PackageVersion Include="GameFinder" Version="4.8.0" />
+    <PackageVersion Include="GameFinder" Version="4.9.0" />
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="ini-parser-netstandard" Version="2.5.2" />
     <PackageVersion Include="Mutagen.Bethesda.Skyrim" Version="0.44.0" />

--- a/src/NexusMods.Abstractions.GameLocators/Stores/GOG/GOGLocatorResultMetadata.cs
+++ b/src/NexusMods.Abstractions.GameLocators/Stores/GOG/GOGLocatorResultMetadata.cs
@@ -18,11 +18,19 @@ public record GOGLocatorResultMetadata : IGameLocatorResultMetadata
     /// </summary>
     public required ulong BuildId { get; init; }
     
+    /// <summary>
+    /// BuildIds of other installed DLC
+    /// </summary>
+    public required ulong[] DLCBuildIds { get; init; }
+    
     /// <inheritdoc/>
     public ILinuxCompatibilityDataProvider? LinuxCompatibilityDataProvider { get; init; }
 
     /// <inheritdoc />
-    public IEnumerable<LocatorId> ToLocatorIds() => [LocatorId.From(BuildId.ToString())];
+    public IEnumerable<LocatorId> ToLocatorIds() => [
+        LocatorId.From(BuildId.ToString()), 
+        ..DLCBuildIds.Select(x => LocatorId.From(x.ToString())),
+    ];
 }
 
 [PublicAPI]

--- a/src/NexusMods.DataModel/MissingArchiveException.cs
+++ b/src/NexusMods.DataModel/MissingArchiveException.cs
@@ -1,4 +1,5 @@
 using NexusMods.Hashing.xxHash3;
+using NexusMods.Paths;
 
 namespace NexusMods.DataModel;
 
@@ -11,4 +12,11 @@ public class MissingArchiveException : Exception
     /// Constructor.
     /// </summary>
     public MissingArchiveException(Hash hash) : base($"Missing archive for {hash.ToHex()}") { }
+    
+    /// <summary>
+    /// Constructor with an absolute path that specifies where the file would be extracted to
+    /// </summary>
+    public MissingArchiveException(Hash hash, AbsolutePath path) : base($"Missing archive for {hash.ToHex()} intended for output path {path}") { }
 }
+
+

--- a/src/NexusMods.DataModel/NxFileStore.cs
+++ b/src/NexusMods.DataModel/NxFileStore.cs
@@ -183,7 +183,7 @@ public class NxFileStore : IFileStore
             }
             else
             {
-                throw new MissingArchiveException(file.Hash);
+                throw new MissingArchiveException(file.Hash, file.Dest);
             }
         });
 

--- a/src/NexusMods.Games.FileHashes/FileHashesServiceSettings.cs
+++ b/src/NexusMods.Games.FileHashes/FileHashesServiceSettings.cs
@@ -16,7 +16,7 @@ public record FileHashesServiceSettings : ISettings
     /// <summary>
     /// Only checks GitHub for updates this often, in order to avoid API rate limits.
     /// </summary>
-    public TimeSpan HashDatabaseUpdateInterval { get; init; } = TimeSpan.FromHours(1);
+    public TimeSpan HashDatabaseUpdateInterval { get; init; } = TimeSpan.FromMinutes(30);
     
     /// <summary>
     /// The URL to the Github API to get the latest release.

--- a/src/NexusMods.Games.FileHashes/FileHashesServiceSettings.cs
+++ b/src/NexusMods.Games.FileHashes/FileHashesServiceSettings.cs
@@ -16,7 +16,7 @@ public record FileHashesServiceSettings : ISettings
     /// <summary>
     /// Only checks GitHub for updates this often, in order to avoid API rate limits.
     /// </summary>
-    public TimeSpan HashDatabaseUpdateInterval { get; init; } = TimeSpan.FromHours(6);
+    public TimeSpan HashDatabaseUpdateInterval { get; init; } = TimeSpan.FromHours(1);
     
     /// <summary>
     /// The URL to the Github API to get the latest release.

--- a/src/NexusMods.Games.RedEngine/Cyberpunk2077/Cyberpunk2077Game.cs
+++ b/src/NexusMods.Games.RedEngine/Cyberpunk2077/Cyberpunk2077Game.cs
@@ -10,6 +10,7 @@ using NexusMods.Abstractions.Library.Installers;
 using NexusMods.Abstractions.Loadouts.Synchronizers;
 using NexusMods.Abstractions.NexusWebApi.Types;
 using NexusMods.Abstractions.NexusWebApi.Types.V2;
+using NexusMods.Games.FileHashes.Emitters;
 using NexusMods.Games.FOMOD;
 using NexusMods.Games.RedEngine.Cyberpunk2077.Emitters;
 using NexusMods.Games.RedEngine.Cyberpunk2077.SortOrder;
@@ -92,6 +93,8 @@ public class Cyberpunk2077Game : AGame, ISteamGame, IGogGame, IEpicGame
     
     public override IDiagnosticEmitter[] DiagnosticEmitters =>
     [
+        new NoWayToSourceFilesOnDisk(),
+        new UndeployableLoadoutDueToMissingGameFiles(),
         new PatternBasedDependencyEmitter(PatternDefinitions.Definitions, _serviceProvider),
         new MissingProtontricksForRedModEmitter(_serviceProvider),
         new MissingRedModEmitter(),

--- a/src/NexusMods.Games.RedEngine/NexusMods.Games.RedEngine.csproj
+++ b/src/NexusMods.Games.RedEngine/NexusMods.Games.RedEngine.csproj
@@ -5,6 +5,7 @@
       <ProjectReference Include="..\NexusMods.Abstractions.Games.Diagnostics\NexusMods.Abstractions.Games.Diagnostics.csproj" />
       <ProjectReference Include="..\NexusMods.Abstractions.Games\NexusMods.Abstractions.Games.csproj" />
       <ProjectReference Include="..\NexusMods.Abstractions.Telemetry\NexusMods.Abstractions.Telemetry.csproj" />
+      <ProjectReference Include="..\NexusMods.Games.FileHashes\NexusMods.Games.FileHashes.csproj" />
       <ProjectReference Include="..\NexusMods.Games.FOMOD\NexusMods.Games.FOMOD.csproj" />
       <ProjectReference Include="..\NexusMods.App.Generators.Diagnostics\NexusMods.App.Generators.Diagnostics.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
       <PackageReference Include="NexusMods.MnemonicDB.SourceGenerator" PrivateAssets="all" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />

--- a/src/NexusMods.StandardGameLocators/AGameLocator.cs
+++ b/src/NexusMods.StandardGameLocators/AGameLocator.cs
@@ -100,7 +100,7 @@ public abstract class AGameLocator<TGameType, TId, TGame, TParent> : IGameLocato
         foreach (var id in Ids(tg))
         {
             if (!_cachedGames.TryGetValue(id, out var found)) continue;
-            yield return new GameLocatorResult(Path(found), GetMappedFileSystem(found), Store, CreateMetadata(found));
+            yield return new GameLocatorResult(Path(found), GetMappedFileSystem(found), Store, CreateMetadata(found, _cachedGames.Values));
         }
     }
 
@@ -128,7 +128,9 @@ public abstract class AGameLocator<TGameType, TId, TGame, TParent> : IGameLocato
     /// <summary>
     /// Creates <see cref="IGameLocatorResultMetadata"/> for the specific result.
     /// </summary>
-    /// <param name="game"></param>
+    /// <param name="game">the game data that was find by the GameFinder library</param>
+    /// <param name="otherFoundGames">all the other games found in the same store by the GameFinder library, this is most often
+    /// used to locate DLC installed into the game folder along with the game</param>
     /// <returns></returns>
-    protected abstract IGameLocatorResultMetadata CreateMetadata(TGameType game);
+    protected abstract IGameLocatorResultMetadata CreateMetadata(TGameType game, IEnumerable<TGameType> otherFoundGames);
 }

--- a/src/NexusMods.StandardGameLocators/EADesktopLocator.cs
+++ b/src/NexusMods.StandardGameLocators/EADesktopLocator.cs
@@ -25,7 +25,7 @@ public class EADesktopLocator : AGameLocator<EADesktopGame, EADesktopGameId, IEA
     protected override AbsolutePath Path(EADesktopGame record) => record.BaseInstallPath;
 
     /// <inheritdoc />
-    protected override IGameLocatorResultMetadata CreateMetadata(EADesktopGame game)
+    protected override IGameLocatorResultMetadata CreateMetadata(EADesktopGame game, IEnumerable<EADesktopGame> otherFoundGames)
     {
         return new EADesktopLocatorResultMetadata
         {

--- a/src/NexusMods.StandardGameLocators/EpicLocator.cs
+++ b/src/NexusMods.StandardGameLocators/EpicLocator.cs
@@ -24,7 +24,7 @@ public class EpicLocator : AGameLocator<EGSGame, EGSGameId, IEpicGame, EpicLocat
     protected override AbsolutePath Path(EGSGame record) => record.InstallLocation;
 
     /// <inheritdoc />
-    protected override IGameLocatorResultMetadata CreateMetadata(EGSGame game) => CreateMetadataCore(game);
+    protected override IGameLocatorResultMetadata CreateMetadata(EGSGame game, IEnumerable<EGSGame> otherFoundGames) => CreateMetadataCore(game);
 
     internal static IGameLocatorResultMetadata CreateMetadataCore(EGSGame game)
     {

--- a/src/NexusMods.StandardGameLocators/GogLocator.cs
+++ b/src/NexusMods.StandardGameLocators/GogLocator.cs
@@ -24,14 +24,20 @@ public class GogLocator : AGameLocator<GOGGame, GOGGameId, IGogGame, GogLocator>
     protected override AbsolutePath Path(GOGGame record) => record.Path;
 
     /// <inheritdoc/>
-    protected override IGameLocatorResultMetadata CreateMetadata(GOGGame game) => CreateMetadataCore(game);
+    protected override IGameLocatorResultMetadata CreateMetadata(GOGGame game, IEnumerable<GOGGame> otherFoundGames) => CreateMetadataCore(game, otherFoundGames);
 
-    internal static IGameLocatorResultMetadata CreateMetadataCore(GOGGame game)
+    internal static IGameLocatorResultMetadata CreateMetadataCore(GOGGame game, IEnumerable<GOGGame> otherFoundGames)
     {
+        var dlcIds = otherFoundGames
+            .Where(g => g.ParentGameId == game.Id)
+            .Select(g => (ulong)g.Id.Value)
+            .ToArray();
+        
         return new GOGLocatorResultMetadata
         {
             Id = game.Id.Value,
             BuildId = game.BuildId,
+            DLCBuildIds = dlcIds,
         };
     }
 }

--- a/src/NexusMods.StandardGameLocators/HeroicGogLocator.cs
+++ b/src/NexusMods.StandardGameLocators/HeroicGogLocator.cs
@@ -17,7 +17,7 @@ public class HeroicGogLocator : IGameLocator
     private readonly ILogger _logger;
 
     private readonly HeroicGOGHandler _handler;
-    private IReadOnlyDictionary<GOGGameId, GOGGame>? _cachedGames;
+    private IReadOnlyDictionary<GOGGameId, HeroicGOGGame>? _cachedGames;
 
     /// <summary>
     /// Constructor.
@@ -78,6 +78,8 @@ public class HeroicGogLocator : IGameLocator
                     Id = id,
                     BuildId = found.BuildId,
                     LinuxCompatibilityDataProvider = linuxCompatibilityDataProvider,
+                    // TODO: FIX THIS
+                    DLCBuildIds = [],
                 }
             );
         }

--- a/src/NexusMods.StandardGameLocators/OriginLocator.cs
+++ b/src/NexusMods.StandardGameLocators/OriginLocator.cs
@@ -24,7 +24,7 @@ public class OriginLocator : AGameLocator<OriginGame, OriginGameId, IOriginGame,
     protected override AbsolutePath Path(OriginGame record) => record.InstallPath;
 
     /// <inheritdoc />
-    protected override IGameLocatorResultMetadata CreateMetadata(OriginGame game) => CreateMetadataCore(game);
+    protected override IGameLocatorResultMetadata CreateMetadata(OriginGame game, IEnumerable<OriginGame> otherFoundGames) => CreateMetadataCore(game);
 
     internal static IGameLocatorResultMetadata CreateMetadataCore(OriginGame game)
     {

--- a/src/NexusMods.StandardGameLocators/Services.cs
+++ b/src/NexusMods.StandardGameLocators/Services.cs
@@ -122,7 +122,7 @@ public static class Services
                                 CreateDelegateFor<GOGGame, IGogGame>(
                                     (foundGame, requestedGame) => requestedGame.GogIds.Any(x => foundGame.Id.Equals(x)),
                                     game => new GameLocatorResult(game.Path, game.Path.FileSystem, GameStore.GOG,
-                                        GogLocator.CreateMetadataCore(game)
+                                        GogLocator.CreateMetadataCore(game, [])
                                     )
                                 ),
                                 CreateDelegateFor<EGSGame, IEpicGame>(

--- a/src/NexusMods.StandardGameLocators/SteamLocator.cs
+++ b/src/NexusMods.StandardGameLocators/SteamLocator.cs
@@ -39,7 +39,7 @@ public class SteamLocator : AGameLocator<SteamGame, AppId, ISteamGame, SteamLoca
     }
 
     /// <inheritdoc />
-    protected override IGameLocatorResultMetadata CreateMetadata(SteamGame game)
+    protected override IGameLocatorResultMetadata CreateMetadata(SteamGame game, IEnumerable<SteamGame> otherFoundGames)
     {
         var winePrefixDirectoryPath = game.GetProtonPrefix()?.ProtonDirectory.Combine("pfx");
         var linuxCompatibilityDataProvider = winePrefixDirectoryPath is not null ? new LinuxCompatibilityDataProvider(game, winePrefixDirectoryPath.Value) : null;

--- a/src/NexusMods.StandardGameLocators/XboxLocator.cs
+++ b/src/NexusMods.StandardGameLocators/XboxLocator.cs
@@ -24,7 +24,7 @@ public class XboxLocator : AGameLocator<XboxGame, XboxGameId, IXboxGame, XboxLoc
     protected override AbsolutePath Path(XboxGame record) => record.Path;
 
     /// <inheritdoc />
-    protected override IGameLocatorResultMetadata CreateMetadata(XboxGame game)
+    protected override IGameLocatorResultMetadata CreateMetadata(XboxGame game, IEnumerable<XboxGame> otherFoundGames)
     {
         return new XboxLocatorResultMetadata
         {


### PR DESCRIPTION
Fixes for several issues found in my testing: 

* Update to the latest version of GameFinder
* Make sure the GOG code correctly locates DLC
* Check for game hash DBs more often (lazily every 30min right now)
* Fixes to how we index files for Epic, the API we were calling has changed a bit, so this brings the indexing code in line with those changes
* Adds an optional path to the `MissingHashException` class so that the file extractor can state where it was planning to extract the file to, should help a bit with debugging