### PR TITLE
Cloning Collections

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,8 +18,8 @@
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.7.0" />
     <PackageVersion Include="Nerdbank.FullDuplexStream" Version="1.1.12" />
     <PackageVersion Include="Nerdbank.Streams" Version="2.11.79" />
-    <PackageVersion Include="NexusMods.MnemonicDB" Version="0.20.0" />
-    <PackageVersion Include="NexusMods.MnemonicDB.Abstractions" Version="0.20.0" />
+    <PackageVersion Include="NexusMods.MnemonicDB" Version="0.21.0" />
+    <PackageVersion Include="NexusMods.MnemonicDB.Abstractions" Version="0.21.0" />
     <PackageVersion Include="NexusMods.Hashing.xxHash3.Paths" Version="3.0.4" />
     <PackageVersion Include="NexusMods.Hashing.xxHash3" Version="3.0.4" />
     <PackageVersion Include="NexusMods.Archives.Nx" Version="0.6.4" />
@@ -149,7 +149,7 @@
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="ini-parser-netstandard" Version="2.5.2" />
     <PackageVersion Include="Mutagen.Bethesda.Skyrim" Version="0.44.0" />
-    <PackageVersion Include="NexusMods.MnemonicDB.SourceGenerator" Version="0.20.0" />
+    <PackageVersion Include="NexusMods.MnemonicDB.SourceGenerator" Version="0.21.0" />
     <PackageVersion Include="NLog.Extensions.Logging" Version="5.3.14" />
     <PackageVersion Include="OneOf" Version="3.0.271" />
     <PackageVersion Include="ReactiveUI.Fody" Version="19.5.41" />

--- a/src/NexusMods.Abstractions.Loadouts/Models/CollectionGroup.cs
+++ b/src/NexusMods.Abstractions.Loadouts/Models/CollectionGroup.cs
@@ -1,9 +1,12 @@
+using System.Runtime.InteropServices;
 using DynamicData.Kernel;
 using NexusMods.HyperDuck;
 using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.MnemonicDB.Abstractions.Attributes;
+using NexusMods.MnemonicDB.Abstractions.ElementComparers;
 using NexusMods.MnemonicDB.Abstractions.IndexSegments;
 using NexusMods.MnemonicDB.Abstractions.Models;
+using NexusMods.MnemonicDB.Abstractions.ValueSerializers;
 
 namespace NexusMods.Abstractions.Loadouts;
 
@@ -19,6 +22,82 @@ public partial class CollectionGroup : IModelDefinition
     /// If the collection is read-only it won't support adding new mods or modifying the existing files. 
     /// </summary>
     public static readonly BooleanAttribute IsReadOnly = new(Namespace, nameof(IsReadOnly)) { IsIndexed = true };
