### PR TITLE
Add preferences paths to Skyrim/Fallout4 

### DIFF
--- a/src/NexusMods.Games.CreationEngine/ACreationEngineSynchronizer.cs
+++ b/src/NexusMods.Games.CreationEngine/ACreationEngineSynchronizer.cs
@@ -21,7 +21,11 @@ public abstract class ACreationEngineSynchronizer : ALoadoutSynchronizer
             {pluginsFile.Path, pluginsFile},
         };
     }
- 
+
+    
+    private static readonly GamePath SavesPath = new GamePath(LocationId.Preferences, "Saves");
+    protected override bool ShouldIgnorePathWhenIndexing(GamePath path) => path.InFolder(SavesPath);
+
     public override Dictionary<GamePath, IIntrinsicFile> IntrinsicFiles(Loadout.ReadOnly _) => _intrinsicFiles;
     
     public override bool IsIgnoredBackupPath(GamePath path)

--- a/src/NexusMods.Games.CreationEngine/Fallout4/Fallout4.cs
+++ b/src/NexusMods.Games.CreationEngine/Fallout4/Fallout4.cs
@@ -52,7 +52,8 @@ public partial class Fallout4 : AGame, ISteamGame, IGogGame, ICreationEngineGame
         return new Dictionary<LocationId, AbsolutePath>()
         {
             { LocationId.Game, installation.Path },
-            { LocationId.AppData, fileSystem.GetKnownPath(KnownPath.LocalApplicationDataDirectory) / "Fallout 4" },
+            { LocationId.AppData, fileSystem.GetKnownPath(KnownPath.LocalApplicationDataDirectory) / "Fallout4" },
+            { LocationId.Preferences, fileSystem.GetKnownPath(KnownPath.MyGamesDirectory) / "Fallout4" },
         };
     }
 

--- a/src/NexusMods.Games.CreationEngine/Fallout4/Fallout4KnownPaths.cs
+++ b/src/NexusMods.Games.CreationEngine/Fallout4/Fallout4KnownPaths.cs
@@ -4,6 +4,5 @@ namespace NexusMods.Games.CreationEngine.Fallout4;
 
 public class Fallout4KnownPaths
 {
-    public static readonly GamePath AppDataPath = new(LocationId.AppData, "Fallout 4");
-    public static readonly GamePath PluginsFile = AppDataPath / "plugins.txt";
+    public static readonly GamePath PluginsFile = new (LocationId.AppData, "plugins.txt");
 }

--- a/src/NexusMods.Games.CreationEngine/SkyrimSE/SkyrimSE.cs
+++ b/src/NexusMods.Games.CreationEngine/SkyrimSE/SkyrimSE.cs
@@ -48,10 +48,14 @@ public partial class SkyrimSE : AGame, ISteamGame, IGogGame, ICreationEngineGame
 
     protected override IReadOnlyDictionary<LocationId, AbsolutePath> GetLocations(IFileSystem fileSystem, GameLocatorResult installation)
     {
+        string postfix = "";
+        if (installation.Store == GameStore.GOG)
+            postfix = " GOG";
         return new Dictionary<LocationId, AbsolutePath>()
         {
             { LocationId.Game, installation.Path },
             { LocationId.AppData, fileSystem.GetKnownPath(KnownPath.LocalApplicationDataDirectory) / "Skyrim Special Edition" },
+            { LocationId.Preferences, fileSystem.GetKnownPath(KnownPath.MyGamesDirectory) / ("Skyrim Special Edition" + postfix)},
         };
     }
 


### PR DESCRIPTION
Adds a mapping for `LocationId.Preferences` for Fallout4/SkyrimSE and ignores saves in those folders. I'll add some diagnostics for this in the future, but at least for now we can track/change inis for the games. I was planning to go deeper with this by parsing/ingesting the contents of the INIs themselves, but that code ended up way more complex than I had hoped. This is a simpler approach and works for now.

In a future PR we'll add a diagnostic to inform the user about FO4 changes they need to make