### PR TITLE
Force kill unresponsive process

### DIFF
--- a/src/NexusMods.App/Program.cs
+++ b/src/NexusMods.App/Program.cs
@@ -71,7 +71,8 @@ public class Program
         var services = host.Services;
         _logger = services.GetRequiredService<ILogger<Program>>();
 
-        CleanupOldProcesses(services).Wait(timeout: TimeSpan.FromSeconds(10));
+        // NOTE(erri120): has to come before host startup
+        CleanupUnresponsiveProcesses(services).Wait(timeout: TimeSpan.FromSeconds(10));
 
         // Okay to do wait here, as we are in the main process thread.
         host.StartAsync().Wait(timeout: TimeSpan.FromMinutes(5));
@@ -169,8 +170,9 @@ public class Program
         }
     }
 
-    private static async Task CleanupOldProcesses(IServiceProvider serviceProvider)
+    private static async Task CleanupUnresponsiveProcesses(IServiceProvider serviceProvider)
     {
+        // NOTE(erri120): this is a hack, see https://github.com/Nexus-Mods/NexusMods.App/issues/3633
         var logger = serviceProvider.GetRequiredService<ILogger<Program>>();
         var syncFile = serviceProvider.GetRequiredService<SyncFile>();
 


### PR DESCRIPTION
Resolves #3633.

How to test:

1) Enable multiple run instances in Rider.
2) Set a breakpoint in the `DebuggingHost.Dispose` method and start the first instance.
3) Close the first instance normally, this should hit the breakpoint in the dispose method. The first instance is now in an unresponsive state because of the debugger.
4) Set a breakpoint in the new `CleanupOldProcess` method and start the second instance.
5) Observe how the new method tries to connect to the first instance and fails. The first instance should be killed by the second instance.