### PR TITLE
First pass at download page UI

### DIFF
--- a/src/NexusMods.App.UI/Pages/Downloads/DownloadsPageView.axaml
+++ b/src/NexusMods.App.UI/Pages/Downloads/DownloadsPageView.axaml
@@ -30,73 +30,67 @@
 
         <!-- Content area with toolbar and main content -->
         <Grid Grid.Row="1" RowDefinitions="Auto, *" Margin="0,16,0,0">
+
             <!-- Toolbar with command 'all' buttons -->
-            <StackPanel Grid.Row="0" Orientation="Horizontal">
-                
-                <controls:Toolbar Margin="4, 0">
-                    <ItemsControl>
-                        <search:SearchControl x:Name="SearchControl"
-                                              PageName="Downloads"
-                                              ButtonSize="Toolbar" />
-                    </ItemsControl>
-                </controls:Toolbar>
-                
-                <controls:Toolbar Margin="4, 0">
-                    <ItemsControl>
-                        <controls:StandardButton x:Name="PauseAllButton"
-                                                 Text="Pause all"
-                                                 Type="Tertiary"
-                                                 Size="Toolbar"
-                                                 Fill="None"
-                                                 ShowIcon="Left"
-                                                 LeftIcon="{x:Static icons:IconValues.Pause}"
-                                                 Command="{Binding PauseAllCommand}" />
-                        
-                        <controls:StandardButton x:Name="ResumeAllButton"
-                                                 Text="Resume all"
-                                                 Type="Tertiary"
-                                                 Size="Toolbar"
-                                                 Fill="None"
-                                                 ShowIcon="Left"
-                                                 LeftIcon="{x:Static icons:IconValues.PlayArrow}"
-                                                 Command="{Binding ResumeAllCommand}" />
-                    </ItemsControl>
-                </controls:Toolbar>
-            
-                <!-- Toolbar with command 'selected' buttons -->
-                <controls:Toolbar Margin="4, 0">
-                    <ItemsControl>
-                        <controls:StandardButton x:Name="PauseSelectedButton"
-                                                 Text=""
-                                                 Type="Tertiary"
-                                                 Size="Toolbar"
-                                                 Fill="None"
-                                                 ShowIcon="Left"
-                                                 LeftIcon="{x:Static icons:IconValues.Pause}"
-                                                 Command="{Binding PauseSelectedCommand}"
-                                                 IsVisible="{Binding HasRunningItems^}" />
-                        
-                        <controls:StandardButton x:Name="ResumeSelectedButton"
-                                                 Text=""
-                                                 Type="Tertiary"
-                                                 Size="Toolbar"
-                                                 Fill="None"
-                                                 ShowIcon="Left"
-                                                 LeftIcon="{x:Static icons:IconValues.PlayArrow}"
-                                                 Command="{Binding ResumeSelectedCommand}"
-                                                 IsVisible="{Binding HasPausedItems^}" />
-                        
-                        <controls:StandardButton x:Name="CancelSelectedButton"
-                                                 Text=""
-                                                 Type="Tertiary"
-                                                 Size="Toolbar"
-                                                 Fill="None"
-                                                 ShowIcon="Left"
-                                                 LeftIcon="{x:Static icons:IconValues.Close}"
-                                                 Command="{Binding CancelSelectedCommand}" />
-                    </ItemsControl>
-                </controls:Toolbar>
-            </StackPanel>
+
+            <controls:Toolbar Margin="24, 0">
+                <ItemsControl>
+                    <search:SearchControl x:Name="SearchControl"
+                                          PageName="Downloads"
+                                          ButtonSize="Toolbar" />
+                </ItemsControl>
+
+                <ItemsControl>
+                    <controls:StandardButton x:Name="PauseAllButton"
+                                             Text="Pause all"
+                                             Type="Tertiary"
+                                             Size="Toolbar"
+                                             Fill="None"
+                                             ShowIcon="Left"
+                                             LeftIcon="{x:Static icons:IconValues.Pause}"
+                                             Command="{Binding PauseAllCommand}" />
+
+                    <controls:StandardButton x:Name="ResumeAllButton"
+                                             Text="Resume all"
+                                             Type="Tertiary"
+                                             Size="Toolbar"
+                                             Fill="None"
+                                             ShowIcon="Left"
+                                             LeftIcon="{x:Static icons:IconValues.PlayArrow}"
+                                             Command="{Binding ResumeAllCommand}" />
+                </ItemsControl>
+
+                <ItemsControl>
+                    <controls:StandardButton x:Name="PauseSelectedButton"
+                                             Text=""
+                                             Type="Tertiary"
+                                             Size="Toolbar"
+                                             Fill="None"
+                                             ShowIcon="Left"
+                                             LeftIcon="{x:Static icons:IconValues.Pause}"
+                                             Command="{Binding PauseSelectedCommand}"
+                                             IsVisible="{Binding HasRunningItems^}" />
+
+                    <controls:StandardButton x:Name="ResumeSelectedButton"
+                                             Text=""
+                                             Type="Tertiary"
+                                             Size="Toolbar"
+                                             Fill="None"
+                                             ShowIcon="Left"
+                                             LeftIcon="{x:Static icons:IconValues.PlayArrow}"
+                                             Command="{Binding ResumeSelectedCommand}"
+                                             IsVisible="{Binding HasPausedItems^}" />
+
+                    <controls:StandardButton x:Name="CancelSelectedButton"
+                                             Text=""
+                                             Type="Tertiary"
+                                             Size="Toolbar"
+                                             Fill="None"
+                                             ShowIcon="Left"
+                                             LeftIcon="{x:Static icons:IconValues.Close}"
+                                             Command="{Binding CancelSelectedCommand}" />
+                </ItemsControl>
+            </controls:Toolbar>
 
             <!-- Main content with TreeDataGrid -->
             <controls:EmptyState Grid.Row="1"

