### PR TITLE
Fix nx archive File in use exception

### DIFF
--- a/src/NexusMods.DataModel/NxFileStore.cs
+++ b/src/NexusMods.DataModel/NxFileStore.cs
@@ -364,7 +364,7 @@ public class NxFileStore : IFileStore, IReadOnlyStreamSource
         // Extract from all source archives.
         Parallel.ForEach(groupedFiles, group =>
         {
-            var file = group.Key.Read();
+            using var file = group.Key.Read();
             var provider = new FromStreamProvider(file);
             var unpacker = new NxUnpacker(provider);
 


### PR DESCRIPTION
Fix nx archive files potentially being kept open after files were extracted from them (e.g. during Synchronize).

Attempts to delete the archives later during unmanage would result in exceptions.