### PR TITLE
Performance Improvements for loading disk state entries

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,5 +1,6 @@
 <Project>
   <ItemGroup>
+    <PackageVersion Include="CommunityToolkit.HighPerformance" Version="8.4.0" />
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />
     <PackageVersion Include="TUnit" Version="0.25.0" />
     <PackageVersion Include="Avalonia.AvaloniaEdit" Version="11.3.0" />

--- a/src/NexusMods.Abstractions.Loadouts.Synchronizers/NexusMods.Abstractions.Loadouts.Synchronizers.csproj
+++ b/src/NexusMods.Abstractions.Loadouts.Synchronizers/NexusMods.Abstractions.Loadouts.Synchronizers.csproj
@@ -8,6 +8,7 @@
       <ProjectReference Include="..\NexusMods.Abstractions.GC\NexusMods.Abstractions.GC.csproj" />
       <ProjectReference Include="..\NexusMods.Abstractions.Jobs\NexusMods.Abstractions.Jobs.csproj" />
       <ProjectReference Include="..\NexusMods.Abstractions.Loadouts\NexusMods.Abstractions.Loadouts.csproj" />
+      <PackageReference Include="CommunityToolkit.HighPerformance" />
       <PackageReference Include="NexusMods.Hashing.xxHash3" />
       <PackageReference Include="NexusMods.Hashing.xxHash3.Paths" />
       <PackageReference Include="NexusMods.MnemonicDB.SourceGenerator" PrivateAssets="all" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />

--- a/src/NexusMods.Abstractions.Loadouts/Models/DiskStateExtensions.cs
+++ b/src/NexusMods.Abstractions.Loadouts/Models/DiskStateExtensions.cs
@@ -56,17 +56,4 @@ public static class DiskStateExtensions
         return DiskStateAsOf(metadata, TxId.From(tx.Id.Value));
     }
 
-    /// <summary>
-    /// Load the disk state of the game as of the last applied loadout
-    /// </summary>
-    public static Entities<DiskStateEntry.ReadOnly> GetLastAppliedDiskState(this GameInstallMetadata.ReadOnly metadata)
-    {
-        // No previously applied loadout, return an empty state
-        if (!metadata.Contains(GameInstallMetadata.LastSyncedLoadout))
-        {
-            return new(new EntityIds { Data = new byte[sizeof(uint)] }, metadata.Db);
-        }
-
-        return metadata.DiskStateAsOf(metadata.LastSyncedLoadoutTransaction);
-    }
 }

--- a/src/NexusMods.Abstractions.Loadouts/Models/DiskStateExtensions.cs
+++ b/src/NexusMods.Abstractions.Loadouts/Models/DiskStateExtensions.cs
@@ -12,17 +12,6 @@ namespace NexusMods.Abstractions.Loadouts;
 /// </summary>
 public static class DiskStateExtensions
 {
-
-    /// <summary>
-    /// Returns the last synchronized loadout for the game, if any
-    /// </summary>
-    public static Optional<LoadoutId> LastSynchronizedLoadout(this GameInstallMetadata.ReadOnly metadata)
-    {
-        if (GameInstallMetadata.LastSyncedLoadout.TryGetValue(metadata, out var lastApplied))
-            return LoadoutId.From(lastApplied);
-        return Optional<LoadoutId>.None;
-    }
-
     
     /// <summary>
     /// Gets the latest game metadata for the installation
@@ -31,29 +20,4 @@ public static class DiskStateExtensions
     {
         return GameInstallMetadata.Load(connection.Db, installation.GameMetadataId);
     }
-
-    /// <summary>
-    /// Gets the disk state of the game as of a specific transaction
-    /// </summary>
-    /// <param name="metadata"></param>
-    /// <param name="txId"></param>
-    /// <returns></returns>
-    public static Entities<DiskStateEntry.ReadOnly> DiskStateAsOf(this GameInstallMetadata.ReadOnly metadata, TxId txId)
-    {
-        // Get an as-of db for the last applied loadout
-        var asOfDb = metadata.Db.Connection.AsOf(txId);
-        // Get the attributes for the entries in the disk state
-
-        var ret = DiskStateEntry.FindByGame(asOfDb, metadata.Id);
-        return ret;
-    }
-    
-    /// <summary>
-    /// Gets the disk state of the game as of a specific transaction
-    /// </summary>
-    public static Entities<DiskStateEntry.ReadOnly> DiskStateAsOf(this GameInstallMetadata.ReadOnly metadata, Transaction.ReadOnly tx)
-    {
-        return DiskStateAsOf(metadata, TxId.From(tx.Id.Value));
-    }
-
 }

--- a/src/NexusMods.Abstractions.Loadouts/NexusMods.Abstractions.Loadouts.csproj
+++ b/src/NexusMods.Abstractions.Loadouts/NexusMods.Abstractions.Loadouts.csproj
@@ -9,6 +9,7 @@
       <ProjectReference Include="..\NexusMods.Abstractions.Library.Models\NexusMods.Abstractions.Library.Models.csproj" />
       <ProjectReference Include="..\NexusMods.Abstractions.NexusWebApi\NexusMods.Abstractions.NexusWebApi.csproj" />
       <ProjectReference Include="..\NexusMods.Abstractions.Serialization\NexusMods.Abstractions.Serialization.csproj" />
+      <PackageReference Include="CommunityToolkit.HighPerformance" />
       <PackageReference Include="NexusMods.MnemonicDB.Abstractions" />
       <PackageReference Include="TransparentValueObjects" PrivateAssets="all" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
         <PackageReference Include="TransparentValueObjects.Abstractions" />