--- a/src/NexusMods.App.UI/Pages/Downloads/TreeDataGridDownloadsResources.axaml
+++ b/src/NexusMods.App.UI/Pages/Downloads/TreeDataGridDownloadsResources.axaml
@@ -92,34 +92,38 @@
                             <StackPanel Orientation="Horizontal" Spacing="8">
                                 <!-- Progress Bar -->
                                 <ProgressBar Value="{Binding Progress.Value}" 
-                                             Minimum="0" Maximum="1" 
-                                             Width="120" Height="8" />
+                                             Classes="DownloadBar"
+                                             Minimum="0" Maximum="1" Width="120"  />
                                 
                                 <!-- Action Buttons -->
                                 <StackPanel Orientation="Horizontal" Spacing="4">
+                                    
                                     <!-- Pause Button -->
-                                    <Button Command="{CompiledBinding PauseCommand}" 
+                                    <controls:StandardButton Command="{CompiledBinding PauseCommand}" 
                                             IsVisible="{CompiledBinding CanPause.Value}"
-                                            Classes="IconButton" 
-                                            ToolTip.Tip="Pause Download">
-                                        <icons:UnifiedIcon Value="{x:Static icons:IconValues.Pause}" />
-                                    </Button>
+                                            LeftIcon="{x:Static icons:IconValues.Pause}"
+                                            ShowIcon="Left"
+                                            ShowLabel="False"
+                                            Size="Small"
+                                            ToolTip.Tip="Pause Download"/>
                                     
                                     <!-- Resume Button -->
-                                    <Button Command="{CompiledBinding ResumeCommand}" 
-                                            IsVisible="{CompiledBinding CanResume.Value}"
-                                            Classes="IconButton" 
-                                            ToolTip.Tip="Resume Download">
-                                        <icons:UnifiedIcon Value="{x:Static icons:IconValues.PlayArrow}" />
-                                    </Button>
+                                    <controls:StandardButton Command="{CompiledBinding ResumeCommand}" 
+                                                             IsVisible="{CompiledBinding CanResume.Value}"
+                                                             LeftIcon="{x:Static icons:IconValues.PlayArrow}"
+                                                             ShowIcon="Left"
+                                                             ShowLabel="False"
+                                                             Size="Small"
+                                                             ToolTip.Tip="Resume Download"/>
                                     
                                     <!-- Cancel Button -->
-                                    <Button Command="{CompiledBinding CancelCommand}" 
-                                            IsVisible="{CompiledBinding CanCancel.Value}"
-                                            Classes="IconButton" 
-                                            ToolTip.Tip="Cancel Download">
-                                        <icons:UnifiedIcon Value="{x:Static icons:IconValues.Close}" />
-                                    </Button>
+                                    <controls:StandardButton Command="{CompiledBinding CancelCommand}" 
+                                                             IsVisible="{CompiledBinding CanCancel.Value}"
+                                                             LeftIcon="{x:Static icons:IconValues.Close}"
+                                                             ShowIcon="Left"
+                                                             ShowLabel="False"
+                                                             Size="Small"
+                                                             ToolTip.Tip="Cancel Download"/>
                                 </StackPanel>
                             </StackPanel>
                         </DataTemplate>