+    
+    
+
+    private const string CollectionEntities = """
+                                              WITH RECURSIVE ChildLoadoutItems (Id) AS
+                                              (SELECT $Id
+                                               UNION
+                                               SELECT Id FROM (SELECT Id, Parent FROM mdb_LoadoutItem(Db=>$Db)
+                                                               UNION ALL
+                                                               SELECT Id, ParentEntity FROM mdb_SortOrder(Db=>$Db)
+                                                               UNION ALL
+                                                               SELECT Id, ParentSortOrder FROM mdb_SortOrderItem(Db=>$Db))
+                                               WHERE Parent in (SELECT Id FROM ChildLoadoutItems))
+                                              SELECT DISTINCT Id FROM ChildLoadoutItems
+                                              """;
+    
+    /// <summary>
+    /// Performs a deep clone of the collection, and includes all child loadout items and sortable items and lists
+    /// </summary>
+    public static async Task<EntityId> Clone(IConnection conn, EntityId id)
+    {
+        Span<byte> refScratch = stackalloc byte[8];
+        using var writer = new PooledMemoryBufferWriter();
+
+        var basisDb = conn.Db;
+
+        Dictionary<EntityId, EntityId> remappedIds = new();
+        var query = conn.Query<EntityId>(CollectionEntities, new { Db = basisDb, Id = id});
+        using var tx = conn.BeginTransaction();
+        foreach (var itemId in query)
+        {
+            remappedIds.TryAdd(itemId, tx.TempId());
+        }
+
+        foreach (var (oldId, newId) in remappedIds)
+        {
+            var entity = basisDb.Get(oldId);
+            foreach (var datom in entity)
+            {
+                // Remap the value part of references
+                if (datom.Prefix.ValueTag == ValueTag.Reference)
+                {
+                    var oldRef = EntityId.From(UInt64Serializer.Read(datom.ValueSpan));
+                    if (!remappedIds.TryGetValue(oldRef, out var newRef))
+                    {
+                        tx.Add(newId, datom.A, datom.Prefix.ValueTag, datom.ValueSpan);
+                        continue;
+                    }
+                    MemoryMarshal.Write(refScratch, newRef);
+                    tx.Add(newId, datom.A, datom.Prefix.ValueTag, refScratch);
+                }
+                // It's rare, but the Ref,UShort/String tuple type may include a ref that needs to be remapped
+                else if (datom.Prefix.ValueTag == ValueTag.Tuple3_Ref_UShort_Utf8I)
+                {
+                    var (r, s, str) = Tuple3_Ref_UShort_Utf8I_Serializer.Read(datom.ValueSpan);
+                    if (!remappedIds.TryGetValue(r, out var newR))
+                    {
+                        tx.Add(newId, datom.A, datom.Prefix.ValueTag, datom.ValueSpan);
+                        continue;
+                    }
+                    writer.Reset();
+                    var newTuple = (newR, s, str);
+                    Tuple3_Ref_UShort_Utf8I_Serializer.Write(newTuple, writer);
+                    tx.Add(newId, datom.A, datom.Prefix.ValueTag, writer.GetWrittenSpan());
+                }
+                // Otherwise just remap the E value
+                else
+                {
+                    tx.Add(newId, datom.A, datom.Prefix.ValueTag, datom.ValueSpan);
+                }
+            }
+        }
+
+        var result = await tx.Commit();
+        return result[remappedIds[id]];
+    }
 }
 
 public static partial class CollectionGroupLoaderExtensions

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutDesignViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutDesignViewModel.cs
@@ -30,6 +30,8 @@ public class CollectionLoadoutDesignViewModel : APageViewModel<ICollectionLoadou
     public Bitmap BackgroundImage { get; } = new(AssetLoader.Open(new Uri("avares://NexusMods.App.UI/Assets/DesignTime/header-background.webp")));
     public ReactiveCommand<Unit> CommandToggle { get; } = new ReactiveCommand();
     public ReactiveCommand<Unit> CommandDeleteCollection { get; } = new ReactiveCommand();
+    public ReactiveCommand<Unit> CommandMakeLocalEditableCopy { get; } = new ReactiveCommand();
+
     public ReactiveUI.ReactiveCommand<NavigationInformation, System.Reactive.Unit> CommandViewCollectionDownloadPage { get; } 
         = ReactiveUI.ReactiveCommand.Create<NavigationInformation, System.Reactive.Unit>(_ => System.Reactive.Unit.Default);
     public bool IsLocalCollection { get; } = false;

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutView.axaml
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutView.axaml
@@ -32,6 +32,13 @@
 
                     <controls:StandardButton.Flyout>
                         <MenuFlyout>
+                            <navigation:NavigationMenuItem Header="Make an editable local copy"
+                                                           x:Name="MakeEditableLocalCopy">
+                                <MenuItem.Icon>
+                                    <icons:UnifiedIcon Size="16"
+                                                       Value="{x:Static icons:IconValues.Copy}" />
+                                </MenuItem.Icon>
+                            </navigation:NavigationMenuItem>
                             <navigation:NavigationMenuItem Header="View collection download page"
                                                            x:Name="ViewCollectionDownloadMenuItem">
                                 <MenuItem.Icon>

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutView.axaml.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutView.axaml.cs
@@ -66,6 +66,8 @@ public partial class CollectionLoadoutView : ReactiveUserControl<ICollectionLoad
                 .AddTo(disposables);
             this.BindCommand(ViewModel, vm => vm.CommandDeleteCollection, view => view.RemoveCollectionMenuItem)
                 .AddTo(disposables);
