### PR TITLE
[Feedback Wanted!] Proposal/Prototype for Standardised way to represent both Internal Job Mutable state and Externally Visible State

### DIFF
--- a/src/Examples/Jobs/README.md
+++ b/src/Examples/Jobs/README.md
@@ -75,14 +75,14 @@ Jobs can expose internal state for external monitoring via `IPublicJobStateData`
 
 ```csharp
 // Public interface - subset of internal state
-public interface IReadOnlyHttpDownloadState : IPublicJobStateData
+public interface IHttpDownloadState : IPublicJobStateData
 {
     Optional<Size> ContentLength { get; }
     Size TotalBytesDownloaded { get; }
 }
 
 // Internal state - includes both public and private properties
-internal sealed class HttpDownloadState : IReadOnlyHttpDownloadState
+internal sealed class HttpDownloadState : IHttpDownloadState
 {
     public Optional<Size> ContentLength { get; set; }          // ← Exposed
     public Size TotalBytesDownloaded { get; set; }             // ← Exposed
@@ -103,7 +103,7 @@ public class HttpDownloadJob : IJobDefinition<AbsolutePath>
 }
 
 // Usage
-var downloadState = job.GetJobStateData<IReadOnlyHttpDownloadState>();
+var downloadState = job.GetJobStateData<IHttpDownloadState>();
 ```
 
 Usually, the read-only interface is a subset of the full internal state; which is sometimes also used across suspend/resume cycles.

--- a/src/NexusMods.Abstractions.Jobs/IJob.cs
+++ b/src/NexusMods.Abstractions.Jobs/IJob.cs
@@ -71,6 +71,11 @@ public interface IJob
     /// IJob is the reader side, IJobContext is the writer side.
     /// </summary>
     internal IJobContext AsContext();
+    
+    /// <summary>
+    /// Get the current readonly state of the job. Returns null if no state of this type exists.
+    /// </summary>
+    TState? GetReadOnlyState<TState>() where TState : class, IReadOnlyJobState => Definition.GetReadOnlyState() as TState;
 }
 
 /// <summary>

--- a/src/NexusMods.Abstractions.Jobs/IJob.cs
+++ b/src/NexusMods.Abstractions.Jobs/IJob.cs
@@ -73,9 +73,9 @@ public interface IJob
     internal IJobContext AsContext();
     
     /// <summary>
-    /// Get the current readonly state of the job. Returns null if no state of this type exists.
+    /// Get the current job state data. Returns null if no state of this type exists.
     /// </summary>
-    TState? GetReadOnlyState<TState>() where TState : class, IReadOnlyJobState => Definition.GetReadOnlyState() as TState;
+    TState? GetJobStateData<TState>() where TState : class, IPublicJobStateData => Definition.GetJobStateData() as TState;
 }
 
 /// <summary>

--- a/src/NexusMods.Abstractions.Jobs/IJobDefinition.cs
+++ b/src/NexusMods.Abstractions.Jobs/IJobDefinition.cs
@@ -10,6 +10,11 @@ public interface IJobDefinition
     /// When false, calls to <see cref="IJobMonitor.Pause(NexusMods.Abstractions.Jobs.JobId)"/> will cancel the job instead.
     /// </summary>
     bool SupportsPausing => false;
+
+    /// <summary>
+    /// Get the readonly state for external access. Returns null if job has no externally visible state.
+    /// </summary>
+    IReadOnlyJobState? GetReadOnlyState() => null;
 }
 
 /// <summary>

--- a/src/NexusMods.Abstractions.Jobs/IJobDefinition.cs
+++ b/src/NexusMods.Abstractions.Jobs/IJobDefinition.cs
@@ -12,9 +12,9 @@ public interface IJobDefinition
     bool SupportsPausing => false;
 
     /// <summary>
-    /// Get the readonly state for external access. Returns null if job has no externally visible state.
+    /// Get the job state data for external access. Returns null if job has no externally visible state.
     /// </summary>
-    IReadOnlyJobState? GetReadOnlyState() => null;
+    IPublicJobStateData? GetJobStateData() => null;
 }
 
 /// <summary>

--- a/src/NexusMods.Abstractions.Jobs/IPublicJobStateData.cs
+++ b/src/NexusMods.Abstractions.Jobs/IPublicJobStateData.cs
@@ -1,0 +1,8 @@
+namespace NexusMods.Abstractions.Jobs;
+
+/// <summary>
+/// Marker interface for public job state data containers
+/// </summary>
+public interface IPublicJobStateData
+{
+}