--- a/src/NexusMods.Themes.NexusFluentDark/Styles/Controls/ProgressBar/ProgressBarStyles.axaml
+++ b/src/NexusMods.Themes.NexusFluentDark/Styles/Controls/ProgressBar/ProgressBarStyles.axaml
@@ -31,7 +31,7 @@
     <!-- Download ProgressBar -->
     <Style Selector="ProgressBar.DownloadBar">
         <Setter Property="ShowProgressText" Value="True" />
-        <Setter Property="Height" Value="24" />
+        <Setter Property="MinHeight" Value="28" />
         <Setter Property="Foreground" Value="{StaticResource InfoWeakBrush}" />
         <Setter Property="Background">
             <SolidColorBrush Color="{StaticResource InfoWeak}"
@@ -39,6 +39,10 @@
         </Setter>
 
         <Setter Property="CornerRadius" Value="{StaticResource Rounded-sm}" />
+        
+        <Setter Property="BorderBrush" Value="{StaticResource BrandInfo900Brush}" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="BackgroundSizing" Value="OuterBorderEdge" />
 
         <Style Selector="^ /template/ Border#PART_Indicator">
             <Setter Property="CornerRadius" Value="{StaticResource Rounded-none}" />

--- a/src/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/SharedStyles.axaml
+++ b/src/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/SharedStyles.axaml
@@ -1,14 +1,16 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:icons="clr-namespace:NexusMods.UI.Sdk.Icons;assembly=NexusMods.UI.Sdk">
-    
+
     <!-- name column -->
-    <Style Selector="TreeDataGridTemplateCell.SharedColumn_Name /template/ ContentPresenter#PART_ContentPresenter, TreeDataGridTemplateCell.DownloadColumns_Name /template/ ContentPresenter#PART_ContentPresenter">
+    <Style
+        Selector="TreeDataGridTemplateCell.SharedColumn_Name /template/ ContentPresenter#PART_ContentPresenter, 
+    TreeDataGridTemplateCell.DownloadColumns_Name /template/ ContentPresenter#PART_ContentPresenter">
 
         <Style Selector="^ StackPanel">
-            <Setter Property="Spacing" Value="{StaticResource Spacing-3}"/>
+            <Setter Property="Spacing" Value="{StaticResource Spacing-3}" />
         </Style>
-        
+
         <!-- fallback icon -->
         <Style Selector="^ icons|UnifiedIcon#FallbackIcon">
             <Setter Property="Foreground" Value="{StaticResource NeutralSubduedBrush}" />
@@ -25,36 +27,36 @@
             <Setter Property="Height" Value="26" />
             <!-- easy way to get the rounded corner to mask the image below -->
             <Setter Property="ClipToBounds" Value="True" />
-                        
+
             <Style Selector="^ > Panel > icons|UnifiedIcon">
                 <Setter Property="Foreground" Value="{StaticResource NeutralSubduedBrush}" />
                 <Setter Property="Size" Value="16" />
             </Style>
-                        
+
             <Style Selector="^ > Panel > Image">
                 <Setter Property="Stretch" Value="UniformToFill" />
                 <Setter Property="StretchDirection" Value="Both" />
             </Style>
-            
+
             <!-- The below aren't used yet but thought I'd placeholder it for future -->
             <Style Selector="^ Border#ModFileCountBadgeBorder">
                 <Setter Property="Width" Value="14" />
                 <Setter Property="Height" Value="14" />
                 <Setter Property="Background" Value="{StaticResource BrandTranslucentDark600Brush}" />
                 <Setter Property="CornerRadius" Value="0,0,4,0" />
-                
+
                 <Style Selector="^ > TextBlock">
                     <Setter Property="HorizontalAlignment" Value="Center" />
                     <Setter Property="Foreground" Value="{StaticResource NeutralStrongBrush}" />
                 </Style>
             </Style>
-            
+
             <Style Selector="^ Border#UpdateAvailableBadgeBorder">
                 <Setter Property="Width" Value="14" />
                 <Setter Property="Height" Value="14" />
                 <Setter Property="Background" Value="{StaticResource InfoModerateBrush}" />
                 <Setter Property="CornerRadius" Value="0,0,0,4" />
-                
+
                 <Style Selector="^ > icons|UnifiedIcon">
                     <Setter Property="Size" Value="12" />
                     <Setter Property="Foreground" Value="{StaticResource NeutralInvertedBrush}" />
@@ -63,14 +65,16 @@
         </Style>
 
         <!-- name -->
-        <Style Selector="^ Border.SharedColumn_Name_NameComponent TextBlock, ^ Border.DownloadColumns_Name_NameComponent TextBlock">
+        <Style
+            Selector="^ Border.SharedColumn_Name_NameComponent TextBlock, ^ Border.DownloadColumns_Name_NameComponent TextBlock">
             <Setter Property="Foreground" Value="{StaticResource NeutralModerateBrush}" />
         </Style>
 
     </Style>
 
     <!-- NameWithFileIcon.ColumnTemplateResourceKey column -->
