### PR TITLE
Pass sync tree to diagnostic emitters

### DIFF
--- a/src/NexusMods.Abstractions.Games.Diagnostics/Emitters/ILoadoutDiagnosticEmitter.cs
+++ b/src/NexusMods.Abstractions.Games.Diagnostics/Emitters/ILoadoutDiagnosticEmitter.cs
@@ -1,5 +1,8 @@
+using System.Collections.Frozen;
 using JetBrains.Annotations;
+using NexusMods.Abstractions.GameLocators;
 using NexusMods.Abstractions.Loadouts;
+using NexusMods.Abstractions.Loadouts.Synchronizers;
 
 namespace NexusMods.Abstractions.Diagnostics.Emitters;
 
@@ -16,5 +19,14 @@ public interface ILoadoutDiagnosticEmitter : IDiagnosticEmitter
     /// <summary>
     /// Diagnoses a loadout and creates instances of <see cref="Diagnostic"/>.
     /// </summary>
+    [Obsolete("To be replaced with the overload that takes in the sync tree")]
     IAsyncEnumerable<Diagnostic> Diagnose(Loadout.ReadOnly loadout, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Diagnoses a loadout and creates instances of <see cref="Diagnostic"/>.
+    /// </summary>
+    IAsyncEnumerable<Diagnostic> Diagnose(Loadout.ReadOnly loadout, FrozenDictionary<GamePath, SyncNode> syncTree, CancellationToken cancellationToken)
+    {
+        return Diagnose(loadout, cancellationToken);
+    }
 }

--- a/src/NexusMods.DataModel/Diagnostics/DiagnosticManager.cs
+++ b/src/NexusMods.DataModel/Diagnostics/DiagnosticManager.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
@@ -78,6 +79,8 @@ internal sealed class DiagnosticManager : IDiagnosticManager
     private async Task<Diagnostic[]> GetLoadoutDiagnostics(Loadout.ReadOnly loadout, CancellationToken cancellationToken)
     {
         var diagnosticEmitters = loadout.InstallationInstance.GetGame().DiagnosticEmitters;
+        var synchronizer = loadout.InstallationInstance.GetGame().Synchronizer;
+        var syncTree = (await synchronizer.BuildSyncTree(loadout)).ToFrozenDictionary();
 
         try
         {
@@ -89,7 +92,7 @@ internal sealed class DiagnosticManager : IDiagnosticManager
 
                 try
                 {
-                    await foreach (var diagnostic in emitter.Diagnose(loadout, token))
+                    await foreach (var diagnostic in emitter.Diagnose(loadout, syncTree, token))
                     {
                         lock(diagnostics)
                         {


### PR DESCRIPTION
Part of #2806.

This allows us to update diagnostic emitters one at a time. We'll see if we need to do more API changes to the emitters when we get to it.