### PR TITLE
Fixed: Unrecognised AppImage environment variable after handler fix.

### DIFF
--- a/src/NexusMods.CrossPlatform/Process/AOSInterop.cs
+++ b/src/NexusMods.CrossPlatform/Process/AOSInterop.cs
@@ -86,12 +86,15 @@ internal abstract class AOSInterop : IOSInterop
     }
 
     /// <inheritdoc />
-    public virtual AbsolutePath GetOwnExe()
+    public virtual AbsolutePath GetOwnExe() => FileSystem.Shared.FromUnsanitizedFullPath(GetOwnExeUnsanitized());
+
+    /// <inheritdoc />
+    public virtual string GetOwnExeUnsanitized()
     {
         var processPath = Environment.ProcessPath;
         Debug.Assert(processPath is not null);
 
-        return FileSystem.Shared.FromUnsanitizedFullPath(processPath);
+        return processPath;
     }
 
     /// <inheritdoc />

--- a/src/NexusMods.CrossPlatform/Process/IOSInterop.cs
+++ b/src/NexusMods.CrossPlatform/Process/IOSInterop.cs
@@ -40,6 +40,17 @@ public interface IOSInterop
     AbsolutePath GetOwnExe();
 
     /// <summary>
+    /// Get the path to the current executable as an unsanitized string.
+    /// This preserves the original path without conversion through the paths library.
+    /// </summary>
+    /// <remarks>
+    /// Do not use in production *unless you have a very good reason to do so*.
+    /// This API exists to resolve an edge case with protocol registration on Linux,
+    /// https://github.com/Nexus-Mods/NexusMods.Paths/issues/71
+    /// </remarks>
+    string GetOwnExeUnsanitized();
+
+    /// <summary>
     /// Gets all file system mounts.
     /// </summary>
     ValueTask<IReadOnlyList<FileSystemMount>> GetFileSystemMounts(CancellationToken cancellationToken = default);

--- a/src/NexusMods.CrossPlatform/Process/OSInteropLinux.cs
+++ b/src/NexusMods.CrossPlatform/Process/OSInteropLinux.cs
@@ -69,14 +69,14 @@ internal class OSInteropLinux : AOSInterop
     protected override Command CreateCommand(Uri uri) => throw new UnreachableException("Should never be called");
 
     /// <inheritdoc />
-    public override AbsolutePath GetOwnExe()
+    public override string GetOwnExeUnsanitized()
     {
         // https://docs.appimage.org/packaging-guide/environment-variables.html#type-2-appimage-runtime
         // APPIMAGE: (Absolute) path to AppImage file (with symlinks resolved)
         var appImagePath = Environment.GetEnvironmentVariable("APPIMAGE", EnvironmentVariableTarget.Process);
-        if (appImagePath is null) return base.GetOwnExe();
+        if (appImagePath is not null) return appImagePath;
 
-        return _fileSystem.FromUnsanitizedFullPath(appImagePath);
+        return base.GetOwnExeUnsanitized();
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
fixes #3668 , while preserving functional compatibility for all valid Linux file paths.

<img width="778" height="505" alt="image" src="https://github.com/user-attachments/assets/3c9a6a36-189e-4d28-9b05-881cd08b3947" />

Originally reported in:  https://discord.com/channels/1134149061080002713/1134149062589960215/1400174190627389491