### PR TITLE
Fix TreeDataGrid selection on source reset events

### DIFF
--- a/src/NexusMods.App.UI/Controls/Search/SearchControl.axaml.cs
+++ b/src/NexusMods.App.UI/Controls/Search/SearchControl.axaml.cs
@@ -87,6 +87,7 @@ public partial class SearchControl : UserControl
 
         // Setup search text binding
         this.WhenAnyValue(x => x.SearchTextBox.Text)
+            .Throttle(dueTime: TimeSpan.FromMilliseconds(100))
             .OnUI()
             .Subscribe(ApplySearchFilter);
 

--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridAdapter.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridAdapter.cs
@@ -95,13 +95,22 @@ public abstract class TreeDataGridAdapter<TModel, TKey> : ReactiveR3Object, ISea
 
                     self.Roots.Clear();
 
-                    // NOTE(erri120): we have to do this manually, the TreeDataGrid doesn't deselect when changing source
-                    self.SelectedModels.Clear();
-
-                    var (source, selection, selectionObservable) = self.CreateSource(self.RootsCollectionChangedView, createHierarchicalSource: viewHierarchical);
+                    var (source, selection, selectionObservable, selectionResetObservable) = self.CreateSource(self.RootsCollectionChangedView, createHierarchicalSource: viewHierarchical);
                     self._selectionModel = selection;
 
-                    self._selectionModelsSerialDisposable.Disposable = selectionObservable.Subscribe(self, static (eventArgs, self) =>
+                    var selectionResetDisposable = selectionResetObservable.Subscribe(self, static (_, self) =>
+                    {
+                        foreach (var item in self.SelectedModels)
+                        {
+                            Debug.Assert(!item.IsDisposed);
+                            if (item.IsDisposed) continue;
+                            item.IsSelected.Value = false;
+                        }
+
+                        self.SelectedModels.Clear();
+                    });
+
+                    var selectionDisposable = selectionObservable.Subscribe(self, static (eventArgs, self) =>
                     {
                         self.SelectedModels.RemoveRange(eventArgs.DeselectedItems.NotNull());
                         foreach (var item in eventArgs.DeselectedItems)
@@ -123,6 +132,8 @@ public abstract class TreeDataGridAdapter<TModel, TKey> : ReactiveR3Object, ISea
                             item.IsSelected.Value = true;
                         }
                     });
+
+                    self._selectionModelsSerialDisposable.Disposable = Disposable.Combine(selectionResetDisposable, selectionDisposable);
 
                     self.Source.Value = source;
                 })
@@ -278,7 +289,7 @@ public abstract class TreeDataGridAdapter<TModel, TKey> : ReactiveR3Object, ISea
         RowDropSubject.OnNext((sourceModels.ToArray(), targetModel, e));
     }
 
-    private static (TreeDataGridRowSelectionModel<TModel>, Observable<TreeSelectionModelSelectionChangedEventArgs<TModel>>) CreateSelection(ITreeDataGridSource<TModel> source)
+    private static (TreeDataGridRowSelectionModel<TModel> selection, Observable<TreeSelectionModelSelectionChangedEventArgs<TModel>> selectionObservable, Observable<TreeSelectionModelSourceResetEventArgs> resetObservable) CreateSelection(ITreeDataGridSource<TModel> source)
     {
         var selection = new TreeDataGridRowSelectionModel<TModel>(source)
         {
@@ -290,28 +301,33 @@ public abstract class TreeDataGridAdapter<TModel, TKey> : ReactiveR3Object, ISea
             removeHandler: handler => selection.SelectionChanged -= handler
         ).Select(tuple => tuple.e);
 
-        return (selection, selectionObservable);
+        var resetObservable = R3.Observable.FromEventHandler<TreeSelectionModelSourceResetEventArgs>(
+            addHandler: handler => selection.SourceReset += handler,
+            removeHandler: handler => selection.SourceReset -= handler
+        ).Select(tuple => tuple.e);
+
+        return (selection, selectionObservable, resetObservable);
     }
 
-    private (ITreeDataGridSource<TModel> source, TreeDataGridRowSelectionModel<TModel> selection, Observable<TreeSelectionModelSelectionChangedEventArgs<TModel>> selectionObservable) CreateSource(IEnumerable<TModel> models, bool createHierarchicalSource)
+    private (ITreeDataGridSource<TModel> source,TreeDataGridRowSelectionModel<TModel> selection, Observable<TreeSelectionModelSelectionChangedEventArgs<TModel>> selectionObservable, Observable<TreeSelectionModelSourceResetEventArgs> resetObservable) CreateSource(IEnumerable<TModel> models, bool createHierarchicalSource)
     {
         if (createHierarchicalSource)
         {
             var source = new HierarchicalTreeDataGridSource<TModel>(models);
-            var (selection, selectionObservable) = CreateSelection(source);
+            var (selection, selectionObservable, resetObservable) = CreateSelection(source);
             source.Selection = selection;
 
             source.Columns.AddRange(CreateColumns(viewHierarchical: createHierarchicalSource));
-            return (source, selection, selectionObservable);
+            return (source, selection, selectionObservable, resetObservable);
         }
         else
         {
             var source = new FlatTreeDataGridSource<TModel>(models);
-            var (selection, selectionObservable) = CreateSelection(source);
+            var (selection, selectionObservable, resetObservable) = CreateSelection(source);
             source.Selection = selection;
 
             source.Columns.AddRange(CreateColumns(viewHierarchical: createHierarchicalSource));
-            return (source, selection, selectionObservable);
+            return (source, selection, selectionObservable, resetObservable);
         }
     }
 


### PR DESCRIPTION
Fixes #3900.

Fixes various issues we've had with not getting notifications on
the `SelectionChanged`.