### PR TITLE
Use dynamic version in `EventTrackerTests.Test_PrepareRequest`

### DIFF
--- a/tests/NexusMods.Backend.Tests/EventTrackerTests.Test_PrepareRequest.verified.txt
+++ b/tests/NexusMods.Backend.Tests/EventTrackerTests.Test_PrepareRequest.verified.txt
@@ -4,7 +4,7 @@
     properties: {
       time: 0,
       app_name: Nexus Mods App,
-      app_version: 0.0.1,
+      app_version: {{app_version}},
       platform_type: app,
       token: Guid_1,
       $device_id: Guid_Empty,
@@ -22,7 +22,7 @@
     properties: {
       time: 0,
       app_name: Nexus Mods App,
-      app_version: 0.0.1,
+      app_version: {{app_version}},
       platform_type: app,
       token: Guid_1,
       $device_id: Guid_Empty,
@@ -40,7 +40,7 @@
     properties: {
       time: 0,
       app_name: Nexus Mods App,
-      app_version: 0.0.1,
+      app_version: {{app_version}},
       platform_type: app,
       token: Guid_1,
       $device_id: Guid_Empty,
@@ -58,7 +58,7 @@
     properties: {
       time: 0,
       app_name: Nexus Mods App,
-      app_version: 0.0.1,
+      app_version: {{app_version}},
       platform_type: app,
       token: Guid_1,
       $device_id: Guid_Empty,
@@ -76,7 +76,7 @@
     properties: {
       time: 0,
       app_name: Nexus Mods App,
-      app_version: 0.0.1,
+      app_version: {{app_version}},
       platform_type: app,
       token: Guid_1,
       $device_id: Guid_Empty,

--- a/tests/NexusMods.Backend.Tests/EventTrackerTests.cs
+++ b/tests/NexusMods.Backend.Tests/EventTrackerTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Time.Testing;
 using NexusMods.Abstractions.NexusWebApi;
 using NexusMods.Backend.Tracking;
 using NexusMods.Paths;
+using NexusMods.Sdk;
 using NexusMods.Sdk.Settings;
 using NexusMods.Sdk.Tracking;
 using NSubstitute;
@@ -52,6 +53,10 @@ public class EventTrackerTests
         await Assert.That(buffer).IsNotNull();
 
         var json = Encoding.UTF8.GetString(buffer!.WrittenSpan);
-        await VerifyJson(json);
+        await VerifyJson(json)
+            .AddScrubber(s => s.Replace(
+                ApplicationConstants.Version.ToSafeString(maxFieldCount: 3),
+                "{{app_version}}"
+            ));
     }
 }


### PR DESCRIPTION
The `EventTrackerTests.Test_PrepareRequest.verified.txt` test fixture snapshot had a hard-coded expected version, causing test failures when testing against a production build, or a build built with `/p:Version=1.2.3`

This change replaces that with a placeholder (`{{app_version}}`) and uses a [Verify scrubber](https://github.com/VerifyTests/Verify/blob/main/docs/scrubbers.md) to expect the actual `ApplicationConstants.Version` dynamically.

Fixes: #4030