--- a/src/NexusMods.Abstractions.Jobs/IReadOnlyJobState.cs
+++ b/src/NexusMods.Abstractions.Jobs/IReadOnlyJobState.cs
@@ -1,0 +1,8 @@
+namespace NexusMods.Abstractions.Jobs;
+
+/// <summary>
+/// Marker interface for readonly job state containers
+/// </summary>
+public interface IReadOnlyJobState
+{
+}

--- a/src/NexusMods.Abstractions.Jobs/IReadOnlyJobState.cs
+++ b/src/NexusMods.Abstractions.Jobs/IReadOnlyJobState.cs
@@ -1,8 +1,0 @@
-namespace NexusMods.Abstractions.Jobs;
-
-/// <summary>
-/// Marker interface for readonly job state containers
-/// </summary>
-public interface IReadOnlyJobState
-{
-}

--- a/src/NexusMods.Networking.HttpDownloader/HttpDownloadJob.cs
+++ b/src/NexusMods.Networking.HttpDownloader/HttpDownloadJob.cs
@@ -57,12 +57,13 @@ public record HttpDownloadJob : IJobDefinitionWithStart<HttpDownloadJob, Absolut
         return ValueTask.CompletedTask;
     }
 
-    private Optional<Size> ContentLength { get; set; }
-    private Optional<EntityTagHeaderValue> ETag { get; set; }
-    private Optional<bool> AcceptRanges { get; set; }
+    private readonly HttpDownloadState _state = new();
     
-    private Size TotalBytesDownloaded { get; set; }
     public bool SupportsPausing => true;
+    /// <summary>
+    /// Implementation for external readonly access
+    /// </summary>
+    public IReadOnlyJobState? GetReadOnlyState() => _state;
     
     /// <summary>
     /// Constructor for the job
@@ -105,6 +106,9 @@ public record HttpDownloadJob : IJobDefinitionWithStart<HttpDownloadJob, Absolut
     private async ValueTask<AbsolutePath> StartAsyncImpl(IJobContext<HttpDownloadJob> context)
     {
         await context.YieldAsync();
+        if (_state.TotalBytesDownloaded > Size.Zero)
+            Logger.LogInformation("Resuming download from {Bytes} bytes", _state.TotalBytesDownloaded);
+        
         await FetchMetadata(context);
 
         await context.YieldAsync();
@@ -117,18 +121,19 @@ public record HttpDownloadJob : IJobDefinitionWithStart<HttpDownloadJob, Absolut
         {
             var (bytesWritten, speed) = tuple;
 
-            TotalBytesDownloaded = bytesWritten;
-            state.SetPercent(bytesWritten, ContentLength.ValueOr(static () => Size.One));
+            _state.TotalBytesDownloaded = bytesWritten;
+            
+            state.SetPercent(bytesWritten, _state.ContentLength.ValueOr(static () => Size.One));
             state.SetRateOfProgress(speed);
         });
 
-        if (ContentLength.HasValue)
+        if (_state.ContentLength.HasValue)
         {
-            var contentLength = (long)ContentLength.Value.Value;
+            var contentLength = (long)_state.ContentLength.Value.Value;
             if (outputStream.Length != contentLength) outputStream.SetLength(contentLength);
         }
 
-        outputStream.Position = (long)TotalBytesDownloaded.Value;
+        outputStream.Position = (long)_state.TotalBytesDownloaded.Value;
 
         await context.YieldAsync();
         using var request = PrepareRequest(out var isRangeRequest);
@@ -143,20 +148,20 @@ public record HttpDownloadJob : IJobDefinitionWithStart<HttpDownloadJob, Absolut
         if (response.StatusCode == HttpStatusCode.OK)
         {
             // NOTE(erri120): We might've not gotten the content length in the initial HEAD request.
-            if (!ContentLength.HasValue)
+            if (!_state.ContentLength.HasValue)
             {
                 // For full requests only, the response should contain the content length at this point.
                 // For range requests, the content length equals the length of the range, so we can't use that here.
                 var newContentLength = response.Content.Headers.ContentLength;
                 if (newContentLength is not null)
                 {
-                    ContentLength = Size.FromLong(newContentLength.Value);
+                    _state.ContentLength = Size.FromLong(newContentLength.Value);
                     outputStream.SetLength(newContentLength.Value);
                 }
             }
         } else if (response.StatusCode == HttpStatusCode.PartialContent)
         {
-            if (!ContentLength.HasValue)
+            if (!_state.ContentLength.HasValue)
             {
                 // Responses to range requests should have this header
                 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Range
@@ -164,7 +169,7 @@ public record HttpDownloadJob : IJobDefinitionWithStart<HttpDownloadJob, Absolut
                 var length = contentRange?.Length;
                 if (length is not null)
                 {
-                    ContentLength = Size.FromLong(length.Value);
+                    _state.ContentLength = Size.FromLong(length.Value);
                     outputStream.SetLength(length.Value);
                 }
             }
@@ -177,9 +182,9 @@ public record HttpDownloadJob : IJobDefinitionWithStart<HttpDownloadJob, Absolut
             Logger.LogWarning("Server `{ServerName}` responded with 200 to a valid range request for download from `{PageUri}`. The download will be reset", response.Headers.Server.ToString(), DownloadPageUri);
 
             // NOTE(erri120): The only thing we can do here is to reset everything and start from scratch.
-            TotalBytesDownloaded = Size.Zero;
+            _state.TotalBytesDownloaded = Size.Zero;
             outputStream.Position = 0;
-            AcceptRanges = false;
+            _state.AcceptRanges = false;
         }
 
         try
