### PR TITLE
Add isDisposed checks to `TreeDataGridAdapter`

### DIFF
--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridAdapter.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridAdapter.cs
@@ -106,14 +106,14 @@ public abstract class TreeDataGridAdapter<TModel, TKey> : ReactiveR3Object, ISea
                         self.SelectedModels.RemoveRange(eventArgs.DeselectedItems.NotNull());
                         foreach (var item in eventArgs.DeselectedItems)
                         {
-                            if (item is null) continue;
+                            if (item is null || item.IsDisposed) continue;
                             item.IsSelected.Value = false;
                         }
 
                         self.SelectedModels.AddRange(eventArgs.SelectedItems.NotNull());
                         foreach (var item in eventArgs.SelectedItems)
                         {
-                            if (item is null) continue;
+                            if (item is null || item.IsDisposed) continue;
                             item.IsSelected.Value = true;
                         }
                     });
@@ -131,7 +131,7 @@ public abstract class TreeDataGridAdapter<TModel, TKey> : ReactiveR3Object, ISea
                             // so they get values before the TreeDataGrid even sees them.
                             foreach (var change in changeSet)
                             {
-                                if (change.Reason is ChangeReason.Add)
+                                if (change.Reason is ChangeReason.Add && !change.Current.IsDisposed)
                                 {
                                     self.BeforeModelActivationHook(change.Current);
                                     change.Current.Activate();

--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridAdapter.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridAdapter.cs
@@ -106,14 +106,20 @@ public abstract class TreeDataGridAdapter<TModel, TKey> : ReactiveR3Object, ISea
                         self.SelectedModels.RemoveRange(eventArgs.DeselectedItems.NotNull());
                         foreach (var item in eventArgs.DeselectedItems)
                         {
-                            if (item is null || item.IsDisposed) continue;
+                            if (item is null) continue;
+                            Debug.Assert(!item.IsDisposed);
+                            if (item.IsDisposed) continue;
+                            
                             item.IsSelected.Value = false;
                         }
 
                         self.SelectedModels.AddRange(eventArgs.SelectedItems.NotNull());
                         foreach (var item in eventArgs.SelectedItems)
                         {
-                            if (item is null || item.IsDisposed) continue;
+                            if (item is null) continue;
+                            Debug.Assert(!item.IsDisposed);
+                            if (item.IsDisposed) continue;
+                            
                             item.IsSelected.Value = true;
                         }
                     });
@@ -131,8 +137,11 @@ public abstract class TreeDataGridAdapter<TModel, TKey> : ReactiveR3Object, ISea
                             // so they get values before the TreeDataGrid even sees them.
                             foreach (var change in changeSet)
                             {
-                                if (change.Reason is ChangeReason.Add && !change.Current.IsDisposed)
+                                if (change.Reason is ChangeReason.Add)
                                 {
+                                    Debug.Assert(!change.Current.IsDisposed);
+                                    if (change.Current.IsDisposed) continue;
+                                    
                                     self.BeforeModelActivationHook(change.Current);
                                     change.Current.Activate();
                                 }


### PR DESCRIPTION
- Fix #3631 

I wasn't able to reproduce the issue, but I added explicit `IsDisposed` checks to the locations where the exception would trigger.
This should fix the issue for now.  