### PR TITLE
Add shared semaphore lock for un-managing game from loadout synchronization

### DIFF
--- a/src/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -1788,65 +1788,76 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
     /// <inheritdoc />
     public async Task UnManage(GameInstallation installation, bool runGc = true, bool cleanGameFolder = true)
     {
-        await _jobMonitor.Begin(new UnmanageGameJob(installation), async ctx =>
-            {
-                var metadata = installation.GetMetadata(Connection);
-
-                if (GetCurrentlyActiveLoadout(installation).HasValue && cleanGameFolder)
-                    await DeactivateCurrentLoadout(installation);
-
-                await ctx.YieldAsync();
-
+        var sharedSemaphore = _synchronizerService.GetSharedSemaphore();
+        await sharedSemaphore.WaitAsync();
+        try
+        {
+            await _jobMonitor.Begin(new UnmanageGameJob(installation), async ctx =>
                 {
-                    using var tx1 = Connection.BeginTransaction();
+                    var metadata = installation.GetMetadata(Connection);
+
+                    if (GetCurrentlyActiveLoadout(installation).HasValue && cleanGameFolder)
+                        await DeactivateCurrentLoadout(installation);
+
+                    await ctx.YieldAsync();
+
+                    {
+                        using var tx1 = Connection.BeginTransaction();
+                        foreach (var loadout in metadata.Loadouts)
+                        {
+                            tx1.Add(loadout.Id, Loadout.LoadoutKind, LoadoutKind.Deleted);
+                        }
+
+                        await tx1.Commit();
+
+                        metadata = installation.GetMetadata(Connection);
+                        Debug.Assert(metadata.Loadouts.All(x => !x.IsVisible()), "all loadouts shouldn't be visible anymore");
+                    }
+
                     foreach (var loadout in metadata.Loadouts)
                     {
-                        tx1.Add(loadout.Id, Loadout.LoadoutKind, LoadoutKind.Deleted);
+                        Logger.LogInformation("Deleting loadout {Loadout} - {ShortName}", loadout.Name, loadout.ShortName);
+                        await ctx.YieldAsync();
+                        await DeleteLoadout(loadout, GarbageCollectorRunMode.DoNotRun, deactivateIfActive: cleanGameFolder);
                     }
-                    await tx1.Commit();
 
-                    metadata = installation.GetMetadata(Connection);
-                    Debug.Assert(metadata.Loadouts.All(x => !x.IsVisible()), "all loadouts shouldn't be visible anymore");
-                }
+                    // Retract all `GameBakedUpFile` entries to allow for game file backups to be cleaned up from the FileStore
+                    using var tx = Connection.BeginTransaction();
+                    foreach (var file in GameBackedUpFile.All(Connection.Db))
+                    {
+                        if (file.GameInstallId.Value == installation.GameMetadataId)
+                            tx.Delete(file, recursive: false);
+                    }
 
-                foreach (var loadout in metadata.Loadouts)
-                {
-                    Logger.LogInformation("Deleting loadout {Loadout} - {ShortName}", loadout.Name, loadout.ShortName);
-                    await ctx.YieldAsync();
-                    await DeleteLoadout(loadout, GarbageCollectorRunMode.DoNotRun, deactivateIfActive: cleanGameFolder);
-                }
-                
-                // Retract all `GameBakedUpFile` entries to allow for game file backups to be cleaned up from the FileStore
-                using var tx = Connection.BeginTransaction();
-                foreach (var file in GameBackedUpFile.All(Connection.Db))
-                {
-                    if (file.GameInstallId.Value == installation.GameMetadataId)
-                        tx.Delete(file, recursive: false);
-                }
-                
-                // Delete the last applied/scanned disk state data
-                metadata = metadata.Rebase();
-                
-                foreach (var entry in metadata.DiskStateEntries)
-                {
-                    tx.Delete(entry, recursive: false);
-                }
-                if (metadata.Contains(GameInstallMetadata.LastSyncedLoadoutId))
-                    tx.Retract(metadata, GameInstallMetadata.LastSyncedLoadoutId, metadata.LastSyncedLoadoutId.Value);
-                if (metadata.Contains(GameInstallMetadata.LastSyncedLoadoutTransactionId))
-                    tx.Retract(metadata, GameInstallMetadata.LastSyncedLoadoutTransactionId, metadata.LastSyncedLoadoutTransactionId.Value);
-                if (metadata.Contains(GameInstallMetadata.InitialDiskStateTransactionId))
-                    tx.Retract(metadata, GameInstallMetadata.InitialDiskStateTransactionId, metadata.InitialDiskStateTransactionId.Value);
-                if (metadata.Contains(GameInstallMetadata.LastScannedDiskStateTransactionId))
-                    tx.Retract(metadata, GameInstallMetadata.LastScannedDiskStateTransactionId ,metadata.LastScannedDiskStateTransactionId.Value);
-                
-                await tx.Commit();
+                    // Delete the last applied/scanned disk state data
+                    metadata = metadata.Rebase();
 
-                if (runGc)
-                    _garbageCollectorRunner.Run();
-                return installation;
-            }
-        );
+                    foreach (var entry in metadata.DiskStateEntries)
+                    {
+                        tx.Delete(entry, recursive: false);
+                    }
+
+                    if (metadata.Contains(GameInstallMetadata.LastSyncedLoadoutId))
+                        tx.Retract(metadata, GameInstallMetadata.LastSyncedLoadoutId, metadata.LastSyncedLoadoutId.Value);
+                    if (metadata.Contains(GameInstallMetadata.LastSyncedLoadoutTransactionId))
+                        tx.Retract(metadata, GameInstallMetadata.LastSyncedLoadoutTransactionId, metadata.LastSyncedLoadoutTransactionId.Value);
+                    if (metadata.Contains(GameInstallMetadata.InitialDiskStateTransactionId))
+                        tx.Retract(metadata, GameInstallMetadata.InitialDiskStateTransactionId, metadata.InitialDiskStateTransactionId.Value);
+                    if (metadata.Contains(GameInstallMetadata.LastScannedDiskStateTransactionId))
+                        tx.Retract(metadata, GameInstallMetadata.LastScannedDiskStateTransactionId, metadata.LastScannedDiskStateTransactionId.Value);
+
+                    await tx.Commit();
+
+                    if (runGc)
+                        _garbageCollectorRunner.Run();
+                    return installation;
+                }
+            );
+        }
+        finally
+        {
+            sharedSemaphore.Release();
+        }
     }
 
     /// <inheritdoc />

