### PR TITLE
Provide Game Target Info (store + OS)

### DIFF
--- a/NexusMods.App.sln.DotSettings
+++ b/NexusMods.App.sln.DotSettings
@@ -45,6 +45,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=JWT/@EntryIndexedValue">JWT</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=MIME/@EntryIndexedValue">MIME</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=NXM/@EntryIndexedValue">NXM</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=OS/@EntryIndexedValue">OS</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=OSX/@EntryIndexedValue">OSX</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=QR/@EntryIndexedValue">QR</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SE/@EntryIndexedValue">SE</s:String>

--- a/src/NexusMods.Abstractions.GameLocators/GameInstallation.cs
+++ b/src/NexusMods.Abstractions.GameLocators/GameInstallation.cs
@@ -36,6 +36,13 @@ public class GameInstallation : IEquatable<GameInstallation>
     public GameStore Store { get; init; } = GameStore.Unknown;
 
     /// <summary>
+    /// OS targeted by the game version.
+    /// </summary>
+    public IOSInformation TargetOS { get; init; } = OSInformation.Shared;
+
+    public GameTargetInfo TargetInfo => new(Store, TargetOS);
+
+    /// <summary>
     /// Gets the metadata returned by the game locator.
     /// </summary>
     public IGameLocatorResultMetadata? LocatorResultMetadata { get; init; }

--- a/src/NexusMods.Abstractions.GameLocators/GameLocatorResult.cs
+++ b/src/NexusMods.Abstractions.GameLocators/GameLocatorResult.cs
@@ -8,12 +8,14 @@ namespace NexusMods.Abstractions.GameLocators;
 /// </summary>
 /// <param name="Path">Full path to the folder which contains the game.</param>
 /// <param name="GameFileSystem">Mapped filesystem of the game. This can either be the real filesystem or a WINE wrapper</param>
+/// <param name="TargetOS">Target OS of the game</param>
 /// <param name="Store"><see cref="GameStore"/> which installed the game.</param>
 /// <param name="Metadata">Metadata about the game.</param>
 /// <param name="Version">Version of the game found.</param>
 public record GameLocatorResult(
     AbsolutePath Path,
     IFileSystem GameFileSystem,
+    IOSInformation TargetOS,
     GameStore Store,
     IGameLocatorResultMetadata Metadata,
     Version? Version = null

--- a/src/NexusMods.Abstractions.GameLocators/GameTargetInfo.cs
+++ b/src/NexusMods.Abstractions.GameLocators/GameTargetInfo.cs
@@ -1,0 +1,7 @@
+using JetBrains.Annotations;
+using NexusMods.Paths;
+
+namespace NexusMods.Abstractions.GameLocators;
+
+[PublicAPI]
+public record struct GameTargetInfo(GameStore Store, IOSInformation OS);

--- a/src/NexusMods.Abstractions.GameLocators/IGameLocatorResultMetadata.cs
+++ b/src/NexusMods.Abstractions.GameLocators/IGameLocatorResultMetadata.cs
@@ -11,10 +11,10 @@ public interface IGameLocatorResultMetadata
     /// <summary>
     /// Converts this metadata to a format that the game locator and file hash db can use to reference a specific build, version, etc.
     /// </summary>
-    public IEnumerable<LocatorId> ToLocatorIds();
+    IEnumerable<LocatorId> ToLocatorIds();
 
     /// <summary>
     /// Gets the linux compatibility data provider instance.
     /// </summary>
-    public ILinuxCompatibilityDataProvider? LinuxCompatibilityDataProvider { get; }
+    ILinuxCompatibilityDataProvider? LinuxCompatibilityDataProvider { get; }
 }

--- a/src/NexusMods.Abstractions.Games/IGame.cs
+++ b/src/NexusMods.Abstractions.Games/IGame.cs
@@ -55,12 +55,11 @@ public interface IGame : ILocatableGame
     /// also marks the installation was sourced from the given <see cref="IGameLocator"/>.
     /// </summary>
     public GameInstallation InstallationFromLocatorResult(GameLocatorResult metadata, EntityId dbId, IGameLocator locator);
