### PR TITLE
Fix hashed service startup issues

### DIFF
--- a/src/NexusMods.Games.FileHashes/FileHashesService.cs
+++ b/src/NexusMods.Games.FileHashes/FileHashesService.cs
@@ -676,12 +676,21 @@ internal sealed class FileHashesService : IFileHashesService, IDisposable, IHost
             databaseInfo.Path.DeleteDirectory(true);
         }
 
-        if (existingDatabases.TryGetFirst(out var latestDatabase))
+        var forceUpdate = false;
+        try
         {
-            _currentDb = OpenDb(latestDatabase);
+            if (existingDatabases.TryGetFirst(out var latestDatabase))
+            {
+                _currentDb = OpenDb(latestDatabase);
+            }
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Failed to open latest database, forcing update");
+            forceUpdate = true;
         }
 
-        await CheckForUpdateCore(forceUpdate: false, cancellationToken: CancellationToken.None);
+        await CheckForUpdateCore(forceUpdate: forceUpdate, cancellationToken);
     }
 
     public Task StopAsync(CancellationToken cancellationToken)

--- a/src/NexusMods.Games.FileHashes/FileHashesService.cs
+++ b/src/NexusMods.Games.FileHashes/FileHashesService.cs
@@ -3,6 +3,7 @@ using System.IO.Compression;
 using System.Text.Json;
 using DynamicData.Kernel;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using NexusMods.Abstractions.EpicGameStore.Values;
 using NexusMods.Abstractions.GameLocators;
@@ -27,7 +28,7 @@ using Connection = NexusMods.MnemonicDB.Connection;
 
 namespace NexusMods.Games.FileHashes;
 
-internal sealed class FileHashesService : IFileHashesService, IDisposable
+internal sealed class FileHashesService : IFileHashesService, IDisposable, IHostedService
 {
     private const string DefaultLanguage = "en-US";
     
@@ -65,8 +66,6 @@ internal sealed class FileHashesService : IFileHashesService, IDisposable
 
         _hashDatabaseLocation = _settings.HashDatabaseLocation.ToPath(_fileSystem);
         _hashDatabaseLocation.CreateDirectory();
-
-        Startup();
     }
 
     private ConnectedDb OpenDb(DatabaseInfo databaseInfo)
@@ -145,23 +144,6 @@ internal sealed class FileHashesService : IFileHashesService, IDisposable
         return diff >= _settings.HashDatabaseUpdateInterval;
     }
 
-    private void Startup()
-    {
-        var existingDatabases = ExistingDBs().ToArray();
-
-        // Cleanup old databases
-        foreach (var databaseInfo in existingDatabases.Skip(1))
-        {
-            databaseInfo.Path.DeleteDirectory(true);
-        }
-
-        if (existingDatabases.TryGetFirst(out var latestDatabase))
-        {
-            _currentDb = OpenDb(latestDatabase);
-        }
-
-        Task.Run(async () => await CheckForUpdateCore(forceUpdate: false, cancellationToken: CancellationToken.None));
-    }
 
     private async Task CheckForUpdateCore(bool forceUpdate, CancellationToken cancellationToken = default)
     {
@@ -682,5 +664,28 @@ internal sealed class FileHashesService : IFileHashesService, IDisposable
             connection.Backend.Dispose();
             connection.Store.Dispose();
         }
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var existingDatabases = ExistingDBs().ToArray();
+
+        // Cleanup old databases
+        foreach (var databaseInfo in existingDatabases.Skip(1))
+        {
+            databaseInfo.Path.DeleteDirectory(true);
+        }
+
+        if (existingDatabases.TryGetFirst(out var latestDatabase))
+        {
+            _currentDb = OpenDb(latestDatabase);
+        }
+
+        await CheckForUpdateCore(forceUpdate: false, cancellationToken: CancellationToken.None);
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
     }
 }

--- a/src/NexusMods.Games.FileHashes/Services.cs
+++ b/src/NexusMods.Games.FileHashes/Services.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using NexusMods.Abstractions.Games.FileHashes;
 using NexusMods.Abstractions.Games.FileHashes.Models;
 using NexusMods.Abstractions.Settings;
@@ -22,6 +23,7 @@ public static class Services
             .AddEpicGameStoreBuildModel()
             .AddFileHashesQueriesSql()
             .AddSingleton<IFileHashesService, FileHashesService>()
+            .AddSingleton<IHostedService>(s => (IHostedService)s.GetRequiredService<IFileHashesService>())
             .AddSettings<FileHashesServiceSettings>()
             .AddHashRelationModel();
     }


### PR DESCRIPTION
Fixes a few issues in the existing file hashes service

* Makes the service a IHostedService so we can get async startup routines. This is required because if there's a connection error
in an existing DB there's no way to force the app startup to halt until we get a fixed DB. This means that something else in the app could call `.Current` causing an error. Now, if the service starts, we'll have an up-to-date db.
* Catches errors connecting to the existing DB, downloads a new DB if the most recent one fails. 

This code helps in the cases where DBs are not forwards compatible. That is a new version of the app, can't work with a old version of the hash db. 