@@ -193,7 +198,7 @@ public record HttpDownloadJob : IJobDefinitionWithStart<HttpDownloadJob, Absolut
         }
         finally
         {
-            TotalBytesDownloaded = Size.FromLong(outputStream.Position);
+            _state.TotalBytesDownloaded = Size.FromLong(outputStream.Position);
         }
 
         return Destination;
@@ -204,13 +209,13 @@ public record HttpDownloadJob : IJobDefinitionWithStart<HttpDownloadJob, Absolut
         var request = new HttpRequestMessage(HttpMethod.Get, Uri);
 
         // NOTE(erri120): use a normal GET request for the entire file
-        if (!AcceptRanges.Value || TotalBytesDownloaded == Size.Zero)
+        if (!_state.AcceptRanges.Value || _state.TotalBytesDownloaded == Size.Zero)
         {
             // NOTE(erri120): Using If-Match to ensure that what we're downloading didn't suddenly change
-            if (ETag.HasValue)
+            if (_state.ETag.HasValue)
             {
                 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Match
-                request.Headers.IfMatch.Add(ETag.Value);
+                request.Headers.IfMatch.Add(_state.ETag.Value);
             }
 
             isRangeRequest = false;
@@ -218,10 +223,10 @@ public record HttpDownloadJob : IJobDefinitionWithStart<HttpDownloadJob, Absolut
         else
         {
             // NOTE(erri120): Using If-Range for range requests instead of If-Match
-            if (ETag.HasValue)
+            if (_state.ETag.HasValue)
             {
                 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Range
-                request.Headers.IfRange = new RangeConditionHeaderValue(ETag.Value);
+                request.Headers.IfRange = new RangeConditionHeaderValue(_state.ETag.Value);
             }
 
             // A server MAY send a Content-Length header field in a response to a HEAD request
@@ -229,13 +234,13 @@ public record HttpDownloadJob : IJobDefinitionWithStart<HttpDownloadJob, Absolut
 
             // NOTE(erri120): As such, we might not know the content length, but since we download
             // in serial, we can omit the end position to request all remaining bytes
-            var range = ContentLength.HasValue
+            var range = _state.ContentLength.HasValue
                 ? new RangeHeaderValue(
-                    from: (long)TotalBytesDownloaded.Value,
-                    to: (long)ContentLength.Value.Value
+                    from: (long)_state.TotalBytesDownloaded.Value,
+                    to: (long)_state.ContentLength.Value.Value
                 )
                 : new RangeHeaderValue(
-                    from: (long)TotalBytesDownloaded.Value,
+                    from: (long)_state.TotalBytesDownloaded.Value,
                     to: null
                 );
 
@@ -261,11 +266,11 @@ public record HttpDownloadJob : IJobDefinitionWithStart<HttpDownloadJob, Absolut
         // https://datatracker.ietf.org/doc/html/rfc7233#section-5.1.2
         // "bytes" and "none" are the only range units we care about,
         // "none" meaning the server doesn't support ranges
-        AcceptRanges = response.Headers.AcceptRanges.Contains("bytes");
-        ETag = response.Headers.ETag;
+        _state.AcceptRanges = response.Headers.AcceptRanges.Contains("bytes");
+        _state.ETag = response.Headers.ETag;
 
         var contentLength = response.Content.Headers.ContentLength;
-        ContentLength = contentLength is not null ? Size.FromLong(contentLength.Value) : Optional<Size>.None;
+        _state.ContentLength = contentLength is not null ? Size.FromLong(contentLength.Value) : Optional<Size>.None;
     }
 
     private static ResiliencePipeline<AbsolutePath> BuildResiliencePipeline()
@@ -290,4 +295,32 @@ public record HttpDownloadJob : IJobDefinitionWithStart<HttpDownloadJob, Absolut
 
         return pipeline;
     }
