### PR TITLE
Add progress reporting to loadout Synchronization

### DIFF
--- a/benchmarks/NexusMods.Benchmarks/Benchmarks/Loadouts/Harness/DummyFileStore.cs
+++ b/benchmarks/NexusMods.Benchmarks/Benchmarks/Loadouts/Harness/DummyFileStore.cs
@@ -22,7 +22,7 @@ public class DummyFileStore : IFileStore
         return Task.CompletedTask;
     }
 
-    public Task ExtractFiles(IEnumerable<(Hash Hash, AbsolutePath Dest)> files, CancellationToken token = default)
+    public Task ExtractFiles(IEnumerable<(Hash Hash, AbsolutePath Dest)> files, CancellationToken token = default, Action<(int Current, int Max)>? progress = null)
     {
         return Task.CompletedTask;
     }

--- a/src/NexusMods.Abstractions.Loadouts.Synchronizers/ILoadoutSynchronizer.cs
+++ b/src/NexusMods.Abstractions.Loadouts.Synchronizers/ILoadoutSynchronizer.cs
@@ -41,13 +41,13 @@ public interface ILoadoutSynchronizer
     /// <summary>
     /// Run the groupings on the game folder and return a new loadout with the changes applied.
     /// </summary>
-    Task<Loadout.ReadOnly> RunActions(Dictionary<GamePath, SyncNode> syncTree, Loadout.ReadOnly loadout);
+    Task<Loadout.ReadOnly> RunActions(Dictionary<GamePath, SyncNode> syncTree, Loadout.ReadOnly loadout, SynchronizeLoadoutJob? job = null);
     
     /// <summary>
     /// Synchronizes the loadout with the game folder, any changes in the game folder will be added to the loadout, and any
     /// new changes in the loadout will be applied to the game folder.
     /// </summary>
-    Task<Loadout.ReadOnly> Synchronize(Loadout.ReadOnly loadout);
+    Task<Loadout.ReadOnly> Synchronize(Loadout.ReadOnly loadout, SynchronizeLoadoutJob? job = null);
     
     
     /// <summary>

--- a/src/NexusMods.Abstractions.Loadouts.Synchronizers/Jobs/SynchronizeLoadoutJob.cs
+++ b/src/NexusMods.Abstractions.Loadouts.Synchronizers/Jobs/SynchronizeLoadoutJob.cs
@@ -8,6 +8,20 @@ namespace NexusMods.Abstractions.Loadouts.Synchronizers;
 /// any changes in the game folder will be added to the loadout,
 /// and any new changes in the loadout will be applied to the game folder.
 /// </summary>
-/// <param name="LoadoutId"></param>
-public record SynchronizeLoadoutJob(LoadoutId LoadoutId) : IJobDefinition<Unit>;
+public record SynchronizeLoadoutJob(LoadoutId LoadoutId, BindableReactiveProperty<string> StatusMessage) : IJobDefinition<Unit>
+{
+    public SynchronizeLoadoutJob(LoadoutId loadoutId) : this(loadoutId, new BindableReactiveProperty<string>()) {}
+    
+    public void SetStatus(string message)
+    {
+        try
+        {
+            StatusMessage.Value = message;
+        }
+        catch (Exception)
+        {
+            // ignored
+        }
+    }
+}
     

--- a/src/NexusMods.App.UI/LeftMenu/Items/ApplyControl/ApplyControlDesignViewModel.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Items/ApplyControl/ApplyControlDesignViewModel.cs
@@ -22,6 +22,8 @@ public class ApplyControlDesignViewModel : AViewModel<IApplyControlViewModel>, I
     public bool IsProcessing { get; } = false;
     public string ApplyButtonText { get; } = Language.ApplyControlViewModel__APPLY;
 
+    public string ProcessingText { get; } = "PROCESSING TEXT";
+
     public ApplyControlDesignViewModel()
     {
         ShowApplyDiffCommand = ReactiveCommand.Create<NavigationInformation>(_ => { });

--- a/src/NexusMods.App.UI/LeftMenu/Items/ApplyControl/ApplyControlView.axaml.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Items/ApplyControl/ApplyControlView.axaml.cs
@@ -42,6 +42,9 @@ public partial class ApplyControlView : ReactiveUserControl<IApplyControlViewMod
 
                 this.OneWayBind(ViewModel, vm => vm.ApplyButtonText, v => v.ApplyButtonTextBlock.Text)
                     .DisposeWith(disposables);
+                
+                this.OneWayBind(ViewModel, vm => vm.ProcessingText, v => v.ProgressBarControl.ProgressTextFormat)
+                    .DisposeWith(disposables);
             }
         );
     }

