### PR TITLE
Update exception message being send

### DIFF
--- a/src/NexusMods.Telemetry/ExceptionData.cs
+++ b/src/NexusMods.Telemetry/ExceptionData.cs
@@ -24,41 +24,62 @@ internal record struct ExceptionData(string Type, string Message, string? StackT
     private static ExceptionData From(Exception exception)
     {
         var type = exception.GetType().ToString();
-        var redacted = RedactUtils.Redact(exception.Message);
+        var originalMessage = RedactUtils.Redact(exception.Message);
+
+        var message = originalMessage;
         var stackTrace = exception.StackTrace;
-        var message = redacted;
-        var stackTraceIsMessage = false;
 
         if (!string.IsNullOrEmpty(stackTrace))
         {
-            var span = stackTrace.AsSpan();
-            var lines = span.EnumerateLines();
-            foreach (var line in lines)
-            {
-                const string prefix = "at ";
-                const string suffix = " in ";
-
-                var trimmed = line.Trim();
-                var prefixIndex = trimmed.IndexOf(prefix, StringComparison.Ordinal);
-                if (prefixIndex != 0) continue;
-                trimmed = trimmed.Slice(start: prefix.Length);
-
-                var suffixIndex = trimmed.IndexOf(suffix, StringComparison.Ordinal);
-                if (suffixIndex != -1)
-                {
-                    trimmed = trimmed.Slice(start: 0, length: suffixIndex);
-                }
-
-                message = trimmed.Trim().ToString();
-                stackTraceIsMessage = true;
-                break;
-            }
+            var firstMethod = ExtractFirstMethod(exception.StackTrace);
+            message = firstMethod ?? originalMessage;
+            stackTrace = firstMethod is null ? stackTrace : $"{originalMessage}\n{stackTrace}";
         }
 
         return new ExceptionData(
             Type: type,
             Message: message,
-            StackTrace: stackTraceIsMessage ? $"{redacted}\n{stackTrace}" : stackTrace
+            StackTrace: stackTrace
         );
+    }
+
+    /// <summary>
+    /// Extracts the first fully qualified method name from the stack trace.
+    /// </summary>
+    private static string? ExtractFirstMethod(ReadOnlySpan<char> stackTrace)
+    {
+        // Input:
+        //   at NexusMods.Abstractions.Loadouts.Synchronizers.ALoadoutSynchronizer.<>c__DisplayClass44_0.<<ReindexState>b__0>d.MoveNext() in /_/src/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs:line 1336
+        // --- End of stack trace from previous location ---
+        //   at System.Threading.Tasks.Parallel.<>c__53`1.<<ForEachAsync>b__53_0>d.MoveNext()
+        // --- End of stack trace from previous location ---
+        //   at NexusMods.Abstractions.Loadouts.Synchronizers.ALoadoutSynchronizer.ReindexState(GameInstallation installation, Boolean ignoreModifiedDates, IConnection connection, ITransaction tx) in /_/src/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs:line 1280
+        // Output:
+        // NexusMods.Abstractions.Loadouts.Synchronizers.ALoadoutSynchronizer.<>c__DisplayClass44_0.<<ReindexState>b__0>d.MoveNext()
+
+        const string prefix = "at ";
+        const string suffix = " in ";
+
+        var lines = stackTrace.EnumerateLines();
+        foreach (var line in lines)
+        {
+            var span = line.Trim();
+
+            var prefixIndex = span.IndexOf(prefix, StringComparison.Ordinal);
+            if (prefixIndex != 0) continue;
+
+            span = span.Slice(start: prefix.Length);
+
+            var suffixIndex = span.IndexOf(suffix, StringComparison.Ordinal);
+            if (suffixIndex != -1)
+            {
+                span = span.Slice(start: 0, length: suffixIndex);
+            }
+
+            var trimmed = span.Trim();
+            return trimmed.ToString();
+        }
+
+        return null;
     }
 }

--- a/src/NexusMods.Telemetry/ExceptionData.cs
+++ b/src/NexusMods.Telemetry/ExceptionData.cs
@@ -1,6 +1,6 @@
 namespace NexusMods.Telemetry;
 
-internal record struct ExceptionData(string Type, string Message, string? StackTrace)
+internal record struct ExceptionData(string Type, string Message, string? StackTrace = null)
 {
     public static List<ExceptionData> Create(Exception exception, List<ExceptionData>? result = null)
     {
@@ -15,13 +15,50 @@ internal record struct ExceptionData(string Type, string Message, string? StackT
         }
         else
         {
-            result.Add(new ExceptionData(
-                Type: exception.GetType().ToString(),
-                Message: RedactUtils.Redact(exception.Message),
-                StackTrace: exception.StackTrace
-            ));
+            result.Add(From(exception));
         }
 
         return result;
+    }
+
+    private static ExceptionData From(Exception exception)
+    {
+        var type = exception.GetType().ToString();
+        var redacted = RedactUtils.Redact(exception.Message);
+        var stackTrace = exception.StackTrace;
+        var message = redacted;
+        var stackTraceIsMessage = false;
+
+        if (!string.IsNullOrEmpty(stackTrace))
+        {
+            var span = stackTrace.AsSpan();
+            var lines = span.EnumerateLines();
+            foreach (var line in lines)
+            {
+                const string prefix = "at ";
+                const string suffix = " in ";
+
+                var trimmed = line.Trim();
+                var prefixIndex = trimmed.IndexOf(prefix, StringComparison.Ordinal);
+                if (prefixIndex != 0) continue;
+                trimmed = trimmed.Slice(start: prefix.Length);
+
+                var suffixIndex = trimmed.IndexOf(suffix, StringComparison.Ordinal);
+                if (suffixIndex != -1)
+                {
+                    trimmed = trimmed.Slice(start: 0, length: suffixIndex);
+                }
+
+                message = trimmed.Trim().ToString();
+                stackTraceIsMessage = true;
+                break;
+            }
+        }
+
+        return new ExceptionData(
+            Type: type,
+            Message: message,
+            StackTrace: stackTraceIsMessage ? $"{redacted}\n{stackTrace}" : stackTrace
+        );
     }
 }

--- a/tests/NexusMods.Telemetry.Tests/TrackingDataSenderTests.cs
+++ b/tests/NexusMods.Telemetry.Tests/TrackingDataSenderTests.cs
@@ -105,8 +105,8 @@ public class TrackingDataSenderTests
 
         var parsedException = parsedExceptions.Should().ContainSingle().Which;
         parsedException.Type.Should().Be("System.NotSupportedException");
-        parsedException.Message.Should().Be("Foo bar baz");
-        parsedException.StackTrace.Should().NotBeNull();
+        parsedException.Message.Should().Be("NexusMods.Telemetry.Tests.TrackingDataSenderTests.Test_ParseSingleException()");
+        parsedException.StackTrace.Should().StartWith("Foo bar baz\n");
     }
 
     [Fact]


### PR DESCRIPTION
Changes the telemetry data for exceptions to use the first location of the stacktrace as the message. Matomo groups by exception message for some ungodly reason, so this will help with organizing exceptions.