+}
+
+/// <summary>
+/// Readonly interface for external access to download information
+/// </summary>
+[PublicAPI]
+public interface IReadOnlyHttpDownloadState : IReadOnlyJobState
+{
+    /// <summary>
+    /// Content length from HTTP headers
+    /// </summary>
+    Optional<Size> ContentLength { get; }
+    
+    /// <summary>
+    /// Total bytes downloaded so far
+    /// </summary>
+    Size TotalBytesDownloaded { get; }
+}
+
+/// <summary>
+/// Internal mutable state that persists across pause/resume cycles
+/// </summary>
+internal sealed class HttpDownloadState : IReadOnlyHttpDownloadState
+{
+    public Optional<Size> ContentLength { get; set; }
+    public Optional<EntityTagHeaderValue> ETag { get; set; }
+    public Optional<bool> AcceptRanges { get; set; }
+    public Size TotalBytesDownloaded { get; set; }
 }

--- a/src/NexusMods.Networking.HttpDownloader/HttpDownloadJob.cs
+++ b/src/NexusMods.Networking.HttpDownloader/HttpDownloadJob.cs
@@ -301,7 +301,7 @@ public record HttpDownloadJob : IJobDefinitionWithStart<HttpDownloadJob, Absolut
 /// Public interface for external access to download information
 /// </summary>
 [PublicAPI]