+            this.BindCommand(ViewModel, vm => vm.CommandMakeLocalEditableCopy, view => view.MakeEditableLocalCopy)
+                .AddTo(disposables);
             this.BindCommand(ViewModel, vm => vm.CommandViewCollectionDownloadPage, view => view.ViewCollectionDownloadMenuItem)
                 .AddTo(disposables);
 

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/CollectionLoadoutViewModel.cs
@@ -14,6 +14,8 @@ using DynamicData;
 using NexusMods.Abstractions.Collections;
 using NexusMods.Abstractions.Jobs;
 using NexusMods.App.UI.Controls.Navigation;
+using NexusMods.App.UI.Dialog;
+using NexusMods.App.UI.Dialog.Enums;
 using NexusMods.App.UI.Extensions;
 using NexusMods.App.UI.Pages.CollectionDownload;
 using NexusMods.MnemonicDB.Abstractions.Query;
@@ -152,6 +154,50 @@ public class CollectionLoadoutViewModel : APageViewModel<ICollectionLoadoutViewM
             }
         );
 
+        CommandMakeLocalEditableCopy = new ReactiveCommand(
+            executeAsync: async (_, _) =>
+            {
+                var dialog = DialogFactory.CreateStandardDialog(
+                    "Collection Name",
+                    new StandardDialogParameters()
+                    {
+                        Text = "This is the name of the new cloned collection.",
+                        InputLabel = "Collection name",
+                        InputWatermark = "(Local) " + group.AsLoadoutItemGroup().AsLoadoutItem().Name,
+                    },
+                    [
+                        DialogStandardButtons.Cancel,
+                        new DialogButtonDefinition(
+                            "Create",
+                            ButtonDefinitionId.Accept,
+                            ButtonAction.Accept,
+                            ButtonStyling.Primary
+                        ),
+                    ]
+                );
+                var result = await WindowManager.ShowDialog(dialog, DialogWindowType.Modal);
+                if (result.ButtonId != ButtonDefinitionId.Accept || string.IsNullOrWhiteSpace(result.InputText))
+                    return;
+                
+                var cloneId = await NexusCollectionLoadoutGroup.MakeEditableLocalCollection(group.Db.Connection, group.Id, result.InputText);
+                
+                var pageData = new PageData
+                {
+                    FactoryId = CollectionLoadoutPageFactory.StaticId,
+                    Context = new CollectionLoadoutPageContext()
+                    {
+                        LoadoutId = group.AsLoadoutItemGroup().AsLoadoutItem().LoadoutId, 
+                        GroupId = CollectionGroupId.From(cloneId),
+                    },
+                };
+
+                var workspaceController = GetWorkspaceController();
+                var behavior = workspaceController.GetOpenPageBehavior(pageData, NavigationInformation.From(OpenPageBehaviorType.ReplaceTab));
+                workspaceController.OpenPage(WorkspaceId, pageData, behavior);
+            }
+        );
+
+
         this.WhenActivated(disposables =>
         {
             Adapter.Activate().AddTo(disposables);
@@ -241,5 +287,7 @@ public class CollectionLoadoutViewModel : APageViewModel<ICollectionLoadoutViewM
     
     public ReactiveCommand<Unit> CommandToggle { get; }
     public ReactiveCommand<Unit> CommandDeleteCollection { get; }
+    
+    public ReactiveCommand<Unit> CommandMakeLocalEditableCopy { get; }
     public ReactiveUI.ReactiveCommand<NavigationInformation, System.Reactive.Unit> CommandViewCollectionDownloadPage { get; }
 }

--- a/src/NexusMods.App.UI/Pages/LoadoutPage/ICollectionLoadoutViewModel.cs
+++ b/src/NexusMods.App.UI/Pages/LoadoutPage/ICollectionLoadoutViewModel.cs
@@ -64,5 +64,7 @@ public interface ICollectionLoadoutViewModel : IPageViewModelInterface
     
     R3.ReactiveCommand<R3.Unit> CommandDeleteCollection { get; }
     
+    R3.ReactiveCommand<R3.Unit> CommandMakeLocalEditableCopy { get; }
+    
     ReactiveCommand<NavigationInformation, Unit> CommandViewCollectionDownloadPage { get; }
 }