--- a/src/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
+++ b/src/NexusMods.Abstractions.Loadouts.Synchronizers/ALoadoutSynchronizer.cs
@@ -1788,11 +1788,11 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
     /// <inheritdoc />
     public async Task UnManage(GameInstallation installation, bool runGc = true, bool cleanGameFolder = true)
     {
-        var sharedSemaphore = _synchronizerService.GetSharedSemaphore();
-        await sharedSemaphore.WaitAsync();
-        try
-        {
-            await _jobMonitor.Begin(new UnmanageGameJob(installation), async ctx =>
+        await _jobMonitor.Begin(new UnmanageGameJob(installation), async ctx =>
+            {
+                var sharedSemaphore = _synchronizerService.GetSharedSemaphore();
+                await sharedSemaphore.WaitAsync();
+                try
                 {
                     var metadata = installation.GetMetadata(Connection);
 
@@ -1850,14 +1850,14 @@ public class ALoadoutSynchronizer : ILoadoutSynchronizer
 
                     if (runGc)
                         _garbageCollectorRunner.Run();
-                    return installation;
                 }
-            );
-        }
-        finally
-        {
-            sharedSemaphore.Release();
-        }
+                finally
+                {
+                    sharedSemaphore.Release();
+                }
+                return installation;
+            }
+        );
     }
 
     /// <inheritdoc />