-    <Style Selector="TreeDataGridTemplateCell.SharedColumn_NameWithFileIcon /template/ ContentPresenter#PART_ContentPresenter">
+    <Style
+        Selector="TreeDataGridTemplateCell.SharedColumn_NameWithFileIcon /template/ ContentPresenter#PART_ContentPresenter">
         <!-- Styles specific to the 'NameWithFileIcon' template (root is Grid) -->
         <Style Selector="^ icons|UnifiedIcon.FileTypeIcon">
             <Setter Property="Margin" Value="0" />
@@ -83,4 +87,3 @@
         </Style>
     </Style>
 </Styles>
-

--- a/src/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/TreeDataGridDownloadPageStyles.axaml
+++ b/src/NexusMods.Themes.NexusFluentDark/Styles/Controls/TreeDataGrid/TreeDataGridDownloadPageStyles.axaml
@@ -1,0 +1,59 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:spinner="clr-namespace:NexusMods.App.UI.Controls.Spinner;assembly=NexusMods.App.UI"
+        xmlns:icons="clr-namespace:NexusMods.UI.Sdk.Icons;assembly=NexusMods.UI.Sdk">
+
+    <Style Selector="TreeDataGrid#TreeDataGridDownloads">
+
+        <!-- <Setter Property="Background" Value="DarkGreen"/> -->
+
+        <!-- ROWS -->
+
+        <Style Selector="^ TreeDataGridRow">
+
+            <!-- child row -->
+            <!-- <Setter Property="Background" Value="{StaticResource SurfaceLowBrush}" /> -->
+
+            <!-- parent row -->
+            <Style Selector="^.RootRow">
+                <!-- <Setter Property="Background" Value="DarkRed" /> -->
+            </Style>
+
+            <!-- CELLS -->
+
+            <!-- all of our cells will be a type of this -->
+            <Style Selector="^ TreeDataGridTemplateCell">
+                
+                <!-- download page -> size cell -->
+                <Style Selector="^.DownloadColumns_Size">
+                    <!-- <Setter Property="HorizontalAlignment" Value="Right" /> -->
+                </Style>
+                
+                <!-- download page -> status cell -->
+                <Style Selector="^.DownloadColumns_Status">
+                    <Setter Property="HorizontalAlignment" Value="Right" />
+
+                    <Style
+                        Selector="^ Border.DownloadColumns_Status_StatusComponent">
+                        <Setter Property="MinWidth" Value="120" />
+                       
+
+                        <!-- <Style Selector="^ > TextBlock"> -->
+                        <!--     <Setter Property="VerticalAlignment" Value="Center" /> -->
+                        <!--     <Setter Property="Foreground" Value="{StaticResource NeutralModerateBrush}" /> -->
+                        <!-- </Style> -->
+                    </Style>
+                </Style>
+
+                <!-- first cell of a row as it can expand -->
+                <Style Selector="^ TreeDataGridExpanderCell">
+                    <!-- <Setter Property="Background" Value="LightCoral" /> -->
+
+                    <Style Selector="^ TreeDataGridTemplateCell">
+                        <!-- <Setter Property="Background" Value="Coral" /> -->
+                    </Style>
+                </Style>
+            </Style>
+        </Style>
+    </Style>
+</Styles>

--- a/src/NexusMods.Themes.NexusFluentDark/Styles/StylesIndex.axaml
+++ b/src/NexusMods.Themes.NexusFluentDark/Styles/StylesIndex.axaml
@@ -42,6 +42,7 @@
     <StyleInclude Source="/Styles/Controls/Expander/ExpanderStyles.axaml" />
     <StyleInclude Source="/Styles/Controls/ScrollBar/ScrollBarStyles.axaml" />
     <StyleInclude Source="/Styles/Controls/Menu/MenuStyles.axaml" />
+    <StyleInclude Source="/Styles/Controls/TreeDataGrid/TreeDataGridDownloadPageStyles.axaml" />
     
      
     <!-- extended avalonia controls -->


### PR DESCRIPTION
Not sure much more is worth doing until more functionality in place.

This PR is part of #3286 and targets the `downloads-page-ui` branch for @Sewer56 

- Now using StandardButton component instead of a random Button
- Uses a single Toolbar component instead of 3
- ProgressBar now uses the 'DownloadBar' class
 
<img width="1208" height="543" alt="image" src="https://github.com/user-attachments/assets/80894670-fd70-4cea-b572-f944bce0db57" />
