### PR TITLE
Load DiskState off the UI thread in DiagnosticManager

### DIFF
--- a/src/NexusMods.DataModel/Diagnostics/DiagnosticManager.cs
+++ b/src/NexusMods.DataModel/Diagnostics/DiagnosticManager.cs
@@ -86,9 +86,10 @@ internal sealed class DiagnosticManager : IDiagnosticManager
         var metaData = GameInstallMetadata.Load(db, loadout.InstallationInstance.GameMetadataId);
         var hasPreviousLoadout = GameInstallMetadata.LastSyncedLoadoutTransaction.TryGetValue(metaData, out var lastId);
 
-        var lastScannedDiskState = synchronizer.GetLastScannedDiskState(metaData);
+        var lastScannedDiskState = await Task.Run(() => synchronizer.GetLastScannedDiskState(metaData), cancellationToken);
+        
         var previousDiskState = hasPreviousLoadout ?
-            synchronizer.GetPreviouslyAppliedDiskState(metaData) : 
+            await Task.Run(() => synchronizer.GetPreviouslyAppliedDiskState(metaData), cancellationToken) : 
             lastScannedDiskState;
         
         var baseSyncTree = synchronizer.BuildSyncTree(lastScannedDiskState, previousDiskState, loadout);


### PR DESCRIPTION
Prevent DiskState loading operation from freezing the UI thread by executing them on thread pool.

Noticed that UI was freezing due to these operations (thanks to new Rider performance metrics UI).