--- a/src/NexusMods.App.UI/LeftMenu/Items/ApplyControl/IApplyControlViewModel.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Items/ApplyControl/IApplyControlViewModel.cs
@@ -20,4 +20,6 @@ public interface IApplyControlViewModel : IViewModelInterface
     bool IsApplying { get; }
     
     string ApplyButtonText { get; }
+    
+    string ProcessingText { get; }
 }

--- a/src/NexusMods.DataModel/NxFileStore.cs
+++ b/src/NexusMods.DataModel/NxFileStore.cs
@@ -157,7 +157,7 @@ public class NxFileStore : IFileStore
     }
     
     /// <inheritdoc />
-    public async Task ExtractFiles(IEnumerable<(Hash Hash, AbsolutePath Dest)> files, CancellationToken token = default)
+    public async Task ExtractFiles(IEnumerable<(Hash Hash, AbsolutePath Dest)> files, CancellationToken token = default, Action<(int Current, int Max)>? progressUpdater = null)
     {
         using var lck = _lock.ReadLock();
 
@@ -207,9 +207,12 @@ public class NxFileStore : IFileStore
             }
         });
 
+        var groupIdx = 0;
         // Extract from all source archives.
         foreach (var group in groupedFiles)
         {
+            groupIdx++;
+            progressUpdater?.Invoke((groupIdx, groupedFiles.Count));
             await using var file = group.Key.Read();
             var provider = new FromStreamProvider(file);
             var unpacker = new NxUnpacker(provider);

--- a/src/NexusMods.DataModel/Synchronizer/SynchronizerService.cs
+++ b/src/NexusMods.DataModel/Synchronizer/SynchronizerService.cs
@@ -84,6 +84,7 @@ public class SynchronizerService : ISynchronizerService
         await _jobMonitor.Begin(new SynchronizeLoadoutJob(loadoutId),
             async ctx =>
             {
+                var job = ctx.Definition;
                 await _semaphore.WaitAsync();
                 try
                 {
@@ -96,7 +97,7 @@ public class SynchronizerService : ISynchronizerService
                     var gameState = GetOrAddGameState(loadout.InstallationInstance.GameMetadataId);
                     using var _2 = gameState.WithLock();
 
-                    await loadout.InstallationInstance.GetGame().Synchronizer.Synchronize(loadout);
+                    await loadout.InstallationInstance.GetGame().Synchronizer.Synchronize(loadout, job);
                 }
                 finally
                 {

--- a/src/NexusMods.Games.RedEngine/Cyberpunk2077/Cyberpunk2077Synchronizer.cs
+++ b/src/NexusMods.Games.RedEngine/Cyberpunk2077/Cyberpunk2077Synchronizer.cs
@@ -51,9 +51,9 @@ public class Cyberpunk2077Synchronizer : ALoadoutSynchronizer
         ArchivePcEp1Folder,
     ];
 
-    public override async Task<Loadout.ReadOnly> Synchronize(Loadout.ReadOnly loadout)
+    public override async Task<Loadout.ReadOnly> Synchronize(Loadout.ReadOnly loadout, SynchronizeLoadoutJob? job)
     {
-        loadout = await base.Synchronize(loadout);
+        loadout = await base.Synchronize(loadout, job);
         if (!MissingRedModEmitter.HasRedMods(loadout, out _, out var numRedModDirs)) return loadout;
         if (!MissingRedModEmitter.HasRedModToolInstalled(loadout, out _))
         {
@@ -62,7 +62,7 @@ public class Cyberpunk2077Synchronizer : ALoadoutSynchronizer
         }
 
         await _redModTool.Execute(loadout, CancellationToken.None);
-        return await base.Synchronize(loadout);
+        return await base.Synchronize(loadout, job);
     }
 
 

--- a/src/NexusMods.Sdk/FileStore/IFileStore.cs
+++ b/src/NexusMods.Sdk/FileStore/IFileStore.cs
@@ -57,7 +57,7 @@ public interface IFileStore
     /// <param name="files"></param>
     /// <param name="token"></param>
     /// <returns></returns>
-    Task ExtractFiles(IEnumerable<(Hash Hash, AbsolutePath Dest)> files, CancellationToken token = default);
+    Task ExtractFiles(IEnumerable<(Hash Hash, AbsolutePath Dest)> files, CancellationToken token = default, Action<(int Current, int Max)>? progress = null);
 
     /// <summary>
     /// Extract the given files from archives.


### PR DESCRIPTION
I tried adding progress bars, but there's just too much variance to the timing of the code. So this is an alternative: updating the text on the spinner during apply. This way we can at least see where stalls are happening (deleting files, extracting files, backups, etc). The updates can be fine-grained like "extracting file X of Y" or more course "gathering information". 