### PR TITLE
Fix "File in use" exception when applying Cyberpunk

### DIFF
--- a/src/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -358,7 +358,16 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
     {
         var metadata = await ReindexState(loadout.InstallationInstance, ignoreModifiedDates: false, Connection);
         var previouslyApplied = loadout.Installation.GetLastAppliedDiskState();
-        return BuildSyncTree(DiskStateToPathPartPair(metadata.DiskStateEntries), DiskStateToPathPartPair(previouslyApplied), loadout);
+        return BuildSyncTree(metadata.DiskStateEntries, previouslyApplied, loadout);
+    }
+    
+    
+    public Dictionary<GamePath, SyncNode> BuildSyncTree<T>(T latestDiskState, T previousDiskState, Loadout.ReadOnly loadout)
+        where T : IEnumerable<DiskStateEntry.ReadOnly>
+    {
+        var currentState = DiskStateToPathPartPair(latestDiskState);
+        var previousTree = DiskStateToPathPartPair(previousDiskState);
+        return BuildSyncTree(currentState, previousTree, loadout);
     }
 
     /// <summary>

--- a/src/NexusMods.Abstractions.Loadouts.Synchronizers/ILoadoutSynchronizer.cs
+++ b/src/NexusMods.Abstractions.Loadouts.Synchronizers/ILoadoutSynchronizer.cs
@@ -27,6 +27,11 @@ public interface ILoadoutSynchronizer
     /// Builds a sync tree from a loadout and the current state of the game folder.
     /// </summary>
     Task<Dictionary<GamePath, SyncNode>> BuildSyncTree(Loadout.ReadOnly loadoutTree);
+
+    /// <summary>
+    /// Builds a sync tree from the latest stored disk state and the previous disk state.
+    /// </summary>
+    Dictionary<GamePath, SyncNode> BuildSyncTree<T>(T latestDiskState, T previousDiskState, Loadout.ReadOnly loadout) where T : IEnumerable<DiskStateEntry.ReadOnly>;
     
     /// <summary>
     /// Processes the sync tree to create the signature and actions for each file, changes are made in-place on the tree.


### PR DESCRIPTION
- Fix #3682 

Running Cyberpunk with a redmod installed would trigger a file in use exception.

This was caused by the diagnostic manger attempting to reindex the disk state while RedMod would still be writing data to disk.

This fixes the problem by using the latest DB stored DiskState rather than reindexing it, same approach as what `ShouldSynchronize` is using.