--- a/src/NexusMods.Abstractions.Loadouts/ISynchronizerService.cs
+++ b/src/NexusMods.Abstractions.Loadouts/ISynchronizerService.cs
@@ -24,6 +24,11 @@ public interface ISynchronizerService
     public FileDiffTree GetApplyDiffTree(LoadoutId loadout);
 
     /// <summary>
+    /// Returns the instance of the synchronizer's semaphore.
+    /// </summary>
+    public SemaphoreSlim GetSharedSemaphore();
+    
+    /// <summary>
     /// Returns the last applied loadout for a given game installation.
     /// </summary>
     public bool TryGetLastAppliedLoadout(GameInstallation gameInstallation, out Loadout.ReadOnly loadout);

--- a/src/NexusMods.App.UI/LeftMenu/Items/ApplyControl/ApplyControlViewModel.cs
+++ b/src/NexusMods.App.UI/LeftMenu/Items/ApplyControl/ApplyControlViewModel.cs
@@ -111,13 +111,14 @@ public class ApplyControlViewModel : AViewModel<IApplyControlViewModel>, IApplyC
                     .Subscribe(status =>
                     {
                         var (ldStatus, isProcessing,  gameStatus, running) = status;
-                        
+                        var hasUnmanageJob = _jobMonitor.Jobs.Any(job => job.Definition is UnmanageGameJob);
                         IsProcessing = isProcessing;
                         CanApply = !isProcessing
                                    && !running
                                    && gameStatus != GameSynchronizerState.Busy
                                    && ldStatus != LoadoutSynchronizerState.Pending
-                                   && ldStatus != LoadoutSynchronizerState.Current;
+                                   && ldStatus != LoadoutSynchronizerState.Current
+                                   && !hasUnmanageJob;
                         IsLaunchButtonEnabled = !isProcessing 
                                                 && !running
                                                 && gameStatus != GameSynchronizerState.Busy

--- a/src/NexusMods.DataModel/Synchronizer/SynchronizerService.cs
+++ b/src/NexusMods.DataModel/Synchronizer/SynchronizerService.cs
@@ -111,6 +111,9 @@ public class SynchronizerService : ISynchronizerService
         );
     }
 
+    /// <inheritdoc />
+    public SemaphoreSlim GetSharedSemaphore() => _semaphore;
+
     private SynchronizerState GetOrAddLoadoutState(LoadoutId loadoutId)
     {
         lock (_lock)

--- a/src/NexusMods.DataModel/Synchronizer/SynchronizerService.cs
+++ b/src/NexusMods.DataModel/Synchronizer/SynchronizerService.cs
@@ -86,6 +86,14 @@ public class SynchronizerService : ISynchronizerService
         await _jobMonitor.Begin(new SynchronizeLoadoutJob(loadoutId),
             async ctx =>
             {
+                var unManageJob = _jobMonitor.Jobs
+                    .FirstOrDefault(j => j.Definition is UnmanageGameJob);
+                if (unManageJob != null)
+                {
+                    _jobMonitor.Cancel(_jobMonitor.Jobs.First(j => j.Definition is SynchronizeLoadoutJob).Id);
+                    return Unit.Default;
+                }
+
                 var job = ctx.Definition;
                 await _semaphore.WaitAsync();
                 try


### PR DESCRIPTION
Fixes #3939 

This PR retrieves the same semaphore instance from `SynchronizerService.cs`, and apply this semaphore in `UnManage()` from `ALoadoutSynchronizer`. Based on the semaphore reference, this will follow the locking mechanism where `UnManage()` will resume its request if there is no other loadouts synchronizing Users will have to wait for the corresponding loadout to complete its synchronization before the un-manage job starts.

There is another bug vice versa, where a user can synchronize a loadout during the un-manage job; users should not be able to synchronize a loadout while the game is un-managing. The PR also adds a fix to the UI where the "Apply" button will not appear when the game is un-managing.  In `Synchronize()`, the latest loadout synchronize job is cancelled if there is an un-manage job. However, I am not sure what to return for this case: whether it should be thrown an error or it should still return the default value.