-    
+
     /// <summary>
     /// Returns the primary (executable) file for the game.
     /// </summary>
-    /// <param name="store">The store used for the game.</param>
-    public GamePath GetPrimaryFile(GameStore store);
+    GamePath GetPrimaryFile(GameTargetInfo targetInfo);
 
     /// <summary>
     /// Gets the fallback directory for mods in collections that don't have matching installers.
@@ -69,5 +68,5 @@ public interface IGame : ILocatableGame
     /// Also is used for bundled mods.
     /// See https://github.com/Nexus-Mods/NexusMods.App/issues/2630 for details.
     /// </summary>
-    Optional<GamePath> GetFallbackCollectionInstallDirectory();
+    Optional<GamePath> GetFallbackCollectionInstallDirectory(GameTargetInfo targetInfo);
 }

--- a/src/NexusMods.Abstractions.Games/RunGameTool.cs
+++ b/src/NexusMods.Abstractions.Games/RunGameTool.cs
@@ -62,7 +62,7 @@ public class RunGameTool<T> : IRunGameTool
         _logger.LogInformation("Starting {Name}", Name);
         
         var program = await GetGamePath(loadout);
-        var primaryFile = _game.GetPrimaryFile(loadout.InstallationInstance.Store).CombineChecked(loadout.InstallationInstance);
+        var primaryFile = _game.GetPrimaryFile(loadout.InstallationInstance.TargetInfo).CombineChecked(loadout.InstallationInstance);
 
         if (OSInformation.Shared.IsLinux && program.Equals(primaryFile))
         {
@@ -264,8 +264,7 @@ public class RunGameTool<T> : IRunGameTool
     /// <returns></returns>
     protected virtual ValueTask<AbsolutePath> GetGamePath(Loadout.ReadOnly loadout)
     {
-        return ValueTask.FromResult(_game.GetPrimaryFile(loadout.InstallationInstance.Store)
-            .Combine(loadout.InstallationInstance.LocationsRegister[LocationId.Game]));
+        return ValueTask.FromResult(_game.GetPrimaryFile(loadout.InstallationInstance.TargetInfo).Combine(loadout.InstallationInstance.LocationsRegister[LocationId.Game]));
     }
 
     /// <inheritdoc />

--- a/src/NexusMods.Abstractions.Library.Installers/ILibraryArchiveInstaller.cs
+++ b/src/NexusMods.Abstractions.Library.Installers/ILibraryArchiveInstaller.cs
@@ -2,6 +2,7 @@ using JetBrains.Annotations;
 using NexusMods.Abstractions.Library.Models;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.MnemonicDB.Abstractions;
+using NexusMods.Paths;
 
 namespace NexusMods.Abstractions.Library.Installers;
 

--- a/src/NexusMods.Collections/FallbackCollectionDownloadInstaller.cs
+++ b/src/NexusMods.Collections/FallbackCollectionDownloadInstaller.cs
@@ -1,4 +1,3 @@
-using DynamicData.Kernel;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.GameLocators;
@@ -20,9 +19,9 @@ internal class FallbackCollectionDownloadInstaller : ALibraryArchiveInstaller
         _defaultPath = defaultPath;
     }
 
-    public static ILibraryItemInstaller? Create(IServiceProvider serviceProvider, IGame game)
+    public static ILibraryItemInstaller? Create(IServiceProvider serviceProvider, Loadout.ReadOnly loadout, IGame game)
     {
-        var defaultPath = game.GetFallbackCollectionInstallDirectory();
+        var defaultPath = game.GetFallbackCollectionInstallDirectory(loadout.InstallationInstance.TargetInfo);
         if (!defaultPath.HasValue) return null;
         return new FallbackCollectionDownloadInstaller(serviceProvider, defaultPath.Value);
     }

--- a/src/NexusMods.Collections/InstallCollectionJob.cs
+++ b/src/NexusMods.Collections/InstallCollectionJob.cs
@@ -129,14 +129,14 @@ public class InstallCollectionJob : IJobDefinitionWithStart<InstallCollectionJob
 
         var loadout = Loadout.Load(Connection.Db, TargetLoadout);
         var game = (loadout.InstallationInstance.Game as IGame)!;
