### PR TITLE
Remove incorrect !isDisposed debug assert from TreeDataGrid selection observable

### DIFF
--- a/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridAdapter.cs
+++ b/src/NexusMods.App.UI/Controls/TreeDataGrid/TreeDataGridAdapter.cs
@@ -101,7 +101,6 @@ public abstract class TreeDataGridAdapter<TModel, TKey> : ReactiveR3Object, ISea
                     {
                         foreach (var item in self.SelectedModels)
                         {
-                            Debug.Assert(!item.IsDisposed);
                             if (item.IsDisposed) continue;
                             item.IsSelected.Value = false;
                         }
@@ -115,7 +114,6 @@ public abstract class TreeDataGridAdapter<TModel, TKey> : ReactiveR3Object, ISea
                         foreach (var item in eventArgs.DeselectedItems)
                         {
                             if (item is null) continue;
-                            Debug.Assert(!item.IsDisposed);
                             if (item.IsDisposed) continue;
                             
                             item.IsSelected.Value = false;


### PR DESCRIPTION
Remove `Debug.Assert(!item.IsDisposed)` for cases where it's valid for items to be disposed.