### PR TITLE
Game Index Fixes

### DIFF
--- a/src/NexusMods.Networking.GOG/Client.cs
+++ b/src/NexusMods.Networking.GOG/Client.cs
@@ -84,7 +84,7 @@ internal class Client : IClient
         
         _pipeline = new ResiliencePipelineBuilder()
             .AddRetry(new RetryStrategyOptions())
-            .AddTimeout(TimeSpan.FromSeconds(10))
+            .AddTimeout(TimeSpan.FromSeconds(60))
             .Build();
     }
     

--- a/src/NexusMods.Networking.Steam/CLI/Verbs.cs
+++ b/src/NexusMods.Networking.Steam/CLI/Verbs.cs
@@ -81,6 +81,9 @@ public static class Verbs
                 // For each depot and each manifest, download the manifest and index the files
                 await Parallel.ForEachAsync(productInfo.Depots, options, async (depot, token) =>
                 {
+                    if (depot.OsList.Length > 0 && !depot.OsList.Contains("windows"))
+                        return;
+                    
                     await Parallel.ForEachAsync(depot.Manifests, options, async (manifestInfo, token) =>
                     {
                         try


### PR DESCRIPTION
Two fixes I keep forgetting to add to the indexer. When downloading new releases, sometimes the servers are overloaded, so this increases the timeout to 60 sec. Also we're only indexing Windows files, since Cyberpunk's Mac hashes aren't currently needed and they bloat the hash times by quite a lot