### PR TITLE
Register `CliClient` for all modes

### DIFF
--- a/src/NexusMods.SingleProcess/Services.cs
+++ b/src/NexusMods.SingleProcess/Services.cs
@@ -33,6 +33,7 @@ public static class Services
         switch (mode)
         {
             case Mode.Main:
+                services.AddTransient<CliClient>();
                 services.AddSingleton<CliServer>();
                 services.AddHostedService(s => s.GetRequiredService<CliServer>());
                 break;


### PR DESCRIPTION
Fixes #3833. `CliClient` has to be available for the Cleanup method to work. I'm surprised we only got issues for this now since the cleanup code has been in the app for a while now...