### PR TITLE
Add embedded games hashes database

### DIFF
--- a/src/NexusMods.Games.FileHashes/FileHashesService.cs
+++ b/src/NexusMods.Games.FileHashes/FileHashesService.cs
@@ -151,7 +151,6 @@ internal sealed class FileHashesService : IFileHashesService, IDisposable
         if (existingDatabases.TryGetFirst(out var latestDatabase))
         {
             _currentDb = OpenDb(latestDatabase);
-            return;
         }
 
         Task.Run(async () => await CheckForUpdateCore(forceUpdate: false, cancellationToken: CancellationToken.None));

--- a/src/NexusMods.Games.FileHashes/NexusMods.Games.FileHashes.csproj
+++ b/src/NexusMods.Games.FileHashes/NexusMods.Games.FileHashes.csproj
@@ -19,4 +19,20 @@
       <ProjectReference Include="..\NexusMods.Networking.EpicGameStore\NexusMods.Networking.EpicGameStore.csproj" />
     </ItemGroup>
 
+    <PropertyGroup>
+        <HashesDatabaseInput>https://github.com/Nexus-Mods/game-hashes/releases/latest/download/game_hashes_db.zip</HashesDatabaseInput>
+        <HashesDatabaseOutput>$(BaseIntermediateOutputPath)games_hashes_db.zip</HashesDatabaseOutput>
+    </PropertyGroup>
+
+    <!-- NOTE(erri120): Downloading the games hashes database at build time if it doesn't exist -->
+    <Target Name="DownloadGamesJson" BeforeTargets="BeforeBuild" Condition="!Exists('$(HashesDatabaseOutput)')" >
+        <MakeDir Directories="$(BaseIntermediateOutputPath)" />
+        <Exec ContinueOnError="true" Condition="'$(OS)' != 'Windows_NT'" Command="curl -sSL -o $(HashesDatabaseOutput) $(HashesDatabaseInput)"  />
+        <Exec ContinueOnError="true" Condition="'$(OS)' == 'Windows_NT'" Command="powershell -NoProfile -ExecutionPolicy Bypass -Command &quot;Invoke-WebRequest -Uri '$(HashesDatabaseInput)' -OutFile '$(HashesDatabaseOutput)'&quot;" />
+    </Target>
+
+    <ItemGroup Condition="Exists('$(HashesDatabaseOutput)')">
+        <EmbeddedResource Include="$(HashesDatabaseOutput)" LogicalName="games_hashes_db.zip" />
+    </ItemGroup>
+
 </Project>

--- a/src/NexusMods.Games.FileHashes/Verbs.cs
+++ b/src/NexusMods.Games.FileHashes/Verbs.cs
@@ -37,7 +37,7 @@ public static class Verbs
         [Injected] IFileHashesService fileHashesService,
         [Injected] CancellationToken token)
     {
-        await fileHashesService.CheckForUpdate(true);
+        await fileHashesService.CheckForUpdate(forceUpdate: true);
 
         var db = await fileHashesService.GetFileHashesDb();
 


### PR DESCRIPTION
Resolves #3561.

Improves the startup time and reliability of the games hashes update code. The embedded database will be used as a default, however we still need to check if GitHub has a newer release. This check is sadly unavoidable, otherwise first time users might start with an outdated database.