-        var fallbackInstaller = FallbackCollectionDownloadInstaller.Create(ServiceProvider, game);
+        var fallbackInstaller = FallbackCollectionDownloadInstaller.Create(ServiceProvider, loadout, game);
 
         await Parallel.ForEachAsync(modsAndDownloads, context.CancellationToken, async (modAndDownload, _) =>
         {
             try
             {
                 Logger.LogDebug("Installing `{DownloadName}` (index={Index}) into `{CollectionName}/{RevisionNumber}`", modAndDownload.Mod.Name, modAndDownload.Download.ArrayIndex, RevisionMetadata.Collection.Name, RevisionMetadata.RevisionNumber);
-                await InstallMod(modAndDownload, collectionGroup, fallbackInstaller, game.GetFallbackCollectionInstallDirectory());
+                await InstallMod(modAndDownload, collectionGroup, fallbackInstaller, game.GetFallbackCollectionInstallDirectory(loadout.InstallationInstance.TargetInfo));
             }
             catch (Exception e)
             {

--- a/src/NexusMods.DataModel/Synchronizer/SynchronizerService.cs
+++ b/src/NexusMods.DataModel/Synchronizer/SynchronizerService.cs
@@ -268,7 +268,7 @@ public class SynchronizerService : ISynchronizerService
         // Solution: Check if EXE (primaryfile) is in use.
         // Note: This doesn't account for CLI calls. I think that's fine; an external CLI user/caller
         var game = loadout.InstallationInstance.GetGame() as AGame;
-        var primaryFile = game!.GetPrimaryFile(loadout.InstallationInstance.Store)
+        var primaryFile = game!.GetPrimaryFile(loadout.InstallationInstance.TargetInfo)
             .Combine(loadout.InstallationInstance.LocationsRegister[LocationId.Game]);
         if (IsFileInUse(primaryFile))
             throw new ExecutableInUseException("Game's main executable file is in use.\n" +

--- a/src/NexusMods.Games.CreationEngine/SkyrimSE/SkyrimSE.cs
+++ b/src/NexusMods.Games.CreationEngine/SkyrimSE/SkyrimSE.cs
@@ -17,7 +17,7 @@ public class SkyrimSE : AGame, ISteamGame, IGogGame
 
     public override string Name => "Skyrim Special Edition";
     public override GameId GameId => GameId.From(1704);
-    public override GamePath GetPrimaryFile(GameStore store) => new(LocationId.Game, "SkyrimSE.exe");
+    public override GamePath GetPrimaryFile(GameTargetInfo targetInfo) => new(LocationId.Game, "SkyrimSE.exe");
 
     protected override IReadOnlyDictionary<LocationId, AbsolutePath> GetLocations(IFileSystem fileSystem, GameLocatorResult installation)
     {

--- a/src/NexusMods.Games.MountAndBlade2Bannerlord/Bannerlord.cs
+++ b/src/NexusMods.Games.MountAndBlade2Bannerlord/Bannerlord.cs
@@ -36,7 +36,6 @@ public sealed class Bannerlord : AGame, ISteamGame, IGogGame, IXboxGame//, IEpic
 
     private readonly IServiceProvider _serviceProvider;
     private readonly LauncherManagerFactory _launcherManagerFactory;
-    private readonly IFileSystem _fs;
 
     public override string Name => DisplayName;
     public override GameId GameId => GameIdStatic;
@@ -78,16 +77,15 @@ public sealed class Bannerlord : AGame, ISteamGame, IGogGame, IXboxGame//, IEpic
     {
         _serviceProvider = serviceProvider;
         _launcherManagerFactory = launcherManagerFactory;
-        _fs = serviceProvider.GetRequiredService<IFileSystem>();
     }
 
-    public override GamePath GetPrimaryFile(GameStore store) => GamePathProvier.PrimaryLauncherFile(store);
+    public override GamePath GetPrimaryFile(GameTargetInfo targetInfo) => GamePathProvier.PrimaryLauncherFile(targetInfo.Store);
 
-    public override Optional<Version> GetLocalVersion(GameInstallMetadata.ReadOnly installation)
+    public override Optional<Version> GetLocalVersion(GameTargetInfo targetInfo, AbsolutePath installationPath)
     {
         // Note(sewer): Bannerlord can use prefixes on versions etc. ,we want to strip them out
         // so we sanitize/parse with `ApplicationVersion`.
-        var bannerlordVerStr = Fetcher.GetVersion(installation.Path, "TaleWorlds.Library.dll");
+        var bannerlordVerStr = Fetcher.GetVersion(installationPath.ToNativeSeparators(OSInformation.Shared), "TaleWorlds.Library.dll");
         var versionStr = ApplicationVersion.TryParse(bannerlordVerStr, out var av) ? $"{av.Major}.{av.Minor}.{av.Revision}.{av.ChangeSet}" : "0.0.0.0";
         return Version.TryParse(versionStr, out var val) ? val : new Version();
     }

--- a/src/NexusMods.Games.RedEngine/Cyberpunk2077/Cyberpunk2077Game.cs
+++ b/src/NexusMods.Games.RedEngine/Cyberpunk2077/Cyberpunk2077Game.cs
@@ -56,7 +56,7 @@ public class Cyberpunk2077Game : AGame, ISteamGame, IGogGame //, IEpicGame
         new(BaseFeatures.HasLoadOrder, IsImplemented: false),
     ];
 
-    public override GamePath GetPrimaryFile(GameStore store) => new(LocationId.Game, "bin/x64/Cyberpunk2077.exe");
+    public override GamePath GetPrimaryFile(GameTargetInfo targetInfo) => new(LocationId.Game, "bin/x64/Cyberpunk2077.exe");
     protected override IReadOnlyDictionary<LocationId, AbsolutePath> GetLocations(IFileSystem fileSystem,
         GameLocatorResult installation)
     {

--- a/src/NexusMods.Games.StardewValley/Emitters/Helpers.cs
+++ b/src/NexusMods.Games.StardewValley/Emitters/Helpers.cs
@@ -34,7 +34,7 @@ internal static class Helpers
         // to it for some reason.
         // See https://github.com/Nexus-Mods/NexusMods.App/pull/2713 for details.
         var localVersion = game
-            .GetLocalVersion(loadout.Installation)
+            .GetLocalVersion(loadout.Installation, loadout.InstallationInstance)
             .Convert(static version => new SemanticVersion(version));
 
         if (localVersion.HasValue) return localVersion.Value;

--- a/src/NexusMods.Games.StardewValley/Installers/SMAPIInstaller.cs
+++ b/src/NexusMods.Games.StardewValley/Installers/SMAPIInstaller.cs
@@ -20,7 +20,6 @@ public class SMAPIInstaller : ALibraryArchiveInstaller
     private static readonly RelativePath WindowsFolder = "windows";
     private static readonly RelativePath MacOSFolder = "macOS";
 
-    private readonly IOSInformation _osInformation;
     private readonly TemporaryFileManager _temporaryFileManager;
     private readonly IFileStore _fileStore;
     private readonly IFileHashesService _fileHashesService;
@@ -28,13 +27,11 @@ public class SMAPIInstaller : ALibraryArchiveInstaller
     public SMAPIInstaller(
         IServiceProvider serviceProvider,
         ILogger<SMAPIInstaller> logger,
-        IOSInformation osInformation,
         TemporaryFileManager temporaryFileManager,
         IFileHashesService fileHashesService,
         IFileStore fileStore)
         : base(serviceProvider, logger)
     {
-        _osInformation = osInformation;
         _temporaryFileManager = temporaryFileManager;
         _fileStore = fileStore;
         _fileHashesService = fileHashesService;
@@ -47,7 +44,8 @@ public class SMAPIInstaller : ALibraryArchiveInstaller
         Loadout.ReadOnly loadout,
         CancellationToken cancellationToken)
     {
-        var targetParentName = _osInformation.MatchPlatform(
+        var targetOS = loadout.InstallationInstance.TargetOS;
+        var targetParentName = targetOS.MatchPlatform(
             onWindows: static () => WindowsFolder,
             onLinux: static () => LinuxFolder,
             onOSX: static () => MacOSFolder
@@ -69,10 +67,10 @@ public class SMAPIInstaller : ALibraryArchiveInstaller
             return new NotSupported(Reason: "Expected the installation data file to be an archive");
         }
 
-        var isUnix = _osInformation.IsUnix();
+        var isUnix = targetOS.IsUnix();
 
         // NOTE(erri120): paths can be verified using Steam depots: https://steamdb.info/app/413150/depots/
-        RelativePath unixLauncherPath = _osInformation.IsOSX
+        RelativePath unixLauncherPath = targetOS.IsOSX
             ? "Contents/MacOS/StardewValley"
             : "StardewValley";
 

--- a/src/NexusMods.StandardGameLocators/AGameLocator.cs
+++ b/src/NexusMods.StandardGameLocators/AGameLocator.cs
@@ -100,7 +100,13 @@ public abstract class AGameLocator<TGameType, TId, TGame, TParent> : IGameLocato
         foreach (var id in Ids(tg))
         {
             if (!_cachedGames.TryGetValue(id, out var found)) continue;
-            yield return new GameLocatorResult(Path(found), GetMappedFileSystem(found), Store, CreateMetadata(found, _cachedGames.Values));
+            yield return new GameLocatorResult(
+                Path(found),
+                GetMappedFileSystem(found),
+                GetTargetOS(found),
+                Store,
+                CreateMetadata(found, _cachedGames.Values)
+            );
         }
     }
 
@@ -124,6 +130,8 @@ public abstract class AGameLocator<TGameType, TId, TGame, TParent> : IGameLocato
     protected abstract AbsolutePath Path(TGameType record);
 
     protected virtual IFileSystem GetMappedFileSystem(TGameType game) => Path(game).FileSystem;
+
+    protected virtual IOSInformation GetTargetOS(TGameType game) => OSInformation.Shared;
 
     /// <summary>
     /// Creates <see cref="IGameLocatorResultMetadata"/> for the specific result.

--- a/src/NexusMods.StandardGameLocators/HeroicGogLocator.cs
+++ b/src/NexusMods.StandardGameLocators/HeroicGogLocator.cs
@@ -50,9 +50,12 @@ public class HeroicGogLocator : IGameLocator
             var gamePath = found.Path;
 
             ILinuxCompatibilityDataProvider? linuxCompatibilityDataProvider = null;
+            var targetOS = OSInformation.Shared;
 
             if (found is HeroicGOGGame heroicGOGGame)
             {
+                targetOS = new OSInformation(heroicGOGGame.Platform);
+
                 var wineData = heroicGOGGame.WineData;
                 var winePrefix = heroicGOGGame.GetWinePrefix();
                 if (wineData is not null && winePrefix is not null)
@@ -72,7 +75,9 @@ public class HeroicGogLocator : IGameLocator
                     gamePath = gamePath.Combine("game");
             }
 
-            yield return new GameLocatorResult(gamePath, fs, GameStore.GOG,
+            yield return new GameLocatorResult(gamePath, fs, 
+                targetOS,
+                GameStore.GOG,
                 new HeroicGOGLocatorResultMetadata
                 {
                     Id = id,

--- a/src/NexusMods.StandardGameLocators/ManuallyAddedLocator.cs
+++ b/src/NexusMods.StandardGameLocators/ManuallyAddedLocator.cs
@@ -46,7 +46,7 @@ public class ManuallyAddedLocator : IGameLocator
         var result = await tx.Commit();
         var addedGame = result.Remap(ent);
         var gameRegistry = _provider.GetRequiredService<IGameRegistry>();
-        var install = await gameRegistry.Register(game, new GameLocatorResult(path, path.FileSystem, GameStore.ManuallyAdded, addedGame, version), this);
+        var install = await gameRegistry.Register(game, new GameLocatorResult(path, path.FileSystem, OSInformation.Shared, GameStore.ManuallyAdded, addedGame, version), this);
         var newId = result[ent.Id];
         return (newId, install);
     }
@@ -72,7 +72,7 @@ public class ManuallyAddedLocator : IGameLocator
     {
         var games = ManuallyAddedGame.FindByGameId(_conn.Value.Db, game.GameId)
             .Select(g => new GameLocatorResult(_fileSystem.FromUnsanitizedFullPath(g.Path), _fileSystem,
-                GameStore.ManuallyAdded, g, Version.Parse(g.Version)));
+                OSInformation.Shared, GameStore.ManuallyAdded, g, Version.Parse(g.Version)));
         return games;
     }
 }

--- a/src/NexusMods.StandardGameLocators/Services.cs
+++ b/src/NexusMods.StandardGameLocators/Services.cs
@@ -121,19 +121,19 @@ public static class Services
                             [
                                 CreateDelegateFor<GOGGame, IGogGame>(
                                     (foundGame, requestedGame) => requestedGame.GogIds.Any(x => foundGame.Id.Equals(x)),
-                                    game => new GameLocatorResult(game.Path, game.Path.FileSystem, GameStore.GOG,
+                                    game => new GameLocatorResult(game.Path, game.Path.FileSystem, OSInformation.FakeWindows, GameStore.GOG,
                                         GogLocator.CreateMetadataCore(game, [])
                                     )
                                 ),
                                 CreateDelegateFor<EGSGame, IEpicGame>(
                                     (foundGame, requestedGame) => requestedGame.EpicCatalogItemId.Any(x => foundGame.CatalogItemId.Equals(x)),
-                                    game => new GameLocatorResult(game.InstallLocation, game.InstallLocation.FileSystem, GameStore.EGS,
+                                    game => new GameLocatorResult(game.InstallLocation, game.InstallLocation.FileSystem, OSInformation.FakeWindows, GameStore.EGS,
                                         EpicLocator.CreateMetadataCore(game)
                                     )
                                 ),
                                 CreateDelegateFor<OriginGame, IOriginGame>(
                                     (foundGame, requestedGame) => requestedGame.OriginGameIds.Any(x => foundGame.Id.Equals(x)),
-                                    game => new GameLocatorResult(game.InstallPath, game.InstallPath.FileSystem, GameStore.Origin,
+                                    game => new GameLocatorResult(game.InstallPath, game.InstallPath.FileSystem, OSInformation.FakeWindows, GameStore.Origin,
                                         OriginLocator.CreateMetadataCore(game)
                                     )
                                 ),

--- a/tests/NexusMods.StandardGameLocators.TestHelpers/StubbedGames/StubbedGame.cs
+++ b/tests/NexusMods.StandardGameLocators.TestHelpers/StubbedGames/StubbedGame.cs
@@ -38,8 +38,8 @@ public class StubbedGame : AGame, IEADesktopGame, IEpicGame, IOriginGame, ISteam
         _locators = locators;
     }
 
-    public override GamePath GetPrimaryFile(GameStore store) => new(LocationId.Game, "");
-    
+    public override GamePath GetPrimaryFile(GameTargetInfo targetInfo) => new(LocationId.Game, "");
+
     public override ILoadoutSynchronizer Synchronizer =>
         // Lazy initialization to avoid circular dependencies
         new DefaultSynchronizer(_serviceProvider);

--- a/tests/NexusMods.StandardGameLocators.TestHelpers/UniversalStubbedGameLocator.cs
+++ b/tests/NexusMods.StandardGameLocators.TestHelpers/UniversalStubbedGameLocator.cs
@@ -38,6 +38,7 @@ public class UniversalStubbedGameLocator<TGame> : IGameLocator, IDisposable
         yield return new GameLocatorResult(
             _path,
             _path.Path.FileSystem,
+            OSInformation.Shared,
             GameStore.Unknown,
             new UnknownLocatorResultMetadata(LocatorIds),
             _version ?? new Version(1, 0, 0, 0));


### PR DESCRIPTION
Fixes how we handle OS specific operations for games targeting OS versions different to the host machine. A Windows game running in WINE will now report the target OS as being Windows.

### QA steps:
- On Linux install the Windows build of Stardew Valley
- Install SMAPI 
- Game should run with SMAPI loaded and working

Prior to this PR SMAPI would not work correctly in that scenario, as the App installer would install the Linux binaries rather than the windows binaries.