-public interface IReadOnlyHttpDownloadState : IPublicJobStateData
+public interface IHttpDownloadState : IPublicJobStateData
 {
     /// <summary>
     /// Content length from HTTP headers
@@ -317,7 +317,7 @@ public interface IReadOnlyHttpDownloadState : IPublicJobStateData
 /// <summary>
 /// Internal mutable state that persists across pause/resume cycles
 /// </summary>
-internal sealed class HttpDownloadState : IReadOnlyHttpDownloadState
+internal sealed class HttpDownloadState : IHttpDownloadState
 {
     public Optional<Size> ContentLength { get; set; }
     public Optional<EntityTagHeaderValue> ETag { get; set; }

--- a/src/NexusMods.Networking.HttpDownloader/HttpDownloadJob.cs
+++ b/src/NexusMods.Networking.HttpDownloader/HttpDownloadJob.cs
@@ -61,9 +61,9 @@ public record HttpDownloadJob : IJobDefinitionWithStart<HttpDownloadJob, Absolut
     
     public bool SupportsPausing => true;
     /// <summary>
-    /// Implementation for external readonly access
+    /// Implementation for external job state data access
     /// </summary>
-    public IReadOnlyJobState? GetReadOnlyState() => _state;
+    public IPublicJobStateData? GetJobStateData() => _state;
     
     /// <summary>
     /// Constructor for the job
@@ -298,10 +298,10 @@ public record HttpDownloadJob : IJobDefinitionWithStart<HttpDownloadJob, Absolut
 }
 
 /// <summary>
-/// Readonly interface for external access to download information
+/// Public interface for external access to download information
 /// </summary>
 [PublicAPI]
-public interface IReadOnlyHttpDownloadState : IReadOnlyJobState
+public interface IReadOnlyHttpDownloadState : IPublicJobStateData
 {
     /// <summary>
     /// Content length from HTTP headers

--- a/tests/NexusMods.Jobs.Tests/Examples/BestPractices/JobStateManagementExample.cs
+++ b/tests/NexusMods.Jobs.Tests/Examples/BestPractices/JobStateManagementExample.cs
@@ -1,0 +1,69 @@
+using FluentAssertions;
+using JetBrains.Annotations;
+using NexusMods.Abstractions.Jobs;
+using Xunit;
+
+namespace NexusMods.Jobs.Tests.Examples.BestPractices;
+
+/// <summary>
+/// Simple example of job state management pattern
+/// </summary>
+[PublicAPI]
+public class JobStateManagementExample(IJobMonitor jobMonitor)
+{
+    [Fact]
+    public async Task RunExample()
+    {
+        var job = new CounterJob { TargetCount = 5 };
+        var task = jobMonitor.Begin<CounterJob, int>(job);
+        
+        // Access job state externally
+        var state = task.Job.GetJobStateData<ICounterState>();
+        state.Should().NotBeNull();
+        
+        var result = await task;
+        result.Should().Be(5);
+        
+        // Verify final state
+        state = task.Job.GetJobStateData<ICounterState>();
+        state!.CurrentCount.Should().Be(5);
+    }
+}
+
+/// <summary>
+/// Public interface - subset of internal state
+/// </summary>
+public interface ICounterState : IPublicJobStateData
+{
+    int CurrentCount { get; }
+}
+
+/// <summary>
+/// Internal state - includes both public and private properties
+/// </summary>
+internal sealed class CounterJobState : ICounterState
+{
+    public int CurrentCount { get; set; }              // ← Exposed
+    internal DateTime StartTime { get; set; }          // ← Internal only
+}
+
+/// <summary>
+/// Example job that exposes state
+/// </summary>
+[PublicAPI]
+public record CounterJob : IJobDefinitionWithStart<CounterJob, int>
+{
+    public required int TargetCount { get; init; }
+    
+    private readonly CounterJobState _state = new();
+    public IPublicJobStateData? GetJobStateData() => _state;
+    
+    public ValueTask<int> StartAsync(IJobContext<CounterJob> context)
+    {
+        _state.StartTime = DateTime.UtcNow;
+        for (var x = 0; x < TargetCount; x++)
+            _state.CurrentCount++;
+
+        return ValueTask.FromResult(_state.CurrentCount);
+    }
+}


### PR DESCRIPTION
***Looking for feedback here***; curious if anyone has other ideas for approaches.
I'm down for a brainstorm.

## Summary

Trying to do two things here; in a way where they harmonize with each other:

- Group mutable state of jobs which gets reused across pause/resume cycles.
    - (This is also a step towards job persistence)
- Expose internal job state for querying by external code.

More info below.

## Design

This design boils down into two items.

- Mutable state is grouped into a struct.
- *ReadOnly state is a slice of that mutable state* which you wish to make world readable.

```csharp
// Public readonly interface for external access
public interface IReadOnlyHttpDownloadState : IReadOnlyJobState
{
    Optional<Size> ContentLength { get; }
    Size TotalBytesDownloaded { get; }
}

// Internal mutable state with additional fields
// Persisted across runs, for pause/resume.
internal sealed class HttpDownloadState : IReadOnlyHttpDownloadState
{
    public Optional<Size> ContentLength { get; set; }           // ← Readonly property
    public Size TotalBytesDownloaded { get; set; }             // ← Readonly property
    
    public Optional<EntityTagHeaderValue> ETag { get; set; }   // ← Internal only
    public Optional<bool> AcceptRanges { get; set; }           // ← Internal only
}
```

Jobs can expose their mutable state through the readonly interface:

```csharp
private readonly HttpDownloadState _state = new();
public IReadOnlyJobState? GetReadOnlyState() => _state;  // ← Exposes as readonly
```

This `GetReadOnlyState` is then re-exposed via `IJob` (the reporting/read-only side of jobs) via `GetReadOnlyState<TState>`.

## Example

Accessing Job State from External Services

```csharp
// Starting a download job
var jobTask = jobMonitor.Begin<HttpDownloadJob, AbsolutePath>(downloadJob);

// External services can now access readonly state safely
var downloadState = jobTask.Job.GetReadOnlyState<IReadOnlyHttpDownloadState>();

// Access specific download metrics
var contentLength = downloadState.ContentLength;
var downloaded = downloadState.TotalBytesDownloaded;
// e.g. Needed for Downloads Menu
```

## Further Thoughts: Reactive Properties

The mutable state could optionally use `[Reactive]` attributes for automatic change notifications:

```csharp
internal sealed class HttpDownloadState : IReadOnlyHttpDownloadState
{
    [Reactive] public Optional<Size> ContentLength { get; set; }
    [Reactive] public Size TotalBytesDownloaded { get; set; }
    
    public Optional<EntityTagHeaderValue> ETag { get; set; }   // ← Non-reactive
    public Optional<bool> AcceptRanges { get; set; }          // ← Non-reactive
}
```

For downloads I plan to poll for efficiency reasons; but I figured I'd mention this as a possibility.
Mostly as I'd want to note this in documentation.

## Changes (Summary)

- Added `IReadOnlyJobState` marker interface for external job state access
- Enhanced `IJob` interface with `GetReadOnlyState<T>()` method for type-safe state retrieval
- Extended `IJobDefinition` with `GetReadOnlyState()` for exposing readonly state
- Refactored `HttpDownloadJob` from scattered private fields to `HttpDownloadState` class
- Added `IReadOnlyHttpDownloadState` interface for external monitoring of download progress.

Left out tests/docs/examples etc. as this is purely a prototype/proposal for thoughts.