### PR TITLE
Add CTRL+A Select All  support to `TreeDataGridAdapter`

### DIFF
--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridAdapter.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridAdapter.cs
@@ -190,6 +190,21 @@ public abstract class TreeDataGridAdapter<TModel, TKey> : ReactiveR3Object, ISea
     }
 
     public void ClearSelection() => _selectionModel?.Clear();
+    
+    public void SelectAll()
+    {
+        if (_selectionModel is null) return;
+
+        _selectionModel.BeginBatchUpdate();
+        using (Disposable.Create(() => _selectionModel.EndBatchUpdate()))
+        {
+            _selectionModel.Clear();
+            for (var i = 0; i < Roots.Count; i++)
+            {
+                _selectionModel.Select(new IndexPath(i));
+            }
+        }
+    }
 
     /// <summary>
     /// Called when a row drag operation is started.

--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridViewHelper.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridViewHelper.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.ReactiveUI;
 using NexusMods.Abstractions.UI;
 using R3;
@@ -68,6 +69,24 @@ public static class TreeDataGridViewHelper
                             state.getAdapter(state.view.ViewModel!).OnRowDrop(eventArgs.sender, eventArgs.e))
                     .AddTo(disposables);
             }
+            
+            // CTRL + A support
+            Observable.FromEventHandler<KeyEventArgs>(
+                addHandler: handler => treeDataGrid.KeyDown += handler,
+                removeHandler: handler => treeDataGrid.KeyDown -= handler)
+                .Where(e => 
+                    e.e.Key == Key.A 
+                    && e.e.KeyModifiers.HasFlag(KeyModifiers.Control)
+                    )
+                .Subscribe((view, getAdapter), static (eventArgs, state) =>
+                {
+                    var adapter = state.getAdapter(state.view.ViewModel!);
+                    // Select all items
+                    adapter.SelectAll();
+                    
+                    eventArgs.e.Handled = true;
+                })
+                .AddTo(disposables);
         });
     }
 }


### PR DESCRIPTION
- Close #2181 

CTRL + A should now work on all TreeDataGrids using the Adapter (all the main ones).

## QA
Please check
- [ ] Loadout page
- [ ] Library page
- [ ] Collection download page
- [ ] Collection installed page
- [ ] View Mod Files page