### PR TITLE
Fix embedded resource name

### DIFF
--- a/src/NexusMods.Backend/OS/LinuxInterop.Protocol.cs
+++ b/src/NexusMods.Backend/OS/LinuxInterop.Protocol.cs
@@ -10,7 +10,7 @@ internal partial class LinuxInterop
 {
     private const string ApplicationId = "com.nexusmods.app";
     private const string DesktopFile = $"{ApplicationId}.desktop";
-    private const string DesktopFileResourceName = $"NexusMods.CrossPlatform.{DesktopFile}";
+    private const string DesktopFileResourceName = $"NexusMods.Backend.{DesktopFile}";
     private const string ExecuteParameterPlaceholder = "${INSTALL_EXEC}";
     private const string TryExecuteParameterPlaceholder = "${INSTALL_TRYEXEC}";
 


### PR DESCRIPTION
I should probably update `EmbeddedResourceStreamFactory` to use the assembly name directly at some point...