### PR TITLE
Upgrade MnemonicDb to 0.27.3 and fix collection cloning

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,8 +20,8 @@
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.8.0" />
     <PackageVersion Include="Nerdbank.FullDuplexStream" Version="1.1.12" />
     <PackageVersion Include="Nerdbank.Streams" Version="2.13.16" />
-    <PackageVersion Include="NexusMods.MnemonicDB" Version="0.24.0" />
-    <PackageVersion Include="NexusMods.MnemonicDB.Abstractions" Version="0.24.0" />
+    <PackageVersion Include="NexusMods.MnemonicDB" Version="0.27.3" />
+    <PackageVersion Include="NexusMods.MnemonicDB.Abstractions" Version="0.27.3" />
     <PackageVersion Include="NexusMods.Hashing.xxHash3.Paths" Version="3.0.4" />
     <PackageVersion Include="NexusMods.Hashing.xxHash3" Version="3.0.4" />
     <PackageVersion Include="NexusMods.Archives.Nx" Version="0.6.4" />
@@ -153,7 +153,7 @@
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="ini-parser-netstandard" Version="2.5.3" />
     <PackageVersion Include="Mutagen.Bethesda.Skyrim" Version="0.51.3" />
-    <PackageVersion Include="NexusMods.MnemonicDB.SourceGenerator" Version="0.24.0" />
+    <PackageVersion Include="NexusMods.MnemonicDB.SourceGenerator" Version="0.27.3" />
     <PackageVersion Include="NLog.Extensions.Logging" Version="6.0.3" />
     <PackageVersion Include="OneOf" Version="3.0.271" />
     <PackageVersion Include="ReactiveUI.Fody" Version="19.5.41" />


### PR DESCRIPTION
- Fixes #3890

### Warning!
This update also fixes the behaviour of `mdb_datoms()` table, to correctly return all the datoms in the database. 

This has significant performance implications, specifically for `RevisionsWithChildUpdates` subscriptions, currently used in:
- `SynchronizerService` to trigger the `ShouldSynchronize` check
- `DiagnosticManager` to trigger health checks
- `LoadoutViewModel` to set value to `HasOutstandingChanges` property

We should keep these monitored