### PR TITLE
Fix Fomods with predefined choices not installing correctly 

### DIFF
--- a/src/NexusMods.Collections/InstallCollectionDownloadJob.cs
+++ b/src/NexusMods.Collections/InstallCollectionDownloadJob.cs
@@ -249,11 +249,17 @@ public class InstallCollectionDownloadJob : IJobDefinitionWithStart<InstallColle
             },
         };
 
-        _ = new NexusCollectionItemLoadoutGroup.New(tx, id)
+        var nexusCollectionItemLoadoutGroup = new NexusCollectionItemLoadoutGroup.New(tx, id)
         {
             DownloadId = Item,
             IsRequired = Item.IsRequired,
             LoadoutItemGroup = loadoutItemGroup,
+        };
+        
+        _ = new LibraryLinkedLoadoutItem.New(tx, id)
+        {
+            LibraryItemId = libraryFile.AsLibraryItem(),
+            LoadoutItemGroup = nexusCollectionItemLoadoutGroup.GetLoadoutItemGroup(tx),
         };
 
         var loadout = new Loadout.ReadOnly(Connection.Db, TargetLoadout);


### PR DESCRIPTION
Missing `LibraryLinkedLoadoutItem` meant that they would install, but then not be detected as such.