### PR TITLE
Fix #3685 `CleanupUnresponsiveProcesses` socket exception in main process 

### DIFF
--- a/src/NexusMods.App/Commandline/StatusVerbs.cs
+++ b/src/NexusMods.App/Commandline/StatusVerbs.cs
@@ -1,0 +1,36 @@
+using System.Diagnostics;
+using Humanizer;
+using Microsoft.Extensions.DependencyInjection;
+using NexusMods.Abstractions.Cli;
+using NexusMods.Sdk.ProxyConsole;
+
+namespace NexusMods.App.Commandline;
+
+
+/// <summary>
+/// These verbs are used for checking the status of the Nexus Mods App.
+/// </summary>
+public static class StatusVerbs
+{
+    // ReSharper disable once UnusedMethodReturnValue.Global
+    internal static IServiceCollection AddStatusVerbs(this IServiceCollection services) =>
+        services.AddVerb(() => Heartbeat);
+
+    /// <summary>
+    /// Returns the processId and the uptime of the Nexus Mods app process.
+    /// </summary>
+    /// <param name="renderer"></param>
+    /// <returns></returns>
+    [Verb("heartbeat", "Returns process uptime for the Nexus Mods app.")]
+    private static async Task<int> Heartbeat([Injected] IRenderer renderer)
+    {
+        var process = Process.GetCurrentProcess();
+        
+        var startTime = process.StartTime;
+        var uptime = DateTime.Now - startTime;
+        
+        await renderer.TextLine($"ProcessId: {process.Id} Uptime: {uptime.Humanize()}");
+
+        return 0;
+    }
+}

--- a/src/NexusMods.App/Commandline/StatusVerbs.cs
+++ b/src/NexusMods.App/Commandline/StatusVerbs.cs
@@ -16,12 +16,13 @@ public static class StatusVerbs
     internal static IServiceCollection AddStatusVerbs(this IServiceCollection services) =>
         services.AddVerb(() => Heartbeat);
 
+    public const string HeartbeatCommand = "heartbeat";
     /// <summary>
     /// Returns the processId and the uptime of the Nexus Mods app process.
     /// </summary>
     /// <param name="renderer"></param>
     /// <returns></returns>
-    [Verb("heartbeat", "Returns process uptime for the Nexus Mods app.")]
+    [Verb(HeartbeatCommand, "Returns process uptime for the Nexus Mods app.")]
     private static async Task<int> Heartbeat([Injected] IRenderer renderer)
     {
         var process = Process.GetCurrentProcess();

--- a/src/NexusMods.App/Services.cs
+++ b/src/NexusMods.App/Services.cs
@@ -100,6 +100,7 @@ public static class Services
                 .AddTestHarness()
                 .AddFileSystem()
                 .AddCleanupVerbs()
+                .AddStatusVerbs()
                 .AddSteamCli()
                 .AddGOG()
                 .AddFileHashes()


### PR DESCRIPTION
- Fixes #3685 

Running a command like an NXM download was resulting in an exception in the main process, due to `CleanupUnresponsiveProcesses` opening a TCP connection to it and then closing it without sending any commands.

I added a heartbeat status command to be used instead of a manual TCP Connection, to respect the expected protocol.