### PR TITLE
Update to MnemonicDB 0.28

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,8 +20,8 @@
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.8.0" />
     <PackageVersion Include="Nerdbank.FullDuplexStream" Version="1.1.12" />
     <PackageVersion Include="Nerdbank.Streams" Version="2.13.16" />
-    <PackageVersion Include="NexusMods.MnemonicDB" Version="0.27.3" />
-    <PackageVersion Include="NexusMods.MnemonicDB.Abstractions" Version="0.27.3" />
+    <PackageVersion Include="NexusMods.MnemonicDB" Version="0.28.0" />
+    <PackageVersion Include="NexusMods.MnemonicDB.Abstractions" Version="0.28.0" />
     <PackageVersion Include="NexusMods.Hashing.xxHash3.Paths" Version="3.0.4" />
     <PackageVersion Include="NexusMods.Hashing.xxHash3" Version="3.0.4" />
     <PackageVersion Include="NexusMods.Archives.Nx" Version="0.6.4" />
@@ -153,7 +153,7 @@
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="ini-parser-netstandard" Version="2.5.3" />
     <PackageVersion Include="Mutagen.Bethesda.Skyrim" Version="0.51.3" />
-    <PackageVersion Include="NexusMods.MnemonicDB.SourceGenerator" Version="0.27.3" />
+    <PackageVersion Include="NexusMods.MnemonicDB.SourceGenerator" Version="0.28.0" />
     <PackageVersion Include="NLog.Extensions.Logging" Version="6.0.3" />
     <PackageVersion Include="OneOf" Version="3.0.271" />
     <PackageVersion Include="ReactiveUI.Fody" Version="19.5.41" />

--- a/src/NexusMods.Games.FileHashes/FileHashesQueries.sql
+++ b/src/NexusMods.Games.FileHashes/FileHashesQueries.sql
@@ -6,11 +6,11 @@ CREATE SCHEMA IF NOT EXISTS file_hashes;
 CREATE MACRO file_hashes.resolve_gog_build(GameMetadataId, DefaultLanguage := 'en-US') AS TABLE
 SELECT build.BuildId, ANY_VALUE(build.ProductId) AS BuildProductId, COUNT(*) matching_files, ANY_VALUE(build."version"), list_distinct(LIST(depot.ProductId)) ProductIds
 FROM MDB_DISKSTATEENTRY() entry
-         LEFT JOIN HASHES_HASHRELATION() hashrel on entry.Hash = hashRel.xxHash3
-         LEFT JOIN HASHES_PATHHASHRELATION() pathrel on pathrel.Path = entry.Path.Item3 AND pathrel.Hash = hashrel.Id
-         LEFT JOIN (SELECT Id, unnest(Files) FileId FROM HASHES_GOGMANIFEST()) manifest on pathRel.Id = manifest.FileId
-         LEFT JOIN HASHES_GOGDEPOT() depot on depot.Manifest = Manifest.Id
-         LEFT JOIN (SELECT Id, unnest(depots) depot, ProductId, buildId, "version" FROM HASHES_GOGBUILD()) build on depot.Id = build.Depot
+         LEFT JOIN MDB_HASHRELATION(DBName=>"hashes") hashrel on entry.Hash = hashRel.xxHash3
+         LEFT JOIN MDB_PATHHASHRELATION(DBName=>"hashes") pathrel on pathrel.Path = entry.Path.Item3 AND pathrel.Hash = hashrel.Id
+         LEFT JOIN (SELECT Id, unnest(Files) FileId FROM MDB_GOGMANIFEST(DBName=>"hashes")) manifest on pathRel.Id = manifest.FileId
+         LEFT JOIN MDB_GOGDEPOT(DBName=>"hashes") depot on depot.Manifest = Manifest.Id
+         LEFT JOIN (SELECT Id, unnest(depots) depot, ProductId, buildId, "version" FROM MDB_GOGBUILD(DBName=>"hashes")) build on depot.Id = build.Depot
 WHERE entry.Game = GameMetadataId
 AND DefaultLanguage in depot.Languages
 GROUP BY build.BuildId
@@ -20,9 +20,9 @@ ORDER BY COUNT(*) DESC;
 CREATE MACRO file_hashes.resolve_steam_manifests(GameMetadataId) AS TABLE
 SELECT ANY_VALUE(steam.depotId) DepotId, COUNT(*) matching_count, ANY_VALUE(steam.AppId) AppId, ANY_VALUE(steam.ManifestId)
 FROM MDB_DISKSTATEENTRY() entry
-         LEFT JOIN HASHES_HASHRELATION() hashrel on entry.Hash = hashRel.xxHash3
-         LEFT JOIN HASHES_PATHHASHRELATION() pathrel on pathrel.Path = entry.Path.Item3 AND pathrel.Hash = hashrel.Id
-         LEFT JOIN (SELECT AppId, ManifestId, DepotId, unnest(Files) File FROM HASHES_STEAMMANIFEST()) steam on steam.File = pathrel.Id
+         LEFT JOIN MDB_HASHRELATION(DBName=>"hashes") hashrel on entry.Hash = hashRel.xxHash3
+         LEFT JOIN MDB_PATHHASHRELATION(DBName=>"hashes") pathrel on pathrel.Path = entry.Path.Item3 AND pathrel.Hash = hashrel.Id
+         LEFT JOIN (SELECT AppId, ManifestId, DepotId, unnest(Files) File FROM MDB_STEAMMANIFEST(DBName=>"hashes")) steam on steam.File = pathrel.Id
 WHERE entry.Game = GameMetadataId
 GROUP BY steam.ManifestId
 ORDER BY COUNT(*) DESC;


### PR DESCRIPTION
As discussed, we discussed in #3912 MnemonicDB was upgraded so that all connections get a global ID and all models are read via `mdb_{name}()`.  Now to access the file hashes you can call a model function via `mdb_gogbuilds(DbName=>'hashes')` (case insensitive). This connection is resolved at query execution time, so new hash databases will be read as soon as the new connection is spun up (and the old one shut down? Need to look into that). If no name is provided, `default` is used instead, meaning we only need to use DbName when not providing the DB as a parameter or when using the non-primary database.

This won't crash as before, may still be some issues around db upgrades. 