--- a/tests/NexusMods.DataModel.Tests/AArchivedDatabaseTest.cs
+++ b/tests/NexusMods.DataModel.Tests/AArchivedDatabaseTest.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.FileExtractor;
 using NexusMods.Abstractions.GameLocators;
+using NexusMods.Abstractions.Games;
 using NexusMods.Abstractions.Library.Models;
 using NexusMods.Abstractions.Loadouts;
 using NexusMods.Abstractions.NexusModsLibrary;
@@ -89,6 +90,7 @@ public abstract class AArchivedDatabaseTest
             .AddStubbedStardewValley()
             .AddNexusModsCollections()
             .AddNexusModsLibraryModels()
+            .AddSortOrderItemModel()
             .OverrideSettingsForTests<FileHashesServiceSettings>(settings => settings with
             {
                 HashDatabaseLocation = new ConfigurablePath(baseKnownPath, $"{baseDirectory}/FileHashService"),

--- a/tests/NexusMods.DataModel.Tests/CollectionTests.cs
+++ b/tests/NexusMods.DataModel.Tests/CollectionTests.cs
@@ -1,0 +1,37 @@
+using FluentAssertions;
+using NexusMods.Abstractions.Collections;
+using NexusMods.Abstractions.Loadouts;
+using NexusMods.MnemonicDB.Abstractions;
+using Xunit.Abstractions;
+
+namespace NexusMods.DataModel.Tests;
+
+public class CollectionTests(ITestOutputHelper helper) : AArchivedDatabaseTest(helper)
+{
+    [Fact]
+    public async Task CanMakeNexusModsCollectionsEditable()
+    {
+        // Load up a database with two collections installed, and the first one deleted
+        await using var tmpConn = await ConnectionFor("two_sdv_collections_added_removed.zip");
+        
+        var collId = tmpConn.Connection.Query<EntityId>("SELECT Id FROM mdb_NexusCollectionLoadoutGroup(Db => $db) ORDER BY Name DESC", tmpConn.Connection.Db).First();
+        var coll = NexusCollectionLoadoutGroup.Load(tmpConn.Connection.Db, collId);
+        
+        coll.AsCollectionGroup().AsLoadoutItemGroup().AsLoadoutItem().Name.Should().BeEquivalentTo("Aesthetic Valley | Witchcore");
+
+        var newId = await NexusCollectionLoadoutGroup.MakeEditableLocalCollection(tmpConn.Connection, coll, "[Copy Of] Aesthetic Valley | Witchcore");
+        var newColl = CollectionGroup.Load(tmpConn.Connection.Db, newId);
+        
+        newColl.AsLoadoutItemGroup().AsLoadoutItem().Name.Should().BeEquivalentTo("[Copy Of] Aesthetic Valley | Witchcore");
+        newColl.IsReadOnly.Should().BeFalse();
+
+        NexusCollectionLoadoutGroup.Collection.Contains(newColl).Should().BeFalse();
+        NexusCollectionLoadoutGroup.Collection.Contains(coll).Should().BeTrue();
+        
+        NexusCollectionLoadoutGroup.Revision.Contains(newColl).Should().BeFalse();
+        NexusCollectionLoadoutGroup.Revision.Contains(coll).Should().BeTrue();
+        
+        NexusCollectionLoadoutGroup.LibraryFile.Contains(newColl).Should().BeFalse();
+        NexusCollectionLoadoutGroup.LibraryFile.Contains(coll).Should().BeTrue();
+    }
+}


### PR DESCRIPTION
Adds support for #3517, adds a button on the menu of Nexus Collections allowing the user to provide a name (via a dialog box). 

The resulting collection is a clone of the first, with the name changed, the `readonly` flag removed, and references to the Nexus Collection purged. 

Known Issue: the UI glitches slightly and is still orange for "nexus collection" even though the collection is now editable. 