--- a/src/NexusMods.DataModel/Diagnostics/DiagnosticManager.cs
+++ b/src/NexusMods.DataModel/Diagnostics/DiagnosticManager.cs
@@ -86,9 +86,9 @@ internal sealed class DiagnosticManager : IDiagnosticManager
         var metaData = GameInstallMetadata.Load(db, loadout.InstallationInstance.GameMetadataId);
         var hasPreviousLoadout = GameInstallMetadata.LastSyncedLoadoutTransaction.TryGetValue(metaData, out var lastId);
 
-        var lastScannedDiskState = metaData.DiskStateEntries;
-        var previousDiskState = hasPreviousLoadout ? 
-            metaData.DiskStateAsOf(Transaction.Load(db, lastId)) : 
+        var lastScannedDiskState = synchronizer.GetLastScannedDiskState(metaData);
+        var previousDiskState = hasPreviousLoadout ?
+            synchronizer.GetPreviouslyAppliedDiskState(metaData) : 
             lastScannedDiskState;
         
         var baseSyncTree = synchronizer.BuildSyncTree(lastScannedDiskState, previousDiskState, loadout);

--- a/src/NexusMods.DataModel/Synchronizer/SynchronizerService.cs
+++ b/src/NexusMods.DataModel/Synchronizer/SynchronizerService.cs
@@ -53,8 +53,8 @@ public class SynchronizerService : ISynchronizerService
         var metaData = GameInstallMetadata.Load(db, loadout.InstallationInstance.GameMetadataId);
         var hasPreviousLoadout = GameInstallMetadata.LastSyncedLoadoutTransaction.TryGetValue(metaData, out var lastId);
 
-        var lastScannedDiskState = metaData.DiskStateAsOf(metaData.LastScannedDiskStateTransaction);
-        var previousDiskState = hasPreviousLoadout ? metaData.DiskStateAsOf(Transaction.Load(db, lastId)) : lastScannedDiskState;
+        var lastScannedDiskState = synchronizer.GetLastScannedDiskState(metaData);
+        var previousDiskState = hasPreviousLoadout ? synchronizer.GetPreviouslyAppliedDiskState(metaData) : lastScannedDiskState;
         
         return synchronizer.LoadoutToDiskDiff(loadout, previousDiskState, lastScannedDiskState);
     }
@@ -71,8 +71,8 @@ public class SynchronizerService : ISynchronizerService
                 var metaData = GameInstallMetadata.Load(db, loadout.InstallationInstance.GameMetadataId);
                 var hasPreviousLoadout = GameInstallMetadata.LastSyncedLoadoutTransaction.TryGetValue(metaData, out var lastId);
 
-                var lastScannedDiskState = metaData.DiskStateEntries;
-                var previousDiskState = hasPreviousLoadout ? metaData.DiskStateAsOf(Transaction.Load(db, lastId)) : lastScannedDiskState;
+                var lastScannedDiskState = synchronizer.GetDiskStateForGame(metaData);
+                var previousDiskState = hasPreviousLoadout ? synchronizer.GetLastScannedDiskState(metaData) : lastScannedDiskState;
         
                 return ValueTask.FromResult(synchronizer.ShouldSynchronize(loadout, previousDiskState, lastScannedDiskState));
             });

--- a/tests/Games/NexusMods.Games.TestFramework/AIsolatedGameTest.cs
+++ b/tests/Games/NexusMods.Games.TestFramework/AIsolatedGameTest.cs
@@ -517,17 +517,17 @@ public abstract class AIsolatedGameTest<TTest, TGame> : IAsyncLifetime where TGa
         
         void Section(string sectionName, Transaction.ReadOnly asOf)
         {
-            var entries = metadata.DiskStateAsOf(asOf);
+            var entries = Synchronizer.GetDiskStateForGameAsOf(metadata, TxId.From(asOf.Id.Value));;
             sb.AppendLine($"{sectionName} - ({entries.Count})");
             sb.AppendLine("| Path | Hash | Size |");
             sb.AppendLine("| --- | --- | --- |");
-            foreach (var entry in entries.OrderBy(e=> e.Path)) 
-                sb.AppendLine($"| {FmtPath(entry.Path)} | {entry.Hash} | {entry.Size} |");
+            foreach (var pair in entries.OrderBy(e=> e.Path)) 
+                sb.AppendLine($"| {FmtPath(pair.Path)} | {pair.Part.Hash} | {pair.Part.Size} |");
         }
         
-        static string FmtPath((EntityId entityId, LocationId locationId, RelativePath relativePath) targetPath)
+        static string FmtPath(GamePath targetPath)
         {
-            return $"{{{targetPath.locationId}, {targetPath.relativePath}}}";
+            return $"{{{targetPath.LocationId}, {targetPath.Path}}}";
         }
     }
 


### PR DESCRIPTION
This code optimizes the performance of loading DiskStateEntries in ALoadoutSychronizer.cs. 

- Introduces a string pool for caching the contents of the RelativePaths. DiskStates don't have a lot of churn in these names, so I'm not concerned about GC'ing these values
- Implements a sorted merge join for loading entries. 
- Updates the existing code to use these new methods. 

Old Behavior: 
- Find a list of all entries
- Load them one at a time, doing a "lookup by Id" for each, this is *very* expensive since each entity being loaded has to do a search into the RocksDB structures from the top, and each involves about 50 datom comparisons
- Convert the DiskStateEntries into C# structures, doing UTF8->UTF16 on every path

New Behavior:
- Create a iterator for the list of entities to load
- Create iterators for each value to load
- For each row, call `.FastForwardTo(eid)` on the value iterators which is *very* fast, involving only a ulong comparison for each datom
- Load the values for each row
- Use a string pool so that after the first load, no future scans involve UTF8->UTF16 conversion

I'd use the new Query code for this, but we don't have a clean way (yet) of implementing this with string pools